### PR TITLE
Added an AndWhichConstraint

### DIFF
--- a/FluentAssertions.Net35/AndWhichConstraint.cs
+++ b/FluentAssertions.Net35/AndWhichConstraint.cs
@@ -1,0 +1,26 @@
+namespace FluentAssertions
+{
+    /// <summary>
+    /// Constraint which can be returned from an assertion which matches a condition and which will allow
+    /// further matches to be performed on the matched condition as well as the parent constraint.
+    /// </summary>
+    /// <typeparam name="TParentConstraint">The type of the original constraint that was matched</typeparam>
+    /// <typeparam name="TMatchedElement">The type of the matched object which the parent constarint matched</typeparam>
+    public class AndWhichConstraint<TParentConstraint, TMatchedElement> : AndConstraint<TParentConstraint>
+    {
+        private readonly TMatchedElement matchedConstraint;
+
+        public AndWhichConstraint(TParentConstraint parentConstraint, TMatchedElement matchedConstraint) : base(parentConstraint)
+        {
+            this.matchedConstraint = matchedConstraint;
+        }
+
+        /// <summary>
+        /// Returns the instance which the original parent constraint matched, so that further matches can be performed
+        /// </summary>
+        public TMatchedElement Which
+        {
+            get { return matchedConstraint; }
+        }
+    }
+}

--- a/FluentAssertions.Net35/FluentAssertions.Net35.csproj
+++ b/FluentAssertions.Net35/FluentAssertions.Net35.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Formatting\ValueFormatterAttribute.cs" />
     <Compile Include="Specialized\ActionAssertions.cs" />
     <Compile Include="AndConstraint.cs" />
+    <Compile Include="AndWhichConstraint.cs" />
     <Compile Include="Equivalency\AllDeclaredPublicPropertiesSelectionRule.cs" />
     <Compile Include="Equivalency\AllRuntimePublicPropertiesSelectionRule.cs" />
     <Compile Include="Equivalency\ApplyAssertionRulesEquivalencyStep.cs" />

--- a/FluentAssertions.Net35/Xml/XDocumentAssertions.cs
+++ b/FluentAssertions.Net35/Xml/XDocumentAssertions.cs
@@ -227,7 +227,7 @@ namespace FluentAssertions.Xml
         /// <param name="expected">
         /// The name of the expected child element of the current document's Root <see cref="XDocument.Root"/> element.
         /// </param>
-        public AndConstraint<XDocumentAssertions> HaveElement(string expected)
+        public AndWhichConstraint<XDocumentAssertions, XElement> HaveElement(string expected)
         {
             return HaveElement(expected, string.Empty);
         }
@@ -239,7 +239,7 @@ namespace FluentAssertions.Xml
         /// <param name="expected">
         /// The full name <see cref="XName"/> of the expected child element of the current document's Root <see cref="XDocument.Root"/> element.
         /// </param>
-        public AndConstraint<XDocumentAssertions> HaveElement(XName expected)
+        public AndWhichConstraint<XDocumentAssertions, XElement> HaveElement(XName expected)
         {
             return HaveElement(expected, string.Empty);
         }
@@ -258,7 +258,7 @@ namespace FluentAssertions.Xml
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<XDocumentAssertions> HaveElement(string expected, string reason, params object[] reasonArgs)
+        public AndWhichConstraint<XDocumentAssertions, XElement> HaveElement(string expected, string reason, params object[] reasonArgs)
         {
             return HaveElement(XNamespace.None + expected, reason, reasonArgs);
         }
