### PR TITLE
Migration from MSTest and improved assertions

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,10 +7,11 @@ github_username:  fluentassertions
 google_analytics: UA-99995670-1
 
 header_pages:
-  - about.md
-  - documentation.md
   - examples.md
+  - documentation.md
+  - tips.md
   - releases.md
+  - about.md
 
 theme: minima
 gems:

--- a/docs/_data/mstest-migration/assert.yml
+++ b/docs/_data/mstest-migration/assert.yml
@@ -1,0 +1,330 @@
+- old: |
+    Assert.IsTrue(actual);
+
+  new: |
+    actual.Should().BeTrue();
+
+  old-message: |
+    Assert.IsTrue failed.
+
+  new-message: |
+    Expected True, but found False.
+
+- old: |
+    Assert.IsFalse(actual);
+
+  new: |
+    actual.Should().BeFalse();
+
+  old-message: |
+    Assert.IsFalse failed.
+
+  new-message: |
+    Expected False, but found True.
+
+- old: |
+    Assert.IsNull(actual);
+
+  new: |
+    actual.Should().BeNull();
+
+  old-message: |
+    Assert.IsNull failed.
+
+  new-message: |
+    Expected object to be <null>, but found System.Object (HashCode=51904525).
+
+- old: |
+    Assert.IsNotNull(actual);
+
+  new: |
+    actual.Should().NotBeNull();
+
+  old-message: |
+    Assert.IsNotNull failed.
+
+  new-message: |
+    Expected object not to be <null>.
+
+- old: |
+    Assert.AreEqual(expected, actual);
+
+  new: |
+    actual.Should().Be(expected);
+
+  old-message: |
+    Assert.AreEqual failed. Expected:<SomeProperty: 2, OtherProperty: expected>. Actual:<SomeProperty: 1, OtherProperty: actual>.
+
+  new-message: |
+    Expected object to be SomeProperty: 2, OtherProperty: expected, but found SomeProperty: 1, OtherProperty: actual.
+
+- old: |
+    Assert.AreEqual(expected, actual, delta);
+
+  new: |
+    actual.Should().BeApproximately(expected, delta);
+
+  old-message: |
+    Assert.AreEqual failed. Expected a difference no greater than <0.5> between expected value <2> and actual value <1.25>.
+
+  new-message: |
+    Expected value 1.25 to approximate 2.0 +/- 0.5, but it differed by 0.75.
+
+- old: |
+    Assert.AreNotEqual(expected, actual);
+
+  new: |
+    actual.Should().NotBe(expected);
+
+  old-message: |
+    Assert.AreNotEqual failed. Expected any value except:<SomeProperty: 1, OtherProperty: expected>. Actual:<SomeProperty: 1, OtherProperty: expected>.
+
+  new-message: |
+    Did not expect object to be equal to SomeProperty: 1, OtherProperty: expected.
+
+- old: |
+    Assert.AreNotEqual(expected, actual, delta);
+
+  new: |
+    // Will be available in Fluent Assertions 5.0
+    actual.Should().NotBeApproximately(expected, delta);
+
+  old-message: |
+    Assert.AreNotEqual failed. Expected a difference greater than <0.5> between expected value <2> and actual value <2>.
+
+  new-message: |
+    Expected value 2.0 to not approximate 2.0 +/- 0.5, but it only differed by 0.0.
+
+- old: |
+    Assert.AreSame(expected, actual);
+
+  new: |
+    actual.Should().BeSameAs(expected);
+
+  old-message: |
+    Assert.AreSame failed.
+
+  new-message: |
+    Expected object to refer to 
+    SomeProperty: 1, OtherProperty: actual, but found 
+    SomeProperty: 1, OtherProperty: actual.
+
+- old: |
+    Assert.AreNotSame(expected, actual);
+
+  new: |
+    actual.Should().NotBeSameAs(expected);
+
+  old-message: |
+    Assert.AreNotSame failed.
+
+  new-message: |
+    Did not expect reference to object SomeProperty: 1, OtherProperty: actual.
+
+- old: |
+    Assert.IsInstanceOfType(actual, typeof(T));
+
+  new: |
+    actual.Should().BeOfType<T>();
+
+  old-message: |
+    Assert.IsInstanceOfType failed.  Expected type:<UnitTests2.MyIdenticalClass>. Actual type:<UnitTests2.MyClass>.
+
+  new-message: |
+    Expected type to be UnitTests2.MyIdenticalClass, but found UnitTests2.MyClass.
+
+- old: |
+    Assert.IsNotInstanceOfType(actual, typeof(T));
+
+  new: |
+    actual.Should().NotBeOfType<T>();
+
+  old-message: |
+    Assert.IsNotInstanceOfType failed. Wrong Type:<UnitTests2.MyClass>. Actual type:<UnitTests2.MyClass>.
+
+  new-message: |
+    Expected type not to be [UnitTests2.MyClass, UnitTests2, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null], but it is.
+
+- old: |
+    Assert.IsTrue(actual == expected);
+
+  new: |
+    // functionally equal
+    actual.Should().Be(expected);
+
+  new: |
+    // refer to the exact same object in memory
+    actual.Should().BeSameAs(expected);
+
+  old-message: |
+    Assert.IsTrue failed.
+
+  new-message: |
+    Expected value to be 2, but found 1.
+
+  new-message: |
+    Expected object to refer to 
+    SomeProperty: 2, OtherProperty: expected, but found 
+    SomeProperty: 1, OtherProperty: actual.
+
+- old: |
+    Assert.IsFalse(actual == expected);
+
+  new: |
+    // functionally unequal
+    actual.Should().NotBe(expected);
+
+  new: |
+    // refer to the different object in memory
+    actual.Should().NotBeSameAs(expected);
+
+  old-message: |
+    Assert.IsFalse failed.
+
+  new-message: |
+    Did not expect 1.
+
+  new-message: |
+    Did not expect reference to object 
+    SomeProperty: 1, OtherProperty: expected.
+
+- old: |
+    Assert.IsTrue(actual != expected);
+
+  new: |
+    // functionally unequal
+    actual.Should().NotBe(expected);
+
+  new: |
+    // refer to the different object in memory
+    actual.Should().NotBeSameAs(expected);
+
+  old-message: |
+    Assert.IsTrue failed.
+
+  new-message: |
+    Did not expect 1.
+
+  new-message: |
+    Did not expect reference to object 
+    SomeProperty: 1, OtherProperty: expected.
+
+- old: |
+    Assert.IsFalse(actual != expected);
+
+  new: |
+    // functionally equal
+    actual.Should().Be(expected);
+
+  new: |
+    // refer to the exact same object in memory
+    actual.Should().BeSameAs(expected)
+
+  old-message: |
+    Assert.IsFalse failed.
+
+  new-message: |
+    Expected value to be 2, but found 1.
+
+  new-message: |
+    Expected object to refer to 
+    SomeProperty: 2, OtherProperty: expected, but found 
+    SomeProperty: 1, OtherProperty: actual.
+
+- old: |
+    Assert.IsTrue(actual > expected);
+
+  new: |
+    actual.Should().BeGreaterThan(expected);
+
+  old-message: |
+    Assert.IsTrue failed.
+
+  new-message: |
+    Expected a value greater than 2, but found 1.
+
+- old: |
+    Assert.IsFalse(actual > expected);
+
+  new: |
+    actual.Should().BeLessOrEqualTo(expected);
+
+  old-message: |
+    Assert.IsFalse failed.
+
+  new-message: |
+    Expected a value less or equal to 1, but found 2.
+
+- old: |
+    Assert.IsTrue(actual >= expected);
+
+  new: |
+    actual.Should().BeGreaterOrEqualTo(expected);
+
+  old-message: |
+    Assert.IsTrue failed.
+
+  new-message: |
+    Expected a value greater or equal to 2, but found 1.
+
+- old: |
+    Assert.IsFalse(actual >= expected);
+
+  new: |
+    actual.Should().BeLessThan(expected);
+
+  old-message: |
+    Assert.IsFalse failed.
+
+  new-message: |
+    Expected a value less than 1, but found 2.
+
+- old: |
+    Assert.IsTrue(actual < expected);
+
+  new: |
+    actual.Should().BeLessThan(expected);
+
+  old-message: |
+    Assert.IsTrue failed.
+
+  new-message: |
+    Expected a value less than 1, but found 2.
+
+- old: |
+    Assert.IsFalse(actual < expected);
+
+  new: |
+    actual.Should().BeGreaterOrEqualTo(expected);
+
+  old-message: |
+    Assert.IsFalse failed.
+
+  new-message: |
+    Expected a value greater or equal to 2, but found 1.
+
+- old: |
+    Assert.IsTrue(actual <= expected);
+
+  new: |
+    actual.Should().BeLessOrEqualTo(expected);
+
+  old-message: |
+    Assert.IsTrue failed.
+
+  new-message: |
+    Expected a value less or equal to 1, but found 2.
+
+- old: |
+    Assert.IsFalse(actual <= expected);
+
+  new: |
+    actual.Should().BeGreaterThan(expected);
+
+  old-message: |
+    Assert.IsFalse failed.
+
+  new-message: |
+    Expected a value greater than 2, but found 1.
+
+

