### PR TITLE
Add DateTimeOffset Support

### DIFF
--- a/FluentAssertions.Core/FluentAssertions.Core.csproj
+++ b/FluentAssertions.Core/FluentAssertions.Core.csproj
@@ -121,7 +121,7 @@
     <Compile Include="FluentDateTimeExtensions.cs" />
     <Compile Include="Formatting\AggregateExceptionValueFormatter.cs" />
     <Compile Include="Formatting\AttributeBasedFormatter.cs" />
-    <Compile Include="Formatting\DateTimeValueFormatter.cs" />
+    <Compile Include="Formatting\DateTimeOffsetValueFormatter.cs" />
     <Compile Include="Formatting\DefaultValueFormatter.cs" />
     <Compile Include="Formatting\EnumerableValueFormatter.cs" />
     <Compile Include="Formatting\ExceptionValueFormatter.cs" />
@@ -144,11 +144,11 @@
     <Compile Include="Numeric\NumericAssertions.cs" />
     <Compile Include="Primitives\BooleanAssertions.cs" />
     <Compile Include="Primitives\ComparisonMode.cs" />
-    <Compile Include="Primitives\DateTimeAssertions.cs" />
+    <Compile Include="Primitives\DateTimeOffsetAssertions.cs" />
     <Compile Include="Primitives\GuidAssertions.cs" />
     <Compile Include="Primitives\NegatedStringStartValidator.cs" />
     <Compile Include="Primitives\NullableBooleanAssertions.cs" />
-    <Compile Include="Primitives\NullableDateTimeAssertions.cs" />
+    <Compile Include="Primitives\NullableDateTimeOffsetAssertions.cs" />
     <Compile Include="Primitives\NullableGuidAssertions.cs" />
     <Compile Include="Primitives\NullableSimpleTimeSpanAssertions.cs" />
     <Compile Include="Primitives\ObjectAssertions.cs" />

