### PR TITLE
NotBeDecoratedWith and ThatAreNotDecoratedWith

### DIFF
--- a/Src/FluentAssertions/TypeEnumerableExtensions.cs
+++ b/Src/FluentAssertions/TypeEnumerableExtensions.cs
@@ -19,6 +19,14 @@ namespace FluentAssertions
         }
 
         /// <summary>
+        /// Filters to only include types not decorated with a particular attribute.
+        /// </summary>
+        public static IEnumerable<Type> ThatAreNotDecoratedWith<TAttribute>(this IEnumerable<Type> types)
+        {
+            return new TypeSelector(types).ThatAreNotDecoratedWith<TAttribute>();
+        }
+
+        /// <summary>
         /// Filters to only include types where the namespace of type is exactly <paramref name="namespace"/>.
         /// </summary>
         public static IEnumerable<Type> ThatAreInNamespace(this IEnumerable<Type> types, string @namespace)

--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -76,6 +76,15 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
+        /// Only select the methods that are not decorated with an attribute of the specified type.
+        /// </summary>
+        public MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+        {
+            selectedMethods = selectedMethods.Where(method => !method.GetCustomAttributes(false).OfType<TAttribute>().Any());
+            return this;
+        }
+
+        /// <summary>
         /// The resulting <see cref="MethodInfo"/> objects.
         /// </summary>
         public MethodInfo[] ToArray()

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -113,10 +113,64 @@ namespace FluentAssertions.Types
             return new AndConstraint<MethodInfoSelectorAssertions>(this);
         }
 
