### PR TITLE
Add NotHaveSameCount

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -932,6 +932,47 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
+        /// Assert that the current collection does not have the same number of elements as <paramref name="otherCollection" />.
+        /// </summary>
+        /// <param name="otherCollection">The other collection with the unexpected number of elements</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotHaveSameCount(IEnumerable otherCollection, string because = "",
+            params object[] becauseArgs)
+        {
+            if (otherCollection == null)
+            {
+                throw new NullReferenceException("Cannot verify count against a <null> collection.");
+            }
+
+            if (ReferenceEquals(Subject, null))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:collection} to not have the same count as {0}{reason}, but found {1}.",
+                        otherCollection,
+                        Subject);
+            }
+
+            IEnumerable<object> enumerable = Subject.Cast<object>();
+
+            int actualCount = enumerable.Count();
+            int expectedCount = otherCollection.Cast<object>().Count();
+
+            Execute.Assertion
+                .ForCondition(actualCount != expectedCount)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:collection} to not have {0} item(s){reason}, but found {1}.", expectedCount, actualCount);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
         /// Asserts that the current collection has the supplied <paramref name="element" /> at the
         /// supplied <paramref name="index" />.
         /// </summary>

--- a/Tests/Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/CollectionAssertionSpecs.cs
@@ -3482,6 +3482,110 @@ namespace FluentAssertions.Specs
 
         #endregion
 
+        #region Not Have Same Count
+
+        [Fact]
+        public void When_asserting_not_same_count_and_collections_have_different_number_elements_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable firstCollection = new[] { 1, 2, 3 };
+            IEnumerable secondCollection = new[] { 4, 6 };
+
+            var extensions = firstCollection.Should();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            extensions.NotHaveSameCount(secondCollection);
+        }
+
+        [Fact]
+        public void When_asserting_not_same_count_and_both_collections_have_the_same_number_elements_it_should_fail()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable firstCollection = new[] { 1, 2, 3 };
+            IEnumerable secondCollection = new[] { 4, 5, 6 };
+
+            var extensions = firstCollection.Should();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            extensions
+                .Invoking(e => e.NotHaveSameCount(secondCollection))
+                .ShouldThrow<XunitException>()
+                .WithMessage("Expected collection to not have 3 item(s), but found 3.");
+        }
+
+        [Fact]
+        public void When_comparing_not_same_item_counts_and_a_reason_is_specified_it_should_it_in_the_exception()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable firstCollection = new[] { 1, 2, 3 };
+            IEnumerable secondCollection = new[] { 4, 5, 6 };
+
+            var extensions = firstCollection.Should();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            extensions
+                .Invoking(e => e.NotHaveSameCount(secondCollection, "we want to test the {0}", "reason"))
+                .ShouldThrow<XunitException>()
+                .WithMessage("Expected collection to not have 3 item(s) because we want to test the reason, but found 3.");
+        }
+
+        [Fact]
+        public void When_asserting_collections_to_not_have_same_count_against_null_collection_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = null;
+            IEnumerable collection1 = new[] { 1, 2, 3 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotHaveSameCount(collection1,
+                "because we want to test the behaviour with a null subject");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Expected collection to not have the same count as {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_collections_to_not_have_same_count_against_an_other_null_collection_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new[] { 1, 2, 3 };
+            IEnumerable otherCollection = null;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotHaveSameCount(otherCollection);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<NullReferenceException>().WithMessage(
+                "Cannot verify count against a <null> collection.");
+        }
+
+        #endregion
+
         #region ShouldAllBeAssignableTo
 
         [Fact]

--- a/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
@@ -1829,6 +1829,110 @@ namespace FluentAssertions.Specs
 
         #endregion
 
+        #region Not Have Same Count
+
+        [Fact]
+        public void When_asserting_not_same_count_and_collections_have_different_number_elements_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<string> firstCollection = new[] { "one", "two", "three" };
+            IEnumerable<string> secondCollection = new[] { "four", "six" };
+
+            var extensions = firstCollection.Should();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            extensions.NotHaveSameCount(secondCollection);
+        }
+
+        [Fact]
+        public void When_asserting_not_same_count_and_both_collections_have_the_same_number_elements_it_should_fail()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<string> firstCollection = new[] { "one", "two", "three" };
+            IEnumerable<string> secondCollection = new[] { "four", "five", "six" };
+
+            var extensions = firstCollection.Should();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            extensions
+                .Invoking(e => e.NotHaveSameCount(secondCollection))
+                .ShouldThrow<XunitException>()
+                .WithMessage("Expected collection to not have 3 item(s), but found 3.");
+        }
+
+        [Fact]
+        public void When_comparing_not_same_item_counts_and_a_reason_is_specified_it_should_it_in_the_exception()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<string> firstCollection = new[] { "one", "two", "three" };
+            IEnumerable<string> secondCollection = new[] { "four", "five", "six" };
+
+            var extensions = firstCollection.Should();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            extensions
+                .Invoking(e => e.NotHaveSameCount(secondCollection, "we want to test the {0}", "reason"))
+                .ShouldThrow<XunitException>()
+                .WithMessage("Expected collection to not have 3 item(s) because we want to test the reason, but found 3.");
+        }
+
+        [Fact]
+        public void When_asserting_collections_to_not_have_same_count_against_null_collection_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<string> collection = null;
+            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotHaveSameCount(collection1,
+                "because we want to test the behaviour with a null subject");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Expected collection to not have the same count as {\"one\", \"two\", \"three\"} because we want to test the behaviour with a null subject, but found <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_collections_to_not_have_same_count_against_an_other_null_collection_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> otherCollection = null;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotHaveSameCount(otherCollection);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<NullReferenceException>().WithMessage(
+                "Cannot verify count against a <null> collection.");
+        }
+
+        #endregion
+
         [Fact]
         public void
             When_using_StringCollectionAssertions_the_AndConstraint_should_have_the_correct_type()

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -321,6 +321,7 @@ collection.Should().NotBeEquivalentTo(8, 2, 3, 5);
 
 collection.Should().HaveCount(c => c > 3).And.OnlyHaveUniqueItems();
 collection.Should().HaveSameCount(new[] {6, 2, 0, 5});
+collection.Should().NotHaveSameCount(new[] {6, 2, 0});
 
 collection.Should().StartWith(element);
 collection.Should().EndWith(element);


### PR DESCRIPTION
* [ ] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* x] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/)/.
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).

This closes #597  