### PR TITLE
Correction of bacause to because.

### DIFF
--- a/Shared/Specialized/AssemblyAssertions.cs
+++ b/Shared/Specialized/AssemblyAssertions.cs
@@ -28,14 +28,14 @@ namespace FluentAssertions.Reflection
         /// Asserts that an assembly does not reference the specified assembly.
         /// </summary>
         /// <param name="assembly">The assembly which should not be referenced.</param>
-        /// <param name="bacause">
+        /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public void NotReference(Assembly assembly, string bacause, params string[] reasonArgs)
+        public void NotReference(Assembly assembly, string because, params string[] reasonArgs)
         {
             var subjectName = Subject.GetName().Name;
             var assemblyName = assembly.GetName().Name;
@@ -43,7 +43,7 @@ namespace FluentAssertions.Reflection
             var references = Subject.GetReferencedAssemblies().Select(x => x.Name);
 
             Execute.Assertion
-                   .BecauseOf(bacause, reasonArgs)
+                   .BecauseOf(because, reasonArgs)
                    .ForCondition(references.All(x => x != assemblyName))
                    .FailWith("Assembly {0} should not reference assembly {1}{reason}", subjectName, assemblyName);
         }
@@ -61,14 +61,14 @@ namespace FluentAssertions.Reflection
         /// Asserts that an assembly references the specified assembly.
         /// </summary>
         /// <param name="assembly">The assembly which should be referenced.</param>
-        /// <param name="bacause">
+        /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="reasonArgs">
         /// Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        public void Reference(Assembly assembly, string bacause, params string[] reasonArgs)
+        public void Reference(Assembly assembly, string because, params string[] reasonArgs)
         {
             var subjectName = Subject.GetName().Name;
             var assemblyName = assembly.GetName().Name;
@@ -76,7 +76,7 @@ namespace FluentAssertions.Reflection
             var references = Subject.GetReferencedAssemblies().Select(x => x.Name);
 
             Execute.Assertion
-                   .BecauseOf(bacause, reasonArgs)
+                   .BecauseOf(because, reasonArgs)
                    .ForCondition(references.Any(x => x == assemblyName))
                    .FailWith("Assembly {0} should reference assembly {1}{reason}, but it does not", subjectName, assemblyName);
         }


### PR DESCRIPTION
Simple spelling correction in AssemblyAssertions: bacause to because.