+        /// <summary>
+        /// Asserts that the selected methods are not decorated with the specified <typeparamref name="TAttribute"/>.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : Attribute
+        {
+            return NotBeDecoratedWith<TAttribute>(attr => true, because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts that the selected methods are not decorated with an attribute of type <typeparamref name="TAttribute"/>
+        /// that matches the specified <paramref name="isMatchingAttributePredicate"/>.
+        /// </summary>
+        /// <param name="isMatchingAttributePredicate">
+        /// The predicate that the attribute must match.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(
+            Expression<Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : Attribute
+        {
+            IEnumerable<MethodInfo> methodsWithAttribute = GetMethodsWith<TAttribute>(isMatchingAttributePredicate);
+
+            string failureMessage =
+                "Expected all selected methods to not be decorated with {0}{reason}, but the following methods are:\r\n" +
+                GetDescriptionsFor(methodsWithAttribute);
+
+            Execute.Assertion
+                .ForCondition(!methodsWithAttribute.Any())
+                .BecauseOf(because, becauseArgs)
+                .FailWith(failureMessage, typeof(TAttribute));
+
+            return new AndConstraint<MethodInfoSelectorAssertions>(this);
+        }
+
         private MethodInfo[] GetMethodsWithout<TAttribute>(Expression<Func<TAttribute, bool>> isMatchingPredicate)
             where TAttribute : Attribute
         {
             return SubjectMethods.Where(method => !method.HasMatchingAttribute(isMatchingPredicate)).ToArray();
+        }
+
+        private MethodInfo[] GetMethodsWith<TAttribute>(Expression<Func<TAttribute, bool>> isMatchingPredicate)
+            where TAttribute : Attribute
+        {
+            return SubjectMethods.Where(method => method.HasMatchingAttribute(isMatchingPredicate)).ToArray();
         }
 
         private static string GetDescriptionsFor(IEnumerable<MethodInfo> methods)

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -59,6 +59,15 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
+        /// Only select the properties that are not decorated with an attribute of the specified type.
+        /// </summary>
+        public PropertyInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+        {
+            selectedProperties = selectedProperties.Where(property => !property.GetCustomAttributes(false).OfType<TAttribute>().Any());
+            return this;
+        }
+
+        /// <summary>
         /// Only select the properties that return the specified type 
         /// </summary>
         public PropertyInfoSelector OfType<TReturn>()

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -244,6 +244,55 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
+        /// Asserts that the current <see cref="System.Type"/> is not decorated with the specified <typeparamref name="TAttribute"/>.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TypeAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : Attribute
+        {
+            Execute.Assertion
+                .ForCondition(!Subject.IsDecoratedWith<TAttribute>())
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected type {0} to not be decorated with {1}{reason}, but the attribute was found.",
+                    Subject, typeof(TAttribute));
+
+            return new AndConstraint<TypeAssertions>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="System.Type"/> is not decorated with an attribute of type <typeparamref name="TAttribute"/>
+        /// that matches the specified <paramref name="isMatchingAttributePredicate"/>.
+        /// </summary>
+        /// <param name="isMatchingAttributePredicate">
+        /// The predicate that the attribute must match.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TypeAssertions> NotBeDecoratedWith<TAttribute>(
+            Expression<Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : Attribute
+        {
+            Execute.Assertion
+                .ForCondition(!Subject.HasMatchingAttribute(isMatchingAttributePredicate))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected type {0} to not be decorated with {1} that matches {2}{reason}, but a matching attribute was found.",
+                    Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
+
+            return new AndConstraint<TypeAssertions>(this);
+        }
+
+        /// <summary>
         /// Asserts that the current <see cref="System.Type"/> implements Interface <paramref name="interfaceType"/>.
         /// </summary>
         /// <param name="interfaceType">The interface that should be implemented.</param>

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -61,6 +61,19 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
+        /// Determines whether a type is not decorated with a particular attribute.
+        /// </summary>
+        public TypeSelector ThatAreNotDecoratedWith<TAttribute>()
+        {
+            types = types
+
+                .Where(t => !t.GetTypeInfo().GetCustomAttributes(typeof(TAttribute), true).Any())
+                .ToList();
+
+            return this;
+        }
+
+        /// <summary>
         /// Determines whether the namespace of type is exactly <paramref name="namespace"/>.
         /// </summary>
         public TypeSelector ThatAreInNamespace(string @namespace)

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -88,6 +88,65 @@ namespace FluentAssertions.Types
             return new AndConstraint<TypeSelectorAssertions>(this);
         }
 
+        /// <summary>
+        /// Asserts that the current <see cref="Type"/> is not decorated with the specified <typeparamref name="TAttribute"/>.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : Attribute
+        {
+            IEnumerable<Type> typesWithAttribute = Subject
+                .Where(type => type.IsDecoratedWith<TAttribute>())
+                .ToArray();
+
+            Execute.Assertion
+                .ForCondition(!typesWithAttribute.Any())
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected all types to not be decorated with {0}{reason}," +
+                    " but the attribute was found on the following types:\r\n" + GetDescriptionsFor(typesWithAttribute),
+                    typeof(TAttribute));
+
+            return new AndConstraint<TypeSelectorAssertions>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Type"/> is not decorated with an attribute of type <typeparamref name="TAttribute"/>
+        /// that matches the specified <paramref name="isMatchingAttributePredicate"/>.
+        /// </summary>
+        /// <param name="isMatchingAttributePredicate">
+        /// The predicate that the attribute must match.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(
+            Expression<Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : Attribute
+        {
+            IEnumerable<Type> typesWithMatchingAttribute = Subject
+                .Where(type => type.HasMatchingAttribute(isMatchingAttributePredicate))
+                .ToArray();
+
+            Execute.Assertion
+                .ForCondition(!typesWithMatchingAttribute.Any())
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected all types to not be decorated with {0} that matches {1}{reason}," +
+                    " but a matching attribute was found on the following types:\r\n" + GetDescriptionsFor(typesWithMatchingAttribute),
+                    typeof(TAttribute), isMatchingAttributePredicate.Body);
+
+            return new AndConstraint<TypeSelectorAssertions>(this);
+        }
+
         private static string GetDescriptionsFor(IEnumerable<Type> types)
         {
             return string.Join(Environment.NewLine, types.Select(GetDescriptionFor).ToArray());

--- a/Tests/Shared.Specs/MethodInfoSelectorAssertionSpecs.cs
+++ b/Tests/Shared.Specs/MethodInfoSelectorAssertionSpecs.cs
@@ -141,5 +141,74 @@ namespace FluentAssertions.Specs
                              "Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.ProtectedDoNothing\r\n" +
                              "Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PrivateDoNothing");
         }
