### PR TITLE
Remove reference to non-existing file

### DIFF
--- a/Tests/NetCore20.Specs/NetCore20.Specs.csproj
+++ b/Tests/NetCore20.Specs/NetCore20.Specs.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>FluentAssertions.NetCore20.Specs</AssemblyName>
     <RootNamespace>FluentAssertions.NetCore20.Specs</RootNamespace>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.1" />


### PR DESCRIPTION
MSBuild complains that it cannot find the `AllRules.ruleset` for code analysis.
This aligns the project file for NetCore20 with NetCore