@@ -277,7 +277,7 @@ namespace FluentAssertions.Xml
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<XDocumentAssertions> HaveElement(XName expected, string reason, params object[] reasonArgs)
+        public AndWhichConstraint<XDocumentAssertions, XElement> HaveElement(XName expected, string reason, params object[] reasonArgs)
         {
             string expectedText = expected.ToString().Escape();
             Execute.Assertion
@@ -286,13 +286,14 @@ namespace FluentAssertions.Xml
                 .FailWith("Expected XML document {0} to have root element with child \"" + expectedText + "\"{reason}" +
                     ", but XML document has no Root element.", Subject);
 
+            XElement xElement = Subject.Root.Element(expected);
             Execute.Assertion
-                .ForCondition(Subject.Root.Element(expected) != null)
+                .ForCondition(xElement != null)
                 .BecauseOf(reason, reasonArgs)
                 .FailWith("Expected XML document {0} to have root element with child \"" + expectedText + "\"{reason}" +
                     ", but no such child element was found.", Subject);
 
-            return new AndConstraint<XDocumentAssertions>(this);
+            return new AndWhichConstraint<XDocumentAssertions, XElement>(this, xElement);
         }
 
         /// <summary>

--- a/FluentAssertions.Net35/Xml/XElementAssertions.cs
+++ b/FluentAssertions.Net35/Xml/XElementAssertions.cs
@@ -260,7 +260,7 @@ namespace FluentAssertions.Xml
         /// <paramref name="expected"/> name.
         /// </summary>
         /// <param name="expected">The name of the expected child element</param>
-        public AndConstraint<XElementAssertions> HaveElement(string expected)
+        public AndWhichConstraint<XElementAssertions, XElement> HaveElement(string expected)
         {
             return HaveElement(expected, string.Empty);
         }
@@ -270,7 +270,7 @@ namespace FluentAssertions.Xml
         /// <paramref name="expected"/> name.
         /// </summary>
         /// <param name="expected">The name <see cref="XName"/> of the expected child element</param>
-        public AndConstraint<XElementAssertions> HaveElement(XName expected)
+        public AndWhichConstraint<XElementAssertions, XElement> HaveElement(XName expected)
         {
             return HaveElement(expected, string.Empty);
         }
@@ -287,7 +287,7 @@ namespace FluentAssertions.Xml
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<XElementAssertions> HaveElement(string expected, string reason, params object[] reasonArgs)
+        public AndWhichConstraint<XElementAssertions, XElement> HaveElement(string expected, string reason, params object[] reasonArgs)
         {
             return HaveElement(XNamespace.None + expected, reason, reasonArgs);
         }
@@ -304,15 +304,16 @@ namespace FluentAssertions.Xml
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<XElementAssertions> HaveElement(XName expected, string reason, params object[] reasonArgs)
+        public AndWhichConstraint<XElementAssertions,XElement> HaveElement(XName expected, string reason, params object[] reasonArgs)
         {
+            XElement xElement = Subject.Element(expected);
             Execute.Assertion
-                .ForCondition(Subject.Element(expected) != null)
+                .ForCondition(xElement != null)
                 .BecauseOf(reason, reasonArgs)
                 .FailWith("Expected XML element {0} to have child element \"" + expected.ToString().Escape() + "\"{reason}" +
                         ", but no such child element was found.", Subject);
 
-            return new AndConstraint<XElementAssertions>(this);
+            return new AndWhichConstraint<XElementAssertions, XElement>(this, xElement);
         }
 
         /// <summary>

--- a/FluentAssertions.Net40/FluentAssertions.Net40.csproj
+++ b/FluentAssertions.Net40/FluentAssertions.Net40.csproj
@@ -67,6 +67,9 @@
     <Compile Include="..\FluentAssertions.Net35\AndConstraint.cs">
       <Link>AndConstraint.cs</Link>
     </Compile>
+	<Compile Include="..\FluentAssertions.Net35\AndWhichConstraint.cs">
+      <Link>AndWhichConstraint.cs</Link>
+    </Compile>
     <Compile Include="..\FluentAssertions.Net35\AssertionExtensions.cs">
       <Link>AssertionExtensions.cs</Link>
     </Compile>

--- a/FluentAssertions.Net45/FluentAssertions.Net45.csproj
+++ b/FluentAssertions.Net45/FluentAssertions.Net45.csproj
@@ -65,6 +65,9 @@
     <Compile Include="..\FluentAssertions.Net35\AndConstraint.cs">
       <Link>AndConstraint.cs</Link>
     </Compile>
+	<Compile Include="..\FluentAssertions.Net35\AndWhichConstraint.cs">
+      <Link>AndWhichConstraint.cs</Link>
+    </Compile>
     <Compile Include="..\FluentAssertions.Net35\AssertionExtensions.cs">
       <Link>AssertionExtensions.cs</Link>
     </Compile>