--- a/FluentAssertions.Core/Formatting/DateTimeOffsetValueFormatter.cs
+++ b/FluentAssertions.Core/Formatting/DateTimeOffsetValueFormatter.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace FluentAssertions.Formatting
 {
-    public class DateTimeValueFormatter : IValueFormatter
+    public class DateTimeOffsetValueFormatter : IValueFormatter
     {
         /// <summary>
         /// Indicates whether the current <see cref="IValueFormatter"/> can handle the specified <paramref name="value"/>.

--- a/FluentAssertions.Core/Formatting/Formatter.cs
+++ b/FluentAssertions.Core/Formatting/Formatter.cs
@@ -17,7 +17,7 @@ namespace FluentAssertions.Formatting
             new PropertyInfoFormatter(),
             new NullValueFormatter(),
             new GuidValueFormatter(),
-            new DateTimeValueFormatter(),
+            new DateTimeOffsetValueFormatter(),
             new TimeSpanValueFormatter(),
             new NumericValueFormatter(),
             new StringValueFormatter(),

--- a/FluentAssertions.Core/InternalAssertionExtensions.cs
+++ b/FluentAssertions.Core/InternalAssertionExtensions.cs
@@ -164,21 +164,21 @@ namespace FluentAssertions
         }
 
         /// <summary>
-        /// Returns an <see cref="DateTimeAssertions"/> object that can be used to assert the
+        /// Returns an <see cref="DateTimeOffsetAssertions"/> object that can be used to assert the
         /// current <see cref="DateTime"/>.
         /// </summary>
-        public static DateTimeAssertions Should(this DateTime actualValue)
+        public static DateTimeOffsetAssertions Should(this DateTime actualValue)
         {
-            return new DateTimeAssertions(actualValue);
+            return new DateTimeOffsetAssertions(actualValue);
         }
 
         /// <summary>
-        /// Returns an <see cref="NullableDateTimeAssertions"/> object that can be used to assert the
+        /// Returns an <see cref="NullableDateTimeOffsetAssertions"/> object that can be used to assert the
         /// current nullable <see cref="DateTime"/>.
         /// </summary>
-        public static NullableDateTimeAssertions Should(this DateTime? actualValue)
+        public static NullableDateTimeOffsetAssertions Should(this DateTime? actualValue)
         {
-            return new NullableDateTimeAssertions(actualValue);
+            return new NullableDateTimeOffsetAssertions(actualValue);
         }
 
         /// <summary>

--- a/FluentAssertions.Core/Primitives/DateTimeOffsetAssertions.cs
+++ b/FluentAssertions.Core/Primitives/DateTimeOffsetAssertions.cs
@@ -6,15 +6,15 @@ using FluentAssertions.Execution;
 namespace FluentAssertions.Primitives
 {
     /// <summary>
-    /// Contains a number of methods to assert that a <see cref="DateTime"/> is in the expected state.
+    /// Contains a number of methods to assert that a <see cref="DateTime"/> or <see cref="DateTimeOffset"/> is in the expected state.
     /// </summary>
     /// <remarks>
     /// You can use the <see cref="FluentDateTimeExtensions"/> for a more fluent way of specifying a <see cref="DateTime"/>.
     /// </remarks>
     [DebuggerNonUserCode]
-    public class DateTimeAssertions
+    public class DateTimeOffsetAssertions
     {
-        public DateTimeAssertions(DateTimeOffset? value)
+        public DateTimeOffsetAssertions(DateTimeOffset? value)
         {
             Subject = value;
         }
@@ -25,7 +25,7 @@ namespace FluentAssertions.Primitives
         public DateTimeOffset? Subject { get; private set; }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTime"/> is exactly equal to the <paramref name="expected"/> value.
+        /// Asserts that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> is exactly equal to the <paramref name="expected"/> value.
         /// </summary>
         /// <param name="expected">The expected value</param>
         /// <param name="reason">
@@ -35,7 +35,7 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> Be(DateTimeOffset expected, string reason = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeOffsetAssertions> Be(DateTimeOffset expected, string reason = "", params object[] reasonArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && (Subject.Value == expected))
@@ -43,11 +43,11 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context:date and time} to be {0}{reason}, but found {1}.",
                     expected, Subject.HasValue ? Subject.Value : default(DateTimeOffset?));
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTime"/> is not equal to the <paramref name="unexpected"/> value.
+        /// Asserts that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> is not equal to the <paramref name="unexpected"/> value.
         /// </summary>
         /// <param name="unexpected">The unexpected value</param>
         /// <param name="reason">
@@ -57,18 +57,18 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> NotBe(DateTimeOffset unexpected, string reason = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeOffsetAssertions> NotBe(DateTimeOffset unexpected, string reason = "", params object[] reasonArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue || (Subject.Value != unexpected))
                 .BecauseOf(reason, reasonArgs)
                 .FailWith("Did not expect {context:date and time} to be {0}{reason}.", unexpected);
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTime"/> is within the specified number of milliseconds (default = 20 ms)
+        /// Asserts that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> is within the specified number of milliseconds (default = 20 ms)
         /// from the specified <paramref name="nearbyTime"/> value.
         /// </summary>
         /// <remarks>
@@ -88,7 +88,7 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> BeCloseTo(DateTimeOffset nearbyTime, int precision = 20, string reason = "",
+        public AndConstraint<DateTimeOffsetAssertions> BeCloseTo(DateTimeOffset nearbyTime, int precision = 20, string reason = "",
             params object[] reasonArgs)
         {
             DateTimeOffset minimumValue = nearbyTime.AddMilliseconds(-precision);
@@ -100,13 +100,13 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context:date and time} to be within {0} ms from {1}{reason}, but found {2}.", precision,
                     nearbyTime, Subject.HasValue ? Subject.Value : default(DateTimeOffset?));
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTime"/> is before the specified value.
+        /// Asserts that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> is before the specified value.
         /// </summary>
-        /// <param name="expected">The <see cref="DateTime"/> that the current value is expected to be before.</param>
+        /// <param name="expected">The <see cref="DateTime"/> or <see cref="DateTimeOffset"/> that the current value is expected to be before.</param>
         /// <param name="reason">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -114,7 +114,7 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> BeBefore(DateTimeOffset expected, string reason = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeOffsetAssertions> BeBefore(DateTimeOffset expected, string reason = "", params object[] reasonArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) < 0)
@@ -122,13 +122,13 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected a {context:date and time} before {0}{reason}, but found {1}.", expected,
                     Subject.HasValue ? Subject.Value : default(DateTimeOffset?));
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTime"/> is either on, or before the specified value.
+        /// Asserts that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> is either on, or before the specified value.
         /// </summary>
-        /// <param name="expected">The <see cref="DateTime"/> that the current value is expected to be on or before.</param>
+        /// <param name="expected">The <see cref="DateTime"/> or <see cref="DateTimeOffset"/> that the current value is expected to be on or before.</param>
         /// <param name="reason">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -136,7 +136,7 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> BeOnOrBefore(DateTimeOffset expected, string reason = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeOffsetAssertions> BeOnOrBefore(DateTimeOffset expected, string reason = "", params object[] reasonArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) <= 0)
@@ -144,13 +144,13 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected a {context:date and time} on or before {0}{reason}, but found {1}.", expected,
                     Subject.HasValue ? Subject.Value : default(DateTimeOffset?));
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTime"/> is after the specified value.
+        /// Asserts that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> is after the specified value.
         /// </summary>
-        /// <param name="expected">The <see cref="DateTime"/> that the current value is expected to be after.</param>
+        /// <param name="expected">The <see cref="DateTime"/> or <see cref="DateTimeOffset"/> that the current value is expected to be after.</param>
         /// <param name="reason">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -158,7 +158,7 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> BeAfter(DateTimeOffset expected, string reason = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeOffsetAssertions> BeAfter(DateTimeOffset expected, string reason = "", params object[] reasonArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) > 0)
@@ -166,13 +166,13 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected a {context:date and time} after {0}{reason}, but found {1}.", expected,
                     Subject.HasValue ? Subject.Value : default(DateTimeOffset?));
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTime"/> is either on, or after the specified value.
+        /// Asserts that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> is either on, or after the specified value.
         /// </summary>
-        /// <param name="expected">The <see cref="DateTime"/> that the current value is expected to be on or after.</param>
+        /// <param name="expected">The <see cref="DateTime"/> or <see cref="DateTimeOffset"/> that the current value is expected to be on or after.</param>
         /// <param name="reason">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -180,7 +180,7 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> BeOnOrAfter(DateTimeOffset expected, string reason = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeOffsetAssertions> BeOnOrAfter(DateTimeOffset expected, string reason = "", params object[] reasonArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) >= 0)
