### PR TITLE
Excluded indexer properties from StructuralEqualityEquivalencyStep.

### DIFF
--- a/FluentAssertions.Core/Equivalency/StructuralEqualityEquivalencyStep.cs
+++ b/FluentAssertions.Core/Equivalency/StructuralEqualityEquivalencyStep.cs
@@ -89,14 +89,19 @@ namespace FluentAssertions.Equivalency
         internal IEnumerable<PropertyInfo> GetSelectedProperties(EquivalencyValidationContext context, 
             IEquivalencyAssertionOptions config)
         {
-            IEnumerable<PropertyInfo> properties = new List<PropertyInfo>();
+            IEnumerable<PropertyInfo> properties = Enumerable.Empty<PropertyInfo>();
 
             foreach (ISelectionRule selectionRule in config.SelectionRules)
             {
                 properties = selectionRule.SelectProperties(properties, context);
             }
 
-            return properties;
+            return properties.Where(IsNotIndexer);
+        }
+
+        private static bool IsNotIndexer(PropertyInfo property)
+        {
+            return (property.GetIndexParameters().Length == 0);
         }
     }
 }

--- a/FluentAssertions.Shared.Specs/EquivalencySpecs.cs
+++ b/FluentAssertions.Shared.Specs/EquivalencySpecs.cs
@@ -382,6 +382,27 @@ namespace FluentAssertions.Specs
             action.ShouldNotThrow();
         }
 
+        [TestMethod]
+        public void When_a_property_is_an_indexer_it_should_be_ignored()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var expected = new ClassWithIndexer {Foo = "test"};
+            var result = new ClassWithIndexer { Foo = "test" };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => result.ShouldBeEquivalentTo(expected);
+
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
         public class BaseWithFoo
         {
             public object Foo { get; set; }
@@ -409,6 +430,21 @@ namespace FluentAssertions.Specs
                 get { return (T)base.Foo; }
 
                 set { base.Foo = value; }
+            }
+        }
+
+        public class ClassWithIndexer
+        {
+            public object Foo { get; set; }
+
+            public string this[int n]
+            {
+                get
+                {
+                    return
+                        n.ToString(
+                            System.Globalization.CultureInfo.InvariantCulture);
+                }
             }
         }
 


### PR DESCRIPTION
 They are more like methods because they take a parameter, and we would not know what parameter values to pass.

This should fix #130.