+
+        [Fact]
+        public void When_asserting_methods_are_not_decorated_with_attribute_and_they_are_not_it_should_succeed()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var methodSelector = new MethodInfoSelector(typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute));
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                methodSelector.Should().NotBeDecoratedWith<DummyMethodAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_methods_are_not_decorated_with_attribute_but_they_are_it_should_throw()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            MethodInfoSelector methodSelector =
+                new MethodInfoSelector(typeof(ClassWithAllMethodsDecoratedWithDummyAttribute))
+                    .ThatArePublicOrInternal;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                methodSelector.Should().NotBeDecoratedWith<DummyMethodAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>();
+        }
+
+        [Fact]
+        public void When_asserting_methods_are_not_decorated_with_attribute_but_they_are_it_should_throw_with_descriptive_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var methodSelector = new MethodInfoSelector(typeof(ClassWithAllMethodsDecoratedWithDummyAttribute));
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                methodSelector.Should().NotBeDecoratedWith<DummyMethodAttribute>("because we want to test the error {0}", "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage("Expected all selected methods to not be decorated with" +
+                             " FluentAssertions.Specs.DummyMethodAttribute because we want to test the error message," +
+                             " but the following methods are:\r\n" +
+                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing\r\n" +
+                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothingWithSameAttributeTwice\r\n" +
+                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.ProtectedDoNothing\r\n" +
+                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PrivateDoNothing");
+        }
     }
 }

--- a/Tests/Shared.Specs/MethodInfoSelectorAssertionSpecs.cs
+++ b/Tests/Shared.Specs/MethodInfoSelectorAssertionSpecs.cs
@@ -202,13 +202,11 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.ShouldThrow<XunitException>()
-                .WithMessage("Expected all selected methods to not be decorated with" +
-                             " FluentAssertions.Specs.DummyMethodAttribute because we want to test the error message," +
-                             " but the following methods are:\r\n" +
-                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing\r\n" +
-                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothingWithSameAttributeTwice\r\n" +
-                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.ProtectedDoNothing\r\n" +
-                             "Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PrivateDoNothing");
+                .WithMessage("Expected all selected methods to not be decorated*DummyMethodAttribute*because we want to test the error message" +
+                             "*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing*" +
+                             "*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothingWithSameAttributeTwice*" +
+                             "*ClassWithAllMethodsDecoratedWithDummyAttribute.ProtectedDoNothing*" +
+                             "*ClassWithAllMethodsDecoratedWithDummyAttribute.PrivateDoNothing");
         }
     }
 }

--- a/Tests/Shared.Specs/MethodInfoSelectorSpecs.cs
+++ b/Tests/Shared.Specs/MethodInfoSelectorSpecs.cs
@@ -77,6 +77,28 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_selecting_methods_not_decorated_with_specific_attribute_it_should_return_only_the_applicable_methods()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForMethodSelector);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<MethodInfo> methods = type.Methods().ThatAreNotDecoratedWith<DummyMethodAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            methods.Should()
+                .NotBeEmpty()
+                .And.NotContain(m => m.Name == "PublicVirtualVoidMethodWithAttribute")
+                .And.NotContain(m => m.Name == "ProtectedVirtualVoidMethodWithAttribute");
+        }
+
+        [Fact]
         public void When_selecting_methods_that_return_a_specific_type_it_should_return_only_the_applicable_methods()
         {
             //-------------------------------------------------------------------------------------------------------------------

--- a/Tests/Shared.Specs/PropertyInfoSelectorSpecs.cs
+++ b/Tests/Shared.Specs/PropertyInfoSelectorSpecs.cs
@@ -77,6 +77,28 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_selecting_properties_not_decorated_with_specific_attribute_it_should_return_only_the_applicable_properties()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForPropertySelector);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<PropertyInfo> properties = type.Properties().ThatAreNotDecoratedWith<DummyPropertyAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            properties.Should()
+                .NotBeEmpty()
+                .And.NotContain(p => p.Name == "PublicVirtualStringPropertyWithAttribute")
+                .And.NotContain(p => p.Name == "ProtectedVirtualIntPropertyWithAttribute");
+        }
+
+        [Fact]
         public void When_selecting_methods_that_return_a_specific_type_it_should_return_only_the_applicable_methods()
         {
             //-------------------------------------------------------------------------------------------------------------------

--- a/Tests/Shared.Specs/TypeAssertionSpecs.cs
+++ b/Tests/Shared.Specs/TypeAssertionSpecs.cs
@@ -910,9 +910,8 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.ShouldThrow<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.ClassWithAttribute to not be decorated with " +
-                    "FluentAssertions.Specs.DummyClassAttribute because we want to test the error message, but the attribute " +
-                        "was found.");
+                .WithMessage("Expected type*ClassWithAttribute to not be decorated with" +
+                    "*DummyClassAttribute*because we want to test the error message*attribute was found.");
         }
 
         [Fact]
