### PR TITLE
Added NotBeDecoratedWith to TypeAssertions, TypeSelectorAssertions, P…

### DIFF
--- a/Src/Core/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/Core/Types/MethodInfoSelectorAssertions.cs
@@ -188,7 +188,7 @@ namespace FluentAssertions.Types
         private static string GetDescriptionsFor(IEnumerable<MethodInfo> methods)
         {
             return string.Join(Environment.NewLine,
-                methods.Select(MethodInfoAssertions.GetDescriptionFor).ToArray());
+                methods.Select(MethodInfoAssertions.GetDescriptionFor).OrderBy(d => d).ToArray());
         }
 
         /// <summary>

--- a/Src/Core/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/Core/Types/MethodInfoSelectorAssertions.cs
@@ -113,10 +113,76 @@ namespace FluentAssertions.Types
             return new AndConstraint<MethodInfoSelectorAssertions>(this);
         }
 
+        /// <summary>
+        /// Asserts that the selected methods are not decorated with the specified <typeparamref name="TAttribute"/>.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : Attribute
+        {
+            IEnumerable<MethodInfo> methodsWithAttribute = GetMethodsWith<TAttribute>(attr => true);
+
+            string failureMessage =
+                "Expected no selected methods to be decorated with {0}{reason}, but the following methods are:\r\n" +
+                GetDescriptionsFor(methodsWithAttribute);
+
+            Execute.Assertion
+                .ForCondition(!methodsWithAttribute.Any())
+                .BecauseOf(because, becauseArgs)
+                .FailWith(failureMessage, typeof(TAttribute));
+
+            return new AndConstraint<MethodInfoSelectorAssertions>(this);
+            //return NotBeDecoratedWith<TAttribute>(attr => true, because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts that the selected methods are not decorated with an attribute of type <typeparamref name="TAttribute"/>
+        /// that matches the specified <paramref name="isMatchingAttributePredicate"/>.
+        /// </summary>
+        /// <param name="isMatchingAttributePredicate">
+        /// The predicate that the attribute must match.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(
+            Expression<Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : Attribute
+        {
+            IEnumerable<MethodInfo> methodsWithAttribute = GetMethodsWith<TAttribute>(isMatchingAttributePredicate);
+
+            string failureMessage =
+                "Expected no selected methods to be decorated with {0} that matches {1}{reason}, but the matching attribute was found on the following methods:\r\n" +
+                GetDescriptionsFor(methodsWithAttribute);
+
+            Execute.Assertion
+                .ForCondition(!methodsWithAttribute.Any())
+                .BecauseOf(because, becauseArgs)
+                .FailWith(failureMessage, typeof(TAttribute), isMatchingAttributePredicate.Body);
+
+            return new AndConstraint<MethodInfoSelectorAssertions>(this);
+        }
+
         private MethodInfo[] GetMethodsWithout<TAttribute>(Expression<Func<TAttribute, bool>> isMatchingPredicate)
             where TAttribute : Attribute
         {
             return SubjectMethods.Where(method => !method.HasMatchingAttribute(isMatchingPredicate)).ToArray();
+        }
+
+        private MethodInfo[] GetMethodsWith<TAttribute>(Expression<Func<TAttribute, bool>> isMatchingPredicate)
+            where TAttribute : Attribute
+        {
+            return SubjectMethods.Where(method => method.HasMatchingAttribute(isMatchingPredicate)).ToArray();
         }
 
         private static string GetDescriptionsFor(IEnumerable<MethodInfo> methods)

--- a/Src/Core/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/Core/Types/PropertyInfoSelectorAssertions.cs
@@ -122,10 +122,43 @@ namespace FluentAssertions.Types
             return new AndConstraint<PropertyInfoSelectorAssertions>(this);
         }
 
