### PR TITLE
string.ContainAllOf and string.ContainAnyOf

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,11 @@
 Contributing to Fluent Assertions
 -----------
 
-No open-source projection is going to be successfull without contributions. After we decided to move to Github, the involvement of the .NET community has increased significantly. However, contributing to this project involves a few steps that will seriously increase the change we will accept it.
+No open-source projection is going to be successful without contributions. After we decided to move to Github, the involvement of the .NET community has increased significantly. However, contributing to this project involves a few steps that will seriously increase the chance we will accept it.
 
-* The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
-* The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://csharpguidelines.codeplex.com/)/. 
+* The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `develop` branch.
+* The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://csharpguidelines.codeplex.com/)/.
 * The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33). 
 * If the contribution affects the documentation, please update [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md), which is published on the [website](http://fluentassertions.com/documentation.html).
+
+**PLEASE NOTE:** FluentAssertions is currently under going some significant refactoring for version 5 so major/significant PRs may not be accepted. Sorry for any inconvenience.

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -669,6 +669,93 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
+        /// Asserts that a string contains all values present in <paramref name="values"/>.
+        /// </summary>
+        /// <param name="values">
+        /// The values that should all be present in the string
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<StringAssertions> ContainAll(IEnumerable<string> values, string because = "", params object[] becauseArgs)
+        {
+            ThrowIfValuesNullOrEmpty(values);
+
+            var missing = values.Where(v => !Contains(Subject, v, StringComparison.Ordinal)).ToArray();
+            Execute.Assertion
+                .ForCondition(values.All(v => Contains(Subject, v, StringComparison.Ordinal)))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:string} {0} to contain the strings: {1}{reason}.", Subject, missing);
+
+            return new AndConstraint<StringAssertions>(this);
+        }
+
+        /// <summary>
+        /// Asserts that a string contains all values present in <paramref name="values"/>.
+        /// </summary>
+        /// <param name="values">
+        /// The values that should not be present in the string
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<StringAssertions> ContainAll(params string[] values)
+        {
+            return ContainAll(values, because: string.Empty);
+        }
+		
+		/// <summary>
+        /// Asserts that a string contains at least one value present in <paramref name="values"/>,.
+        /// </summary>
+        /// <param name="values">
+        /// The values that should will be tested against the string
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<StringAssertions> ContainAny(IEnumerable<string> values, string because = "", params object[] becauseArgs)
+        {
+            ThrowIfValuesNullOrEmpty(values);
+
+            Execute.Assertion
+                .ForCondition(values.Any(v => Contains(Subject, v, StringComparison.Ordinal)))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:string} {0} to contain at least one of the strings: {1}{reason}.", Subject, values.ToArray());
+
+            return new AndConstraint<StringAssertions>(this);
+        }
+
+        /// <summary>
+        /// Asserts that a string contains at least one value present in <paramref name="values"/>,.
+        /// </summary>
+        /// <param name="values">
+        /// The values that should will be tested against the string
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<StringAssertions> ContainAny(params string[] values)
+        {
+            return ContainAny(values, because: string.Empty);
+        }
+
+        /// <summary>
         /// Asserts that a string does not contain another (fragment of a) string.
         /// </summary>
         /// <param name="expected">

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -751,6 +751,52 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
+        /// Asserts that a string does not contain any of the strings provided in <paramref name="values"/>.
+        /// </summary>
+        /// <param name="values">
+        /// The values that should not be present in the string
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<StringAssertions> NotContainAny(IEnumerable<string> values, string because = "",
+            params object[] becauseArgs)
+        {
+            ThrowIfValuesNullOrEmpty(values);
+
+            var matches = values.Where(v => Contains(Subject, v, StringComparison.Ordinal));
+
+            Execute.Assertion
+                .ForCondition(!matches.Any())
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Did not expect the {context:string} {0} to contain any of the strings: {1}{reason}.", Subject, matches);
+
+            return new AndConstraint<StringAssertions>(this);
+        }
+
+        /// <summary>
+        /// Asserts that a string does not contain any of the strings provided in <paramref name="values"/>.
+        /// </summary>
+        /// <param name="values">
+        /// The values that should not be present in the string
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<StringAssertions> NotContainAny(params string[] values)
+        {
+            return NotContainAny(values, because: string.Empty);
+        }
+
+        /// <summary>
         /// Asserts that a string does not contain the specified <paramref name="unexpected"/> string,
         /// including any leading or trailing whitespace, with the exception of the casing.
         /// </summary>

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -703,6 +703,54 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
+        /// Asserts that a string does not contain all of the strings provided in <paramref name="values"/>. The string
+        /// may contain some subset of the provided values.
+        /// </summary>
+        /// <param name="values">
+        /// The values that should not be present in the string
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<StringAssertions> NotContainAll(IEnumerable<string> values, string because = "",
+            params object[] becauseArgs)
+        {
+            ThrowIfValuesNullOrEmpty(values);
+
+            var matches = values.Where(v => Contains(Subject, v, StringComparison.Ordinal));
+
+            Execute.Assertion
+                .ForCondition(matches.Count() != values.Count())
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Did not expect the {context:string} {0} to contain all of the strings: {1}{reason}.", Subject, values);
+
+            return new AndConstraint<StringAssertions>(this);
+        }
+
+        /// <summary>
+        /// Asserts that a string does not contain all of the strings provided in <paramref name="values"/>. The string
+        /// may contain some subset of the provided values.
+        /// </summary>
+        /// <param name="values">
+        /// The values that should not be present in the string
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<StringAssertions> NotContainAll(params string[] values)
+        {
+            return NotContainAll(values, because: string.Empty);
+        }
+
+        /// <summary>
         /// Asserts that a string does not contain the specified <paramref name="unexpected"/> string,
         /// including any leading or trailing whitespace, with the exception of the casing.
         /// </summary>
