### PR TITLE
Adds a maximum recursion depth limitation to ShouldBeEquivalentTo.

### DIFF
--- a/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptions.cs
+++ b/FluentAssertions.Core/Equivalency/EquivalencyAssertionOptions.cs
@@ -35,6 +35,8 @@ namespace FluentAssertions.Equivalency
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private bool isRecursive;
 
+        private bool allowInfiniteRecursion;
+
         #endregion
 
         private EquivalencyAssertionOptions()
@@ -108,6 +110,11 @@ namespace FluentAssertions.Equivalency
         bool IEquivalencyAssertionOptions.IsRecursive
         {
             get { return isRecursive; }
+        }
+
+        bool IEquivalencyAssertionOptions.AllowInfiniteRecursion
+        {
+            get { return allowInfiniteRecursion; }
         }
 
         /// <summary>
@@ -231,6 +238,16 @@ namespace FluentAssertions.Equivalency
         public EquivalencyAssertionOptions<TSubject> IgnoringCyclicReferences()
         {
             cyclicReferenceHandling = CyclicReferenceHandling.Ignore;
+            return this;
+        }
+
+
+        /// <summary>
+        /// Disables limitations on recusion depth when the structural equality check is configured to include nested objects
+        /// </summary>
+        public EquivalencyAssertionOptions<TSubject> AllowingInfiniteRecursion()
+        {
+            allowInfiniteRecursion = true;
             return this;
         }
 

--- a/FluentAssertions.Core/Equivalency/IEquivalencyAssertionOptions.cs
+++ b/FluentAssertions.Core/Equivalency/IEquivalencyAssertionOptions.cs
@@ -30,6 +30,11 @@ namespace FluentAssertions.Equivalency
         bool IsRecursive { get; }
 
         /// <summary>
+        /// Gets a value indicating whether recursion is allowed to continue infinitely.
+        /// </summary>
+        bool AllowInfiniteRecursion { get; }
+
+        /// <summary>
         /// Gets value indicating how cyclic references should be handled. By default, it will throw an exception.
         /// </summary>
         CyclicReferenceHandling CyclicReferenceHandling { get; }


### PR DESCRIPTION
Should fix issue #15 per suggestion by @dennisdoomen.  I considered implementing a repetition recognition algorithm to try to detect such occurrences, rather than a simple maximum-depth limitation.  However, I was not sure if there was a need for that and if it would worth the additional complexity.

This does not address the issue with `Formatter.ToString`  indicated in that issues's the comments by @marklam.