--- a/docs/_data/mstest-migration/collectionAssert.yml
+++ b/docs/_data/mstest-migration/collectionAssert.yml
@@ -1,0 +1,133 @@
+- old: |
+    CollectionAssert.AllItemsAreUnique(actual);
+
+  new: |
+    actual.Should().OnlyHaveUniqueItems();
+
+  old-message: |
+    CollectionAssert.AllItemsAreUnique failed. Duplicate item found:<SomeProperty: 1, OtherProperty: item>.
+
+  new-message: |
+    Expected collection to only have unique items, but item SomeProperty: 1, OtherProperty: item is not unique.
+
+- old: |
+    CollectionAssert.AreEqual(expected, actual);
+
+  new: |
+    actual.Should().Equal(expected);
+
+  old-message: |
+    CollectionAssert.AreEqual failed. (Element at index 0 do not match.)
+
+  new-message: |
+    Expected collection to be equal to {SomeProperty: 1, OtherProperty: item}, but {SomeProperty: 1, OtherProperty: different} differs at index 0.
+
+- old: |
+    CollectionAssert.AreNotEqual(expected, actual);
+
+  new: |
+    actual.Should().NotEqual(expected);
+
+  old-message: |
+    CollectionAssert.AreNotEqual failed. (Both collection contain same elements.)
+
+  new-message: |
+    Did not expect collections {SomeProperty: 1, OtherProperty: item} and {SomeProperty: 1, OtherProperty: item} to be equal.
+
+- old: |
+    CollectionAssert.AreEquivalent(expected, actual);
+
+  new: |
+    actual.Should().BeEquivalentTo(expected);
+
+  old-message: |
+    CollectionAssert.AreEquivalent failed. The expected collection contains 1 occurrence(s) of <SomeProperty: 2, OtherProperty: other>. The actual collection contains 0 occurrence(s).
+
+  new-message: |
+    Expected collection {SomeProperty: 1, OtherProperty: item, SomeProperty: 2, OtherProperty: item} to be equivalent to {SomeProperty: 1, OtherProperty: item, SomeProperty: 2, OtherProperty: other}, but it misses {SomeProperty: 2, OtherProperty: other}.
+
+- old: |
+    CollectionAssert.AreNotEquivalent(expected, actual);
+
+  new: |
+    actual.Should().NotBeEquivalentTo(expected);
+
+  old-message: |
+    CollectionAssert.AreNotEquivalent failed. Both collections contain the same elements.
+
+  new-message: |
+    Expected collection {SomeProperty: 1, OtherProperty: item, SomeProperty: 2, OtherProperty: other} not be equivalent with collection {SomeProperty: 1, OtherProperty: item, SomeProperty: 2, OtherProperty: other}.
+
+- old: |
+    CollectionAssert.Contains(actual, expected);
+
+  new: |
+    actual.Should().Contain(expected);
+
+  old-message: |
+    CollectionAssert.Contains failed.
+
+  new-message: |
+    Expected collection {SomeProperty: 2, OtherProperty: other} to contain SomeProperty: 1, OtherProperty: item.
+
+- old: |
+    CollectionAssert.DoesNotContain(actual, expected);
+
+  new: |
+    actual.Should().NotContain(expected);
+
+  old-message: |
+    CollectionAssert.DoesNotContain failed.
+
+  new-message: |
+    Expected collection {SomeProperty: 1, OtherProperty: item} to not contain SomeProperty: 1, OtherProperty: item.
+
+- old: |
+    CollectionAssert.IsSubsetOf(actual, expectedSuperset);
+
+  new: |
+    actual.Should().BeSubsetOf(expectedSuperset);
+
+  old-message: |
+    CollectionAssert.IsSubsetOf failed.
+
+  new-message: |
+    Expected collection to be a subset of {SomeProperty: 1, OtherProperty: item}, but items {SomeProperty: 2, OtherProperty: other} are not part of the superset.
+
+- old: |
+    CollectionAssert.IsNotSubsetOf(actual, expectedSuperset);
+
+  new: |
+    actual.Should().NotBeSubsetOf(expectedSuperset);
+
+  old-message: |
+    CollectionAssert.IsNotSubsetOf failed.
+
+  new-message: |
+    Did not expect collection {SomeProperty: 1, OtherProperty: item} to be a subset of {SomeProperty: 1, OtherProperty: item}.
+
+- old: |
+    CollectionAssert.AllItemsAreNotNull(actual);
+
+  new: |
+    actual.Should().NotContainNulls();
+
+  old-message: |
+    CollectionAssert.AllItemsAreNotNull failed.
+
+  new-message: |
+    Expected collection not to contain nulls, but found one at index 0.
+
+- old: |
+    CollectionAssert.AllItemsAreInstancesOfType(actual, typeof(T));
+
+  new: |
+    actual.Should().ContainItemsAssignableTo<T>();
+
+  old-message: |
+    CollectionAssert.AllItemsAreInstancesOfType failed. Element at index 0 is not of expected type. Expected type:<UnitTests2.MyIdenticalClass>. Actual type:<UnitTests2.MyClass>.
+
+  new-message: |
+    Expected collection to contain only items of type UnitTests2.MyIdenticalClass, but item SomeProperty: 1, OtherProperty: item at index 0 is of type UnitTests2.MyClass.
+
+

