### PR TITLE
net451 tests are not discovered

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -72,7 +72,7 @@ Task("Build")
 Task("Run-Unit-Tests")
     .Does(() =>
 {
-    XUnit2("./Tests/Net45.Specs/**/bin/" + configuration + "/*.Specs.dll", new XUnit2Settings { });
+    XUnit2("./Tests/Net45.Specs/**/bin/" + configuration + "/**/*.Specs.dll", new XUnit2Settings { });
 
     DotNetCoreTool("./Tests/NetCore.Specs/NetCore.Specs.csproj", "xunit", "-configuration " + configuration);
 


### PR DESCRIPTION
When running `build.ps1` net451 tests are not discovered due to a typo in the path pattern.