### PR TITLE
Add nested AggregateException support for ShouldThrow

### DIFF
--- a/FluentAssertions.Net40/ExceptionExtensionsNet40.cs
+++ b/FluentAssertions.Net40/ExceptionExtensionsNet40.cs
@@ -145,7 +145,9 @@ namespace FluentAssertions
                 var aggregateException = actualException as AggregateException;
                 if (aggregateException != null)
                 {
-                    exceptions.AddRange(aggregateException.InnerExceptions.OfType<T>());
+                    var flattenedExceptions = aggregateException.Flatten();
+                    
+                    exceptions.AddRange(flattenedExceptions.InnerExceptions.OfType<T>());
                 }
                 else if (actualException is T)
                 {


### PR DESCRIPTION
Suggested fix for Issue #19. AggregateException.InnerExceptions does not express the hierarchy. ShouldThrow<SqlException> with a hierarchy of AggregateException -> AggregateException -> AggregateException -> AggregateException -> SqlException does not find the SqlException because InnerExceptions will only contain the first child AggregateException.
