### PR TITLE
Not be assignable to

### DIFF
--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -246,8 +246,8 @@ namespace FluentAssertions.Primitives
         /// <typeparam name="T">The type to which the object should not be assignable.</typeparam>
         /// <param name="because">The reason why the object should not be assignable to the type.</param>
         /// <param name="becauseArgs">The parameters used when formatting the <paramref name="because"/>.</param>
-        /// <returns>An <see cref="AndWhichConstraint{TAssertions, TSubject}"/> which can be used to chain assertions.</returns>
-        public AndWhichConstraint<TAssertions, TSubject> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs)
+        /// <returns>An <see cref="AndConstraint{TAssertions}"/> which can be used to chain assertions.</returns>
+        public AndConstraint<TAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs)
         {
             return NotBeAssignableTo(typeof(T), because, becauseArgs);
         }
@@ -258,8 +258,8 @@ namespace FluentAssertions.Primitives
         /// <param name="type">The type to which the object should not be assignable.</param>
         /// <param name="because">The parameters used when formatting the <paramref name="because"/>.</param>
         /// <param name="becauseArgs"></param>
-        /// <returns>An <see cref="AndWhichConstraint{TAssertions, TSubject}"/> which can be used to chain assertions.</returns>
-        public AndWhichConstraint<TAssertions, TSubject> NotBeAssignableTo(Type type, string because = "", params object[] becauseArgs)
+        /// <returns>An <see cref="AndConstraint{TAssertions}"/> which can be used to chain assertions.</returns>
+        public AndConstraint<TAssertions> NotBeAssignableTo(Type type, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!ReferenceEquals(Subject, null))
@@ -273,7 +273,7 @@ namespace FluentAssertions.Primitives
                     type,
                     Subject.GetType());
 
