### PR TITLE
fixed ShouldAllBeEquivalentTo when comparing collections with duplicates

### DIFF
--- a/FluentAssertions.Net35/Equivalency/EnumerableEquivalencyStep.cs
+++ b/FluentAssertions.Net35/Equivalency/EnumerableEquivalencyStep.cs
@@ -107,6 +107,8 @@ namespace FluentAssertions.Equivalency
 
         private void AssertElementGraphEquivalency(object[] subjects, object[] expectations)
         {
+            matchedSubjectIndexes = new System.Collections.Generic.List<int>();
+
             for (int index = 0; index < expectations.Length; index++)
             {
                 object expectation = expectations[index];
@@ -122,18 +124,24 @@ namespace FluentAssertions.Equivalency
             }
         }
 
+        private System.Collections.Generic.List<int> matchedSubjectIndexes;
+
         private void LooselyMatchAgainst(object[] subjects, object expectation, int expectationIndex)
         {
             var results = new AssertionResultSet();
 
             for (int index = 0; index < subjects.Length; index++)
             {
-                object subject = subjects[index];
-
-                results.AddSet(index, TryToMatch(subject, expectation, expectationIndex));
-                if (results.ContainsSuccessfulSet)
+                if (!matchedSubjectIndexes.Contains(index))
                 {
-                    break;
+                    object subject = subjects[index];
+
+                    results.AddSet(index, TryToMatch(subject, expectation, expectationIndex));
+                    if (results.ContainsSuccessfulSet)
+                    {
+                        matchedSubjectIndexes.Add(index);
+                        break;
+                    }
                 }
             }
 

--- a/FluentAssertions.Specs/EquivalencySpecs.cs
+++ b/FluentAssertions.Specs/EquivalencySpecs.cs
@@ -1156,6 +1156,167 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
+        public void When_the_subject_contains_same_number_of_items_but_subject_contains_duplicates_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new List<Customer>
+            {
+                new Customer
+                {
+                    Name = "John",
+                    Age = 27,
+                    Id = 1
+                },
+                new Customer
+                {
+                    Name = "John",
+                    Age = 27,
+                    Id = 1
+                },
+            };
+
+            var expectation = new List<Customer>
+            {
+                new Customer
+                {
+                    Name = "John",
+                    Age = 27,
+                    Id = 1
+                },
+                new Customer
+                {
+                    Name = "Jane",
+                    Age = 24,
+                    Id = 2
+                }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => subject.ShouldAllBeEquivalentTo(expectation);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected item[1].Name to be \"Jane\", but \"John\" differs near*", ComparisonMode.Wildcard);
+        }
+
+        [TestMethod]
+        public void When_the_subject_contains_same_number_of_items_but_expectation_contains_duplicates_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new List<Customer>
+            {
+                new Customer
+                {
+                    Name = "John",
+                    Age = 27,
+                    Id = 1
+                },
+                new Customer
+                {
+                    Name = "Jane",
+                    Age = 24,
+                    Id = 2
+                }
+            };
+
+            var expectation = new List<Customer>
+            {
+                new Customer
+                {
+                    Name = "John",
+                    Age = 27,
+                    Id = 1
+                },
+                new Customer
+                {
+                    Name = "John",
+                    Age = 27,
+                    Id = 1
+                },
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => subject.ShouldAllBeEquivalentTo(expectation);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected item[1].Name to be \"John\", but \"Jane\" differs near*", ComparisonMode.Wildcard);
+        }
+
+        [TestMethod]
+        public void When_the_subject_contains_same_number_of_items_and_both_contain_duplicates_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new List<Customer>
+            {
+                new Customer
+                {
+                    Name = "John",
+                    Age = 27,
+                    Id = 1
+                },
+                new Customer
+                {
+                    Name = "John",
+                    Age = 27,
+                    Id = 1
+                },
+                new Customer
+                {
+                    Name = "Jane",
+                    Age = 24,
+                    Id = 2
+                }
+            };
+
+            var expectation = new List<Customer>
+            {
+                new Customer
+                {
+                    Name = "Jane",
+                    Age = 24,
+                    Id = 2
+                },
+                new Customer
+                {
+                    Name = "John",
+                    Age = 27,
+                    Id = 1
+                },
+                new Customer
+                {
+                    Name = "John",
+                    Age = 27,
+                    Id = 1
+                },
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => subject.ShouldAllBeEquivalentTo(expectation);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.ShouldNotThrow();
+        }
+
+        [TestMethod]
         public void When_a_collection_is_compared_to_a_non_collection_it_should_throw()
         {
             //-----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
When using ShouldAllBeEquivalentTo to compare two collections with same number of elements but subject containing duplicates (so some items are missing) the assertion wouldn't fail. Check the "When_the_subject_contains_same_number_of_items_but_expectation_contains_duplicates_it_should_throw" test.
