### PR TITLE
FluentAssertions.com example -- correction for clarity

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,12 +19,12 @@ To verify that a collection contains a specified number of elements and that all
 
 ```c#
 IEnumerable collection = new[] { 1, 2, 3 };
-collection.Should().HaveCount(4, "because we thought we put three items in the collection"))
+collection.Should().HaveCount(4, "because we thought we put four items in the collection"))
 ```
 
 The nice thing about the second failing example is that it will throw an exception with the message
 
-> "Expected <4> items because we thought we put three items in the collection, but found <3>." 
+> "Expected <4> items because we thought we put four items in the collection, but found <3>." 
 
 To verify that a particular business rule is enforced using exceptions.
 


### PR DESCRIPTION
Hi all,

I know FV is under heavy refactoring but I wanted to submit a minor fix for the home page; I won't be offended if you reject. :) 

The home page current has an example where a list of 3 items is created but the example expects four. The explanation reads "because we thought we added three items", but it really means "because we thought we added four items." This will make the failure message make more sense.

Would have submitted an issue first, but this seemed minor enough. Thanks for your consideration!