### PR TITLE
Constrain TAttribute to Attribute

### DIFF
--- a/Src/FluentAssertions/TypeEnumerableExtensions.cs
+++ b/Src/FluentAssertions/TypeEnumerableExtensions.cs
@@ -14,6 +14,7 @@ namespace FluentAssertions
         /// Filters to only include types decorated with a particular attribute.
         /// </summary>
         public static IEnumerable<Type> ThatAreDecoratedWith<TAttribute>(this IEnumerable<Type> types)
+            where TAttribute : Attribute
         {
             return new TypeSelector(types).ThatAreDecoratedWith<TAttribute>();
         }
@@ -22,6 +23,7 @@ namespace FluentAssertions
         /// Filters to only include types not decorated with a particular attribute.
         /// </summary>
         public static IEnumerable<Type> ThatAreNotDecoratedWith<TAttribute>(this IEnumerable<Type> types)
+            where TAttribute : Attribute
         {
             return new TypeSelector(types).ThatAreNotDecoratedWith<TAttribute>();
         }

--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -91,6 +91,7 @@ namespace FluentAssertions.Types
         /// Only select the methods that are decorated with an attribute of the specified type.
         /// </summary>
         public MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : Attribute
         {
             selectedMethods = selectedMethods.Where(method => method.GetCustomAttributes(false).OfType<TAttribute>().Any());
             return this;
@@ -100,6 +101,7 @@ namespace FluentAssertions.Types
         /// Only select the methods that are not decorated with an attribute of the specified type.
         /// </summary>
         public MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : Attribute
         {
             selectedMethods = selectedMethods.Where(method => !method.GetCustomAttributes(false).OfType<TAttribute>().Any());
             return this;

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -53,6 +53,7 @@ namespace FluentAssertions.Types
         /// Only select the properties that are decorated with an attribute of the specified type.
         /// </summary>
         public PropertyInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : Attribute
         {
             selectedProperties = selectedProperties.Where(property => property.GetCustomAttributes(false).OfType<TAttribute>().Any());
             return this;
@@ -62,6 +63,7 @@ namespace FluentAssertions.Types
         /// Only select the properties that are not decorated with an attribute of the specified type.
         /// </summary>
         public PropertyInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : Attribute
         {
             selectedProperties = selectedProperties.Where(property => !property.GetCustomAttributes(false).OfType<TAttribute>().Any());
             return this;

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -72,6 +72,7 @@ namespace FluentAssertions.Types
         /// Determines whether a type is decorated with a particular attribute.
         /// </summary>
         public TypeSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : Attribute
         {
             types = types
 
@@ -85,6 +86,7 @@ namespace FluentAssertions.Types
         /// Determines whether a type is not decorated with a particular attribute.
         /// </summary>
         public TypeSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : Attribute
         {
             types = types
 


### PR DESCRIPTION
Asserting that a type is (not) decorated with something that isn't an attribute is most likely a wrong assertion.
Let us help preventing wrong assertions by constraining `TAttribute` to `Attribute`