-            return new AndWhichConstraint<TAssertions, TSubject>((TAssertions)this, Subject);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -241,6 +241,42 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
+        /// Asserts that the object is not assignable to a variable of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type to which the object should not be assignable.</typeparam>
+        /// <param name="because">The reason why the object should not be assignable to the type.</param>
+        /// <param name="becauseArgs">The parameters used when formatting the <paramref name="because"/>.</param>
+        /// <returns>An <see cref="AndWhichConstraint{TAssertions, TSubject}"/> which can be used to chain assertions.</returns>
+        public AndWhichConstraint<TAssertions, TSubject> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs)
+        {
+            return NotBeAssignableTo(typeof(T), because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts that the object is not assignable to a variable of given <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">The type to which the object should not be assignable.</param>
+        /// <param name="because">The parameters used when formatting the <paramref name="because"/>.</param>
+        /// <param name="becauseArgs"></param>
+        /// <returns>An <see cref="AndWhichConstraint{TAssertions, TSubject}"/> which can be used to chain assertions.</returns>
+        public AndWhichConstraint<TAssertions, TSubject> NotBeAssignableTo(Type type, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(!ReferenceEquals(Subject, null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:type} not to be {0}{reason}, but found <null>.", type);
+
+            Execute.Assertion
+                .ForCondition(!type.IsAssignableFrom(Subject.GetType()))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:" + Context + "} to not be assignable to {0}{reason}, but {1} is",
+                    type,
+                    Subject.GetType());
+
+            return new AndWhichConstraint<TAssertions, TSubject>((TAssertions)this, Subject);
+        }
+
+        /// <summary>
         /// Asserts that the <paramref name="predicate" /> is satisfied.
         /// </summary>
         /// <param name="predicate">The predicate which must be satisfied by the <typeparamref name="TSubject" />.</param>

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -98,6 +98,38 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
+        /// Asserts than an instance of the subject type is not assignable variable of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type to which instances of the type should not be assignable.</typeparam>
+        /// <param name="because">The reason why instances of the type should not be assignable to the type.</param>
+        /// <param name="becauseArgs">The parameters used when formatting the <paramref name="because"/>.</param>
+        /// <returns>An <see cref="AndConstraint{T}"/> which can be used to chain assertions.</returns>
+        public new AndConstraint<TypeAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs)
+        {
+            return NotBeAssignableTo(typeof(T), because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts than an instance of the subject type is not assignable variable of given <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">The type to which instances of the type should not be assignable.</param>
+        /// <param name="because">The reason why instances of the type should not be assignable to the type.</param>
+        /// <param name="becauseArgs"></param>
+        /// <returns>An <see cref="AndConstraint{T}"/> which can be used to chain assertions.</returns>
+        public new AndConstraint<TypeAssertions> NotBeAssignableTo(Type type, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(!type.IsAssignableFrom(Subject))
+                .BecauseOf(because, becauseArgs)
+                .FailWith(
+                    "Expected {context:" + Context + "} {0} to not be assignable to {1}{reason}, but it is",
+                    Subject,
+                    type);
+
+            return new AndConstraint<TypeAssertions>(this);
+        }
+
+        /// <summary>
         /// Creates an error message in case the specified <paramref name="actual"/> type differs from the 
         /// <paramref name="expected"/> type.
         /// </summary>

--- a/Tests/Shared.Specs/ObjectAssertionSpecs.cs
+++ b/Tests/Shared.Specs/ObjectAssertionSpecs.cs
@@ -660,7 +660,7 @@ namespace FluentAssertions.Specs
             // Act
             //-------------------------------------------------------------------------------------------------------------------
             Action act = () => someObject.Should().NotBeAssignableTo<DummyImplementingClass>()
-                .Which.Should().BeOfType<Exception>()
+                .And.Subject.Should().BeOfType<Exception>()
                 .Which.Message.Should().Be("Other Message");
 
             //-------------------------------------------------------------------------------------------------------------------

--- a/Tests/Shared.Specs/ObjectAssertionSpecs.cs
+++ b/Tests/Shared.Specs/ObjectAssertionSpecs.cs
@@ -584,6 +584,155 @@ namespace FluentAssertions.Specs
 
         #endregion
 
+        #region NotBeAssignableTo
+
+        [Fact]
+        public void When_its_own_type_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var someObject = new DummyImplementingClass();
+            Action act = () => someObject.Should().NotBeAssignableTo<DummyImplementingClass>("because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage($"*not be assignable to {typeof(DummyImplementingClass)}*failure message*{typeof(DummyImplementingClass)} is*");
+        }
+
+        [Fact]
+        public void When_its_base_type_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var someObject = new DummyImplementingClass();
+            Action act = () => someObject.Should().NotBeAssignableTo<DummyBaseClass>("because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage($"*not be assignable to {typeof(DummyBaseClass)}*failure message*{typeof(DummyImplementingClass)} is*");
+        }
+
+        [Fact]
+        public void When_an_implemented_interface_type_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var someObject = new DummyImplementingClass();
+            Action act = () => someObject.Should().NotBeAssignableTo<IDisposable>("because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage($"*not be assignable to {typeof(IDisposable)}*failure message*{typeof(DummyImplementingClass)} is*");
+        }
+
+        [Fact]
+        public void When_an_unrelated_type_and_asserting_not_assignable_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var someObject = new DummyImplementingClass();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            someObject.Should().NotBeAssignableTo<DateTime>();
+        }
+
+        [Fact]
+        public void When_not_to_the_unexpected_type_and_asserting_not_assignable_it_should_not_cast_the_returned_object_for_chaining()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var someObject = new Exception("Actual Message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => someObject.Should().NotBeAssignableTo<DummyImplementingClass>()
+                .Which.Should().BeOfType<Exception>()
+                .Which.Message.Should().Be("Other Message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage("*Expected*Other*Actual*");
+        }
+
+        [Fact]
+        public void When_its_own_type_instance_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var someObject = new DummyImplementingClass();
+            Action act = () => someObject.Should().NotBeAssignableTo(typeof(DummyImplementingClass), "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage($"*not be assignable to {typeof(DummyImplementingClass)}*failure message*{typeof(DummyImplementingClass)} is*");
+        }
+
+        [Fact]
+        public void When_its_base_type_instance_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var someObject = new DummyImplementingClass();
+            Action act = () => someObject.Should().NotBeAssignableTo(typeof(DummyBaseClass), "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage($"*not be assignable to {typeof(DummyBaseClass)}*failure message*{typeof(DummyImplementingClass)} is*");
+        }
+
+        [Fact]
+        public void When_an_implemented_interface_type_instance_and_asserting_not_assignable_it_should_fail_with_a_useful_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var someObject = new DummyImplementingClass();
+            Action act = () => someObject.Should().NotBeAssignableTo(typeof(IDisposable), "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage($"*not be assignable to {typeof(IDisposable)}*failure message*{typeof(DummyImplementingClass)} is*");
+        }
+
+        [Fact]
+        public void When_an_unrelated_type_instance_and_asserting_not_assignable_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var someObject = new DummyImplementingClass();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            someObject.Should().NotBeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
+        }
+
+        #endregion
+
         #region HaveFlag / NotHaveFlag
 
         [Fact]

--- a/Tests/Shared.Specs/TypeAssertionSpecs.cs
+++ b/Tests/Shared.Specs/TypeAssertionSpecs.cs
@@ -447,6 +447,118 @@ namespace FluentAssertions.Specs
 
         #endregion
 
+        #region NotBeAssignableTo
+
+        [Fact]
+        public void When_its_own_type_and_asserting_not_assignable_it_fails_with_a_useful_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo<DummyImplementingClass>("because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage($"*{typeof(DummyImplementingClass)} to not be assignable to {typeof(DummyImplementingClass)}*failure message*");
+        }
+
+        [Fact]
+        public void When_its_base_type_and_asserting_not_assignable_it_fails_with_a_useful_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo<DummyBaseClass>("because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage($"*{typeof(DummyImplementingClass)} to not be assignable to {typeof(DummyBaseClass)}*failure message*");
+        }
+
+        [Fact]
+        public void When_implemented_interface_type_and_asserting_not_assignable_it_fails_with_a_useful_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo<IDisposable>("because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage($"*{typeof(DummyImplementingClass)} to not be assignable to {typeof(IDisposable)}*failure message*");
+        }
+
+        [Fact]
+        public void When_an_unrelated_type_and_asserting_not_assignable_it_succeeds()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange / Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            typeof(DummyImplementingClass).Should().NotBeAssignableTo<DateTime>();
+        }
+
+        [Fact]
+        public void When_its_own_type_instance_and_asserting_not_assignable_it_fails_with_a_useful_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(DummyImplementingClass), "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage($"*{typeof(DummyImplementingClass)} to not be assignable to {typeof(DummyImplementingClass)}*failure message*");
+        }
+
+        [Fact]
+        public void When_its_base_type_instance_and_asserting_not_assignable_it_fails_with_a_useful_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(DummyBaseClass), "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage($"*{typeof(DummyImplementingClass)} to not be assignable to {typeof(DummyBaseClass)}*failure message*");
+        }
+
+        [Fact]
+        public void When_an_implemented_interface_type_instance_and_asserting_not_assignable_it_fails_with_a_useful_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(IDisposable), "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage($"*{typeof(DummyImplementingClass)} to not be assignable to {typeof(IDisposable)}*failure message*");
+        }
+
+        [Fact]
+        public void When_an_unrelated_type_instance_and_asserting_not_assignable_it_succeeds()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange / Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(DateTime));
+        }
+
+        #endregion
+
         #region BeDerivedFrom
 
         [Fact]

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -68,6 +68,7 @@ Other examples of some general purpose assertions include
 ```csharp
 var ex = new ArgumentException();
 ex.Should().BeAssignableTo<Exception>("because it is an exception");
+ex.Should().NotBeAssignableTo<DateTime>("because it is an exception");
 
 var dummy = new Object();
 dummy.Should().Match(d => (d.ToString() == "System.Object"));


### PR DESCRIPTION
* [ ] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [x] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/)/.
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).

I would say it's done, but I'm unsure about one thing.
Like `BeAssignableTo<T>` returns an `AndWhichConstraint` where `Which` points to casted type, I wanted `NotBeAssignableTo` to return the Subject as an `AndConstraint` for chaining. 
But as the type is lost in `ObjectAssertions Should(this object actualValue)` `NotAssignableTo<T>().And` is of type `object``.

This gives some ugly code, where one needs to cast `someObject` back to `Exception` for chaining.
```csharp`
var someObject = new Exception("Actual Message");

Action act = () => someObject.Should().NotBeAssignableTo<DummyImplementingClass>()
                .And.Subject.Should().BeOfType<Exception>()
                .Which.Message.Should().Be("Other Message");
``` 

Is there a way to retain the type of `someObject`,
 or would it just be so confusing that it should just be a void function? 