### PR TITLE
Add HaveCount variants for generic collections

### DIFF
--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -95,6 +95,156 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
+        /// Asserts that the number of items in the collection does not match the supplied <paramref name="unexpected" /> amount.
+        /// </summary>
+        /// <param name="unexpected">The unexpected number of items in the collection.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs)
+        {
+            if (ReferenceEquals(Subject, null))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:collection} to not contain {0} item(s){reason}, but found <null>.", unexpected);
+            }
+
+            int actualCount = Subject.Count();
+
+            Execute.Assertion
+                .ForCondition(actualCount != unexpected)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:collection} to not contain {0} item(s){reason}, but found {1}.", unexpected, actualCount);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the number of items in the collection is greater than the supplied <paramref name="expected" /> amount.
+        /// </summary>
+        /// <param name="expected">The number to which the actual number items in the collection will be compared.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs)
+        {
+            if (ReferenceEquals(Subject, null))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:collection} to contain more than {0} item(s){reason}, but found <null>.", expected);
+            }
+
+            int actualCount = Subject.Count();
+
+            Execute.Assertion
+                .ForCondition(actualCount > expected)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:collection} to contain more than {0} item(s){reason}, but found {1}.", expected, actualCount);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the number of items in the collection is greater or equal to the supplied <paramref name="expected" /> amount.
+        /// </summary>
+        /// <param name="expected">The number to which the actual number items in the collection will be compared.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs)
+        {
+            if (ReferenceEquals(Subject, null))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:collection} to contain at least {0} item(s){reason}, but found <null>.", expected);
+            }
+
+            int actualCount = Subject.Count();
+
+            Execute.Assertion
+                .ForCondition(actualCount >= expected)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:collection} to contain at least {0} item(s){reason}, but found {1}.", expected, actualCount);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the number of items in the collection is less than the supplied <paramref name="expected" /> amount.
+        /// </summary>
+        /// <param name="expected">The number to which the actual number items in the collection will be compared.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs)
+        {
+            if (ReferenceEquals(Subject, null))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:collection} to contain fewer than {0} item(s){reason}, but found <null>.", expected);
+            }
+
+            int actualCount = Subject.Count();
+
+            Execute.Assertion
+                .ForCondition(actualCount < expected)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:collection} to contain fewer than {0} item(s){reason}, but found {1}.", expected, actualCount);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the number of items in the collection is less or equal to the supplied <paramref name="expected" /> amount.
+        /// </summary>
+        /// <param name="expected">The number to which the actual number items in the collection will be compared.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs)
+        {
+            if (ReferenceEquals(Subject, null))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:collection} to contain at most {0} item(s){reason}, but found <null>.", expected);
+            }
+
+            int actualCount = Subject.Count();
+
+            Execute.Assertion
+                .ForCondition(actualCount <= expected)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:collection} to contain at most {0} item(s){reason}, but found {1}.", expected, actualCount);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
         /// Expects the current collection to contain all the same elements in the same order as the collection identified by 
         /// <paramref name="elements" />. Elements are compared using their <see cref="T.Equals(T)" /> method.
         /// </summary>

--- a/Tests/Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/CollectionAssertionSpecs.cs
@@ -314,6 +314,302 @@ namespace FluentAssertions.Specs
         #region Not Have Count
 
         [Fact]