@@ -955,9 +954,9 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.ShouldThrow<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.ClassWithAttribute to not be decorated with " +
-                    "FluentAssertions.Specs.DummyClassAttribute that matches ((a.Name == \"Expected\")*a.IsEnabled), " +
-                        "but a matching attribute was found.");
+                .WithMessage("Expected type*ClassWithAttribute to not be decorated with" +
+                    "*DummyClassAttribute that matches ((a.Name == \"Expected\")*a.IsEnabled)" +
+                        "*matching attribute was found.");
         }
 
         [Fact]
@@ -1006,9 +1005,8 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.ShouldThrow<XunitException>()
-                .WithMessage("Expected all types to not be decorated with FluentAssertions.Specs.DummyClassAttribute" +
-                    " because we do, but the attribute was found on the following types:\r\n" +
-                    "FluentAssertions.Specs.ClassWithAttribute");
+                .WithMessage("Expected all types to not be decorated*DummyClassAttribute" +
+                    "*because we do*attribute was found*ClassWithAttribute");
         }
 
 
@@ -1035,10 +1033,9 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.ShouldThrow<XunitException>()
-                .WithMessage("Expected all types to not be decorated with FluentAssertions.Specs.DummyClassAttribute" +
-                    " that matches ((a.Name == \"Expected\")*a.IsEnabled) because we do," +
-                    " but a matching attribute was found on the following types:\r\n" +
-                    "FluentAssertions.Specs.ClassWithAttribute");
+                .WithMessage("Expected all types to not be decorated*DummyClassAttribute" +
+                    "*((a.Name == \"Expected\")*a.IsEnabled) because we do" +
+                    "*matching attribute was found*FluentAssertions.Specs.ClassWithAttribute");
         }
 
         #endregion

--- a/Tests/Shared.Specs/TypeAssertionSpecs.cs
+++ b/Tests/Shared.Specs/TypeAssertionSpecs.cs
@@ -848,6 +848,201 @@ namespace FluentAssertions.Specs
 
         #endregion
 