@@ -875,6 +923,19 @@ namespace FluentAssertions.Primitives
         private static bool IsBlank(string value)
         {
             return (value == null) || string.IsNullOrEmpty(value.Trim());
+        }
+
+        private static void ThrowIfValuesNullOrEmpty(IEnumerable<string> values)
+        {
+            if (values == null)
+            {
+                throw new ArgumentException("Cannot assert string containment of values in null collection");
+            }
+
+            if (!values.Any())
+            {
+                throw new ArgumentException("Cannot assert string containment of values in empty collection");
+            }
         }
 
         /// <summary>

--- a/Tests/Shared.Specs/StringAssertionSpecs.cs
+++ b/Tests/Shared.Specs/StringAssertionSpecs.cs
@@ -1995,6 +1995,164 @@ namespace FluentAssertions.Specs
 
         #endregion
 
+        #region NotContainAny
+        [Fact]
+        public void When_exclusion_of_any_string_in_null_collection_is_asserted_it_should_throw_an_argument_exception()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => "a".Should().NotContainAny(null);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<ArgumentException>()
+                .WithMessage(_nullCollectionMessagePattern);
+        }
+
+        [Fact]
+        public void When_exclusion_of_any_string_in_an_empty_collection_is_asserted_it_should_throw_an_argument_exception()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => "a".Should().NotContainAny();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<ArgumentException>()
+                .WithMessage(_emptyCollectionMessagePattern);
+        }
+
+        [Fact]
+        public void When_exclusion_of_any_string_in_a_collection_is_asserted_and_all_of_the_strings_are_present_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string red = "red";
+            const string green = "green";
+            const string yellow = "yellow";
+            var testString = $"{red} {green} {yellow}";
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().NotContainAny(red, green, yellow);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<XunitException>()
+                .WithMessage($"*not*{testString}*contain any*{red}*{green}*{yellow}*");
+        }
+
+        [Fact]
+        public void When_exclusion_of_any_string_in_a_collection_is_asserted_and_only_some_of_the_strings_are_present_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string red = "red";
+            const string green = "green";
+            const string yellow = "yellow";
+            const string purple = "purple";
+            var testString = $"{red} {green} {yellow}";
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().NotContainAny(red, purple, green);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<XunitException>()
+                .WithMessage($"*not*{testString}*contain any*{red}*{green}*");
+        }
+
+        [Fact]
+        public void When_exclusion_of_any_strings_is_asserted_with_reason_and_assertion_fails_then_error_message_contains_reason()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string red = "red";
+            const string green = "green";
+            const string yellow = "yellow";
+            var testString = $"{red} {green} {yellow}";
+
+            const string because = "some {0} reason";
+            var becauseArgs = new[] { "special" };
+            var expectedErrorReason = string.Format(because, becauseArgs);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().NotContainAny(new[] { red }, because, becauseArgs);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<XunitException>()
+                .WithMessage($"*not*{testString}*contain any*{red}*because*{expectedErrorReason}*");
+        }
+
+        [Fact]
+        public void When_exclusion_of_any_string_in_a_collection_is_asserted_and_there_are_equivalent_but_not_exact_matches_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string redLowerCase = "red";
+            const string redUpperCase = "RED";
+            const string greenWithoutWhitespace = "green";
+            const string greenWithWhitespace = " green  ";
+            var testString = $"{redLowerCase} {greenWithoutWhitespace}";
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().NotContainAny(redUpperCase, greenWithWhitespace);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_exclusion_of_any_string_in_a_collection_is_asserted_and_none_of_the_strings_are_present_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string red = "red";
+            const string green = "green";
+            const string yellow = "yellow";
+            const string purple = "purple";
+            var testString = $"{red} {green}";
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().NotContainAny(yellow, purple);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        #endregion 
+
         #region Not Contain Equivalent Of
 
         [Fact]