+        /// <summary>
+        /// Asserts that the selected properties are not decorated with the specified <typeparamref name="TAttribute"/>.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<PropertyInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : Attribute
+        {
+            IEnumerable<PropertyInfo> propertiesWithAttribute = GetPropertiesWith<TAttribute>();
+
+            string failureMessage =
+                "Expected no selected properties to be decorated with {0}{reason}, but the following properties are:\r\n" +
+                GetDescriptionsFor(propertiesWithAttribute);
+
+            Execute.Assertion
+                .ForCondition(!propertiesWithAttribute.Any())
+                .BecauseOf(because, becauseArgs)
+                .FailWith(failureMessage, typeof(TAttribute));
+
+            return new AndConstraint<PropertyInfoSelectorAssertions>(this);
+        }
+
         private PropertyInfo[] GetPropertiesWithout<TAttribute>()
             where TAttribute : Attribute
         {
             return SubjectProperties.Where(property => !property.IsDecoratedWith<TAttribute>()).ToArray();
+        }
+
+        private PropertyInfo[] GetPropertiesWith<TAttribute>()
+            where TAttribute : Attribute
+        {
+            return SubjectProperties.Where(property => property.IsDecoratedWith<TAttribute>()).ToArray();
         }
 
         private static string GetDescriptionsFor(IEnumerable<PropertyInfo> properties)

--- a/Src/Core/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/Core/Types/PropertyInfoSelectorAssertions.cs
@@ -163,7 +163,7 @@ namespace FluentAssertions.Types
 
         private static string GetDescriptionsFor(IEnumerable<PropertyInfo> properties)
         {
-            return string.Join(Environment.NewLine, properties.Select(PropertyInfoAssertions.GetDescriptionFor).ToArray());
+            return string.Join(Environment.NewLine, properties.Select(PropertyInfoAssertions.GetDescriptionFor).OrderBy(d => d).ToArray());
         }
 
         /// <summary>

--- a/Src/Core/Types/TypeAssertions.cs
+++ b/Src/Core/Types/TypeAssertions.cs
@@ -212,6 +212,55 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
+        /// Asserts that the current <see cref="System.Type"/> is not decorated with the specified <typeparamref name="TAttribute"/>.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TypeAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : Attribute
+        {
+            Execute.Assertion
+                .ForCondition(!Subject.IsDecoratedWith<TAttribute>())
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected type {0} to not be decorated with {1}{reason}, but the attribute was found.",
+                    Subject, typeof(TAttribute));
+
+            return new AndConstraint<TypeAssertions>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="System.Type"/> is not decorated with an attribute of type <typeparamref name="TAttribute"/>
+        /// that matches the specified <paramref name="isMatchingAttributePredicate"/>.
+        /// </summary>
+        /// <param name="isMatchingAttributePredicate">
+        /// The predicate that the attribute must match.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TypeAssertions> NotBeDecoratedWith<TAttribute>(
+            Expression<Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : Attribute
+        {
+            Execute.Assertion
+                .ForCondition(!Subject.HasMatchingAttribute(isMatchingAttributePredicate))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected type {0} to not be decorated with {1} that matches {2}{reason}, but the matching attribute was found.",
+                    Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
+
+            return new AndConstraint<TypeAssertions>(this);
+        }
+
+        /// <summary>
         /// Asserts that the current <see cref="System.Type"/> implements Interface <paramref name="interfaceType"/>.
         /// </summary>
         /// <param name="interfaceType">The interface that should be implemented.</param>

--- a/Src/Core/Types/TypeSelectorAssertions.cs
+++ b/Src/Core/Types/TypeSelectorAssertions.cs
@@ -88,6 +88,65 @@ namespace FluentAssertions.Types
             return new AndConstraint<TypeSelectorAssertions>(this);
         }
 
