### PR TITLE
Add support in core for Xamarin.iOS

### DIFF
--- a/FluentAssertions.Core/Core.csproj
+++ b/FluentAssertions.Core/Core.csproj
@@ -29,11 +29,11 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\Package\Lib\portable-monotouch+monoandroid\</OutputPath>
+    <OutputPath>..\Package\Lib\portable-monotouch+monoandroid+xamarin.ios\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>..\Package\Lib\portable-monotouch+monoandroid\\FluentAssertions.Core.xml</DocumentationFile>
+    <DocumentationFile>..\Package\Lib\portable-monotouch+monoandroid+xamarin.ios\FluentAssertions.Core.xml</DocumentationFile>
     <NoWarn>1591; 1572; 1573; 1574; 618</NoWarn>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Make sure the core assm goes into portable-monoandroid+monotouch+xamarin.ios to support the 64-bit unified profile