--- a/Tests/Shared.Specs/StringAssertionSpecs.cs
+++ b/Tests/Shared.Specs/StringAssertionSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Xunit;
 using Xunit.Sdk;
 
@@ -1769,6 +1770,327 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.ShouldThrow<XunitException>().WithMessage(
                 "Expected string to be equivalent to \"abc\" because I say so, but it has unexpected whitespace at the end.");
+        }
+
+        #endregion
+
+        #region ContainAll
+
+        [Fact]
+        public void When_containment_of_all_strings_in_a_null_collection_is_asserted_it_should_throw_an_argument_exception()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => "a".Should().ContainAll(null);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<ArgumentException>()
+                .WithMessage(_nullCollectionMessagePattern);
+        }
+
+        [Fact]
+        public void When_containment_of_all_strings_in_an_empty_collection_is_asserted_it_should_throw_an_argument_exception()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => "a".Should().ContainAll();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<ArgumentException>()
+                .WithMessage(_emptyCollectionMessagePattern);
+        }
+
+        [Fact]
+        public void When_containment_of_all_strings_in_a_collection_is_asserted_and_all_strings_are_present_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string red = "red";
+            const string green = "green";
+            const string yellow = "yellow";
+            var testString = $"{red} {green} {yellow}";
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().ContainAll(red, green, yellow);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_containment_of_all_strings_in_a_collection_is_asserted_and_equivalent_but_not_exact_matches_exist_for_all_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string redLowerCase = "red";
+            const string redUpperCase = "RED";
+            const string greenWithoutWhitespace = "green";
+            const string greenWithWhitespace = "  green ";
+            var testString = $"{redLowerCase} {greenWithoutWhitespace}";
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().ContainAll(redUpperCase, greenWithWhitespace);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<XunitException>()
+                .WithMessage($"*{testString}*contain*{redUpperCase}*{greenWithWhitespace}*");
+        }
+
+        [Fact]
+        public void When_containment_of_all_strings_in_a_collection_is_asserted_and_none_of_the_strings_are_present_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string red = "red";
+            const string green = "green";
+            const string yellow = "yellow";
+            const string blue = "yellow";
+            var testString = $"{red} {green}";
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().ContainAll(yellow, blue);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<XunitException>()
+                .WithMessage($"*{testString}*contain*{yellow}*{blue}*");
+        }
+
+        [Fact]
+        public void When_containment_of_all_strings_in_a_collection_is_asserted_with_reason_and_assertion_failes_then_failure_message_should_contain_reason()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string red = "red";
+            const string green = "green";
+            const string yellow = "yellow";
+            const string blue = "yellow";
+            var testString = $"{red} {green}";
+
+            const string because = "some {0} reason";
+            var becauseArgs = new[] { "special" };
+            var expectedErrorReason = string.Format(because, becauseArgs);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().ContainAll(new[] { yellow, blue }, because, becauseArgs);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<XunitException>()
+                .WithMessage($"*{testString}*contain*{yellow}*{blue}*because {expectedErrorReason}*");
+        }
+
+        [Fact]
+        public void When_containment_of_all_strings_in_a_collection_is_asserted_and_only_some_of_the_strings_are_present_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string red = "red";
+            const string green = "green";
+            const string yellow = "yellow";
+            const string blue = "blue";
+            var testString = $"{red} {green} {yellow}";
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().ContainAll(red, blue, green);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<XunitException>()
+                .WithMessage($"*{testString}*contain*{blue}*");
+        }
+
+        #endregion
+
+        #region ContainAny
+
+        [Fact]
+        public void When_containment_of_any_string_in_a_null_collection_is_asserted_it_should_throw_an_argument_exception()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => "a".Should().ContainAny(null);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<ArgumentException>()
+                .WithMessage(_nullCollectionMessagePattern);
+        }
+
+        [Fact]
+        public void When_containment_of_any_string_in_an_empty_collection_is_asserted_it_should_throw_an_argument_exception()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => "a".Should().ContainAny();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<ArgumentException>()
+                .WithMessage(_emptyCollectionMessagePattern);
+        }
+
+        [Fact]
+        public void When_containment_of_any_string_in_a_collection_is_asserted_and_all_of_the_strings_are_present_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string red = "red";
+            const string green = "green";
+            const string yellow = "yellow";
+            var testString = $"{red} {green} {yellow}";
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().ContainAny(red, green, yellow);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_containment_of_any_string_in_a_collection_is_asserted_and_only_some_of_the_strings_are_present_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string red = "red";
+            const string green = "green";
+            const string blue = "blue";
+            var testString = $"{red} {green}";
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().ContainAny(red, blue, green);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_containment_of_any_string_in_a_collection_is_asserted_and_none_of_the_strings_are_present_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string red = "red";
+            const string green = "green";
+            const string blue = "blue";
+            const string purple = "purple";
+            var testString = $"{red} {green}";
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().ContainAny(blue, purple);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<XunitException>()
+                .WithMessage($"*{testString}*contain at least one of*{blue}*{purple}*");
+        }
+
+        [Fact]
+        public void When_containment_of_any_string_in_a_collection_is_asserted_and_there_are_equivalent_but_not_exatch_matches_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string redLowerCase = "red";
+            const string redUpperCase = "RED";
+            const string greenWithoutWhitespace = "green";
+            const string greenWithWhitespace = "   green";
+            var testString = $"{redLowerCase} {greenWithoutWhitespace}";
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().ContainAny(redUpperCase, greenWithWhitespace);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<XunitException>()
+                .WithMessage($"*{testString}*contain at least one of*{redUpperCase}*{greenWithWhitespace}*");
+        }
+
+        [Fact]
+        public void When_containment_of_any_string_in_a_collection_is_asserted_with_reason_and_assertion_fails_then_failure_message_contains_reason()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string red = "red";
+            const string green = "green";
+            const string blue = "blue";
+            const string purple = "purple";
+            var testString = $"{red} {green}";
+
+            const string because = "some {0} reason";
+            var becauseArgs = new[] { "special" };
+            var expectedErrorReason = string.Format(because, becauseArgs);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().ContainAny(new[] { blue, purple }, because, becauseArgs);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<XunitException>()
+                .WithMessage($"*{testString}*contain at least one of*{blue}*{purple}*because {expectedErrorReason}*");
         }
 
         #endregion