+        /// <summary>
+        /// Asserts that the current <see cref="Type"/> is not decorated with the specified <typeparamref name="TAttribute"/>.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : Attribute
+        {
+            IEnumerable<Type> typesWithAttribute = Subject
+                .Where(type => type.IsDecoratedWith<TAttribute>())
+                .ToArray();
+
+            Execute.Assertion
+                .ForCondition(!typesWithAttribute.Any())
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected all types to not be decorated with {0}{reason}," +
+                    " but the attribute was found on the following types:\r\n" + GetDescriptionsFor(typesWithAttribute),
+                    typeof(TAttribute));
+
+            return new AndConstraint<TypeSelectorAssertions>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Type"/> is not decorated with an attribute of type <typeparamref name="TAttribute"/>
+        /// that matches the specified <paramref name="isMatchingAttributePredicate"/>.
+        /// </summary>
+        /// <param name="isMatchingAttributePredicate">
+        /// The predicate that the attribute must match.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(
+            Expression<Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : Attribute
+        {
+            IEnumerable<Type> typesWithMatchingAttribute = Subject
+                .Where(type => type.HasMatchingAttribute(isMatchingAttributePredicate))
+                .ToArray();
+
+            Execute.Assertion
+                .ForCondition(!typesWithMatchingAttribute.Any())
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected all types to not be decorated with {0} that matches {1}{reason}," +
+                    " but the matching attribute was found on the following types:\r\n" + GetDescriptionsFor(typesWithMatchingAttribute),
+                    typeof(TAttribute), isMatchingAttributePredicate.Body);
+
+            return new AndConstraint<TypeSelectorAssertions>(this);
+        }
+
         private static string GetDescriptionsFor(IEnumerable<Type> types)
         {
             return string.Join(Environment.NewLine, types.Select(GetDescriptionFor).ToArray());

--- a/Src/Core/Types/TypeSelectorAssertions.cs
+++ b/Src/Core/Types/TypeSelectorAssertions.cs
@@ -149,7 +149,7 @@ namespace FluentAssertions.Types
 
         private static string GetDescriptionsFor(IEnumerable<Type> types)
         {
-            return string.Join(Environment.NewLine, types.Select(GetDescriptionFor).ToArray());
+            return string.Join(Environment.NewLine, types.Select(GetDescriptionFor).OrderBy(d => d).ToArray());
         }
 
         private static string GetDescriptionFor(Type type)

--- a/Tests/FluentAssertions.Shared.Specs/MethodInfoSelectorAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/MethodInfoSelectorAssertionSpecs.cs
@@ -73,9 +73,9 @@ namespace FluentAssertions.Specs
                 .WithMessage("Expected all selected methods" +
                              " to be virtual because we want to test the error message," +
                              " but the following methods are not virtual:\r\n" +
-                             "Void FluentAssertions.Specs.ClassWithNonVirtualPublicMethods.PublicDoNothing\r\n" +
                              "Void FluentAssertions.Specs.ClassWithNonVirtualPublicMethods.InternalDoNothing\r\n" +
-                             "Void FluentAssertions.Specs.ClassWithNonVirtualPublicMethods.ProtectedDoNothing");
+                             "Void FluentAssertions.Specs.ClassWithNonVirtualPublicMethods.ProtectedDoNothing\r\n" +
+                             "Void FluentAssertions.Specs.ClassWithNonVirtualPublicMethods.PublicDoNothing");
         }
 
         [TestMethod]
@@ -141,9 +141,9 @@ namespace FluentAssertions.Specs
                 .WithMessage("Expected all selected methods to be decorated with" +
                              " FluentAssertions.Specs.DummyMethodAttribute because we want to test the error message," +
                              " but the following methods are not:\r\n" +
-                             "Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing\r\n" +
+                             "Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PrivateDoNothing\r\n" +
                              "Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.ProtectedDoNothing\r\n" +
-                             "Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PrivateDoNothing");
+                             "Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing");
         }
 
         [TestMethod]
@@ -209,10 +209,10 @@ namespace FluentAssertions.Specs
                 .WithMessage("Expected no selected methods to be decorated with" +
                              " FluentAssertions.Specs.DummyMethodAttribute because we want to test the error message," +
                              " but the following methods are:\r\n" +
+                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PrivateDoNothing\r\n" +
+                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.ProtectedDoNothing\r\n" + 
                              "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing\r\n" +
-                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothingWithSameAttributeTwice\r\n" +
-                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.ProtectedDoNothing\r\n" +
-                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PrivateDoNothing");
+                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothingWithSameAttributeTwice");
         }
 
         [TestMethod]

