### PR TITLE
Restore 2.0  behavior for `ShouldThrow<AggregateException>`

### DIFF
--- a/FluentAssertions.Net40.Specs/ExceptionAssertionSpecs.cs
+++ b/FluentAssertions.Net40.Specs/ExceptionAssertionSpecs.cs
@@ -298,6 +298,31 @@ namespace FluentAssertions.Specs
             }
         }
 
+        [TestMethod]
+        public void When_asserting_with_an_aggregate_exception_type_the_asserts_should_occur_against_the_aggregate_exception()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IFoo testSubject = A.Fake<IFoo>();
+            A.CallTo(() => testSubject.Do())
+                .Throws(new AggregateException("Outer Message",
+                    new Exception("Inner Message")));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = testSubject.Do;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------            
+            act.ShouldThrow<AggregateException>()
+                .WithMessage("Outer Message")
+                .WithInnerException<Exception>()
+                .WithInnerMessage("Inner Message");
+        }
+
         #endregion
 
         #region Inner Exceptions

--- a/FluentAssertions.Net40/AssertionExtensions.Actions.cs
+++ b/FluentAssertions.Net40/AssertionExtensions.Actions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 using FluentAssertions.Specialized;
@@ -133,6 +134,25 @@ namespace FluentAssertions
         private class AggregateExceptionExtractor : IExtractExceptions
         {
             public IEnumerable<T> OfType<T>(Exception actualException) where T : Exception
+            {
+#if WINRT
+                if (typeof(AggregateException).GetTypeInfo().IsAssignableFrom(typeof(T).GetTypeInfo()))
+#else
+                if (typeof(AggregateException).IsAssignableFrom(typeof (T)))
+#endif
+                {
+                    var exception = actualException as T;
+
+                    return (exception == null)
+                        ? Enumerable.Empty<T>()
+                        : new[] { exception };
+                }
+
+                return GetExtractedExceptions<T>(actualException);
+            }
+
+            private static List<T> GetExtractedExceptions<T>(Exception actualException)
+                where T : Exception
             {
                 var exceptions = new List<T>();
 


### PR DESCRIPTION
Makes `AggregateExceptionExtractor` not extract exceptions if the assertion is against AggregateException (or subclass of AggregateException).  This allows assertions against the thrown exception and its inner exceptions just as in FA 2.0.  The 2.1+ functionality of extracting AggregateExceptions is preserved for all other exception types.

This seemed to be the least change with the least user impact while 'just working' in the issue scenario.

Should fix Issue #62
