### PR TITLE
Fail fast NotEqual if identical references

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -263,6 +263,13 @@ namespace FluentAssertions.Collections
                 throw new ArgumentNullException("unexpected", "Cannot compare collection with <null>.");
             }
 
+            if(ReferenceEquals(Subject, unexpected))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected collections not to be equal{reason}, but they both reference the same object.");
+            }
+
             List<object> actualitems = Subject.Cast<object>().ToList();
 
             if (actualitems.SequenceEqual(unexpected.Cast<object>()))

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -248,6 +248,13 @@ namespace FluentAssertions.Collections
                 throw new ArgumentNullException("unexpected", "Cannot compare dictionary with <null>.");
             }
 
+            if (ReferenceEquals(Subject, unexpected))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected dictionaries not to be equal{reason}, but they both reference the same object.");
+            }
+
             IEnumerable<TKey> missingKeys = unexpected.Keys.Except(Subject.Keys);
             IEnumerable<TKey> additionalKeys = Subject.Keys.Except(unexpected.Keys);
 

--- a/Tests/Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/CollectionAssertionSpecs.cs
@@ -1118,6 +1118,25 @@ namespace FluentAssertions.Specs
                 "Cannot compare collection with <null>.\r\nParameter name: unexpected");
         }
 
+        [Fact]
+        public void When_asserting_collections_not_to_be_equal_but_both_collections_reference_the_same_object_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection1 = new[] { "one", "two", "three" };
+            IEnumerable collection2 = collection1;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection1.Should().NotEqual(collection2, "because we want to test the behaviour with same objects");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Expected collections not to be equal because we want to test the behaviour with same objects, but they both reference the same object.");
+        }
+
         #endregion
 
         #region Be Equivalent To

--- a/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
@@ -655,6 +655,25 @@ namespace FluentAssertions.Specs
                 "Cannot compare collection with <null>.\r\nParameter name: unexpected");
         }
 
+        [Fact]
+        public void When_asserting_collections_not_to_be_equal_but_both_collections_reference_the_same_object_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<string> collection1 = new[] { "one", "two", "three" };
+            IEnumerable<string> collection2 = collection1;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection1.Should().NotEqual(collection2, "because we want to test the behaviour with same objects");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Expected collections not to be equal because we want to test the behaviour with same objects, but they both reference the same object.");
+        }
+
         #endregion
 
         #region Be Equivalent To

--- a/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
@@ -721,6 +721,32 @@ namespace FluentAssertions.Specs
                 "Cannot compare dictionary with <null>.\r\nParameter name: unexpected");
         }
 
+        [Fact]
+        public void When_asserting_dictionaries_not_to_be_equal_subject_but_both_dictionaries_reference_the_same_object_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary1 = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+            var dictionary2 = dictionary1;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act =
+                () => dictionary1.Should().NotEqual(dictionary2, "because we want to test the behaviour with same objects");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Expected dictionaries not to be equal because we want to test the behaviour with same objects, but they both reference the same object.");
+        }
+
         #endregion
 
         #region ContainKey


### PR DESCRIPTION
When asserting that two collections are not equal, we can give a better error descriptions when the collections references the same object and therefore _should_ violate the assertion that the collections are not equal.

This of course relies on the assumption, that two collection which references the same object are equal.
This is not a universal truth, as the example below illustrates.

```csharp
int i = 0;
var sequence1 = Enumerable.Range(1, 10).Select(e => { i++; return e * i; });
var sequence2 = sequence1;
ReferenceEquals(sequence1, sequence2) // true
Enumerable.SequenceEqual(sequence1, sequence2) // false
```

If FA wants to support lazy generated sequences in this way, the reference check could be restricted to `I[ReadOnly]Collection`

This is consistent with the behavior of `CollectionAssert.AreNotEqual(ICollection, ICollection)`



* [ ] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [x] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/)/.
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).