### PR TITLE
#95 added .WithMessageAndParameterName and .WithInnerMessageAndParameterName assertions to ExceptionAssertions<TException>

### DIFF
--- a/FluentAssertions.Core/Specialized/ExceptionAssertions.cs
+++ b/FluentAssertions.Core/Specialized/ExceptionAssertions.cs
@@ -87,6 +87,39 @@ namespace FluentAssertions.Specialized
         }
 
         /// <summary>
+        ///   Asserts that the thrown exception has a message that matches <paramref name = "expectedMessage" />
+        ///   with the given parameter name <paramref name = "parameterName" /> depending on the specified matching mode.
+        /// </summary>
+        /// <param name = "expectedMessage">
+        ///   The expected message of the exception.
+        /// </param>
+        /// <param name = "parameterName">
+        ///   The name of the parameter that was appended to exception message
+        /// </param>
+        /// <param name = "reason">
+        ///   A formatted phrase as is supported by <see cref = "string.Format(string,object[])" /> explaining why the assertion 
+        ///   is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name = "reasonArgs">
+        ///   Zero or more objects to format using the placeholders in <see cref = "reason" />.
+        /// </param>
+        public virtual ExceptionAssertions<TException> WithMessageAndParameterName(string expectedMessage,
+            string parameterName, string because = "", params object[] reasonArgs)
+        {
+            string expectedMessageWithParameterName = expectedMessage;
+
+            // Only add the Parameter Name assertion if an actual parameter name was provided
+            // to mimic the very same behavior of the .NET Framework
+            if (!string.IsNullOrEmpty(parameterName))
+            {
+                expectedMessageWithParameterName = string.Format("{0}\r\nParameter name: {1}", expectedMessage,
+                                                                 parameterName);
+            }
+
+            return WithMessage(expectedMessageWithParameterName, because, reasonArgs);
+        }
+
+        /// <summary>
         ///   Asserts that the thrown exception contains an inner exception of type <typeparamref name = "TInnerException" />.
         /// </summary>
         /// <typeparam name = "TInnerException">The expected type of the inner exception.</typeparam>
@@ -151,6 +184,33 @@ namespace FluentAssertions.Specialized
             innerMessageAssertion.Execute(subjectInnerMessage, expectedInnerMessage, because, reasonArgs);
 
             return this;
+        }
+
+        /// <summary>
+        ///   Asserts that the thrown exception contains an inner exception with the <paramref name = "expectedInnerMessage" />.
+        /// </summary>
+        /// <param name = "expectedInnerMessage">The expected message of the inner exception.</param>
+        /// <param name = "parameterName">
+        ///   The name of the parameter that was appended to inner exception message
+        /// </param>
+        /// <param name = "reason">
+        ///   The reason why the message of the inner exception should match <paramref name = "expectedInnerMessage" />.
+        /// </param>
+        /// <param name = "reasonArgs">The parameters used when formatting the <paramref name = "reason" />.</param>
+        public virtual ExceptionAssertions<TException> WithInnerMessageAndParameterName(string expectedInnerMessage,
+            string parameterName, string because = "", params object[] reasonArgs)
+        {
+            string expectedMessageWithParameterName = expectedInnerMessage;
+
+            // Only add the Parameter Name assertion if an actual parameter name was provided
+            // to mimic the very same behavior of the .NET Framework
+            if (!string.IsNullOrEmpty(parameterName))
+            {
+                expectedMessageWithParameterName = string.Format("{0}\r\nParameter name: {1}", expectedInnerMessage,
+                                                                 parameterName);
+            }
+
+            return WithInnerMessage(expectedMessageWithParameterName, because, reasonArgs);
         }
 
         /// <summary>

--- a/FluentAssertions.Net40.Specs/ExceptionAssertionSpecs.cs
+++ b/FluentAssertions.Net40.Specs/ExceptionAssertionSpecs.cs
@@ -323,6 +323,194 @@ namespace FluentAssertions.Specs
                 .WithInnerMessage("Inner Message");
         }
 