--- a/Tests/Shared.Specs/StringAssertionSpecs.cs
+++ b/Tests/Shared.Specs/StringAssertionSpecs.cs
@@ -1838,6 +1838,163 @@ namespace FluentAssertions.Specs
 
         #endregion
 
+        #region NotContainAll
+
+        [Fact]
+        public void When_exclusion_of_all_strings_in_null_collection_is_asserted_it_should_throw_an_argument_exception()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => "a".Should().NotContainAll(null);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<ArgumentException>()
+                .WithMessage(_nullCollectionMessagePattern);
+        }
+
+        [Fact]
+        public void When_exclusion_of_all_strings_in_an_empty_collection_is_asserted_it_should_throw_an_argument_exception()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => "a".Should().NotContainAll();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<ArgumentException>()
+                .WithMessage(_emptyCollectionMessagePattern);
+        }
+
+        [Fact]
+        public void When_exclusion_of_all_strings_in_a_collection_is_asserted_and_all_strings_in_collection_are_present_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string red = "red";
+            const string green = "green";
+            const string yellow = "yellow";
+            var testString = $"{red} {green} {yellow}";
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().NotContainAll(red, green, yellow);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<XunitException>()
+                .WithMessage($"*not*{testString}*contain all*{red}*{green}*{yellow}*");
+        }
+
+        [Fact]
+        public void When_exclusion_of_all_strings_is_asserted_with_reason_and_assertion_fails_then_error_message_contains_reason()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string red = "red";
+            const string green = "green";
+            const string yellow = "yellow";
+            var testString = $"{red} {green} {yellow}";
+
+            const string because = "some {0} reason";
+            var becauseArgs = new[] { "special" };
+            var expectedErrorReason = string.Format(because, becauseArgs);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().NotContainAll(new []{red, green, yellow}, because, becauseArgs);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .ShouldThrow<XunitException>()
+                .WithMessage($"*not*{testString}*contain all*{red}*{green}*{yellow}*because*{expectedErrorReason}*");
+        }
+
+        [Fact]
+        public void When_exclusion_of_all_strings_in_a_collection_is_asserted_and_only_some_of_the_strings_in_collection_are_present_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string red = "red";
+            const string green = "green";
+            const string yellow = "yellow";
+            const string purple = "purple";
+            var testString = $"{red} {green} {yellow}";
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().NotContainAll(red, green, yellow, purple);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_exclusion_of_all_strings_in_a_collection_is_asserted_and_none_of_the_strings_in_the_collection_are_present_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string red = "red";
+            const string green = "green";
+            const string yellow = "yellow";
+            const string purple = "purple";
+            var testString = $"{red} {green}";
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().NotContainAll(yellow, purple);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        [Fact]
+        public void When_exclusion_of_all_strings_in_a_collection_is_asserted_and_equivalent_but_not_exact_strings_are_present_in_collection_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const string redWithoutWhitespace = "red";
+            const string redWithWhitespace = "  red ";
+            const string lowerCaseGreen = "green";
+            const string upperCaseGreen = "GREEN";
+            var testString = $"{redWithoutWhitespace} {lowerCaseGreen}";
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => testString.Should().NotContainAll(redWithWhitespace, upperCaseGreen);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.ShouldNotThrow();
+        }
+
+        #endregion
+
         #region Not Contain Equivalent Of
 
         [Fact]