+        #region NotBeDecoratedWith
+
+        [Fact]
+        public void When_type_is_not_decorated_with_unexpected_attribute_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type typeWithoutAttribute = typeof(ClassWithoutAttribute);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                typeWithoutAttribute.Should().NotBeDecoratedWith<DummyClassAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_type_is_decorated_with_unexpected_attribute_it_fails()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type typeWithAttribute = typeof(ClassWithAttribute);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                typeWithAttribute.Should().NotBeDecoratedWith<DummyClassAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>();
+        }
+
+        [Fact]
+        public void When_type_is_decorated_with_unexpected_attribute_it_fails_with_a_useful_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type typeWithAttribute = typeof(ClassWithAttribute);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                typeWithAttribute.Should().NotBeDecoratedWith<DummyClassAttribute>(
+                    "because we want to test the error {0}",
+                    "message");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage("Expected type FluentAssertions.Specs.ClassWithAttribute to not be decorated with " +
+                    "FluentAssertions.Specs.DummyClassAttribute because we want to test the error message, but the attribute " +
+                        "was found.");
+        }
+
+        [Fact]
+        public void When_type_is_not_decorated_with_unexpected_attribute_with_the_expected_properties_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type typeWithoutAttribute = typeof(ClassWithAttribute);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                typeWithoutAttribute.Should()
+                    .NotBeDecoratedWith<DummyClassAttribute>(a => ((a.Name == "Unexpected") && a.IsEnabled));
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_type_is_not_decorated_with_expected_attribute_that_has_an_unexpected_property_it_fails()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type typeWithoutAttribute = typeof(ClassWithAttribute);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                typeWithoutAttribute.Should()
+                    .NotBeDecoratedWith<DummyClassAttribute>(a => ((a.Name == "Expected") && a.IsEnabled));
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage("Expected type FluentAssertions.Specs.ClassWithAttribute to not be decorated with " +
+                    "FluentAssertions.Specs.DummyClassAttribute that matches ((a.Name == \"Expected\")*a.IsEnabled), " +
+                        "but a matching attribute was found.");
+        }
+
+        [Fact]
+        public void When_asserting_a_selection_of_non_decorated_types_is_not_decorated_with_an_attribute_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var types = new TypeSelector(new[]
+            {
+                typeof (ClassWithoutAttribute),
+                typeof (OtherClassWithoutAttribute)
+            });
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                types.Should().NotBeDecoratedWith<DummyClassAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_selection_of_decorated_types_is_not_decorated_with_an_attribute_it_fails()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var types = new TypeSelector(new[]
+            {
+                typeof (ClassWithoutAttribute),
+                typeof (ClassWithAttribute)
+            });
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                types.Should().NotBeDecoratedWith<DummyClassAttribute>("because we do");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage("Expected all types to not be decorated with FluentAssertions.Specs.DummyClassAttribute" +
+                    " because we do, but the attribute was found on the following types:\r\n" +
+                    "FluentAssertions.Specs.ClassWithAttribute");
+        }
+
+
+        [Fact]
+        public void When_asserting_a_selection_of_types_with_unexpected_attribute_and_unexpected_attribute_property_it_fails()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var types = new TypeSelector(new[]
+            {
+                typeof (ClassWithoutAttribute),
+                typeof (ClassWithAttribute)
+            });
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                types.Should()
+                    .NotBeDecoratedWith<DummyClassAttribute>(a => ((a.Name == "Expected") && a.IsEnabled), "because we do");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>()
+                .WithMessage("Expected all types to not be decorated with FluentAssertions.Specs.DummyClassAttribute" +
+                    " that matches ((a.Name == \"Expected\")*a.IsEnabled) because we do," +
+                    " but a matching attribute was found on the following types:\r\n" +
+                    "FluentAssertions.Specs.ClassWithAttribute");
+        }
+
+        #endregion
+
         #region Implement
 
         [Fact]

--- a/Tests/Shared.Specs/TypeSelectorSpecs.cs
+++ b/Tests/Shared.Specs/TypeSelectorSpecs.cs
@@ -109,6 +109,30 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_selecting_types_that_are_not_decorated_with_a_specific_attribute_it_should_return_the_correct_types()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+
+            Assembly assembly = typeof(ClassWithSomeAttribute).GetTypeInfo().Assembly;
+
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<Type> types = AllTypes.From(assembly).ThatAreNotDecoratedWith<SomeAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            types.Should()
+                .NotBeEmpty()
+                .And.NotContain(typeof(ClassWithSomeAttribute))
+                .And.NotContain(typeof(ClassWithSomeAttributeThatImplementsSomeInterface));
+        }
+
+        [Fact]
         public void When_selecting_types_from_specific_namespace_it_should_return_the_correct_types()
         {
             //-------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This closes #527 

* [ ] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [x] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/)/.
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).