--- a/docs/_data/mstest-migration/exceptions.yml
+++ b/docs/_data/mstest-migration/exceptions.yml
@@ -1,0 +1,112 @@
+- old: |
+    [ExpectedException(typeof(InvalidOperationException))]
+    public void MyTest()
+    {
+        func();
+    }
+
+  new: |
+    public void MyTest()
+    {
+        Action act = () => func();
+    
+        act.ShouldThrowExactly<InvalidOperationException>();
+    }
+
+  old-message: |
+    Test method threw exception System.InvalidCastException, but exception System.ArgumentNullException was expected. Exception System.InvalidCastException: Specified cast is not valid.
+
+  new-message: |
+    Expected a <System.ArgumentNullException> to be thrown, but found a <System.InvalidCastException>: System.InvalidCastException with message "Specified cast is not valid."
+         at UnitTests2.ExceptionTests.<>c.<Snippet01_New>b__1_0() in C:\Path\To\UnitTests\ExceptionTests.cs:line 31
+         at UnitTests2.ExceptionTests.<>c__DisplayClass1_0.<Snippet01_New>b__1() in C:\Path\To\UnitTests\ExceptionTests.cs:line 34
+         at FluentAssertions.Specialized.ActionAssertions
+           .InvokeSubjectWithInterception()
+    .
+
+- old: |
+    Action act = () => func();
+    
+    // MSTest V2
+    Assert.ThrowsException<InvalidOperationException>(act);
+
+  new: |
+    Action act = () => func();
+    
+    act.ShouldThrowExactly<InvalidOperationException>();
+
+  old-message: |
+    Assert.ThrowsException failed. Threw exception InvalidCastException, but exception ArgumentNullException was expected. 
+    Exception Message: Specified cast is not valid.
+    Stack Trace:    at UnitTests2.ExceptionTests.<>c.<Snippet01v2_Old>b__2_0() in C:\Path\To\UnitTests\ExceptionTests.cs:line 44
+       at UnitTests2.ExceptionTests.<>c__DisplayClass2_0.<Snippet01v2_Old>b__1() in C:\Path\To\UnitTests\ExceptionTests.cs:line 47
+       at Microsoft.VisualStudio.TestTools.UnitTesting.Assert
+         .ThrowsException[T](Action action, String message, Object[] parameters)
+
+  new-message: |
+    Expected a <System.ArgumentNullException> to be thrown, but found a <System.InvalidCastException>: System.InvalidCastException with message "Specified cast is not valid."
+         at UnitTests2.ExceptionTests.<>c.<Snippet01_New>b__1_0() in C:\Path\To\UnitTests\ExceptionTests.cs:line 31
+         at UnitTests2.ExceptionTests.<>c__DisplayClass1_0.<Snippet01_New>b__1() in C:\Path\To\UnitTests\ExceptionTests.cs:line 34
+         at FluentAssertions.Specialized.ActionAssertions
+           .InvokeSubjectWithInterception()
+    .
+
+- old: |
+    [ExpectedException(typeof(SystemException),
+                       AllowDerivedTypes = true)]
+    public void MyTest()
+    {
+        func();
+    }
+
+  new: |
+    public void MyTest()
+    {
+        Action act = () => func();
+    
+        act.ShouldThrow<InvalidOperationException>();
+    }
+
+  old-message: |
+    Test method threw exception System.InvalidCastException, but exception System.ArgumentException or a type derived from it was expected. Exception System.InvalidCastException: Specified cast is not valid.
+
+  new-message: |
+    Expected a <System.ArgumentException> to be thrown, but found a <System.InvalidCastException>: System.InvalidCastException with message "Specified cast is not valid."
+         at UnitTests2.ExceptionTests.<>c.<Snippet02_New>b__3_0() in C:\Path\To\UnitTests\ExceptionTests.cs:line 57
+         at UnitTests2.ExceptionTests.<>c__DisplayClass3_0.<Snippet02_New>b__1() in C:\Path\To\UnitTests\ExceptionTests.cs:line 60
+         at FluentAssertions.Specialized
+            .ActionAssertions.InvokeSubjectWithInterception().
+
+- old: |
+    [ExpectedException(typeof(InvalidOperationException))]
+    public void MyTest()
+    {
+        try
+        {
+            func();
+        }
+        catch (InvalidOperationException ex)
+        {
+            ex.Message.Should().Be(errorMessage);
+            throw;
+        }
+    }
+
+  new: |
+    public void MyTest()
+    {
+        Action act = () => func();
+    
+        act.ShouldThrowExactly<InvalidOperationException>()
+            .WithMessage(errorMessage);
+    }
+
+  old-message: |
+    Expected string to be 
+    "expectedMessage" with a length of 15, but 
+    "actualMessage" has a length of 13.
+
+  new-message: |
+    Expected exception message to match the equivalent of 
+    "expectedMessage", but 
+    "actualMessage" does not.

