### PR TITLE
allowInfiniteRecursion set twice in constructor

### DIFF
--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -66,7 +66,6 @@ namespace FluentAssertions.Equivalency
         /// </summary>
         protected SelfReferenceEquivalencyAssertionOptions(IEquivalencyAssertionOptions defaults)
         {
-            allowInfiniteRecursion = defaults.AllowInfiniteRecursion;
             isRecursive = defaults.IsRecursive;
             cyclicReferenceHandling = defaults.CyclicReferenceHandling;
             allowInfiniteRecursion = defaults.AllowInfiniteRecursion;


### PR DESCRIPTION
## IMPORTANT 
SINCE FLUENT ASSERTIONS IS CURRENTLY UNDER HEAVY REFACTORING FOR [VERSION 5.0](https://github.com/fluentassertions/fluentassertions/issues/463), WE CURRENTLY ONLY ACCEPT BUGFIX REQUESTS. SORRY FOR THE INCONVENIENCE

* [ ] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [x] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/)/.
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).
