### PR TITLE
Fail fast on more assertions 

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -422,6 +422,15 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:collection} not to be equivalent{reason}, but found <null>.");
             }
 
+            if (ReferenceEquals(Subject, unexpected))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:collection} {0} not to be equivalent with collection {1}{reason}, but they both reference the same object.",
+                        Subject,
+                        unexpected);
+            }
+
             IEnumerable<object> actualItems = Subject.Cast<object>();
             IEnumerable<object> unexpectedItems = unexpected.Cast<object>();
 
@@ -907,6 +916,15 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Cannot assert a <null> collection against a subset.");
 
+            if(ReferenceEquals(Subject, unexpectedSuperset))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Did not expect {context:collection} {0} to be a subset of {1}{reason}, but they both reference the same object.",
+                        Subject,
+                        unexpectedSuperset);
+            }
+
             IEnumerable<object> expectedItems = unexpectedSuperset.Cast<object>();
             object[] actualItems = Subject.Cast<object>().ToArray();
 
@@ -987,6 +1005,15 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:collection} to not have the same count as {0}{reason}, but found {1}.",
                         otherCollection,
                         Subject);
+            }
+
+            if (ReferenceEquals(Subject, otherCollection))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:collection} {0} to not have the same count as {1}{reason}, but they both reference the same object.",
+                        Subject,
+                        otherCollection);
             }
 
             IEnumerable<object> enumerable = Subject.Cast<object>();
@@ -1180,6 +1207,15 @@ namespace FluentAssertions.Collections
                     .BecauseOf(because, becauseArgs)
                     .FailWith("Did not expect {context:collection} to intersect with {0}{reason}, but found {1}.", otherCollection,
                         Subject);
+            }
+
+            if (ReferenceEquals(Subject, otherCollection))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Did not expect {context:collection} {0} to intersect with {1}{reason}, but they both reference the same object.",
+                        Subject,
+                        otherCollection);
             }
 
             IEnumerable<object> otherItems = otherCollection.Cast<object>();

--- a/Tests/Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/CollectionAssertionSpecs.cs
@@ -1426,6 +1426,28 @@ namespace FluentAssertions.Specs
                 "Cannot verify inequivalence against a <null> collection.");
         }
 
+        [Fact]
+        public void When_testing_collections_not_to_be_equivalent_against_same_collection_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new[] { 1, 2, 3 };
+            IEnumerable collection1 = collection;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotBeEquivalentTo(collection1,
+                "because we want to test the behaviour with same objects");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "*not to be equivalent*because we want to test the behaviour with same objects*but they both reference the same object.");
+        }
+
         #endregion
 
         #region Be Subset Of
@@ -1585,6 +1607,28 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<XunitException>().WithMessage(
                 "Expected collection to be a subset of {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_collection_to_not_be_subset_against_same_collection_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new[] { 1, 2, 3 };
+            IEnumerable collection1 = collection;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotBeSubsetOf(collection1,
+                "because we want to test the behaviour with same objects");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Did not expect*to be a subset of*because we want to test the behaviour with same objects*but they both reference the same object.");
         }
 
         #endregion
@@ -2307,6 +2351,28 @@ namespace FluentAssertions.Specs
             action.ShouldThrow<XunitException>()
                 .WithMessage("Did not expect collection to intersect with {2, 3, 4} because they should not share items," +
                     " but found the following shared items {2, 3}.");
+        }
+
+        [Fact]
+        public void When_asserting_collection_to_not_intersect_with_same_collection_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new[] { 1, 2, 3 };
+            IEnumerable otherCollection = collection;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotIntersectWith(otherCollection,
+                "because we want to test the behaviour with same objects");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Did not expect*to intersect with*because we want to test the behaviour with same objects*but they both reference the same object.");
         }
 
         #endregion
@@ -3641,6 +3707,28 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<NullReferenceException>().WithMessage(
                 "Cannot verify count against a <null> collection.");
+        }
+
+        [Fact]
+        public void When_asserting_collections_to_not_have_same_count_but_both_collections_references_the_same_object_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new[] { 1, 2, 3 };
+            IEnumerable collection1 = collection;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotHaveSameCount(collection1,
+                "because we want to test the behaviour with same objects");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "*not have the same count*because we want to test the behaviour with same objects*but they both reference the same object.");
         }
 
         #endregion

--- a/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
@@ -933,6 +933,28 @@ namespace FluentAssertions.Specs
                 "Cannot verify inequivalence against a <null> collection.");
         }
 
+        [Fact]
+        public void When_testing_collections_not_to_be_equivalent_against_same_collection_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> collection1 = collection;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotBeEquivalentTo(collection1,
+                "because we want to test the behaviour with same objects");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "*not to be equivalent*because we want to test the behaviour with same objects*but they both reference the same object.");
+        }
+
         #endregion
 
         #region Be Subset Of
@@ -1092,6 +1114,28 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<XunitException>().WithMessage(
                 "Expected collection to be a subset of {\"one\", \"two\", \"three\"} because we want to test the behaviour with a null subject, but found <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_collection_to_not_be_subset_against_same_collection_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> otherCollection = collection;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotBeSubsetOf(otherCollection,
+                "because we want to test the behaviour with same objects");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Did not expect*to be a subset of*because we want to test the behaviour with same objects*but they both reference the same object.");
         }
 
         #endregion
@@ -1536,6 +1580,28 @@ namespace FluentAssertions.Specs
             action.ShouldThrow<XunitException>()
                 .WithMessage("Did not expect collection to intersect with {\"two\", \"three\", \"four\"} because they should not share items," +
                     " but found the following shared items {\"two\", \"three\"}.");
+        }
+
+        [Fact]
+        public void When_asserting_collection_to_not_intersect_with_same_collection_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> otherCollection = collection;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotIntersectWith(otherCollection,
+                "because we want to test the behaviour with same objects");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "*to intersect with*because we want to test the behaviour with same objects*but they both reference the same object.");
         }
 
         #endregion
@@ -1988,6 +2054,28 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<NullReferenceException>().WithMessage(
                 "Cannot verify count against a <null> collection.");
+        }
+
+        [Fact]
+        public void When_asserting_collections_to_not_have_same_count_but_both_collections_references_the_same_object_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<string> collection = new[] { "one", "two", "three" };
+            IEnumerable<string> otherCollection = collection;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotHaveSameCount(otherCollection,
+                "because we want to test the behaviour with same objects");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "*not have the same count*because we want to test the behaviour with same objects*but they both reference the same object.");
         }
 
         #endregion


### PR DESCRIPTION
Just as on `NotEqual` we can fail fast with a better failure message when `Subject` and `unexpected` references the same object.
This PR adds such fail fast on `NotIntersectWith`, `NotBeSubsetOf`, `NotHaveSameCount` and `NotBeEquivalentTo`.

* [ ] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [x] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/)/.
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).