@@ -2262,5 +2419,14 @@ namespace FluentAssertions.Specs
         }
 
         #endregion
+
+        private static string WrapMessageWithPunctuation(string msg, string because)
+        {
+            var ending = string.IsNullOrEmpty(because) ? "." : string.Format(" because {0}.", because);
+            return msg + ending;
+        }
+
+        private const string _nullCollectionMessagePattern = "Cannot*containment*null*";
+        private const string _emptyCollectionMessagePattern = "Cannot*containment*empty*";
     }
 }

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -161,6 +161,7 @@ theString.Should().BeEquivalentTo("THIS IS A STRING");
 
 theString.Should().Contain("is a");
 theString.Should().NotContain("is a");
+theString.Should().NotContainAll("can", "contain", "some", "but", "not", "all");
 theString.Should().ContainEquivalentOf("WE DONT CARE ABOUT THE CASING");
 theString.Should().NotContainEquivalentOf("HeRe ThE CaSiNg Is IgNoReD As WeLl");
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -162,6 +162,7 @@ theString.Should().BeEquivalentTo("THIS IS A STRING");
 theString.Should().Contain("is a");
 theString.Should().NotContain("is a");
 theString.Should().NotContainAll("can", "contain", "some", "but", "not", "all");
+theString.Should().NotContainAny("can't", "contain", "any", "of", "these");
 theString.Should().ContainEquivalentOf("WE DONT CARE ABOUT THE CASING");
 theString.Should().NotContainEquivalentOf("HeRe ThE CaSiNg Is IgNoReD As WeLl");
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -160,6 +160,8 @@ theString.Should().NotBe("This is another String");
 theString.Should().BeEquivalentTo("THIS IS A STRING");
 
 theString.Should().Contain("is a");
+theString.Should().ContainAll("should", "contain", "all", "of", "these");
+theString.Should().ContainAny("any", "of", "these", "will", "do");
 theString.Should().NotContain("is a");
 theString.Should().NotContainAll("can", "contain", "some", "but", "not", "all");
 theString.Should().NotContainAny("can't", "contain", "any", "of", "these");


### PR DESCRIPTION
One thing I always find myself doing is asserting the contents of a string multiple times. Usually I am wanting to assert that something like a log message contains some important information in no particular order (so as to not have an overly rigid test). For example:

```csharp
logMsg.Should().Contain(customerNumber);
logMsg.Should().Contain("success");
logMsg.Should().Contain(timestamp);
```
I thought it might be nice if I could write this instead:

```csharp
logMsg.Should().ContainAllOf(new []{ customerNumber, "success", timestamp"});
```
I also thought a similar `ContainAnyOf` could be useful, so I added it while I was there.

I updated the CONTRIBUTING.MD document as well, adding the disclaimer about the v 5 rework and suggesting PRs be targeted at develop (it said master before).