### PR TITLE
Added an overload for GenericCollectionAssertions.Equals that takes params T[]

### DIFF
--- a/FluentAssertions.Core/Collections/SelfReferencingCollectionAssertions.cs
+++ b/FluentAssertions.Core/Collections/SelfReferencingCollectionAssertions.cs
@@ -96,6 +96,16 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
+        /// Expects the current collection to contain all the same elements in the same order as the collection identified by 
+        /// <paramref name="elements" />. Elements are compared using their <see cref="T.Equals(T)" /> method.
+        /// </summary>
+        /// <param name="elements">A params array with the expected elements.</param>
+        public AndConstraint<TAssertions> Equal(params T[] elements)
+        {
+            return Equal(elements, String.Empty);
+        }
+
+        /// <summary>
         /// Asserts that two collections contain the same items in the same order, where equality is determined using a 
         /// predicate.
         /// </summary>

--- a/FluentAssertions.Shared.Specs/GenericCollectionAssertionsSpecs.cs
+++ b/FluentAssertions.Shared.Specs/GenericCollectionAssertionsSpecs.cs
@@ -13,6 +13,25 @@ namespace FluentAssertions.Specs
     [TestClass]
     public class GenericCollectionAssertionsSpecs
     {
+        [TestMethod]
+        public void When_asserting_equality_with_a_collection_built_from_params_arguments_that_are_assignable_to_the_subjects_type_parameter_it_should_succeed_by_treating_the_arguments_as_of_that_type()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            byte[] byteArray = { 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => byteArray.Should().Equal(0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
         #region (Not) Contain
 
         [TestMethod]


### PR DESCRIPTION
This should resolve the specific issue described in Issue #110.
