### PR TITLE
Report all indices offending NotContainNulls

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -162,14 +162,25 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:collection} not to contain nulls{reason}, but collection is <null>.");
             }
 
-            object[] values = Subject.Cast<object>().ToArray();
-            for (int index = 0; index < values.Length; index++)
+            IEnumerable<int> indices = Subject
+                .Cast<object>()
+                .Select((item, index) => new { Item = item, Index = index })
+                .Where(e => ReferenceEquals(e.Item, null))
+                .Select(e => e.Index);
+
+            if (indices.Any())
             {
-                if (ReferenceEquals(values[index], null))
+                if (indices.Count() > 1)
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} not to contain nulls{reason}, but found one at index {0}.", index);
+                        .FailWith("Expected {context:collection} not to contain nulls{reason}, but found several at indices {0}.", indices);
+                }
+                else
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:collection} not to contain nulls{reason}, but found one at index {0}.", indices.First());
                 }
             }
 

--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -159,28 +159,29 @@ namespace FluentAssertions.Collections
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} not to contain nulls{reason}, but collection is <null>.");
+                    .FailWith("Expected {context:collection} not to contain <null>s{reason}, but collection is <null>.");
             }
 
-            IEnumerable<int> indices = Subject
+            int[] indices = Subject
                 .Cast<object>()
                 .Select((item, index) => new { Item = item, Index = index })
                 .Where(e => ReferenceEquals(e.Item, null))
-                .Select(e => e.Index);
+                .Select(e => e.Index)
+                .ToArray();
 
-            if (indices.Any())
+            if (indices.Length > 0)
             {
-                if (indices.Count() > 1)
+                if (indices.Length > 1)
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} not to contain nulls{reason}, but found several at indices {0}.", indices);
+                        .FailWith("Expected {context:collection} not to contain <null>s{reason}, but found several at indices {0}.", indices);
                 }
                 else
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} not to contain nulls{reason}, but found one at index {0}.", indices.First());
+                        .FailWith("Expected {context:collection} not to contain <null>s{reason}, but found one at index {0}.", indices[0]);
                 }
             }
 

--- a/Tests/Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/CollectionAssertionSpecs.cs
@@ -2329,6 +2329,26 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_collection_contains_multiple_nulls_that_are_unexpected_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new[] { new object(), null, new object(), null };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotContainNulls("because they are {0}", "evil");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Expected collection not to contain nulls because they are evil, but found several at indices {1, 3}.");
+        }
+
+        [Fact]
         public void When_asserting_collection_to_not_contain_nulls_but_collection_is_null_it_should_throw()
         {
             //-----------------------------------------------------------------------------------------------------------

--- a/Tests/Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/CollectionAssertionSpecs.cs
@@ -2325,7 +2325,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<XunitException>().WithMessage(
-                "Expected collection not to contain nulls because they are evil, but found one at index 1.");
+                "Expected collection not to contain <null>s because they are evil, but found one at index 1.");
         }
 
         [Fact]
@@ -2345,7 +2345,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<XunitException>().WithMessage(
-                "Expected collection not to contain nulls because they are evil, but found several at indices {1, 3}.");
+                "Expected collection not to contain <null>s*because they are evil*{1, 3}*");
         }
 
         [Fact]
@@ -2365,7 +2365,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<XunitException>().WithMessage(
-                "Expected collection not to contain nulls because we want to test the behaviour with a null subject, but collection is <null>.");
+                "Expected collection not to contain <null>s because we want to test the behaviour with a null subject, but collection is <null>.");
         }
 
         #endregion

--- a/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
@@ -1554,7 +1554,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<XunitException>().WithMessage(
-                "Expected collection not to contain nulls because they are evil, but found one at index 1.");
+                "Expected collection not to contain <null>s because they are evil, but found one at index 1.");
         }
 
         [Fact]
@@ -1574,7 +1574,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<XunitException>().WithMessage(
-                "Expected collection not to contain nulls because they are evil, but found several at indices {1, 3}.");
+                "Expected collection not to contain <null>s*because they are evil*{1, 3}*");
         }
 
         [Fact]
@@ -1594,7 +1594,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<XunitException>().WithMessage(
-                "Expected collection not to contain nulls because we want to test the behaviour with a null subject, but collection is <null>.");
+                "Expected collection not to contain <null>s because we want to test the behaviour with a null subject, but collection is <null>.");
         }
 
         #endregion

--- a/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
@@ -1558,6 +1558,26 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_collection_contains_multiple_nulls_that_are_unexpected_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<string> collection = new[] { "", null, "", null };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotContainNulls("because they are {0}", "evil");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Expected collection not to contain nulls because they are evil, but found several at indices {1, 3}.");
+        }
+
+        [Fact]
         public void When_asserting_collection_to_not_contain_nulls_but_collection_is_null_it_should_throw()
         {
             //-----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
When asserting using `NotContainNulls` the current behavior is to only report the first index of a null item.
This PR changes that to report indices of all null items instead.

* [ ] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [x] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/)/.
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).
