### PR TITLE
Add predicate overload to OnlyHaveUniqueItems and NotContainNull

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -97,7 +97,8 @@ namespace FluentAssertions.Collections
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} to only have unique items{reason}, but item {0} is not unique.",
+                        .FailWith("Expected {context:collection} to only have unique items on {0}{reason}, but item {1} is not unique.",
+                            predicate.Body,
                             groupWithMultipleItems[0].First());
                 }
             }

--- a/Tests/Shared.Specs/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/Shared.Specs/GenericCollectionAssertionsSpecs.cs
@@ -7,7 +7,7 @@ using Xunit.Sdk;
 
 namespace FluentAssertions.Specs
 {
-
+    
     public class GenericCollectionAssertionsSpecs
     {
         [Fact]

--- a/Tests/Shared.Specs/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/Shared.Specs/GenericCollectionAssertionsSpecs.cs
@@ -7,7 +7,7 @@ using Xunit.Sdk;
 
 namespace FluentAssertions.Specs
 {
-    
+
     public class GenericCollectionAssertionsSpecs
     {
         [Fact]
@@ -1028,6 +1028,186 @@ namespace FluentAssertions.Specs
         private class SomeClass
         {
             public string Text { get; set; }
+        }
+
+        #endregion
+
+        #region Not Contain Nulls (Predicate)
+
+        [Fact]
+        public void When_collection_does_not_contain_nulls_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<SomeClass> collection = new[]
+            {
+                new SomeClass { Text = "one" },
+                new SomeClass { Text = "two" },
+                new SomeClass { Text = "three" }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            collection.Should().NotContainNulls(e => e.Text);
+        }
+
+        [Fact]
+        public void When_collection_contains_nulls_that_are_unexpected_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<SomeClass> collection = new[]
+            {
+                new SomeClass { Text = "" },
+                new SomeClass { Text = null }
+            };
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotContainNulls(e => e.Text, "because they are {0}", "evil");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Expected collection not to contain <null>s*on e.Text*because they are evil*Text = <null>*");
+        }
+
+        [Fact]
+        public void When_collection_contains_multiple_nulls_that_are_unexpected_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<SomeClass> collection = new[]
+            {
+                new SomeClass { Text = "" },
+                new SomeClass { Text = null },
+                new SomeClass { Text = "" },
+                new SomeClass { Text = null }
+            };
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotContainNulls(e => e.Text, "because they are {0}", "evil");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Expected collection not to contain <null>s*because they are evil*Text = <null>*Text = <null>*");
+        }
+
+        [Fact]
+        public void When_asserting_collection_to_not_contain_nulls_but_collection_is_null_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<SomeClass> collection = null;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotContainNulls(e => e.Text, "because we want to test the behaviour with a null subject");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Expected collection not to contain <null>s because we want to test the behaviour with a null subject, but collection is <null>.");
+        }
+
+        #endregion
+
+        #region Only Have Unique Items (Predicate)
+
+        [Fact]
+        public void Should_succeed_when_asserting_collection_with_unique_items_contains_only_unique_items()
+        {
+            IEnumerable<SomeClass> collection = new[]
+            {
+                new SomeClass { Text = "one" },
+                new SomeClass { Text = "two" },
+                new SomeClass { Text = "three" },
+                new SomeClass { Text = "four" }
+            };
+            collection.Should().OnlyHaveUniqueItems(e => e.Text);
+        }
+
+        [Fact]
+        public void When_a_collection_contains_duplicate_items_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<SomeClass> collection = new[]
+            {
+                new SomeClass { Text = "one" },
+                new SomeClass { Text = "two" },
+                new SomeClass { Text = "three" },
+                new SomeClass { Text = "three" }
+            };
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().OnlyHaveUniqueItems(e => e.Text, "{0} don't like {1}", "we", "duplicates");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Expected collection to only have unique items because we don't like duplicates, but item*three*is not unique.");
+        }
+
+        [Fact]
+        public void When_a_collection_contains_multiple_duplicate_items_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<SomeClass> collection = new[]
+            {
+                new SomeClass { Text = "one" },
+                new SomeClass { Text = "two" },
+                new SomeClass { Text = "two" },
+                new SomeClass { Text = "three" },
+                new SomeClass { Text = "three" }
+            };
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().OnlyHaveUniqueItems(e => e.Text, "{0} don't like {1}", "we", "duplicates");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Expected collection to only have unique items*on e.Text*because we don't like duplicates, but items*two*two*three*three*are not unique.");
+        }
+
+        [Fact]
+        public void When_asserting_collection_to_only_have_unique_items_but_collection_is_null_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<SomeClass> collection = null;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act =
+                () => collection.Should().OnlyHaveUniqueItems(e => e.Text, "because we want to test the behaviour with a null subject");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage(
+                "Expected collection to only have unique items because we want to test the behaviour with a null subject, but found <null>.");
         }
 
         #endregion

--- a/Tests/Shared.Specs/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/Shared.Specs/GenericCollectionAssertionsSpecs.cs
@@ -1098,7 +1098,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<XunitException>().WithMessage(
-                "Expected collection not to contain <null>s*because they are evil*Text = <null>*Text = <null>*");
+                "Expected collection not to contain <null>s*on e.Text*because they are evil*Text = <null>*Text = <null>*");
         }
 
         [Fact]
@@ -1160,7 +1160,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<XunitException>().WithMessage(
-                "Expected collection to only have unique items because we don't like duplicates, but item*three*is not unique.");
+                "Expected collection to only have unique items*on e.Text*because we don't like duplicates, but item*three*is not unique.");
         }
 
         [Fact]


### PR DESCRIPTION
Currently one has to do a projection on e.g. a property before using certain assertions on that it.
 
Example:
```csharp
list.Select(e => e.Property).Should().NotContainNull();
list.Select(e => e.Property).Should().OnlyHaveUniqueItems();
```

This PR gives two overloads for generic collections that takes a predicate
```csharp
list.Should().NotContainNull(e => e.Property);
list.Should().OnlyHaveUniqueItems(e => e.Property);
```

The difference lies in the failure message, where the two overloads contains the objects instead of the properties and the predicate body.

This closes #365 

* [ ] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [x] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/)/.
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).
