### PR TITLE
Fix CRLF comparisons when run on Unix/Mono

### DIFF
--- a/FluentAssertions.Core/Formatting/XElementValueFormatter.cs
+++ b/FluentAssertions.Core/Formatting/XElementValueFormatter.cs
@@ -55,8 +55,10 @@ namespace FluentAssertions.Formatting
         {
             string [] lines = SplitIntoSeparateLines(element);
 
-            string firstLine = lines.First().Replace(Environment.NewLine, "");
-            string lastLine = lines.Last().Replace(Environment.NewLine, "");
+            // Can't use env.newline because the input doc may have unix or windows style
+            // line-breaks
+            string firstLine = lines.First().Replace("\r", "").Replace("\n", "");
+            string lastLine = lines.Last().Replace("\r", "").Replace("\n", "");
 
             string formattedElement = firstLine + "..." + lastLine;
             return formattedElement.Escape();

--- a/FluentAssertions.Core/Primitives/StringAssertions.cs
+++ b/FluentAssertions.Core/Primitives/StringAssertions.cs
@@ -182,7 +182,8 @@ namespace FluentAssertions.Primitives
         {
             var validator = new StringWildcardMatchingValidator(Subject, wildcardPattern, reason, reasonArgs)
             {
-                IgnoreCase = true
+                IgnoreCase = true,
+                IgnoreNewLineDifferences = true
             };
 
             validator.Validate();
@@ -209,6 +210,7 @@ namespace FluentAssertions.Primitives
             var validator = new StringWildcardMatchingValidator(Subject, wildcardPattern, reason, reasonArgs)
             {
                 IgnoreCase = true,
+                IgnoreNewLineDifferences = true,
                 Negate = true
             };
 

--- a/FluentAssertions.Core/Primitives/StringWildcardMatchingValidator.cs
+++ b/FluentAssertions.Core/Primitives/StringWildcardMatchingValidator.cs
@@ -29,13 +29,24 @@ namespace FluentAssertions.Primitives
             {
                 var options = IgnoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
 
-                return Regex.IsMatch(subject, ConvertWildcardToRegEx(expected), options | RegexOptions.Singleline);
+                return Regex.IsMatch(CleanNewLines(subject), ConvertWildcardToRegEx(CleanNewLines(expected)), options | RegexOptions.Singleline);
             }
         }
 
-        private static string ConvertWildcardToRegEx(string wildcardExpression)
+        private string ConvertWildcardToRegEx(string wildcardExpression)
         {
             return "^" + Regex.Escape(wildcardExpression).Replace("\\*", ".*").Replace("\\?", ".") + "$";
+        }
+
+        private string CleanNewLines(string input)
+        {
+            if (input == null)
+                return null;
+
+            if (IgnoreNewLineDifferences)
+                return input.Replace("\n", "").Replace("\r", "").Replace("\\r\\n", "");
+
+            return input;
         }
 
         protected override string ExpectationDescription
@@ -61,5 +72,10 @@ namespace FluentAssertions.Primitives
         /// Gets or sets a value indicating whether the matching process should ignore any casing difference.
         /// </summary>
         public bool IgnoreCase { get; set; }
+
+        /// <summary>
+        /// Ignores the difference betweeen environment newline differences
+        /// </summary>
+        public bool IgnoreNewLineDifferences { get; set; }
     }
 }


### PR DESCRIPTION
This addresses issues when strings are compared on Mono/Unix.