--- a/FluentAssertions.Silverlight/FluentAssertions.Silverlight.csproj
+++ b/FluentAssertions.Silverlight/FluentAssertions.Silverlight.csproj
@@ -113,6 +113,9 @@
     <Compile Include="..\FluentAssertions.Net35\AndConstraint.cs">
       <Link>AndConstraint.cs</Link>
     </Compile>
+	<Compile Include="..\FluentAssertions.Net35\AndWhichConstraint.cs">
+      <Link>AndWhichConstraint.cs</Link>
+    </Compile>
     <Compile Include="..\FluentAssertions.Net35\AssertionExtensions.Actions.cs">
       <Link>AssertionExtensions.Actions.cs</Link>
     </Compile>

--- a/FluentAssertions.Specs/XDocumentAssertionSpecs.cs
+++ b/FluentAssertions.Specs/XDocumentAssertionSpecs.cs
@@ -883,6 +883,30 @@ namespace FluentAssertions.Specs
             act.ShouldThrow<AssertFailedException>().WithMessage(expectedMessage);
         }
 
+        [TestMethod]
+        public void When_asserting_document_has_root_with_child_element_with_attributes_it_should_be_possible_to_use_which_to_assert_on_the_element()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var document = XDocument.Parse(
+                @"<parent>
+                    <child attr='1' />
+                  </parent>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            var matchedElement = document.Should().HaveElement("child").Which;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            matchedElement.Should().BeOfType<XElement>()
+                .And.HaveAttribute("attr", "1");
+            matchedElement.Name.Should().Be(XName.Get("child"));
+        }
+
         #endregion
     }
 }

--- a/FluentAssertions.Specs/XElementAssertionSpecs.cs
+++ b/FluentAssertions.Specs/XElementAssertionSpecs.cs
@@ -990,6 +990,31 @@ namespace FluentAssertions.Specs
             act.ShouldThrow<AssertFailedException>().WithMessage(expectedMessage);
         }
 
+        [TestMethod]
+        public void When_asserting_element_has_child_element_it_should_return_the_matched_element_in_the_which_property()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var element = XElement.Parse(
+                @"<parent>
+                    <child attr='1' />
+                  </parent>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            var matchedElement = element.Should().HaveElement("child").Which;
+                
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            matchedElement.Should().BeOfType<XElement>()
+                .And.HaveAttribute("attr", "1");
+            matchedElement.Name.Should().Be(XName.Get("child"));
+        }
+
         #endregion
     }
 }

--- a/FluentAssertions.WinRT/FluentAssertions.WinRT.csproj
+++ b/FluentAssertions.WinRT/FluentAssertions.WinRT.csproj
@@ -53,6 +53,9 @@
     <Compile Include="..\FluentAssertions.Net35\AndConstraint.cs">
       <Link>AndConstraint.cs</Link>
     </Compile>
+	<Compile Include="..\FluentAssertions.Net35\AndWhichConstraint.cs">
+      <Link>AndWhichConstraint.cs</Link>
+    </Compile>
     <Compile Include="..\FluentAssertions.Net35\AssertionExtensions.cs">
       <Link>AssertionExtensions.cs</Link>
     </Compile>


### PR DESCRIPTION
Hi.

I'm proposing an additional class, AndWhichConstraint, which allows access to the matched instance from another constraint so that further validations can be made on the matched instance.  For example given this:

```
XElement xElement = XElement.Parse(@"<parent>
                                         <child someAttribute='1'/>
                                     <parent/>");
```

then this sort of validation becomes possible:

```
xElement.Should().HaveElement("child").Which.Should().HaveAttribute("someAttribute",""1");
```

I have only used it in the XDocumentAssertions and XElementAssertions classes, but if you think this is a reasonable idea then I think there are other places in the library where it could be used, basically anywhere where a match of some object is done as part of the validation.

I was unable to load the silverlight/winRT/windowsPhone projects so I hope that my manual editing of the .cs files in them is ok!
