### PR TITLE
Exclude static constructors when get a constructor by its parameters.

### DIFF
--- a/Src/Core/Common/TypeExtensions.cs
+++ b/Src/Core/Common/TypeExtensions.cs
@@ -343,7 +343,7 @@ namespace FluentAssertions.Common
         public static ConstructorInfo GetConstructor(this Type type, IEnumerable<Type> parameterTypes)
         {
             return type
-                .GetConstructors(AllMembersFlag)
+                .GetConstructors(PublicMembersFlag)
                 .SingleOrDefault(m => m.GetParameters().Select(p => p.ParameterType).SequenceEqual(parameterTypes));
         }
     }

--- a/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs
@@ -3574,6 +3574,17 @@ With configuration:*");
         public string Property3 { get; set; }
     }
 
+    internal class ClassWithCctor
+    {
+        static ClassWithCctor() { }
+    }
+
+    internal class ClassWithCctorAndNonDefaultConstructor
+    {
+        static ClassWithCctorAndNonDefaultConstructor() { }
+        public ClassWithCctorAndNonDefaultConstructor(int i) { }
+    }
+
     internal class MyCompanyLogo
     {
         public string Url { get; set; }

--- a/Tests/FluentAssertions.Shared.Specs/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/TypeAssertionSpecs.cs
@@ -1911,6 +1911,56 @@ namespace FluentAssertions.Specs
             act.ShouldNotThrow();
         }
 
+        [TestMethod]
+        public void When_asserting_a_type_has_a_default_constructor_which_it_does_not_and_a_cctor_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(ClassWithCctor);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            type.Should()
+                    .HaveDefaultConstructor("because the compiler generates one even if not explicitly defined.")
+                    .Which.Should()
+                        .HaveAccessModifier(CSharpAccessModifier.Public);
+            Action act = () =>
+                type.Should()
+                    .HaveDefaultConstructor()
+                    .Which.Should()
+                        .HaveAccessModifier(CSharpAccessModifier.Public);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void When_asserting_a_type_has_a_default_constructor_which_it_does_not_and_a_cctor_it_fails()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(ClassWithCctorAndNonDefaultConstructor);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                type.Should().HaveDefaultConstructor("because we want to test the error {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage(
+                    "Expected constructor FluentAssertions.Specs.ClassWithCctorAndNonDefaultConstructor() to exist because we " +
+                    "want to test the error message, but it does not.");
+        }
+        
         #endregion
 
         #region HaveMethod


### PR DESCRIPTION
Fixes #540 

Unit tests were added to test `HaveDefaultConstructor` with classes that have a static constructor.