+        [TestMethod]
+        public void When_asserting_an_argument_exception_with_a_parameter_name()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IFoo testSubject = A.Fake<IFoo>();
+            A.CallTo(() => testSubject.Do(A<string>._))
+                .Throws(new ArgumentException("Exception Message", "someParam"));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testSubject.Do(string.Empty);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------            
+            act.ShouldThrow<ArgumentException>()
+               .WithMessageAndParameterName("Exception Message", "someParam");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_argument_exception_without_a_parameter_name()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IFoo testSubject = A.Fake<IFoo>();
+            A.CallTo(() => testSubject.Do(A<string>._))
+                .Throws(new ArgumentException("Exception Message", string.Empty));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testSubject.Do(string.Empty);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------            
+            act.ShouldThrow<ArgumentException>()
+               .WithMessageAndParameterName("Exception Message", string.Empty);
+        }
+
+        [TestMethod]
+        public void When_asserting_an_aggregate_exception_with_an_inner_argument_exception_with_a_parameter_name()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IFoo testSubject = A.Fake<IFoo>();
+            A.CallTo(() => testSubject.Do())
+                .Throws(new AggregateException("Outer Message",
+                    new ArgumentException("Exception Message", "someParam")));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = testSubject.Do;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------            
+            act.ShouldThrow<AggregateException>()
+                .WithMessage("Outer Message")
+                .WithInnerException<ArgumentException>()
+                .WithInnerMessageAndParameterName("Exception Message", "someParam");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_aggregate_exception_with_an_inner_argument_exception_without_a_parameter_name()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IFoo testSubject = A.Fake<IFoo>();
+            A.CallTo(() => testSubject.Do())
+                .Throws(new AggregateException("Outer Message",
+                    new ArgumentException("Exception Message", string.Empty)));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = testSubject.Do;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------            
+            act.ShouldThrow<AggregateException>()
+                .WithMessage("Outer Message")
+                .WithInnerException<ArgumentException>()
+                .WithInnerMessageAndParameterName("Exception Message", string.Empty);
+        }
+
+        [TestMethod]
+        public void When_asserting_an_argument_null_exception_with_a_parameter_name()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IFoo testSubject = A.Fake<IFoo>();
+            A.CallTo(() => testSubject.Do(A<string>._))
+                .Throws(new ArgumentNullException("someParam", "Exception Message"));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testSubject.Do(string.Empty);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------            
+            act.ShouldThrow<ArgumentNullException>()
+               .WithMessageAndParameterName("Exception Message", "someParam");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_argument_null_exception_without_a_parameter_name()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IFoo testSubject = A.Fake<IFoo>();
+            A.CallTo(() => testSubject.Do(A<string>._))
+                .Throws(new ArgumentNullException(string.Empty, "Exception Message"));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testSubject.Do(string.Empty);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------            
+            act.ShouldThrow<ArgumentNullException>()
+               .WithMessageAndParameterName("Exception Message", string.Empty);
+        }
+
+        [TestMethod]
+        public void When_asserting_an_aggregate_exception_with_an_inner_argument_null_exception_with_a_parameter_name()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IFoo testSubject = A.Fake<IFoo>();
+            A.CallTo(() => testSubject.Do())
+                .Throws(new AggregateException("Outer Message",
+                    new ArgumentNullException("someParam", "Exception Message")));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = testSubject.Do;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------            
+            act.ShouldThrow<AggregateException>()
+                .WithMessage("Outer Message")
+                .WithInnerException<ArgumentNullException>()
+                .WithInnerMessageAndParameterName("Exception Message", "someParam");
+        }
+
+        [TestMethod]
+        public void When_asserting_an_aggregate_exception_with_an_inner_argument_null_exception_without_a_parameter_name()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IFoo testSubject = A.Fake<IFoo>();
+            A.CallTo(() => testSubject.Do())
+                .Throws(new AggregateException("Outer Message",
+                    new ArgumentNullException(string.Empty, "Exception Message")));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = testSubject.Do;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------            
+            act.ShouldThrow<AggregateException>()
+                .WithMessage("Outer Message")
+                .WithInnerException<ArgumentNullException>()
+                .WithInnerMessageAndParameterName("Exception Message", string.Empty);
+        }
+
         #endregion
 
         #region Inner Exceptions


### PR DESCRIPTION
This is a simple example implementation of #95. I'm not sure if we should go for this very easy implementation or build a more extensive version of it (i.e. the unit testing exception message will be the same as for the normal `WithMessage()` or `WithInnerMessage()` - maybe we want something more descriptive?)

There are also still some tests missing for the InnerException part.

So what do you think?