--- a/Tests/FluentAssertions.Shared.Specs/MethodInfoSelectorAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/MethodInfoSelectorAssertionSpecs.cs
@@ -145,5 +145,100 @@ namespace FluentAssertions.Specs
                              "Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.ProtectedDoNothing\r\n" +
                              "Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PrivateDoNothing");
         }
+
+        [TestMethod]
+        public void When_asserting_methods_are_not_decorated_with_attribute_and_they_are_not_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var methodSelector = new MethodInfoSelector(typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute));
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                methodSelector.Should().NotBeDecoratedWith<DummyMethodAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_methods_are_not_decorated_with_attribute_but_they_are_it_should_throw()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            MethodInfoSelector methodSelector =
+                new MethodInfoSelector(typeof(ClassWithAllMethodsDecoratedWithDummyAttribute))
+                    .ThatArePublicOrInternal;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                methodSelector.Should().NotBeDecoratedWith<DummyMethodAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>();
+        }
+
+        [TestMethod]
+        public void When_asserting_methods_are_not_decorated_with_attribute_but_they_are_it_should_throw_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsDecoratedWithDummyAttribute));
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                methodSelector.Should().NotBeDecoratedWith<DummyMethodAttribute>("because we want to test the error {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected no selected methods to be decorated with" +
+                             " FluentAssertions.Specs.DummyMethodAttribute because we want to test the error message," +
+                             " but the following methods are:\r\n" +
+                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing\r\n" +
+                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothingWithSameAttributeTwice\r\n" +
+                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.ProtectedDoNothing\r\n" +
+                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PrivateDoNothing");
+        }
+
+        [TestMethod]
+        public void When_asserting_a_selection_of_decorated_methods_with_unexpected_attribute_property_is_not_decorated_with_an_attribute_it_fails()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsDecoratedWithDummyAttribute));
+            
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                methodSelector.Should()
+                    .NotBeDecoratedWith<DummyMethodAttribute>(a => ((a.Filter == true)), "because we do");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected no selected methods to be decorated with FluentAssertions.Specs.DummyMethodAttribute" +
+                    " that matches (a.Filter == True) because we do," +
+                    " but the matching attribute was found on the following methods:\r\n" +
+                    "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing\r\n" +
+                    "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothingWithSameAttributeTwice");
+        }
     }
 }

--- a/Tests/FluentAssertions.Shared.Specs/PropertyInfoSelectorAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/PropertyInfoSelectorAssertionSpecs.cs
@@ -76,9 +76,9 @@ namespace FluentAssertions.Specs
                .WithMessage("Expected all selected properties" +
                    " to be virtual because we want to test the error message," +
                    " but the following properties are not virtual:\r\n" +
-                   "String FluentAssertions.Specs.ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty\r\n" +
                    "String FluentAssertions.Specs.ClassWithNonVirtualPublicProperties.InternalNonVirtualProperty\r\n" +
-                   "String FluentAssertions.Specs.ClassWithNonVirtualPublicProperties.ProtectedNonVirtualProperty");
+                   "String FluentAssertions.Specs.ClassWithNonVirtualPublicProperties.ProtectedNonVirtualProperty\r\n" +
+                   "String FluentAssertions.Specs.ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty");
         }
 
         [TestMethod]
@@ -145,9 +145,9 @@ namespace FluentAssertions.Specs
                 .WithMessage("Expected all selected properties to be decorated with" +
                    " FluentAssertions.Specs.DummyPropertyAttribute because we want to test the error message," +
                    " but the following properties are not:\r\n" +
-                   "String FluentAssertions.Specs.ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty\r\n" +
                    "String FluentAssertions.Specs.ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.InternalProperty\r\n" +
-                   "String FluentAssertions.Specs.ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.ProtectedProperty");
+                   "String FluentAssertions.Specs.ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.ProtectedProperty\r\n" +
+                   "String FluentAssertions.Specs.ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty");
         }
 
         [TestMethod]
