### PR TITLE
removed NRE vulnerability in DefaultValueFormatter when value has null ToString()

### DIFF
--- a/FluentAssertions.Net35/Formatting/DefaultValueFormatter.cs
+++ b/FluentAssertions.Net35/Formatting/DefaultValueFormatter.cs
@@ -70,7 +70,7 @@ namespace FluentAssertions.Formatting
 
         private static bool HasDefaultToStringImplementation(object value)
         {
-            return value.ToString().Equals(value.GetType().ToString());
+            return string.Equals(value.ToString(), value.GetType().ToString());
         }
 
         private string GetTypeAndPublicPropertyValues(object obj, int nestedPropertyLevel, IList<object> processedObjects)


### PR DESCRIPTION
This bites us in FakeItEasy and prevents us from using FA for some assertions.

I don't think this PR solves the entire problem we are having but I believe this is a valid fix in it's own right.
