### PR TITLE
Adds a depth limit to the recursion done by `Formatter.ToString`

### DIFF
--- a/FluentAssertions.Core/Formatting/Formatter.cs
+++ b/FluentAssertions.Core/Formatting/Formatter.cs
@@ -51,6 +51,12 @@ namespace FluentAssertions.Formatting
                 processedObjects = new List<object>();
             }
 
+            const int MaxDepth = 15;
+            if (nestedPropertyLevel > MaxDepth)
+            {
+                return "{Maximum recursion depth was reached...}";
+            }
+
             IValueFormatter firstFormatterThatCanHandleValue = Formatters.First(f => f.CanHandle(value));
             return firstFormatterThatCanHandleValue.ToString(value, useLineBreaks, processedObjects, nestedPropertyLevel);
         }

--- a/FluentAssertions.Net40.Specs/FormatterSpecs.cs
+++ b/FluentAssertions.Net40.Specs/FormatterSpecs.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-
+using System.Linq;
 using FluentAssertions.Common;
 using FluentAssertions.Formatting;
 
@@ -126,7 +126,34 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             result.Should().Contain("SomeProperty");
         }
-        
+
+        [TestMethod]
+        public void
+            When_the_maximum_recursion_depth_is_met_it_should_give_a_descriptive_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var head = new Node();
+
+            foreach (int i in Enumerable.Range(0, 20))
+            {
+                var newHead = new Node();
+                newHead.Children.Add(head);
+                head = newHead;
+            }
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            string result = Formatter.ToString(head);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            result.Should().ContainEquivalentOf("maximum recursion depth");
+        }
+
         public class BaseStuff
         {
             public int StuffId { get; set; }


### PR DESCRIPTION
Adds a depth limit to the recursion done by `Formatter.ToString.`  Should address concern raised by @marklam in Issue #15