@@ -213,10 +213,10 @@ namespace FluentAssertions.Specs
                 .WithMessage("Expected no selected properties to be decorated with" +
                    " FluentAssertions.Specs.DummyPropertyAttribute because we want to test the error message," +
                    " but the following properties are:\r\n" +
-                   "String FluentAssertions.Specs.ClassWithAllPropertiesDecoratedWithDummyAttribute.PublicProperty\r\n" +
-                   "String FluentAssertions.Specs.ClassWithAllPropertiesDecoratedWithDummyAttribute.PublicPropertyWithSameAttributeTwice\r\n" +
                    "String FluentAssertions.Specs.ClassWithAllPropertiesDecoratedWithDummyAttribute.InternalProperty\r\n" +
-                   "String FluentAssertions.Specs.ClassWithAllPropertiesDecoratedWithDummyAttribute.ProtectedProperty");
+                   "String FluentAssertions.Specs.ClassWithAllPropertiesDecoratedWithDummyAttribute.ProtectedProperty\r\n" +
+                   "String FluentAssertions.Specs.ClassWithAllPropertiesDecoratedWithDummyAttribute.PublicProperty\r\n" +
+                   "String FluentAssertions.Specs.ClassWithAllPropertiesDecoratedWithDummyAttribute.PublicPropertyWithSameAttributeTwice");
         }
 
         [TestMethod]

