### PR TITLE
Fix resources build errors

### DIFF
--- a/FluentAssertions.WP8.Specs/App.xaml.cs
+++ b/FluentAssertions.WP8.Specs/App.xaml.cs
@@ -4,9 +4,9 @@ using System.Resources;
 using System.Windows;
 using System.Windows.Markup;
 using System.Windows.Navigation;
+using FluentAssertions.Specs.Resources;
 using Microsoft.Phone.Controls;
 using Microsoft.Phone.Shell;
-using FluentAssertions.WP8.Specs.Resources;
 
 namespace FluentAssertions.WP8.Specs
 {

--- a/FluentAssertions.WP8.Specs/LocalizedStrings.cs
+++ b/FluentAssertions.WP8.Specs/LocalizedStrings.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions.WP8.Specs.Resources;
+﻿using FluentAssertions.Specs.Resources;
 
 namespace FluentAssertions.WP8.Specs
 {

--- a/FluentAssertions.WP8.Specs/MainPage.xaml.cs
+++ b/FluentAssertions.WP8.Specs/MainPage.xaml.cs
@@ -7,7 +7,6 @@ using System.Windows.Controls;
 using System.Windows.Navigation;
 using Microsoft.Phone.Controls;
 using Microsoft.Phone.Shell;
-using FluentAssertions.WP8.Specs.Resources;
 using System.Threading;
 using Microsoft.VisualStudio.TestPlatform.Core;
 using vstest_executionengine_platformbridge;


### PR DESCRIPTION
I found the following build errors when trying to build solution:

```
App.xaml.cs(9,34): error CS0234: The type or namespace name 'Resources' does not exist in the namespace 'FluentAssertions.WP8.Specs'
LocalizedStrings.cs(1,34): error CS0234: The type or namespace name 'Resources' does not exist in the namespace 'FluentAssertions.WP8.Specs'
MainPage.xaml.cs(10,34): error CS0234: The type or namespace name 'Resources' does not exist in the namespace 'FluentAssertions.WP8.Specs'
LocalizedStrings.cs(10,24): error CS0246: The type or namespace name 'AppResources' could not be found
LocalizedStrings.cs(12,16): error CS0246: The type or namespace name 'AppResources' could not be found
```

I'm not sure where they are used or what for, but just fixed them up with ReSharper.

HTH
