### PR TITLE
162 BeInDescendingOrder

### DIFF
--- a/FluentAssertions.Core/Collections/CollectionAssertions.cs
+++ b/FluentAssertions.Core/Collections/CollectionAssertions.cs
@@ -669,7 +669,7 @@ namespace FluentAssertions.Collections
 
         /// <summary>
         /// Asserts the current collection does not have all elements in ascending order. Elements are compared
-        /// using their <see cref="object.Equals(object)" /> implementation.
+        /// using their <see cref="IComparable.CompareTo(object)" /> implementation.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
@@ -685,7 +685,7 @@ namespace FluentAssertions.Collections
 
         /// <summary>
         /// Asserts the current collection does not have all elements in descending order. Elements are compared
-        /// using their <see cref="object.Equals(object)" /> implementation.
+        /// using their <see cref="IComparable.CompareTo(object)" /> implementation.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 


### PR DESCRIPTION
Very minor documentation correction: CollectionAssertions.BeInDescendingOrder/BeInAscendingOrder/NotBeInDescendingOrder/NotBeInAscendingOrder should specify IComparable.CompareTo(object) as the method of comparison.
