### PR TITLE
Fix for #124 (.Should().BeEmpty() causes multiple enumerations)

### DIFF
--- a/FluentAssertions.Core/Collections/CollectionAssertions.cs
+++ b/FluentAssertions.Core/Collections/CollectionAssertions.cs
@@ -36,11 +36,12 @@ namespace FluentAssertions.Collections
             }
 
             IEnumerable<object> enumerable = Subject.Cast<object>();
+            int count = enumerable.Count();
 
             Execute.Assertion
-                .ForCondition(!enumerable.Any())
+                .ForCondition(count == 0)
                 .BecauseOf(because, reasonArgs)
-                .FailWith("Expected {context:collection} to be empty{reason}, but found {0}.", enumerable.Count());
+                .FailWith("Expected {context:collection} to be empty{reason}, but found {0}.", count);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/FluentAssertions.Net40.Specs/CollectionAssertionSpecs.cs
+++ b/FluentAssertions.Net40.Specs/CollectionAssertionSpecs.cs
@@ -457,6 +457,26 @@ namespace FluentAssertions.Specs
                 "Expected collection to be empty because we want to test the behaviour with a null subject, but found <null>.");
         }
 
+        [TestMethod]
+        public void When_asserting_collection_to_be_empty_it_should_enumerate_only_once()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new CountingGenericEnumerable<int>(new int[0]);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            collection.Should().BeEmpty();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            collection.GetEnumeratorCallCount.Should().Be(1);
+            
+        }
+
         #endregion
 
         #region Not Be Empty
@@ -479,6 +499,26 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
                 "Expected collection not to be empty because we want to test the behaviour with a null subject, but found <null>.");
+        }
+
+        [TestMethod]
+        public void When_asserting_collection_to_be_not_empty_it_should_enumerate_only_once()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new CountingGenericEnumerable<int>(new[] { 42 });
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            collection.Should().NotBeEmpty();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            collection.GetEnumeratorCallCount.Should().Be(1);
+
         }
 
         #endregion
@@ -537,6 +577,26 @@ namespace FluentAssertions.Specs
                     "Expected collection to be null or empty because we want to test the failure message, but found {1, 2, 3}.");
         }
 
+        [TestMethod]
+        public void When_asserting_collection_to_be_null_or_empty_it_should_enumerate_only_once()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new CountingGenericEnumerable<int>(new int[0]);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            collection.Should().BeNullOrEmpty();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            collection.GetEnumeratorCallCount.Should().Be(1);
+
+        }
+
         #endregion
 
         #region Not Be Null Or Empty
@@ -593,6 +653,26 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>();
+        }
+
+        [TestMethod]
+        public void When_asserting_collection_to_not_be_null_or_empty_it_should_enumerate_only_once()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new CountingGenericEnumerable<int>(new[] { 42 });
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            collection.Should().NotBeNullOrEmpty();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            collection.GetEnumeratorCallCount.Should().Be(1);
+
         }
 
         #endregion


### PR DESCRIPTION
Fixed the implementation of `BeEmpty()` and added a unit test to cover this case. Also added similar tests for `NotBeEmpty`, `BeNullOrEmpty` and `NotBeNullOrEmpty`; they were already working fine, but the tests will ensure a similar bug is not introduced in those methods.
