### PR TITLE
Report all duplicate keys on OnlyHaveUniqueItems

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -128,16 +128,27 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:collection} to only have unique items{reason}, but found {0}.", Subject);
             }
 
-            IGrouping<object, object> groupWithMultipleItems = Subject.Cast<object>()
+            IEnumerable<object> groupWithMultipleItems = Subject.Cast<object>()
                 .GroupBy(o => o)
-                .FirstOrDefault(g => g.Count() > 1);
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key);
 
-            if (groupWithMultipleItems != null)
+            if (groupWithMultipleItems.Any())
             {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to only have unique items{reason}, but item {0} is not unique.",
-                        groupWithMultipleItems.Key);
+                if(groupWithMultipleItems.Count() > 1)
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:collection} to only have unique items{reason}, but items {0} are not unique.",
+                            groupWithMultipleItems);
+                }
+                else
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:collection} to only have unique items{reason}, but item {0} is not unique.",
+                            groupWithMultipleItems.First());
+                }
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Tests/Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/CollectionAssertionSpecs.cs
@@ -2477,6 +2477,26 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_a_collection_contains_multiple_duplicate_items_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new[] { 1, 2, 2, 3, 3 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().OnlyHaveUniqueItems("{0} don't like {1}", "we", "duplicates");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Expected collection to only have unique items because we don't like duplicates, but items {2, 3} are not unique.");
+        }
+
+        [Fact]
         public void When_asserting_collection_to_only_have_unique_items_but_collection_is_null_it_should_throw()
         {
             //-----------------------------------------------------------------------------------------------------------

--- a/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
@@ -1609,6 +1609,26 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_a_collection_contains_multiple_duplicate_items_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<string> collection = new[] { "one", "two", "two", "three", "three" };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().OnlyHaveUniqueItems("{0} don't like {1}", "we", "duplicates");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Expected collection to only have unique items because we don't like duplicates, but items {\"two\", \"three\"} are not unique.");
+        }
+
+        [Fact]
         public void When_asserting_collection_to_only_have_unique_items_but_collection_is_null_it_should_throw()
         {
             //-----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR changes the failure message when OnlyHaveUniqueItems fails.
Instead of only reporting the first duplicate key, it now reports all duplicate keys.

* [ ] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [x] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/)/.
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).
