### PR TITLE
Fixed loading of WinRT projects on a machine with only VS2013/Win8.1

### DIFF
--- a/FluentAssertions.WinRT.Specs/FluentAssertions.WinRT.Specs.csproj
+++ b/FluentAssertions.WinRT.Specs/FluentAssertions.WinRT.Specs.csproj
@@ -221,7 +221,7 @@
     </AppxManifest>
     <None Include="FluentAssertions.WinRT.Specs_TemporaryKey.pfx" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v11.0\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v12.0\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/FluentAssertions.WinRT/FluentAssertions.WinRT.csproj
+++ b/FluentAssertions.WinRT/FluentAssertions.WinRT.csproj
@@ -92,7 +92,7 @@
       <Name>FluentAssertions.Core</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v11.0\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v12.0\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
This is a local change I have been keeping to allow me to load these projects.  It is also the change adamralph details in Issue #59.

Feel free to reject this if it is not a change you want to make, its just that I saw comments on other items indicating that VS2013/Win8.1 was going to be required for working with this branch, so I thought I would throw this this out there.
