### PR TITLE
Add [Not]Have{Implicit,Explicit}ConversionOperator

### DIFF
--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -357,5 +357,34 @@ namespace FluentAssertions.Common
                 .GetConstructors(PublicMembersFlag)
                 .SingleOrDefault(m => m.GetParameters().Select(p => p.ParameterType).SequenceEqual(parameterTypes));
         }
+
+        public static MethodInfo GetImplicitConversionOperator(this Type type, Type sourceType, Type targetType)
+        {
+            return type
+                .GetConversionOperators(sourceType, targetType, name => name == "op_Implicit")
+                .SingleOrDefault();
+        }
+
+        public static MethodInfo GetExplicitConversionOperator(this Type type, Type sourceType, Type targetType)
+        {
+            return type
+                .GetConversionOperators(sourceType, targetType, name => name == "op_Explicit")
+                .SingleOrDefault();
+        }
+
+        private static IEnumerable<MethodInfo> GetConversionOperators(this Type type, Type sourceType, Type targetType, Func<string, bool> predicate)
+        {
+            return type
+                .GetMethods()
+                .Where(m =>
+                  m.IsPublic
+                  && m.IsStatic
+                  && m.IsSpecialName
+                  && m.ReturnType == targetType
+                  && predicate(m.Name)
+                  && m.GetParameters().Length == 1
+                  && m.GetParameters()[0].ParameterType == sourceType
+                );
+        }
     }
 }

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -731,6 +731,138 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
+        /// Asserts that the current type has an implicit conversion operator that converts <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
+        /// </summary>
+        /// <typeparam name="TSource">The type to convert from.</typeparam>
+        /// <typeparam name="TTarget">The type to convert to.</typeparam>
+        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndWhichConstraint<TypeAssertions, MethodInfo> HaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
+        {
+            return HaveImplictConversionOperator(typeof(TSource), typeof(TTarget), because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts that the current type has an implicit conversion operator that converts <paramref name="sourceType"/> into <paramref name="targetType"/>.
+        /// </summary>
+        /// <param name="sourceType">The type to convert from.</param>
+        /// <param name="targetType">The type to convert to.</param>
+        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndWhichConstraint<TypeAssertions, MethodInfo> HaveImplictConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
+        {
+            MethodInfo methodInfo = Subject.GetImplicitConversionOperator(sourceType, targetType);
+
+            Execute.Assertion.ForCondition(methodInfo != null)
+                .BecauseOf(because, becauseArgs)
+                .FailWith(String.Format("Expected public static implicit {0}({1}) to exist{{reason}}, but it does not.",
+                    targetType.FullName, sourceType.FullName));
+
+            return new AndWhichConstraint<TypeAssertions, MethodInfo>(this, methodInfo);
+        }
+
+        /// <summary>
+        /// Asserts that the current type does not have an implicit conversion operator that converts <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
+        /// </summary>
+        /// <typeparam name="TSource">The type to convert from.</typeparam>
+        /// <typeparam name="TTarget">The type to convert to.</typeparam>
+        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> NotHaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
+        {
+            return NotHaveImplictConversionOperator(typeof(TSource), typeof(TTarget), because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts that the current type does not have an implicit conversion operator that converts <paramref name="sourceType"/> into <paramref name="targetType"/>.
+        /// </summary>
+        /// <param name="sourceType">The type to convert from.</param>
+        /// <param name="targetType">The type to convert to.</param>
+        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> NotHaveImplictConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
+        {
+            MethodInfo methodInfo = Subject.GetImplicitConversionOperator(sourceType, targetType);
+
+            Execute.Assertion.ForCondition(methodInfo == null)
+                .BecauseOf(because, becauseArgs)
+                .FailWith(String.Format("Expected public static implicit {0}({1}) to not exist{{reason}}, but it does.",
+                    targetType.FullName, sourceType.FullName));
+
+            return new AndConstraint<TypeAssertions>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the current type has an explicit conversion operator that converts <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
+        /// </summary>
+        /// <typeparam name="TSource">The type to convert from.</typeparam>
+        /// <typeparam name="TTarget">The type to convert to.</typeparam>
+        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndWhichConstraint<TypeAssertions, MethodInfo> HaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
+        {
+            return HaveExplictConversionOperator(typeof(TSource), typeof(TTarget), because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts that the current type has an explicit conversion operator that converts <paramref name="sourceType"/> into <paramref name="targetType"/>.
+        /// </summary>
+        /// <param name="sourceType">The type to convert from.</param>
+        /// <param name="targetType">The type to convert to.</param>
+        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndWhichConstraint<TypeAssertions, MethodInfo> HaveExplictConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
+        {
+            MethodInfo methodInfo = Subject.GetExplicitConversionOperator(sourceType, targetType);
+
+            Execute.Assertion.ForCondition(methodInfo != null)
+                .BecauseOf(because, becauseArgs)
+                .FailWith(String.Format("Expected public static explicit {0}({1}) to exist{{reason}}, but it does not.",
+                    targetType.FullName, sourceType.FullName));
+
+            return new AndWhichConstraint<TypeAssertions, MethodInfo>(this, methodInfo);
+        }
+
+        /// <summary>
+        /// Asserts that the current type does not have an explicit conversion operator that converts <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
+        /// </summary>
+        /// <typeparam name="TSource">The type to convert from.</typeparam>
+        /// <typeparam name="TTarget">The type to convert to.</typeparam>
+        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> NotHaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
+        {
+            return NotHaveExplictConversionOperator(typeof(TSource), typeof(TTarget), because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts that the current type does not have an explicit conversion operator that converts <paramref name="sourceType"/> into <paramref name="targetType"/>.
+        /// </summary>
+        /// <param name="sourceType">The type to convert from.</param>
+        /// <param name="targetType">The type to convert to.</param>
+        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        ///             is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        public AndConstraint<TypeAssertions> NotHaveExplictConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
+        {
+            MethodInfo methodInfo = Subject.GetExplicitConversionOperator(sourceType, targetType);
+
+            Execute.Assertion.ForCondition(methodInfo == null)
+                .BecauseOf(because, becauseArgs)
+                .FailWith(String.Format("Expected public static explicit {0}({1}) to not exist{{reason}}, but it does.",
+                    targetType.FullName, sourceType.FullName));
+
+            return new AndConstraint<TypeAssertions>(this);
+        }
+
+        /// <summary>
         /// Returns the type of the subject the assertion applies on.
         /// </summary>
         protected override string Context

--- a/Tests/Shared.Specs/TypeAssertionSpecs.cs
+++ b/Tests/Shared.Specs/TypeAssertionSpecs.cs
@@ -2516,7 +2516,415 @@ namespace FluentAssertions.Specs
                              "message, but it is ProtectedInternal.");
         }
 
-#endregion
+        #endregion
+
+        #region HaveExplictConversionOperator
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicit_conversion_operator_which_it_does_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(TypeWithConversionOperators);
+            var sourceType = typeof(TypeWithConversionOperators);
+            var targetType = typeof(byte);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                type.Should()
+                    .HaveExplictConversionOperator(sourceType, targetType)
+                    .Which.Should()
+                        .NotBeNull();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicit_conversion_operator_which_it_does_not_it_fails_with_a_useful_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(TypeWithConversionOperators);
+            var sourceType = typeof(TypeWithConversionOperators);
+            var targetType = typeof(string);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                type.Should().HaveExplictConversionOperator(sourceType, targetType, "because we want to test the error {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage(
+                    "Expected public static explicit System.String(FluentAssertions.Specs.TypeWithConversionOperators) to exist " +
+                    "because we want to test the error message, but it does not.");
+        }
+
+        #endregion
+
+        #region HaveExplictConversionOperatorOfT
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicit_conversion_operatorOfT_which_it_does_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(TypeWithConversionOperators);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                type.Should()
+                    .HaveExplictConversionOperator<TypeWithConversionOperators, byte>()
+                    .Which.Should()
+                        .NotBeNull();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicit_conversion_operatorOfT_which_it_does_not_it_fails_with_a_useful_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(TypeWithConversionOperators);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                type.Should().HaveExplictConversionOperator<TypeWithConversionOperators, string>("because we want to test the error {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage(
+                    "Expected public static explicit System.String(FluentAssertions.Specs.TypeWithConversionOperators) to exist " +
+                    "because we want to test the error message, but it does not.");
+        }
+
+        #endregion
+
+        #region NotHaveExplictConversionOperator
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicit_conversion_operator_which_it_does_not_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(TypeWithConversionOperators);
+            var sourceType = typeof(TypeWithConversionOperators);
+            var targetType = typeof(string);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                type.Should()
+                    .NotHaveExplictConversionOperator(sourceType, targetType);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicit_conversion_operator_which_it_does_it_fails_with_a_useful_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(TypeWithConversionOperators);
+            var sourceType = typeof(TypeWithConversionOperators);
+            var targetType = typeof(byte);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                type.Should().NotHaveExplictConversionOperator(sourceType, targetType, "because we want to test the error {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage(
+                    "Expected public static explicit System.Byte(FluentAssertions.Specs.TypeWithConversionOperators) to not exist " +
+                    "because we want to test the error message, but it does.");
+        }
+
+        #endregion
+
+        #region NotHaveExplictConversionOperatorOfT
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicit_conversion_operatorOfT_which_it_does_not_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(TypeWithConversionOperators);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                type.Should()
+                    .NotHaveExplictConversionOperator<TypeWithConversionOperators, string>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicit_conversion_operatorOfT_which_it_does_it_fails_with_a_useful_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(TypeWithConversionOperators);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                type.Should().NotHaveExplictConversionOperator<TypeWithConversionOperators, byte>("because we want to test the error {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage(
+                    "Expected public static explicit System.Byte(FluentAssertions.Specs.TypeWithConversionOperators) to not exist " +
+                    "because we want to test the error message, but it does.");
+        }
+
+        #endregion
+
+        #region HaveImplictConversionOperator
+
+        [Fact]
+        public void When_asserting_a_type_has_an_implicit_conversion_operator_which_it_does_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(TypeWithConversionOperators);
+            var sourceType = typeof(TypeWithConversionOperators);
+            var targetType = typeof(int);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                type.Should()
+                    .HaveImplictConversionOperator(sourceType, targetType)
+                    .Which.Should()
+                        .NotBeNull();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_implicit_conversion_operator_which_it_does_not_it_fails_with_a_useful_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(TypeWithConversionOperators);
+            var sourceType = typeof(TypeWithConversionOperators);
+            var targetType = typeof(string);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                type.Should().HaveImplictConversionOperator(sourceType, targetType, "because we want to test the error {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage(
+                    "Expected public static implicit System.String(FluentAssertions.Specs.TypeWithConversionOperators) to exist " +
+                    "because we want to test the error message, but it does not.");
+        }
+
+        #endregion
+
+        #region HaveImplictConversionOperatorOfT
+
+        [Fact]
+        public void When_asserting_a_type_has_an_implicit_conversion_operatorOfT_which_it_does_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(TypeWithConversionOperators);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                type.Should()
+                    .HaveImplictConversionOperator<TypeWithConversionOperators, int>()
+                    .Which.Should()
+                        .NotBeNull();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_implicit_conversion_operatorOfT_which_it_does_not_it_fails_with_a_useful_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(TypeWithConversionOperators);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                type.Should().HaveImplictConversionOperator<TypeWithConversionOperators, string>("because we want to test the error {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage(
+                    "Expected public static implicit System.String(FluentAssertions.Specs.TypeWithConversionOperators) to exist " +
+                    "because we want to test the error message, but it does not.");
+        }
+
+        #endregion
+
+        #region NotHaveImplictConversionOperator
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_implicit_conversion_operator_which_it_does_not_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(TypeWithConversionOperators);
+            var sourceType = typeof(TypeWithConversionOperators);
+            var targetType = typeof(string);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                type.Should()
+                    .NotHaveImplictConversionOperator(sourceType, targetType);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_implicit_conversion_operator_which_it_does_it_fails_with_a_useful_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(TypeWithConversionOperators);
+            var sourceType = typeof(TypeWithConversionOperators);
+            var targetType = typeof(int);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                type.Should().NotHaveImplictConversionOperator(sourceType, targetType, "because we want to test the error {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage(
+                    "Expected public static implicit System.Int32(FluentAssertions.Specs.TypeWithConversionOperators) to not exist " +
+                    "because we want to test the error message, but it does.");
+        }
+
+        #endregion
+
+        #region NotHaveImplictConversionOperatorOfT
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_implicit_conversion_operatorOfT_which_it_does_not_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(TypeWithConversionOperators);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                type.Should()
+                    .NotHaveImplictConversionOperator<TypeWithConversionOperators, string>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_implicit_conversion_operatorOfT_which_it_does_it_fails_with_a_useful_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(TypeWithConversionOperators);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                type.Should().NotHaveImplictConversionOperator<TypeWithConversionOperators, int>("because we want to test the error {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage(
+                    "Expected public static implicit System.Int32(FluentAssertions.Specs.TypeWithConversionOperators) to not exist " +
+                    "because we want to test the error message, but it does.");
+        }
+
+        #endregion
     }
 
     #region Internal classes used in unit tests
@@ -2616,6 +3024,19 @@ namespace FluentAssertions.Specs
         internal class InternalClass { }
 
         protected internal interface IProtectedInternalInterface { }
+    }
+
+    struct TypeWithConversionOperators
+    {
+        private readonly int value;
+
+        private TypeWithConversionOperators(int value)
+        {
+            this.value = value;
+        }
+
+        public static implicit operator int(TypeWithConversionOperators typeWithConversionOperators) => typeWithConversionOperators.value;
+        public static explicit operator byte(TypeWithConversionOperators typeWithConversionOperators) => (byte)typeWithConversionOperators.value;
     }
 
     #endregion


### PR DESCRIPTION
* [ ] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [x] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/)/.
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).

This closes #559 
