### PR TITLE
Add Google Analytics to website

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,6 +4,7 @@ description: "\"With Fluent Assertions, the assertions look beautiful, natural a
 email:
 twitter_username: ddoomen
 github_username:  fluentassertions
+google_analytics: UA-99995670-1
 
 theme: minima
 gems:


### PR DESCRIPTION
Could be useful or at least interesting.  Since the content is no longer on the wiki, GitHub's analytics no longer covers this.  I also think there may be some integration possible with the advertisement if you wanted to link them.