--- a/docs/_data/mstest-migration/stringAssert.yml
+++ b/docs/_data/mstest-migration/stringAssert.yml
@@ -1,0 +1,67 @@
+- old: |
+    StringAssert.Contains(actual, expectedSubstring);
+
+  new: |
+    actual.Should().Contain(expectedSubstring);
+
+  old-message: |
+    StringAssert.Contains failed. String 'SomeLongString' does not contain string 'Short'. .
+
+  new-message: |
+    Expected string "SomeLongString" to contain "Short".
+
+- old: |
+    StringAssert.StartWith(actual, expectedPrefix);
+
+  new: |
+    actual.Should().StartWith(expectedPrefix);
+
+  old-message: |
+    StringAssert.StartsWith failed. String 'LongString' does not start with string 'Short'. .
+
+  new-message: |
+    Expected string to start with 
+    "Short", but 
+    "LongString" differs near "Lon" (index 0).
+
+- old: |
+    StringAssert.EndsWith(actual, expectedSuffix);
+
+  new: |
+    actual.Should().EndWith(expectedSuffix);
+
+  old-message: |
+    StringAssert.EndsWith failed. String 'StringLong' does not end with string 'Short'. .
+
+  new-message: |
+    Expected string "StringLong" to end with "Short".
+
+- old: |
+    StringAssert.Matches(actual, expectedPattern);
+
+  new: |
+    actual.Should().MatchRegex(expectedPattern);
+
+  old-message: |
+    StringAssert.Matches failed. String 'SomeLong' does not match pattern '.*String.*'. .
+
+  new-message: |
+    Expected string to match regex 
+    ".*String.*", but 
+    "SomeLong" does not match.
+
+- old: |
+    StringAssert.DoesNotMatch(actual, expectedPattern);
+
+  new: |
+    actual.Should().NotMatchRegex(expectedPattern);
+
+  old-message: |
+    StringAssert.DoesNotMatch failed. String 'SomeStringLong' matches pattern '.*String.*'. .
+
+  new-message: |
+    Did not expect string to match regex 
+    ".*String.*", but 
+    "SomeStringLong" matches.
+
+

