### PR TITLE
Fix issues with curly braces

### DIFF
--- a/Src/Core/Collections/CollectionAssertions.cs
+++ b/Src/Core/Collections/CollectionAssertions.cs
@@ -220,13 +220,13 @@ namespace FluentAssertions.Collections
                 throw new ArgumentNullException("expectation", "Cannot compare collection with <null>.");
             }
 
+            TExpected[] expectedItems = expectation.Cast<TExpected>().ToArray();
+
             AssertionScope assertion = Execute.Assertion.BecauseOf(because, becauseArgs);
             if (subjectIsNull)
             {
-                assertion.FailWith("Expected {context:collection} to be equal{reason}, but found <null>.");
+                assertion.FailWith("Expected {context:collection} to be equal to {0}{reason}, but found <null>.", expectedItems);
             }
-
-            TExpected[] expectedItems = expectation.Cast<TExpected>().ToArray();
 
             assertion
                 .WithExpectation("Expected {context:collection} to be equal to {0}{reason}, ", expectedItems)

--- a/Src/Core/Execution/MessageBuilder.cs
+++ b/Src/Core/Execution/MessageBuilder.cs
@@ -53,16 +53,17 @@ namespace FluentAssertions.Execution
             return regex.Replace(message, match =>
             {
                 string key = match.Groups["key"].Value;
-                return contextData.AsStringOrDefault(key) ?? match.Groups["default"].Value;
+                return 
+                    contextData.AsStringOrDefault(key)?.Replace("{", "{{").Replace("}", "}}") ??
+                    match.Groups["default"].Value;
             });
         }
 
         private string FormatArgumentPlaceholders(string failureMessage, object[] failureArgs)
         {
-            var values = new List<string>();
-            values.AddRange(failureArgs.Select(a => Formatter.ToString(a, useLineBreaks)));
+            string[] values = failureArgs.Select(a => Formatter.ToString(a, useLineBreaks)).ToArray();
 
-            string formattedMessage = values.Any() ? String.Format(failureMessage, values.ToArray()) : failureMessage;
+            string formattedMessage = string.Format(failureMessage, values);
             return formattedMessage.Replace("{{{{", "{{").Replace("}}}}", "}}");
         }
 

--- a/Src/Core/Specialized/ExceptionAssertions.cs
+++ b/Src/Core/Specialized/ExceptionAssertions.cs
@@ -268,7 +268,7 @@ namespace FluentAssertions.Specialized
 
                     foreach (string failure in results.SelectClosestMatchFor())
                     {
-                        AssertionScope.Current.FailWith(failure);
+                        AssertionScope.Current.FailWith(failure.Replace("{", "{{").Replace("}", "}}"));
                     }
                 }
             }

--- a/Tests/FluentAssertions.Shared.Specs/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/AssertionScopeSpecs.cs
@@ -181,6 +181,27 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
+        public void When_an_assertion_fails_in_a_scope_with_braces_it_should_use_the_name_as_the_assertion_context()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () =>
+            {
+                using (new AssertionScope("{}"))
+                {
+                    default(Array).Should().Equal(3, 2, 1);
+                }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<AssertFailedException>()
+                .WithMessage("Expected {} to be equal to*");
+        }
+
+        [TestMethod]
         public void When_parentheses_are_used_in_the_because_arguments_it_should_render_them_correctly()
         {
             //-----------------------------------------------------------------------------------------------------------

--- a/Tests/FluentAssertions.Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/CollectionAssertionSpecs.cs
@@ -818,7 +818,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
-                "Expected collection to be equal because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to be equal to {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
         }
 
         [TestMethod]

--- a/Tests/FluentAssertions.Shared.Specs/ExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/ExceptionAssertionSpecs.cs
@@ -345,6 +345,38 @@ namespace FluentAssertions.Specs
         }
 
         [TestMethod]
+        public void When_subject_throws_exception_with_message_with_braces_but_a_different_message_is_expected_it_should_report_that()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IFoo subjectThatThrows = A.Fake<IFoo>();
+            A.CallTo(() => subjectThatThrows.Do(A<string>.Ignored))
+                .Throws(new Exception("message with {}"));
+
+            try
+            {
+                //-----------------------------------------------------------------------------------------------------------
+                // Act
+                //-----------------------------------------------------------------------------------------------------------
+                subjectThatThrows
+                    .Invoking(x => x.Do("something"))
+                    .ShouldThrow<Exception>()
+                    .WithMessage("message without");
+
+                Assert.Fail("This point should not be reached");
+            }
+            catch (AssertFailedException ex)
+            {
+                //-----------------------------------------------------------------------------------------------------------
+                // Assert
+                //-----------------------------------------------------------------------------------------------------------
+                ex.Message.Should().Match(
+                    "Expected exception message to match the equivalent of \r\n\"message without\"*, but \r\n\"message with {}*");
+            }
+        }
+
+        [TestMethod]
         public void When_asserting_with_an_aggregate_exception_type_the_asserts_should_occur_against_the_aggregate_exception()
         {
             //-----------------------------------------------------------------------------------------------------------

--- a/Tests/FluentAssertions.Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
@@ -472,7 +472,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<AssertFailedException>().WithMessage(
-                "Expected collection to be equal because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected collection to be equal to {\"one\", \"two\", \"three\"} because we want to test the behaviour with a null subject, but found <null>.");
         }
 
         [TestMethod]


### PR DESCRIPTION
This PR resolve issues with curly braces in assertion scopes.

When providing single braces ( {} ) string.Format() would fail.
When providing double braces ( {{}} ) and skipping string.Format() because no args were provided, the double braces would not be undoubled.
This is especially annoying when working with JSON.

## IMPORTANT 
SINCE FLUENT ASSERTIONS IS CURRENTLY UNDER HEAVY REFACTORING FOR [VERSION 5.0](https://github.com/fluentassertions/fluentassertions/issues/463), WE CURRENTLY ONLY ACCEPT BUGFIX REQUESTS. SORRY FOR THE INCONVENIENCE

* [x] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [x] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/)/.
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] ~~If the contribution affects the documentation, please include your changes to [**documentation.md**]~~(https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).
