### PR TITLE
check nuget.exe version

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -89,7 +89,8 @@ if(!$PSScriptRoot){
 $TOOLS_DIR = Join-Path $PSScriptRoot "Build"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
 $CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
-$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/v4.3.0/nuget.exe"
+$NUGET_VERSION = "4.3.0"
+$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/v$($NUGET_VERSION)/nuget.exe"
 $PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
 $PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
 
@@ -139,7 +140,7 @@ if (!(Test-Path $PACKAGES_CONFIG)) {
 #}
 
 # Try download NuGet.exe if not exists
-if (!(Test-Path $NUGET_EXE)) {
+if (!(Test-Path $NUGET_EXE) -Or (Get-Item $NUGET_EXE).VersionInfo.ProductVersion -ne $NUGET_VERSION) {
     Write-Verbose -Message "Downloading NuGet.exe..."
     try {
         (New-Object System.Net.WebClient).DownloadFile($NUGET_URL, $NUGET_EXE)


### PR DESCRIPTION
Checks that the version of `nuget.exe` matches the expected version.

Will save me late hours the next time I swear about FA not building when:
* Having run `build.ps1` earlier and therefore having a `Build\nuget.exe`.
* The required version of `nuget.exe` is updated in `buid.ps1`
* does not work running `build.ps1` again 
* works in Visual Studio