--- a/docs/_data/tips/collections.yml
+++ b/docs/_data/tips/collections.yml
@@ -1,0 +1,452 @@
+- old: |
+    actual.Any().Should().BeTrue();
+
+  new: |
+    actual.Should().NotBeEmpty();
+
+  old-message: |
+    Expected True, but found False.
+
+  new-message: |
+    Expected collection not to be empty.
+
+- old: |
+    actual.Any().Should().BeFalse();
+
+  new: |
+    actual.Should().BeEmpty();
+
+  old-message: |
+    Expected False, but found True.
+
+  new-message: |
+    Expected collection to be empty, but found {SomeProperty: 0, OtherProperty: }.
+
+- old: |
+    actual.Any(x => x.SomeProperty).Should().BeTrue();
+
+  new: |
+    actual.Should().Contain(x => x.SomeProperty);
+
+  old-message: |
+    Expected True, but found False.
+
+  new-message: |
+    Collection {SomeProperty: 0, OtherProperty: Actual} should have an item matching (x.OtherProperty == value(UnitTests2.CollectionTests+<>c__DisplayClass5_0).expectedValue).
+
+- old: |
+    actual.Any(x => x.SomeProperty).Should().BeFalse();
+
+  new: |
+    actual.Should().NotContain(x => x.SomeProperty);
+
+  old-message: |
+    Expected False, but found True.
+
+  new-message: |
+    Expected Collection {SomeProperty: 0, OtherProperty: Unexpected} to not have any items matching (x.OtherProperty == value(UnitTests2.CollectionTests+<>c__DisplayClass7_0).unexpectedValue).
+
+- old: |
+    actual.All(x => x.SomeProperty).Should().BeTrue();
+
+  new: |
+    // now fails on empty collection;
+    actual.Should().OnlyContain(x => x.SomeProperty)
+
+  old-message: |
+    Expected True, but found False.
+
+  new-message: |
+    Expected collection to contain only items matching (x.OtherProperty == value(UnitTests2.CollectionTests+<>c__DisplayClass9_0).expectedValue), but {SomeProperty: 0, OtherProperty: Actual} do(es) not match.
+
+- old: |
+    actual.Contains(expected).Should().BeTrue();
+
+  new: |
+    actual.Should().Contain(expected);
+
+  old-message: |
+    Expected True, but found False.
+
+  new-message: |
+    Expected collection {"Actual"} to contain "Expected".
+
+- old: |
+    actual.Contains(unexpected).Should().BeFalse();
+
+  new: |
+    actual.Should().NotContain(unexpected);
+
+  old-message: |
+    Expected False, but found True.
+
+  new-message: |
+    Expected collection {"Expected"} to not contain "Expected".
+
+- old: |
+    actual.Any(x => x == unexpected).Should().BeFalse();
+
+  new: |
+    actual.Should().NotContain(unexpected);
+
+  old-message: |
+    Expected False, but found True.
+
+  new-message: |
+    Expected collection {"Unexpected"} to not contain "Unexpected".
+
+- old: |
+    actual.Count().Should().Be(k);
+
+  new: |
+    actual.Should().HaveCount(k);
+
+  old-message: |
+    Expected value to be 2, but found 3.
+
+  new-message: |
+    Expected collection to contain 2 item(s), but found 3.
+
+- old: |
+    actual.Count().Should().BeGreaterThan(k);
+
+  new: |
+    // Will be available in Fluent Assertions 5.0
+    actual.Should().HaveCountGreaterThan(k);
+
+  old-message: |
+    Expected a value greater than 4, but found 3.
+
+  new-message: |
+    Expected collection to contain more than 4 item(s), but found 3.
+
+- old: |
+    actual.Count().Should().BeGreaterOrEqualTo(k);
+
+  new: |
+    // Will be available in Fluent Assertions 5.0
+    actual.Should().HaveCountGreaterOrEqualTo(k);
+
+  old-message: |
+    Expected a value greater or equal to 4, but found 3.
+
+  new-message: |
+    Expected collection to contain at least 4 item(s), but found 3.
+
+- old: |
+    actual.Count().Should().BeLessThan(k);
+
+  new: |
+    // Will be available in Fluent Assertions 5.0
+    actual.Should().HaveCountLessThan(k);
+
+  old-message: |
+    Expected a value less than 2, but found 3.
+
+  new-message: |
+    Expected collection to contain fewer than 2 item(s), but found 3.
+
+- old: |
+    actual.Count().Should().BeLessOrEqualTo(k);
+
+  new: |
+    // Will be available in Fluent Assertions 5.0
+    actual.Should().HaveCountLessOrEqualTo(k);
+
+  old-message: |
+    Expected a value less or equal to 2, but found 3.
+
+  new-message: |
+    Expected collection to contain at most 2 item(s), but found 3.
+
+- old: |
+    actual.Count().Should().NotBe(k);
+
+  new: |
+    // Will be available in Fluent Assertions 5.0
+    actual.Should().NotHaveCount(k);
+
+  old-message: |
+    Did not expect 3.
+
+  new-message: |
+    Expected collection to not contain 3 item(s), but found 3.
+
+- old: |
+    actual.Should().HaveCount(1);
+
+  new: |
+    actual.Should().ContainSingle();
+
+  old-message: |
+    Expected collection to contain 1 item(s), but found 3.
+
+  new-message: |
+    Expected collection to contain a single item, but found {"", "", ""}.
+
+- old: |
+    actual.Should().HaveCount(0);
+
+  new: |
+    actual.Should().BeEmpty();
+
+  old-message: |
+    Expected collection to contain 0 item(s), but found 3.
+
+  new-message: |
+    Expected collection to be empty, but found {"", "", ""}.
+
+- old: |
+    actual.Should().HaveCount(expected.Count());
+
+  new: |
+    actual.Should().HaveSameCount(expected);
+
+  old-message: |
+    Expected collection to contain 2 item(s), but found 3.
+
+  new-message: |
+    Expected collection to have 2 item(s), but found 3.
+
+- old: |
+    actual.Count().Should().NotBe(unexpected.Count());
+
+  new: |
+    // Will be available in Fluent Assertions 5.0
+    actual.Should().NotHaveSameCount(unexpected);
+
+  old-message: |
+    Did not expect 2.
+
+  new-message: |
+    Expected collection to not have 2 item(s), but found 2.
+
+- old: |
+    actual.Where(x => x.SomeProperty).Should().NotBeEmpty();
+
+  new: |
+    actual.Should().Contain(x => x.SomeProperty);
+
+  old-message: |
+    Expected collection not to be empty.
+
+  new-message: |
+    Collection {SomeProperty: 0, OtherProperty: Actual} should have an item matching (x.OtherProperty == value(UnitTests2.CollectionTests+<>c__DisplayClass39_0).expectedValue).
+
+- old: |
+    actual.Where(x => x.SomeProperty).Should().BeEmpty();
+
+  new: |
+    actual.Should().NotContain(x => x.SomeProperty);
+
+  old-message: |
+    Expected collection to be empty, but found {SomeProperty: 0, OtherProperty: Expected}.
+
+  new-message: |
+    Expected Collection {SomeProperty: 0, OtherProperty: Expected} to not have any items matching (x.OtherProperty == value(UnitTests2.CollectionTests+<>c__DisplayClass41_0).expectedValue).
+
+- old: |
+    actual.Where(x => x.SomeProperty).Should().HaveCount(1);
+
+  new: |
+    actual.Should().ContainSingle(x => x.SomeProperty);
+
+  old-message: |
+    Expected collection to contain 1 item(s), but found 0.
+
+  new-message: |
+    Expected collection to contain a single item matching (x.OtherProperty == value(UnitTests2.CollectionTests+<>c__DisplayClass43_0).expectedValue), but no such item was found.
+
+- old: |
+    actual.Should().OnlyContain(e => !e.SomeProperty);
+
+  new: |
+    actual.Should().NotContain(x => x.SomeProperty);
+
+  old-message: |
+    Expected collection to contain only items matching (x.OtherProperty != value(UnitTests2.CollectionTests+<>c__DisplayClass44_0).unexpectedValue), but {SomeProperty: 0, OtherProperty: Unexpected} do(es) not match.
+
+  new-message: |
+    Expected Collection {SomeProperty: 0, OtherProperty: Unexpected} to not have any items matching (x.OtherProperty == value(UnitTests2.CollectionTests+<>c__DisplayClass45_0).unexpectedValue).
+
+- old: |
+    actual.Should().NotBeNull().And.NotBeEmpty();
+
+  new: |
+    actual.Should().NotBeNullOrEmpty();
+
+  old-message: |
+    Expected collection not to be empty.
+
+  new-message: |
+    Expected collection not to be empty.
+
+- old: |
+    actual.ElementAt(k).Should().Be(expected);
+
+  new: |
+    actual.Should().HaveElementAt(k, expected);
+
+  old-message: |
+    Expected string to be 
+    "Expected" with a length of 8, but 
+    "Unexpected" has a length of 10.
+
+  new-message: |
+    Expected "Expected" at index 0, but found "Unexpected".
+
+- old: |
+    actual[k].Should().Be(expected);
+
+  new: |
+    actual.Should().HaveElementAt(k, expected);
+
+  old-message: |
+    Expected string to be 
+    "Expected" with a length of 8, but 
+    "Unexpected" has a length of 10.
+
+  new-message: |
+    Expected "Expected" at index 0, but found "Unexpected".
+
+- old: |
+    actual.Skip(k).First().Should().Be(expected);
+
+  new: |
+    actual.Should().HaveElementAt(k, expected);
+
+  old-message: |
+    Expected string to be 
+    "Expected" with a length of 8, but 
+    "Unexpected" has a length of 10.
+
+  new-message: |
+    Expected "Expected" at index 1, but found "Unexpected".
+
+- old: |
+    actual.OrderBy(x => x.SomeProperty)
+        .Should().Equal(actual);
+
+  new: |
+    actual.Should().BeInAscendingOrder(x => x.SomeProperty);
+
+  old-message: |
+    Expected collection to be equal to {SomeProperty: 2, OtherProperty: , SomeProperty: 1, OtherProperty: }, but {SomeProperty: 1, OtherProperty: , SomeProperty: 2, OtherProperty: } differs at index 0.
+
+  new-message: |
+    Expected collection {SomeProperty: 2, OtherProperty: , SomeProperty: 1, OtherProperty: } to be ordered" by SomeProperty" and result in {SomeProperty: 1, OtherProperty: , SomeProperty: 2, OtherProperty: }.
+
+- old: |
+    actual.OrderByDescending(x => x.SomeProperty)
+        .Should().Equal(actual);
+
+  new: |
+    actual.Should().BeInDescendingOrder(x => x.SomeProperty);
+
+  old-message: |
+    Expected collection to be equal to {SomeProperty: 1, OtherProperty: , SomeProperty: 2, OtherProperty: }, but {SomeProperty: 2, OtherProperty: , SomeProperty: 1, OtherProperty: } differs at index 0.
+
+  new-message: |
+    Expected collection {SomeProperty: 1, OtherProperty: , SomeProperty: 2, OtherProperty: } to be ordered" by SomeProperty" and result in {SomeProperty: 2, OtherProperty: , SomeProperty: 1, OtherProperty: }.
+
+- old: |
+    actual.Select(e1 => e1.SomeProperty).Should()
+        .Equal(expected.Select(e2 => e2.SomeProperty));
+
+  new: |
+    actual.Should()
+        .Equal(expected, 
+            (e1, e2) => e1.SomeProperty == e2.SomeProperty);
+
+  old-message: |
+    Expected collection to be equal to {"Expected", "Expected"}, but {"Actual", "Actual"} differs at index 0.
+
+  new-message: |
+    Expected collection to be equal to {SomeProperty: 1, OtherProperty: Expected, SomeProperty: 2, OtherProperty: Expected}, but {SomeProperty: 1, OtherProperty: Actual, SomeProperty: 2, OtherProperty: Actual} differs at index 0.
+
+- old: |
+    actual.Intersect(expected).Should().BeEmpty();
+
+  new: |
+    actual.Should().NotIntersectWith(expected);
+
+  old-message: |
+    Expected collection to be empty, but found {SomeProperty: 1, OtherProperty: Expected}.
+
+  new-message: |
+    Did not expect collection to intersect with {SomeProperty: 1, OtherProperty: Expected}, but found the following shared items {SomeProperty: 1, OtherProperty: Expected}.
+
+- old: |
+    actual.Intersect(expected).Should().NotBeEmpty();
+
+  new: |
+    actual.Should().IntersectWith(expected);
+
+  old-message: |
+    Expected collection not to be empty.
+
+  new-message: |
+    Expected collection to intersect with {SomeProperty: 1, OtherProperty: Expected}, but {SomeProperty: 1, OtherProperty: Actual} does not contain any shared items.
+
+- old: |
+    actual.Select(x => x.SomeProperty)
+        .Should().NotContainNulls();
+
+  new: |
+    // Will be available in Fluent Assertions 5.0
+    actual.Should().NotContainNulls(e => e.OtherProperty);
+
+  old-message: |
+    Expected collection not to contain nulls, but found one at index 0.
+
+  new-message: |
+    Expected collection not to contain <null>s on e.OtherProperty, but found {SomeProperty: 1, OtherProperty: }.
+
+- old: |
+    actual.Should().HaveSameCount(actual.Distinct());
+
+  new: |
+    actual.Should().OnlyHaveUniqueItems();
+
+  old-message: |
+    Expected collection to have 1 item(s), but found 2.
+
+  new-message: |
+    Expected collection to only have unique items, but item SomeProperty: 1, OtherProperty:  is not unique.
+
+- old: |
+    actual.Select(x => x.SomeProperty)
+        .Should().OnlyHaveUniqueItems();
+
+  new: |
+    // Will be available in Fluent Assertions 5.0
+    actual.Should().OnlyHaveUniqueItems(x => x.SomeProperty);
+
+  old-message: |
+    Expected collection to only have unique items, but item 1 is not unique.
+
+  new-message: |
+    Expected collection to only have unique items on x.SomeProperty, but item SomeProperty: 1, OtherProperty:  is not unique.
+
+- old: |
+    // From the assertion it is unclear what is being tested.
+    actual.FirstOrDefault().Should().BeNull();
+
+  new: |
+    // The enumerable is empty.
+    actual.Should().BeEmpty();
+
+  new: |
+    // The first element is null.
+    actual.Should().HaveElementAt(0, null);
+
+  old-message: |
+    Expected string to be <null>, but found "".
+
+  new-message: |
+    Expected collection to be empty, but found {""}.
+
+  new-message: |
+    Expected <null> at index 0, but found "".
+
+

