### PR TITLE
`Invoke(...)` extension method for async await (named `Awaiting(..)`)

### DIFF
--- a/FluentAssertions.Net45.Specs/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/FluentAssertions.Net45.Specs/AsyncFunctionExceptionAssertionSpecs.cs
@@ -23,11 +23,9 @@ namespace FluentAssertions.Net45.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action action = () =>
-            {
-                Func<Task> asyncFunction = async () => { await asyncObject.ThrowAsync<ArgumentException>(); };
-                asyncFunction.ShouldThrow<ArgumentException>();
-            };
+            Action action = () => asyncObject
+                .Awaiting(async x => await x.ThrowAsync<ArgumentException>())
+                .ShouldThrow<ArgumentException>();
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -46,11 +44,9 @@ namespace FluentAssertions.Net45.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action action = () =>
-            {
-                Func<Task> asyncFunction = async () => { await asyncObject.SucceedAsync(); };
-                asyncFunction.ShouldThrow<InvalidOperationException>();
-            };
+            Action action = () => asyncObject
+                .Awaiting(async x => await x.SucceedAsync())
+                .ShouldThrow<InvalidOperationException>();
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -70,17 +66,15 @@ namespace FluentAssertions.Net45.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action action = () =>
-            {
-                Func<Task> asyncFunction = async () => { await asyncObject.ThrowAsync<ArgumentException>(); };
-                asyncFunction.ShouldThrow<InvalidOperationException>();
-            };
+            Action action = () => asyncObject
+                .Awaiting(async x => await x.ThrowAsync<ArgumentException>())
+                .ShouldThrow<InvalidOperationException>();
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-                        action.ShouldThrow<AssertFailedException>()
-                            .WithMessage("Expected System.InvalidOperationException, but found*System.ArgumentException*");
+            action.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected System.InvalidOperationException, but found*System.ArgumentException*");
         }
 
         [TestMethod]
@@ -94,11 +88,9 @@ namespace FluentAssertions.Net45.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action action = () =>
-            {
-                Func<Task> asyncFunction = async () => { await asyncObject.SucceedAsync(); };
-                asyncFunction.ShouldNotThrow();
-            };
+            Action action = () => asyncObject
+                .Awaiting(async x => await x.SucceedAsync())
+                .ShouldNotThrow();
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -117,11 +109,9 @@ namespace FluentAssertions.Net45.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action action = () =>
-            {
-                Func<Task> asyncFunction = async () => { await asyncObject.ThrowAsync<ArgumentException>(); };
-                asyncFunction.ShouldNotThrow();
-            };
+            Action action = () => asyncObject
+                .Awaiting(async x => await x.ThrowAsync<ArgumentException>())
+                .ShouldNotThrow();
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -141,11 +131,9 @@ namespace FluentAssertions.Net45.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action action = () =>
-            {
-                Func<Task> asyncFunction = async () => { await asyncObject.ThrowAsync<ArgumentException>(); };
-                asyncFunction.ShouldNotThrow<InvalidOperationException>();
-            };
+            Action action = () => asyncObject
+                .Awaiting(async x => await x.ThrowAsync<ArgumentException>())
+                .ShouldNotThrow<InvalidOperationException>();
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -164,11 +152,9 @@ namespace FluentAssertions.Net45.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action action = () =>
-            {
-                Func<Task> asyncFunction = async () => { await asyncObject.SucceedAsync(); };
-                asyncFunction.ShouldNotThrow<InvalidOperationException>();
-            };
+            Action action = () => asyncObject
+                .Awaiting(async x => await asyncObject.SucceedAsync())
+                .ShouldNotThrow<InvalidOperationException>();
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -187,11 +173,9 @@ namespace FluentAssertions.Net45.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action action = () =>
-            {
-                Func<Task> asyncFunction = async () => { await asyncObject.ThrowAsync<ArgumentException>(); };
-                asyncFunction.ShouldNotThrow<ArgumentException>();
-            };
+            Action action = () => asyncObject
+                .Awaiting(async x => await x.ThrowAsync<ArgumentException>())
+                .ShouldNotThrow<ArgumentException>();
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert

--- a/Shared/AssertionExtensions.cs
+++ b/Shared/AssertionExtensions.cs
@@ -40,6 +40,13 @@ namespace FluentAssertions
             return () => action(subject);
         }
 
+#if NET45 || WINRT
+        public static Func<Task> Awaiting<T>(this T subject, Func<T, Task> action)
+        {
+            return () => action(subject);
+        }
+#endif
+
 #if !SILVERLIGHT && !PORTABLE
 
     /// <summary>


### PR DESCRIPTION
usage:

```
foo
     .Awaiting(async x => await x.DoSomething())
     .ShouldThrow<InvalidOperationException>();
```