--- a/Tests/FluentAssertions.Shared.Specs/PropertyInfoSelectorAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/PropertyInfoSelectorAssertionSpecs.cs
@@ -151,6 +151,75 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
+        public void When_asserting_properties_are_not_decorated_with_attribute_and_they_are_not_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute));
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                propertyInfoSelector.Should().NotBeDecoratedWith<DummyPropertyAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_properties_are_not_decorated_with_attribute_and_they_are_it_should_throw()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute))
+                .ThatArePublicOrInternal;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                propertyInfoSelector.Should().NotBeDecoratedWith<DummyPropertyAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>();
+        }
+
+        [TestMethod]
+        public void When_asserting_properties_are_not_decorated_with_attribute_and_they_are_it_should_throw_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute));
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                propertyInfoSelector.Should()
+                                    .NotBeDecoratedWith<DummyPropertyAttribute>("because we want to test the error {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected no selected properties to be decorated with" +
+                   " FluentAssertions.Specs.DummyPropertyAttribute because we want to test the error message," +
+                   " but the following properties are:\r\n" +
+                   "String FluentAssertions.Specs.ClassWithAllPropertiesDecoratedWithDummyAttribute.PublicProperty\r\n" +
+                   "String FluentAssertions.Specs.ClassWithAllPropertiesDecoratedWithDummyAttribute.PublicPropertyWithSameAttributeTwice\r\n" +
+                   "String FluentAssertions.Specs.ClassWithAllPropertiesDecoratedWithDummyAttribute.InternalProperty\r\n" +
+                   "String FluentAssertions.Specs.ClassWithAllPropertiesDecoratedWithDummyAttribute.ProtectedProperty");
+        }
+
+        [TestMethod]
         public void When_a_read_only_property_is_expected_to_be_writable_it_should_throw_with_descriptive_message()
         {
             //-------------------------------------------------------------------------------------------------------------------

--- a/Tests/FluentAssertions.Shared.Specs/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/TypeAssertionSpecs.cs
@@ -744,6 +744,204 @@ namespace FluentAssertions.Specs
 
         #endregion
 
+        #region NotBeDecoratedWith
+
+        [TestMethod]
+        public void When_asserting_a_type_is_not_decorated_with_attribute_and_it_is_not_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type typeWithoutAttribute = typeof(ClassWithoutAttribute);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                typeWithoutAttribute.Should().NotBeDecoratedWith<DummyClassAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_a_type_is_not_decorated_with_attribute_and_it_is_it_fails()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type typeWithAttribute = typeof(ClassWithAttribute);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                typeWithAttribute.Should().NotBeDecoratedWith<DummyClassAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>();
+        }
+
+        [TestMethod]
+        public void When_asserting_a_type_is_not_decorated_with_attribute_and_it_is_it_fails_with_a_useful_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type typeWithAttribute = typeof(ClassWithAttribute);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                typeWithAttribute.Should().NotBeDecoratedWith<DummyClassAttribute>(
+                    "because we want to test the error {0}",
+                    "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected type FluentAssertions.Specs.ClassWithAttribute to not be decorated with " +
+                    "FluentAssertions.Specs.DummyClassAttribute because we want to test the error message, but the attribute " +
+                        "was found.");
+        }
+
+        [TestMethod]
+        public void When_asserting_a_type_is_not_decorated_with_attribute_matching_a_predicate_and_it_is_not_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type typeWithAttribute = typeof(ClassWithAttribute);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                typeWithAttribute.Should()
+                    .NotBeDecoratedWith<DummyClassAttribute>(a => ((a.Name == "Unexpected") && a.IsEnabled));
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_a_type_is_not_decorated_with_attribute_matching_a_predicate_and_it_is_it_fails()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type typeWithAttribute = typeof(ClassWithAttribute);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                typeWithAttribute.Should()
+                    .NotBeDecoratedWith<DummyClassAttribute>(a => ((a.Name == "Expected") && a.IsEnabled));
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected type FluentAssertions.Specs.ClassWithAttribute to not be decorated with " +
+                    "FluentAssertions.Specs.DummyClassAttribute that matches ((a.Name == \"Expected\")*a.IsEnabled), " +
+                        "but the matching attribute was found.");
+        }
+
+        [TestMethod]
+        public void When_asserting_a_selection_of_non_decorated_types_is_not_decorated_with_an_attribute_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var types = new TypeSelector(new[]
+            {
+                typeof (ClassWithoutAttribute)
+            });
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                types.Should().NotBeDecoratedWith<DummyClassAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_a_selection_of_decorated_types_is_not_decorated_with_an_attribute_it_fails()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var types = new TypeSelector(new[]
+            {
+                typeof (ClassWithoutAttribute),
+                typeof (ClassWithAttribute),
+                typeof (OtherClassWithAttribute)
+            });
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                types.Should().NotBeDecoratedWith<DummyClassAttribute>("because we do");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected all types to not be decorated with FluentAssertions.Specs.DummyClassAttribute" +
+                    " because we do, but the attribute was found on the following types:\r\n" +
+                    "FluentAssertions.Specs.ClassWithAttribute\r\n" +
+                    "FluentAssertions.Specs.OtherClassWithAttribute");
+        }
+
+
+        [TestMethod]
+        public void When_asserting_a_selection_of_decorated_types_with_unexpected_attribute_property_is_not_decorated_with_an_attribute_it_fails()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var types = new TypeSelector(new[]
+            {
+                typeof (ClassWithoutAttribute),
+                typeof (ClassWithAttribute),
+                typeof (OtherClassWithAttribute)
+            });
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                types.Should()
+                    .NotBeDecoratedWith<DummyClassAttribute>(a => ((a.Name == "Expected") && a.IsEnabled), "because we do");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected all types to not be decorated with FluentAssertions.Specs.DummyClassAttribute" +
+                    " that matches ((a.Name == \"Expected\")*a.IsEnabled) because we do," +
+                    " but the matching attribute was found on the following types:\r\n" +
+                    "FluentAssertions.Specs.ClassWithAttribute\r\n" +
+                    "FluentAssertions.Specs.OtherClassWithAttribute");
+        }
+
+        #endregion
+
         #region Implement
 
         [TestMethod]
@@ -2381,6 +2579,11 @@ namespace FluentAssertions.Specs
     }
 
     public class ClassWithoutAttribute
+    {
+    }
+
+    [DummyClass("Expected", true)]
+    public class OtherClassWithAttribute
     {
     }
 


### PR DESCRIPTION
…ropertyInfoSelectorAssertions and MethodInfoSelectorAssertions.

Added unit tests for above additions.

Resolves (part of) issue #527 (did not add `ThatAreNotDecoratedWith`, only added `NotBeDecoratedWith`).