--- a/docs/_data/tips/comparable.yml
+++ b/docs/_data/tips/comparable.yml
@@ -1,0 +1,50 @@
+- old: |
+    actual.Should().BeGreaterThan(0);
+
+  new: |
+    actual.Should().BePositive();
+
+  old-message: |
+    Expected a value greater than 0, but found -1.
+
+  new-message: |
+    Expected positive value, but found -1
+
+- old: |
+    actual.Should().BeLessThan(0);
+
+  new: |
+    actual.Should().BeNegative();
+
+  old-message: |
+    Expected a value less than 0, but found 1.
+
+  new-message: |
+    Expected negative value, but found 1
+
+- old: |
+    (lower <= actual && actual <= upper).Should().BeTrue();
+
+  new: |
+    actual.Should().BeInRange(lower, upper);
+
+  old-message: |
+    Expected True, but found False.
+
+  new-message: |
+    Expected value to be between 1 and 5, but found 6.
+
+- old: |
+    (lower <= actual && actual <= upper).Should().BeFalse();
+
+  new: |
+    // Will be available in Fluent Assertions 5.0
+    actual.Should().NotBeInRange(lower, upper);
+
+  old-message: |
+    Expected False, but found True.
+
+  new-message: |
+    Expected value to not be between 1 and 5, but found 4.
+
+

