### PR TITLE
Update CONTRIBUTING.md to reflect the change of documentation location

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,5 +5,5 @@ No open-source projection is going to be successfull without contributions. Afte
 
 * The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
 * The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://csharpguidelines.codeplex.com/)/. 
-* The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/dennisdoomen/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33). 
-* If the contribution affects the documentation, please help us by providing a paragraph of text and/or examples that we can include in the [documentation](https://github.com/dennisdoomen/fluentassertions/wiki) wiki. 
+* The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33). 
+* If the contribution affects the documentation, please update [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md), which is published on the [website](http://fluentassertions.com/documentation.html).


### PR DESCRIPTION
Update CONTRIBUTING.md to reflect the change of documentation location since it is now on the website rather than the wiki.

Also, fixed another the example specs url since I noticed it while I was there.