@@ -188,11 +188,11 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected a {context:date and time} on or after {0}{reason}, but found {1}.", expected,
                     Subject.HasValue ? Subject.Value : default(DateTimeOffset?));
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTime"/> has the <paramref name="expected"/> year.
+        /// Asserts that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> has the <paramref name="expected"/> year.
         /// </summary>
         /// <param name="expected">The expected year of the current value.</param>
         /// <param name="reason">
@@ -202,12 +202,12 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> HaveYear(int expected, string reason = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeOffsetAssertions> HaveYear(int expected, string reason = "", params object[] reasonArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
                 .BecauseOf(reason, reasonArgs)
-                .FailWith("Expected year {0}{reason}, but found a <null> DateTime.", expected);
+                .FailWith("Expected year {0}{reason}, but found a <null> DateTime or DateTimeOffset.", expected);
 
             if (success)
             {
@@ -218,11 +218,11 @@ namespace FluentAssertions.Primitives
                         Subject.Value.Year);
             }
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTime"/> has the <paramref name="expected"/> month.
+        /// Asserts that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> has the <paramref name="expected"/> month.
         /// </summary>
         /// <param name="expected">The expected month of the current value.</param>
         /// <param name="reason">
@@ -232,12 +232,12 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> HaveMonth(int expected, string reason = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeOffsetAssertions> HaveMonth(int expected, string reason = "", params object[] reasonArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
                 .BecauseOf(reason, reasonArgs)
-                .FailWith("Expected month {0}{reason}, but found a <null> DateTime.", expected);
+                .FailWith("Expected month {0}{reason}, but found a <null> DateTime or DateTimeOffset.", expected);
 
             if (success)
             {
@@ -246,11 +246,11 @@ namespace FluentAssertions.Primitives
                     .BecauseOf(reason, reasonArgs)
                     .FailWith("Expected month {0}{reason}, but found {1}.", expected, Subject.Value.Month);
             }
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTime"/> has the <paramref name="expected"/> day.
+        /// Asserts that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> has the <paramref name="expected"/> day.
         /// </summary>
         /// <param name="expected">The expected day of the current value.</param>
         /// <param name="reason">
@@ -260,12 +260,12 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> HaveDay(int expected, string reason = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeOffsetAssertions> HaveDay(int expected, string reason = "", params object[] reasonArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
                 .BecauseOf(reason, reasonArgs)
-                .FailWith("Expected day {0}{reason}, but found a <null> DateTime.", expected);
+                .FailWith("Expected day {0}{reason}, but found a <null> DateTime or DateTimeOffset.", expected);
 
             if (success)
             {
@@ -275,11 +275,11 @@ namespace FluentAssertions.Primitives
                     .FailWith("Expected day {0}{reason}, but found {1}.", expected, Subject.Value.Day);
             }
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTime"/> has the <paramref name="expected"/> hour.
+        /// Asserts that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> has the <paramref name="expected"/> hour.
         /// </summary>
         /// <param name="expected">The expected hour of the current value.</param>
         /// <param name="reason">
@@ -289,12 +289,12 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> HaveHour(int expected, string reason = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeOffsetAssertions> HaveHour(int expected, string reason = "", params object[] reasonArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
                 .BecauseOf(reason, reasonArgs)
-                .FailWith("Expected hour {0}{reason}, but found a <null> DateTime.", expected);
+                .FailWith("Expected hour {0}{reason}, but found a <null> DateTime or DateTimeOffset.", expected);
 
             if (success)
             {
@@ -304,11 +304,11 @@ namespace FluentAssertions.Primitives
                     .FailWith("Expected hour {0}{reason}, but found {1}.", expected, Subject.Value.Hour);
             }
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTime"/> has the <paramref name="expected"/> minute.
+        /// Asserts that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> has the <paramref name="expected"/> minute.
         /// </summary>
         /// <param name="expected">The expected minutes of the current value.</param>
         /// <param name="reason">
@@ -318,12 +318,12 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> HaveMinute(int expected, string reason = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeOffsetAssertions> HaveMinute(int expected, string reason = "", params object[] reasonArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
                 .BecauseOf(reason, reasonArgs)
-                .FailWith("Expected minute {0}{reason}, but found a <null> DateTime.", expected);
+                .FailWith("Expected minute {0}{reason}, but found a <null> DateTime or DateTimeOffset.", expected);
 
             if (success)
             {
@@ -333,11 +333,11 @@ namespace FluentAssertions.Primitives
                     .FailWith("Expected minute {0}{reason}, but found {1}.", expected, Subject.Value.Minute);
             }
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTime"/> has the <paramref name="expected"/> second.
+        /// Asserts that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> has the <paramref name="expected"/> second.
         /// </summary>
         /// <param name="expected">The expected seconds of the current value.</param>
         /// <param name="reason">
@@ -347,12 +347,12 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> HaveSecond(int expected, string reason = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeOffsetAssertions> HaveSecond(int expected, string reason = "", params object[] reasonArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(Subject.HasValue)
                 .BecauseOf(reason, reasonArgs)
-                .FailWith("Expected secind {0}{reason}, but found a <null> DateTime.", expected);
+                .FailWith("Expected second {0}{reason}, but found a <null> DateTime or DateTimeOffset.", expected);
 
             if (success)
             {
@@ -362,15 +362,15 @@ namespace FluentAssertions.Primitives
                     .FailWith("Expected second {0}{reason}, but found {1}.", expected, Subject.Value.Second);
             }
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
 
         /// <summary>
-        /// Returns a <see cref="TimeSpanAssertions"/> object that can be used to assert that the current <see cref="DateTime"/>
-        /// exceeds the specified <paramref name="timeSpan"/> compared to another <see cref="DateTime"/>.
+        /// Returns a <see cref="TimeSpanAssertions"/> object that can be used to assert that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/>
+        /// exceeds the specified <paramref name="timeSpan"/> compared to another <see cref="DateTime"/> or <see cref="DateTimeOffset"/>.
         /// </summary>
         /// <param name="timeSpan">
-        /// The amount of time that the current <see cref="DateTime"/> should exceed compared to another <see cref="DateTime"/>.
+        /// The amount of time that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> should exceed compared to another <see cref="DateTime"/> or <see cref="DateTimeOffset"/>.
         /// </param>
         public TimeSpanAssertions BeMoreThan(TimeSpan timeSpan)
         {
@@ -378,11 +378,11 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Returns a <see cref="TimeSpanAssertions"/> object that can be used to assert that the current <see cref="DateTime"/>
-        /// is equal to or exceeds the specified <paramref name="timeSpan"/> compared to another <see cref="DateTime"/>.
+        /// Returns a <see cref="TimeSpanAssertions"/> object that can be used to assert that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/>
+        /// is equal to or exceeds the specified <paramref name="timeSpan"/> compared to another <see cref="DateTime"/> or <see cref="DateTimeOffset"/>.
         /// </summary>
         /// <param name="timeSpan">
-        /// The amount of time that the current <see cref="DateTime"/> should be equal or exceed compared to
+        /// The amount of time that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> should be equal or exceed compared to
         /// another <see cref="DateTime"/>.
         /// </param>
         public TimeSpanAssertions BeAtLeast(TimeSpan timeSpan)
@@ -391,11 +391,11 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Returns a <see cref="TimeSpanAssertions"/> object that can be used to assert that the current <see cref="DateTime"/>
-        /// differs exactly the specified <paramref name="timeSpan"/> compared to another <see cref="DateTime"/>.
+        /// Returns a <see cref="TimeSpanAssertions"/> object that can be used to assert that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/>
+        /// differs exactly the specified <paramref name="timeSpan"/> compared to another <see cref="DateTime"/> or <see cref="DateTimeOffset"/>.
         /// </summary>
         /// <param name="timeSpan">
-        /// The amount of time that the current <see cref="DateTime"/> should differ exactly compared to another <see cref="DateTime"/>.
+        /// The amount of time that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> should differ exactly compared to another <see cref="DateTime"/> or <see cref="DateTimeOffset"/>.
         /// </param>
         public TimeSpanAssertions BeExactly(TimeSpan timeSpan)
         {
@@ -403,11 +403,11 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Returns a <see cref="TimeSpanAssertions"/> object that can be used to assert that the current <see cref="DateTime"/>
-        /// is within the specified <paramref name="timeSpan"/> compared to another <see cref="DateTime"/>.
+        /// Returns a <see cref="TimeSpanAssertions"/> object that can be used to assert that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/>
+        /// is within the specified <paramref name="timeSpan"/> compared to another <see cref="DateTime"/> or <see cref="DateTimeOffset"/>.
         /// </summary>
         /// <param name="timeSpan">
-        /// The amount of time that the current <see cref="DateTime"/> should be within another <see cref="DateTime"/>.
+        /// The amount of time that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> should be within another <see cref="DateTime"/> or <see cref="DateTimeOffset"/>.
         /// </param>
         public TimeSpanAssertions BeWithin(TimeSpan timeSpan)
         {
@@ -415,11 +415,11 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Returns a <see cref="TimeSpanAssertions"/> object that can be used to assert that the current <see cref="DateTime"/>  
-        /// differs at maximum the specified <paramref name="timeSpan"/> compared to another <see cref="DateTime"/>.
+        /// Returns a <see cref="TimeSpanAssertions"/> object that can be used to assert that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/>  
+        /// differs at maximum the specified <paramref name="timeSpan"/> compared to another <see cref="DateTime"/> or <see cref="DateTimeOffset"/>.
         /// </summary>
         /// <param name="timeSpan">
-        /// The maximum amount of time that the current <see cref="DateTime"/> should differ compared to another <see cref="DateTime"/>.
+        /// The maximum amount of time that the current <see cref="DateTime"/> or <see cref="DateTimeOffset"/> should differ compared to another <see cref="DateTime"/> or <see cref="DateTimeOffset"/>.
         /// </param>
         public TimeSpanAssertions BeLessThan(TimeSpan timeSpan)
         {

--- a/FluentAssertions.Core/Primitives/NullableDateTimeOffsetAssertions.cs
+++ b/FluentAssertions.Core/Primitives/NullableDateTimeOffsetAssertions.cs
@@ -5,21 +5,21 @@ using FluentAssertions.Execution;
 namespace FluentAssertions.Primitives
 {
     /// <summary>
-    /// Contains a number of methods to assert that a nullable <see cref="DateTime"/> is in the expected state.
+    /// Contains a number of methods to assert that a nullable <see cref="DateTime"/> or <see cref="DateTimeOffset"/> is in the expected state.
     /// </summary>
     /// <remarks>
     /// You can use the <see cref="FluentDateTimeExtensions"/> for a more fluent way of specifying a <see cref="DateTime"/>.
     /// </remarks>
     [DebuggerNonUserCode]
-    public class NullableDateTimeAssertions : DateTimeAssertions
+    public class NullableDateTimeOffsetAssertions : DateTimeOffsetAssertions
     {
-        public NullableDateTimeAssertions(DateTimeOffset? expected)
+        public NullableDateTimeOffsetAssertions(DateTimeOffset? expected)
             : base(expected)
         {
         }
 
         /// <summary>
-        /// Asserts that a nullable <see cref="DateTime"/> value is not <c>null</c>.
+        /// Asserts that a nullable <see cref="DateTime"/> or <see cref="DateTimeOffset"/> value is not <c>null</c>.
         /// </summary>
         /// <param name="reason">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
@@ -28,18 +28,18 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason"/>.
         /// </param>      
-        public AndConstraint<NullableDateTimeAssertions> HaveValue(string reason = "", params object[] reasonArgs)
+        public AndConstraint<NullableDateTimeOffsetAssertions> HaveValue(string reason = "", params object[] reasonArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue)
                 .BecauseOf(reason, reasonArgs)
                 .FailWith("Expected variable to have a value{reason}, but found {0}", Subject);
 
-            return new AndConstraint<NullableDateTimeAssertions>(this);
+            return new AndConstraint<NullableDateTimeOffsetAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that a nullable <see cref="DateTime"/> value is <c>null</c>.
+        /// Asserts that a nullable <see cref="DateTime"/> or <see cref="DateTimeOffset"/> value is <c>null</c>.
         /// </summary>
         /// <param name="reason">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion 
@@ -48,14 +48,14 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason"/>.
         /// </param>      
-        public AndConstraint<NullableDateTimeAssertions> NotHaveValue(string reason = "", params object[] reasonArgs)
+        public AndConstraint<NullableDateTimeOffsetAssertions> NotHaveValue(string reason = "", params object[] reasonArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue)
                 .BecauseOf(reason, reasonArgs)
                 .FailWith("Did not expect variable to have a value{reason}, but found {0}", Subject);
             
-            return new AndConstraint<NullableDateTimeAssertions>(this);
+            return new AndConstraint<NullableDateTimeOffsetAssertions>(this);
         }
 
         /// <summary>
@@ -69,14 +69,14 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> Be(DateTimeOffset? expected, string reason = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeOffsetAssertions> Be(DateTimeOffset? expected, string reason = "", params object[] reasonArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject == expected)
                 .BecauseOf(reason, reasonArgs)
                 .FailWith("Expected {0}{reason}, but found {1}.", expected, Subject);
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
     }
 }

--- a/FluentAssertions.Core/Primitives/TimeSpanAssertions.cs
+++ b/FluentAssertions.Core/Primitives/TimeSpanAssertions.cs
@@ -18,7 +18,7 @@ namespace FluentAssertions.Primitives
     {
         #region Private Definitions
 
-        private readonly DateTimeAssertions parentAssertions;
+        private readonly DateTimeOffsetAssertions parentAssertions;
         private readonly TimeSpanPredicate predicate;
 
         private readonly Dictionary<TimeSpanCondition, TimeSpanPredicate> predicates = new Dictionary
@@ -36,7 +36,7 @@ namespace FluentAssertions.Primitives
 
         #endregion
 
-        protected internal TimeSpanAssertions(DateTimeAssertions parentAssertions, DateTimeOffset? subject, TimeSpanCondition condition,
+        protected internal TimeSpanAssertions(DateTimeOffsetAssertions parentAssertions, DateTimeOffset? subject, TimeSpanCondition condition,
             TimeSpan timeSpan)
         {
             this.parentAssertions = parentAssertions;
@@ -59,7 +59,7 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public AndConstraint<DateTimeAssertions> Before(DateTimeOffset target, string reason = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeOffsetAssertions> Before(DateTimeOffset target, string reason = "", params object[] reasonArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(subject.HasValue)
@@ -83,7 +83,7 @@ namespace FluentAssertions.Primitives
                 }
             }
 
-            return new AndConstraint<DateTimeAssertions>(parentAssertions);
+            return new AndConstraint<DateTimeOffsetAssertions>(parentAssertions);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace FluentAssertions.Primitives
         /// <param name="reasonArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public AndConstraint<DateTimeAssertions> After(DateTimeOffset target, string reason = "", params object[] reasonArgs)
+        public AndConstraint<DateTimeOffsetAssertions> After(DateTimeOffset target, string reason = "", params object[] reasonArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(subject.HasValue)
@@ -123,7 +123,7 @@ namespace FluentAssertions.Primitives
                 }
             }
 
-            return new AndConstraint<DateTimeAssertions>(parentAssertions);
+            return new AndConstraint<DateTimeOffsetAssertions>(parentAssertions);
         }
 
         /// <summary>

--- a/FluentAssertions.Net40.Specs/DateTimeAssertionSpecs.cs
+++ b/FluentAssertions.Net40.Specs/DateTimeAssertionSpecs.cs
@@ -496,7 +496,7 @@ namespace FluentAssertions.Specs
         [TestMethod]
         public void Should_fail_with_descriptive_message_when_asserting_datetime_is_before_earlier_datetime()
         {
-            DateTimeAssertions assertions = Today.Should();
+            DateTimeOffsetAssertions assertions = Today.Should();
             assertions.Invoking(x => x.BeBefore(Yesterday, "because we want to test the failure {0}", "message"))
                 .ShouldThrow<AssertFailedException>()
                 .WithMessage(string.Format(
@@ -527,7 +527,7 @@ namespace FluentAssertions.Specs
         [TestMethod]
         public void Should_fail_with_descriptive_message_when_asserting_datetime_is_on_or_before_earlier_datetime()
         {
-            DateTimeAssertions assertions = Today.Should();
+            DateTimeOffsetAssertions assertions = Today.Should();
             assertions.Invoking(x => x.BeOnOrBefore(Yesterday, "because we want to test the failure {0}", "message"))
                 .ShouldThrow<AssertFailedException>()
                 .WithMessage(string.Format(
@@ -552,7 +552,7 @@ namespace FluentAssertions.Specs
         [TestMethod]
         public void Should_fail_with_descriptive_message_when_asserting_datetime_is_after_later_datetime()
         {
-            DateTimeAssertions assertions = Today.Should();
+            DateTimeOffsetAssertions assertions = Today.Should();
             assertions.Invoking(x => x.BeAfter(Tomorrow, "because we want to test the failure {0}", "message"))
                 .ShouldThrow<AssertFailedException>()
                 .WithMessage(string.Format(
@@ -583,7 +583,7 @@ namespace FluentAssertions.Specs
         [TestMethod]
         public void Should_fail_with_descriptive_message_when_asserting_datetime_is_on_or_after_later_datetime()
         {
-            DateTimeAssertions assertions = Today.Should();
+            DateTimeOffsetAssertions assertions = Today.Should();
             assertions.Invoking(x => x.BeOnOrAfter(Tomorrow, "because we want to test the failure {0}", "message"))
                 .ShouldThrow<AssertFailedException>()
                 .WithMessage(string.Format(
@@ -608,7 +608,7 @@ namespace FluentAssertions.Specs
         [TestMethod]
         public void Should_fail_with_descriptive_message_when_asserting_datetime_has_a_year_with_a_different_value()
         {
-            DateTimeAssertions assertions = new DateTime(2009, 12, 31).Should();
+            DateTimeOffsetAssertions assertions = new DateTime(2009, 12, 31).Should();
             assertions.Invoking(x => x.HaveYear(2008, "because we want to test the failure {0}", "message"))
                 .ShouldThrow<AssertFailedException>()
                 .WithMessage("Expected year 2008 because we want to test the failure message, but found 2009.");
@@ -631,7 +631,7 @@ namespace FluentAssertions.Specs
         [TestMethod]
         public void Should_fail_with_descriptive_message_when_asserting_datetime_has_a_month_with_a_different_value()
         {
-            DateTimeAssertions assertions = new DateTime(2009, 12, 31).Should();
+            DateTimeOffsetAssertions assertions = new DateTime(2009, 12, 31).Should();
             assertions.Invoking(x => x.HaveMonth(11, "because we want to test the failure {0}", "message"))
                 .ShouldThrow<AssertFailedException>()
                 .WithMessage("Expected month 11 because we want to test the failure message, but found 12.");
@@ -654,7 +654,7 @@ namespace FluentAssertions.Specs
         [TestMethod]
         public void Should_fail_with_descriptive_message_when_asserting_datetime_has_a_day_with_a_different_value()
         {
-            DateTimeAssertions assertions = new DateTime(2009, 12, 31).Should();
+            DateTimeOffsetAssertions assertions = new DateTime(2009, 12, 31).Should();
             assertions.Invoking(x => x.HaveDay(30, "because we want to test the failure {0}", "message"))
                 .ShouldThrow<AssertFailedException>()
                 .WithMessage("Expected day 30 because we want to test the failure message, but found 31.");
@@ -677,7 +677,7 @@ namespace FluentAssertions.Specs
         [TestMethod]
         public void Should_fail_with_descriptive_message_when_asserting_datetime_has_an_hour_with_different_value()
         {
-            DateTimeAssertions assertions = new DateTime(2009, 12, 31, 23, 59, 00).Should();
+            DateTimeOffsetAssertions assertions = new DateTime(2009, 12, 31, 23, 59, 00).Should();
             assertions.Invoking(x => x.HaveHour(22, "because we want to test the failure {0}", "message"))
                 .ShouldThrow<AssertFailedException>()
                 .WithMessage("Expected hour 22 because we want to test the failure message, but found 23.");
@@ -700,7 +700,7 @@ namespace FluentAssertions.Specs
         [TestMethod]
         public void Should_fail_with_descriptive_message_when_asserting_datetime_has_minutes_with_different_value()
         {
-            DateTimeAssertions assertions = new DateTime(2009, 12, 31, 23, 59, 00).Should();
+            DateTimeOffsetAssertions assertions = new DateTime(2009, 12, 31, 23, 59, 00).Should();
             assertions.Invoking(x => x.HaveMinute(58, "because we want to test the failure {0}", "message"))
                 .ShouldThrow<AssertFailedException>()
                 .WithMessage("Expected minute 58 because we want to test the failure message, but found 59.");
@@ -723,7 +723,7 @@ namespace FluentAssertions.Specs
         [TestMethod]
         public void Should_fail_with_descriptive_message_when_asserting_datetime_has_seconds_with_different_value()
         {
-            DateTimeAssertions assertions = new DateTime(2009, 12, 31, 23, 59, 00).Should();
+            DateTimeOffsetAssertions assertions = new DateTime(2009, 12, 31, 23, 59, 00).Should();
             assertions.Invoking(x => x.HaveSecond(1, "because we want to test the failure {0}", "message"))
                 .ShouldThrow<AssertFailedException>()
                 .WithMessage("Expected second 1 because we want to test the failure message, but found 0.");

--- a/FluentAssertions.Net40.Specs/DateTimeOffsetValueFormatterSpecs.cs
+++ b/FluentAssertions.Net40.Specs/DateTimeOffsetValueFormatterSpecs.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace FluentAssertions.Specs
 {
     [TestClass]
-    public class DateTimeFormatterSpecs
+    public class DateTimeOffsetValueFormatterSpecs
     {
         [TestMethod]
         public void When_time_is_not_relevant_it_should_not_be_included_in_the_output()
@@ -19,7 +19,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            var formatter = new DateTimeValueFormatter();
+            var formatter = new DateTimeOffsetValueFormatter();
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -38,7 +38,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            var formatter = new DateTimeValueFormatter();
+            var formatter = new DateTimeOffsetValueFormatter();
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -59,7 +59,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            var formatter = new DateTimeValueFormatter();
+            var formatter = new DateTimeOffsetValueFormatter();
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -79,7 +79,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            var formatter = new DateTimeValueFormatter();
+            var formatter = new DateTimeOffsetValueFormatter();
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -100,7 +100,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            var formatter = new DateTimeValueFormatter();
+            var formatter = new DateTimeOffsetValueFormatter();
 
             var dateOnly = new DateTime(1973, 9, 20);
             var timeOnly = 1.January(0001).At(08, 20, 01);

--- a/FluentAssertions.Net40.Specs/FluentAssertions.Net40.Specs.csproj
+++ b/FluentAssertions.Net40.Specs/FluentAssertions.Net40.Specs.csproj
@@ -106,7 +106,7 @@
     <Compile Include="BooleanAssertionSpecs.cs" />
     <Compile Include="CollectionAssertionSpecs.cs" />
     <Compile Include="DateTimeAssertionSpecs.cs" />
-    <Compile Include="DateTimeFormatterSpecs.cs" />
+    <Compile Include="DateTimeOffsetValueFormatterSpecs.cs" />
     <Compile Include="EventAssertionSpecs.cs" />
     <Compile Include="ExceptionAssertionSpecs.cs" />
     <Compile Include="ExecutionTimeAssertionsSpecs.cs" />

--- a/FluentAssertions.Net40/AssertionExtensions.cs
+++ b/FluentAssertions.Net40/AssertionExtensions.cs
@@ -201,41 +201,41 @@ namespace FluentAssertions
         }
 
         /// <summary>
-        /// Returns an <see cref="DateTimeAssertions"/> object that can be used to assert the
+        /// Returns an <see cref="DateTimeOffsetAssertions"/> object that can be used to assert the
         /// current <see cref="DateTime"/>.
         /// </summary>
-        public static DateTimeAssertions Should(this DateTime actualValue)
+        public static DateTimeOffsetAssertions Should(this DateTime actualValue)
         {
-            return new DateTimeAssertions(actualValue);
+            return new DateTimeOffsetAssertions(actualValue);
         }
 
 
         /// <summary>
-        /// Returns an <see cref="DateTimeAssertions"/> object that can be used to assert the
+        /// Returns an <see cref="DateTimeOffsetAssertions"/> object that can be used to assert the
         /// current <see cref="DateTimeOffset"/>.
         /// </summary>
-        public static DateTimeAssertions Should(this DateTimeOffset actualValue)
+        public static DateTimeOffsetAssertions Should(this DateTimeOffset actualValue)
         {
-            return new DateTimeAssertions(actualValue);
+            return new DateTimeOffsetAssertions(actualValue);
         }
 
 
         /// <summary>
-        /// Returns an <see cref="NullableDateTimeAssertions"/> object that can be used to assert the
+        /// Returns an <see cref="NullableDateTimeOffsetAssertions"/> object that can be used to assert the
         /// current nullable <see cref="DateTime"/>.
         /// </summary>
-        public static NullableDateTimeAssertions Should(this DateTime? actualValue)
+        public static NullableDateTimeOffsetAssertions Should(this DateTime? actualValue)
         {
-            return new NullableDateTimeAssertions(actualValue);
+            return new NullableDateTimeOffsetAssertions(actualValue);
         }
 
         /// <summary>
-        /// Returns an <see cref="NullableDateTimeAssertions"/> object that can be used to assert the
+        /// Returns an <see cref="NullableDateTimeOffsetAssertions"/> object that can be used to assert the
         /// current nullable <see cref="DateTimeOffset"/>.
         /// </summary>
-        public static NullableDateTimeAssertions Should(this DateTimeOffset? actualValue)
+        public static NullableDateTimeOffsetAssertions Should(this DateTimeOffset? actualValue)
         {
-            return new NullableDateTimeAssertions(actualValue);
+            return new NullableDateTimeOffsetAssertions(actualValue);
         }
 
         /// <summary>

--- a/FluentAssertions.Net45.Specs/FluentAssertions.Net45.Specs.csproj
+++ b/FluentAssertions.Net45.Specs/FluentAssertions.Net45.Specs.csproj
@@ -93,8 +93,8 @@
     <Compile Include="..\FluentAssertions.Net40.Specs\DateTimeAssertionSpecs.cs">
       <Link>DateTimeAssertionSpecs.cs</Link>
     </Compile>
-    <Compile Include="..\FluentAssertions.Net40.Specs\DateTimeFormatterSpecs.cs">
-      <Link>DateTimeFormatterSpecs.cs</Link>
+    <Compile Include="..\FluentAssertions.Net40.Specs\DateTimeOffsetValueFormatterSpecs.cs">
+      <Link>DateTimeOffsetValueFormatterSpecs.cs</Link>
     </Compile>
     <Compile Include="..\FluentAssertions.Net40.Specs\EventAssertionSpecs.cs">
       <Link>EventAssertionSpecs.cs</Link>

--- a/FluentAssertions.Silverlight.Specs/FluentAssertions.Silverlight.Specs.csproj
+++ b/FluentAssertions.Silverlight.Specs/FluentAssertions.Silverlight.Specs.csproj
@@ -126,8 +126,8 @@
     <Compile Include="..\FluentAssertions.Net40.Specs\DateTimeAssertionSpecs.cs">
       <Link>DateTimeAssertionSpecs.cs</Link>
     </Compile>
-    <Compile Include="..\FluentAssertions.Net40.Specs\DateTimeFormatterSpecs.cs">
-      <Link>DateTimeFormatterSpecs.cs</Link>
+    <Compile Include="..\FluentAssertions.Net40.Specs\DateTimeOffsetValueFormatterSpecs.cs">
+      <Link>DateTimeOffsetValueFormatterSpecs.cs</Link>
     </Compile>
     <Compile Include="..\FluentAssertions.Net40.Specs\EquivalencySpecs.cs">
       <Link>EquivalencySpecs.cs</Link>

--- a/FluentAssertions.WP8.Specs/FluentAssertions.WP8.Specs.csproj
+++ b/FluentAssertions.WP8.Specs/FluentAssertions.WP8.Specs.csproj
@@ -88,8 +88,8 @@
     <Compile Include="..\FluentAssertions.Net40.Specs\DateTimeAssertionSpecs.cs">
       <Link>DateTimeAssertionSpecs.cs</Link>
     </Compile>
-    <Compile Include="..\FluentAssertions.Net40.Specs\DateTimeFormatterSpecs.cs">
-      <Link>DateTimeFormatterSpecs.cs</Link>
+    <Compile Include="..\FluentAssertions.Net40.Specs\DateTimeOffsetValueFormatterSpecs.cs">
+      <Link>DateTimeOffsetValueFormatterSpecs.cs</Link>
     </Compile>
     <Compile Include="..\FluentAssertions.Net40.Specs\EquivalencySpecs.cs">
       <Link>EquivalencySpecs.cs</Link>

--- a/FluentAssertions.WinRT.Specs/FluentAssertions.WinRT.Specs.csproj
+++ b/FluentAssertions.WinRT.Specs/FluentAssertions.WinRT.Specs.csproj
@@ -78,8 +78,8 @@
     <Compile Include="..\FluentAssertions.Net40.Specs\DateTimeAssertionSpecs.cs">
       <Link>DateTimeAssertionSpecs.cs</Link>
     </Compile>
-    <Compile Include="..\FluentAssertions.Net40.Specs\DateTimeFormatterSpecs.cs">
-      <Link>DateTimeFormatterSpecs.cs</Link>
+    <Compile Include="..\FluentAssertions.Net40.Specs\DateTimeOffsetValueFormatterSpecs.cs">
+      <Link>DateTimeOffsetValueFormatterSpecs.cs</Link>
     </Compile>
     <Compile Include="..\FluentAssertions.Net40.Specs\EventAssertionSpecs.cs">
       <Link>EventAssertionSpecs.cs</Link>


### PR DESCRIPTION
This should be all that is needed to resolve Issue #6 (and Issue #44 which is a subset of #6).  Utilizes the implicit conversion of `DateTime` to `DateTimeOffset` to simply have the existing code support both.

Other considerations:
- Could rename the class(s) since 3.0 is already a breaking change.
- Could update all the doc comments which currently read DateTime.  Was not sure what approach would have least user confusion.
- Could add more tests or change the existing tests to use with DateTimeOffsets rather than DateTimes.  Added a few to show the premise, but is seemed redundant to duplicate all the tests when using the implicit conversion functionality present in the BCL.