--- a/docs/_data/tips/dictionaries.yml
+++ b/docs/_data/tips/dictionaries.yml
@@ -1,0 +1,75 @@
+- old: |
+    actual.ContainsKey(expected).Should().BeTrue();
+
+  new: |
+    actual.Should().ContainKey(expected);
+
+  old-message: |
+    Expected True, but found False.
+
+  new-message: |
+    Expected dictionary {[0, ]} to contain key 1.
+
+- old: |
+    actual.ContainsKey(expected).Should().BeFalse();
+
+  new: |
+    actual.Should().NotContainKey(expected);
+
+  old-message: |
+    Expected False, but found True.
+
+  new-message: |
+    Dictionary {[0, ]} should not contain key 0, but found it anyhow.
+
+- old: |
+    actual.ContainsValue(expected).Should().BeTrue();
+
+  new: |
+    actual.Should().ContainValue(expected);
+
+  old-message: |
+    Expected True, but found False.
+
+  new-message: |
+    Expected dictionary {[0, ]} to contain value "expected".
+
+- old: |
+    actual.ContainsValue(expected).Should().BeFalse();
+
+  new: |
+    actual.Should().NotContainValue(expected);
+
+  old-message: |
+    Expected False, but found True.
+
+  new-message: |
+    Dictionary {[0, expected]} should not contain value "expected", but found it anyhow.
+
+- old: |
+    actual.Should().ContainKey(expectedKey)
+        .And.ContainValue(expectedValue);
+
+  new: |
+    actual.Should().Contain(expectedKey, expectedValue);
+
+  old-message: |
+    Expected dictionary {[0, ]} to contain value "expected".
+
+  new-message: |
+    Expected dictionary to contain value "expected" at key 0, but found "".
+
+- old: |
+    actual.Should().ContainKey(expected.Key)
+        .And.ContainValue(expected.Value);
+
+  new: |
+    actual.Should().Contain(expected);
+
+  old-message: |
+    Expected dictionary {[0, ]} to contain value "expected".
+
+  new-message: |
+    Expected dictionary to contain value "expected" at key 0, but found "".
+
+

--- a/docs/_data/tips/exceptions.yml
+++ b/docs/_data/tips/exceptions.yml
@@ -1,0 +1,20 @@
+- old: |
+    Action act = () => func();
+    
+    act.ShouldThrowExactly<InvalidOperationException>()
+        .Which.Message.Should().Contain("expectedMessage");
+
+  new: |
+    Action act = () => func();
+    
+    // using wildcards
+    act.ShouldThrowExactly<InvalidOperationException>()
+        .WithMessage("*expectedMessage*");
+
+  old-message: |
+    Expected string "Problems, errorCode2 and more Problems" to contain "errorCode1".
+
+  new-message: |
+    Expected exception message to match the equivalent of 
+    "*errorCode1*", but 
+    "Problems, errorCode2 and more Problems" does not.

--- a/docs/_data/tips/nullables.yml
+++ b/docs/_data/tips/nullables.yml
@@ -1,0 +1,23 @@
+- old: |
+    actual.HasValue.Should().BeTrue();
+
+  new: |
+    actual.Should().HaveValue();
+
+  old-message: |
+    Expected True, but found False.
+
+  new-message: |
+    Expected a value.
+
+- old: |
+    actual.HasValue.Should().BeFalse();
+
+  new: |
+    actual.Should().NotHaveValue();
+
+  old-message: |
+    Expected False, but found True.
+
+  new-message: |
+    Did not expect a value, but found 1.

--- a/docs/_data/tips/strings.yml
+++ b/docs/_data/tips/strings.yml
@@ -1,0 +1,97 @@
+- old: |
+    actual.StartsWith(expectedPrefix).Should().BeTrue();
+
+  new: |
+    actual.Should().StartWith(expectedPrefix);
+
+  old-message: |
+    Expected True, but found False.
+
+  new-message: |
+    Expected string to start with 
+    "Expected", but 
+    "ActualString" differs near "Act" (index 0).
+
+- old: |
+    actual.EndsWith(expectedSuffix).Should().BeTrue();
+
+  new: |
+    actual.Should().EndWith(expectedSuffix);
+
+  old-message: |
+    Expected True, but found False.
+
+  new-message: |
+    Expected string "ActualString" to end with "Expected".
+
+- old: |
+    actual.Should().NotBeNull().And.NotBeEmpty();
+
+  new: |
+    actual.Should().NotBeNullOrEmpty();
+
+  old-message: |
+    Did not expect empty string.
+
+  new-message: |
+    Expected string not to be <null> or empty, but found "".
+
+- old: |
+    string.IsNullOrEmpty(actual).Should().BeTrue();
+
+  new: |
+    actual.Should().BeNullOrEmpty();
+
+  old-message: |
+    Expected True, but found False.
+
+  new-message: |
+    Expected string to be <null> or empty, but found "Actual".
+
+- old: |
+    string.IsNullOrEmpty(actual).Should().BeFalse();
+
+  new: |
+    actual.Should().NotBeNullOrEmpty();
+
+  old-message: |
+    Expected False, but found True.
+
+  new-message: |
+    Expected string not to be <null> or empty, but found "".
+
+- old: |
+    string.IsNullOrWhiteSpace(actual).Should().BeTrue();
+
+  new: |
+    actual.Should().BeNullOrWhiteSpace();
+
+  old-message: |
+    Expected True, but found False.
+
+  new-message: |
+    Expected string to be <null> or whitespace, but found "Actual".
+
+- old: |
+    string.IsNullOrWhiteSpace(actual).Should().BeFalse();
+
+  new: |
+    actual.Should().NotBeNullOrWhiteSpace();
+
+  old-message: |
+    Expected False, but found True.
+
+  new-message: |
+    Expected string not to be <null> or whitespace, but found " ".
+
+- old: |
+    actual.Length.Should().Be(k);
+
+  new: |
+    actual.Should().HaveLength(k);
+
+  old-message: |
+    Expected value to be 4, but found 6.
+
+  new-message: |
+    Expected string with length 4, but found string "Actual" with length 6.