+        public void Should_succeed_when_asserting_collection_ofT_has_a_count_different_from_the_number_of_items()
+        {
+            var collection = new[] { 1, 2, 3 };
+            collection.Should().NotHaveCount(2);
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_collection_ofT_has_a_count_that_equals_the_number_of_items()
+        {
+            var collection = new[] { 1, 2, 3 };
+            Action act = () => collection.Should().NotHaveCount(3);
+
+            act.ShouldThrow<XunitException>();
+        }
+
+        [Fact]
+        public void When_collection_ofT_has_a_count_that_equals_than_the_number_of_items_it_should_fail_with_descriptive_message_()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new[] { 1, 2, 3 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => collection.Should().NotHaveCount(3, "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.ShouldThrow<XunitException>()
+                .WithMessage("*not contain*3*because we want to test the failure message*3*");
+        }
+
+        [Fact]
+        public void When_collection_ofT_count_is_same_than_and_collection_ofT_is_null_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<string> collection = null;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().NotHaveCount(1, "we want to test the behaviour with a null subject");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage("*not contain*1*we want to test the behaviour with a null subject*found <null>*");
+        }
+
+        #endregion
+
+        #region Have Count Greater Than
+
+        [Fact]
+        public void Should_succeed_when_asserting_collection_ofT_has_a_count_greater_than_less_the_number_of_items()
+        {
+            var collection = new[] { 1, 2, 3 };
+            collection.Should().HaveCountGreaterThan(2);
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_collection_ofT_has_a_count_greater_than_the_number_of_items()
+        {
+            var collection = new[] { 1, 2, 3 };
+            Action act = () => collection.Should().HaveCountGreaterThan(3);
+
+            act.ShouldThrow<XunitException>();
+        }
+
+        [Fact]
+        public void When_collection_ofT_has_a_count_greater_than_the_number_of_items_it_should_fail_with_descriptive_message_()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new[] { 1, 2, 3 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => collection.Should().HaveCountGreaterThan(3, "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.ShouldThrow<XunitException>()
+                .WithMessage("*more than*3*because we want to test the failure message*3*");
+        }
+
+        [Fact]
+        public void When_collection_ofT_count_is_greater_than_and_collection_ofT_is_null_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<string> collection = null;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().HaveCountGreaterThan(1, "we want to test the behaviour with a null subject");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage("*more than*1*we want to test the behaviour with a null subject*found <null>*");
+        }
+
+        #endregion
+
+        #region Have Count Greater Or Equal To
+
+        [Fact]
+        public void Should_succeed_when_asserting_collection_ofT_has_a_count_greater_or_equal_to_less_the_number_of_items()
+        {
+            var collection = new[] { 1, 2, 3 };
+            collection.Should().HaveCountGreaterOrEqualTo(3);
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_collection_ofT_has_a_count_greater_or_equal_to_the_number_of_items()
+        {
+            var collection = new[] { 1, 2, 3 };
+            Action act = () => collection.Should().HaveCountGreaterOrEqualTo(4);
+
+            act.ShouldThrow<XunitException>();
+        }
+
+        [Fact]
+        public void When_collection_ofT_has_a_count_greater_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new[] { 1, 2, 3 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => collection.Should().HaveCountGreaterOrEqualTo(4, "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.ShouldThrow<XunitException>()
+                .WithMessage("*at least*4*because we want to test the failure message*3*");
+        }
+
+        [Fact]
+        public void When_collection_ofT_count_is_greater_or_equal_to_and_collection_ofT_is_null_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<string> collection = null;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().HaveCountGreaterOrEqualTo(1, "we want to test the behaviour with a null subject");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage("*at least*1*we want to test the behaviour with a null subject*found <null>*");
+        }
+
+        #endregion
+
+        #region Have Count Less Than
+
+        [Fact]
+        public void Should_succeed_when_asserting_collection_ofT_has_a_count_less_than_less_the_number_of_items()
+        {
+            var collection = new[] { 1, 2, 3 };
+            collection.Should().HaveCountLessThan(4);
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_collection_ofT_has_a_count_less_than_the_number_of_items()
+        {
+            var collection = new[] { 1, 2, 3 };
+            Action act = () => collection.Should().HaveCountLessThan(3);
+
+            act.ShouldThrow<XunitException>();
+        }
+
+        [Fact]
+        public void When_collection_ofT_has_a_count_less_than_the_number_of_items_it_should_fail_with_descriptive_message_()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new[] { 1, 2, 3 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => collection.Should().HaveCountLessThan(3, "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.ShouldThrow<XunitException>()
+                .WithMessage("*fewer than*3*because we want to test the failure message*3*");
+        }
+
+        [Fact]
+        public void When_collection_ofT_count_is_less_than_and_collection_ofT_is_null_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<string> collection = null;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().HaveCountLessThan(1, "we want to test the behaviour with a null subject");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage("*fewer than*1*we want to test the behaviour with a null subject*found <null>*");
+        }
+
+        #endregion
+
+        #region Have Count Less Or Equal To
+
+        [Fact]
+        public void Should_succeed_when_asserting_collection_ofT_has_a_count_less_or_equal_to_less_the_number_of_items()
+        {
+            var collection = new[] { 1, 2, 3 };
+            collection.Should().HaveCountLessOrEqualTo(3);
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_collection_ofT_has_a_count_less_or_equal_to_the_number_of_items()
+        {
+            var collection = new[] { 1, 2, 3 };
+            Action act = () => collection.Should().HaveCountLessOrEqualTo(2);
+
+            act.ShouldThrow<XunitException>();
+        }
+
+        [Fact]
+        public void When_collection_ofT_has_a_count_less_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new[] { 1, 2, 3 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => collection.Should().HaveCountLessOrEqualTo(2, "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.ShouldThrow<XunitException>()
+                .WithMessage("*at most*2*because we want to test the failure message*3*");
+        }
+
+        [Fact]
+        public void When_collection_ofT_count_is_less_or_equal_to_and_collection_ofT_is_null_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable<string> collection = null;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().HaveCountLessOrEqualTo(1, "we want to test the behaviour with a null subject");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldThrow<XunitException>().WithMessage("*at most*1*we want to test the behaviour with a null subject*found <null>*");
+        }
+
+        #endregion
+
+
+        #region Not Have Count
+
+        [Fact]
         public void Should_succeed_when_asserting_collection_has_a_count_different_from_the_number_of_items()
         {
             IEnumerable collection = new[] { 1, 2, 3 };


### PR DESCRIPTION
I forgot to include the `HaveCount` overloads for generic collections.


* [ ] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [x] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/)/.
* [X] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).