--- a/docs/_data/tips/types.yml
+++ b/docs/_data/tips/types.yml
@@ -1,0 +1,75 @@
+- old: |
+    actual.GetType().Should().Be(typeof(T));
+
+  new: |
+    actual.Should().BeOfType<T>();
+
+  old-message: |
+    Expected type to be UnitTests2.MyClass, but found UnitTests2.MyIdenticalClass.
+
+  new-message: |
+    Expected type to be UnitTests2.MyClass, but found UnitTests2.MyIdenticalClass.
+
+- old: |
+    actual.GetType().Should().NotBe(typeof(T));
+
+  new: |
+    actual.Should().NotBeOfType<T>();
+
+  old-message: |
+    Expected type not to be [UnitTests2.MyClass, UnitTests2, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null], but it is.
+
+  new-message: |
+    Expected type not to be [UnitTests2.MyClass, UnitTests2, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null], but it is.
+
+- old: |
+    (actual is T).Should().BeTrue();
+
+  new: |
+    actual.Should().BeAssignableTo<T>();
+
+  old-message: |
+    Expected True, but found False.
+
+  new-message: |
+    Expected object to be assignable to UnitTests2.MyClass, but UnitTests2.MyIdenticalClass is not.
+
+- old: |
+    (actual as T).Should().NotBeNull();
+
+  new: |
+    actual.Should().BeAssignableTo<T>();
+
+  old-message: |
+    Expected object not to be <null>.
+
+  new-message: |
+    Expected object to be assignable to UnitTests2.MyClass, but UnitTests2.MyIdenticalClass is not.
+
+- old: |
+    (actual is T).Should().BeFalse();
+
+  new: |
+    // Will be available in Fluent Assertions 5.0
+    actual.Should().NotBeAssignableTo<T>();
+
+  old-message: |
+    Expected False, but found True.
+
+  new-message: |
+    Expected object to not be assignable to UnitTests2.MyClass, but UnitTests2.MyClass is.
+
+- old: |
+    (actual as T).Should().BeNull();
+
+  new: |
+    // Will be available in Fluent Assertions 5.0
+    actual.Should().NotBeAssignableTo<T>();
+
+  old-message: |
+    Expected object to be <null>, but found SomeProperty: 1, OtherProperty: actual.
+
+  new-message: |
+    Expected object to not be assignable to UnitTests2.MyClass, but UnitTests2.MyClass is.
+
+

--- a/docs/_includes/assertion-comparison.html
+++ b/docs/_includes/assertion-comparison.html
@@ -1,0 +1,42 @@
+### {{ include.caption }}
+
+{% for example in include.examples %}
+<table class="code-table">
+<thead>
+<tr>
+	<th>
+		{{ include.header1 }}
+	</th>
+	<th>
+		{{ include.header2 }}
+	</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td markdown="1">
+```c#
+{{ example.old }}
+```
+</td>
+<td markdown="1">
+```c#
+{{ example.new }}
+```
+</td>
+</tr>
+<tr>
+<td markdown="1">
+```text
+{{ example.old-message }}
+```
+</td>
+<td markdown="1">
+```text
+{{ example.new-message }}
+```
+</td>
+</tr>
+</tbody>
+</table>
+{% endfor %}

--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -45,3 +45,10 @@ $fluent-assertions-blue: #00a9ee;
 
 h1 { color: $fluent-assertions-red }
 h2, h3, h4, h5, h6 { color: $fluent-assertions-blue }
+
+.code-table {
+  width: 100%;
+  table-layout: fixed;
+  td { padding-right: 30px; width: 50%}
+  pre.highlight code { white-space: pre-wrap; }
+}

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -44,3 +44,18 @@ xDocument.Should().HaveElement("child").Which.Should().BeOfType<XElement>().And.
 
 I've run into quite a few of these scenarios in which this chaining would make the unit test a lot easier to read.
 
+## MSTest Migration
+{:.no_toc}
+
+The examples below show how you might write equivalent MSTest assertions using Fluent Assertions including the failure message from each case.
+We think this is both a useful migration guide and a convincing argument for switching.
+
+If you see something missing, please consider submitting a pull request.
+
+* TOC
+{:toc}
+
+{% include assertion-comparison.html header1="MSTest" header2="Fluent Assertions" caption="Assert"            examples=site.data.mstest-migration.assert %}
+{% include assertion-comparison.html header1="MSTest" header2="Fluent Assertions" caption="CollectionAssert"  examples=site.data.mstest-migration.collectionAssert %}
+{% include assertion-comparison.html header1="MSTest" header2="Fluent Assertions" caption="StringAssert"      examples=site.data.mstest-migration.stringAssert %}
+{% include assertion-comparison.html header1="MSTest" header2="Fluent Assertions" caption="Exceptions"        examples=site.data.mstest-migration.exceptions %}

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -1,0 +1,27 @@
+---
+title: Tips
+layout: page
+---
+
+General tips:
+* If your assertion ends with `Should().BeTrue()`, there is most likely a better way to write it.
+* By having `Should()` as early as possible in the assertion, we are able to include more information in the failure messages.
+
+## Improved assertions
+{:.no_toc}
+
+The examples below show how you might improve your existing assertions to both get more readable assertions and much more informative failure messages.
+
+If you see something missing, please consider submitting a pull request.
+
+* TOC
+{:toc}
+
+
+{% include assertion-comparison.html header1="Assertion" header2="Improvement" caption="Collections"               examples=site.data.tips.collections %}
+{% include assertion-comparison.html header1="Assertion" header2="Improvement" caption="Comparable and Numerics"   examples=site.data.tips.comparable %}
+{% include assertion-comparison.html header1="Assertion" header2="Improvement" caption="Dictionaries"              examples=site.data.tips.dictionaries %}
+{% include assertion-comparison.html header1="Assertion" header2="Improvement" caption="Exceptions"                examples=site.data.tips.exceptions %}
+{% include assertion-comparison.html header1="Assertion" header2="Improvement" caption="Nullables"                 examples=site.data.tips.nullables %}
+{% include assertion-comparison.html header1="Assertion" header2="Improvement" caption="Strings"                   examples=site.data.tips.strings %}
+{% include assertion-comparison.html header1="Assertion" header2="Improvement" caption="Types"                     examples=site.data.tips.types %}


### PR DESCRIPTION
As promised in #585 here is a list of 104 examples about:
* Converting from MSTest to Fluent Assertions.
* Rewriting assertions for clearer intentions and better failure messages.

Comments on the preface and the layout are very welcome.