### PR TITLE
Align ExecutionTime[Of] with v5 API

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -53,9 +53,9 @@ namespace FluentAssertions
         /// Returns an object for asserting that the execution time matches certain conditions.
         /// </returns>
         [MustUseReturnValue /* do not use Pure because this method executes the action before returning to the caller */]
-        public static MemberExecutionTimeAssertions<T> ExecutionTimeOf<T>(this T subject, Expression<Action<T>> action)
+        public static MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, Expression<Action<T>> action)
         {
-            return new MemberExecutionTimeAssertions<T>(subject, action);
+            return new MemberExecutionTime<T>(subject, action);
         }
 
         /// <summary>
@@ -66,11 +66,20 @@ namespace FluentAssertions
         /// Returns an object for asserting that the execution time matches certain conditions.
         /// </returns>
         [MustUseReturnValue /* do not use Pure because this method executes the action before returning to the caller */]
-        public static ExecutionTimeAssertions ExecutionTime(this Action action)
+        public static ExecutionTime ExecutionTime(this Action action)
         {
-            return new ExecutionTimeAssertions(action);
+            return new ExecutionTime(action);
         }
 
+        /// <summary>
+        /// Returns an <see cref="ExecutionTimeAssertions"/> object that can be used to assert the
+        /// current <see cref="ExecutionTime"/>.
+        /// </summary>
+        [Pure]
+        public static ExecutionTimeAssertions Should(this ExecutionTime executionTime)
+        {
+            return new ExecutionTimeAssertions(executionTime);
+        }
 
         /// <summary>
         /// Returns an <see cref="AssemblyAssertions"/> object that can be used to assert the

--- a/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
@@ -3,8 +3,6 @@ using System.Diagnostics;
 using System.Linq.Expressions;
 using FluentAssertions.Execution;
 
-
-
 namespace FluentAssertions.Specialized
 {
     /// <summary>
@@ -12,65 +10,175 @@ namespace FluentAssertions.Specialized
     /// </summary>
     public class ExecutionTimeAssertions
     {
-        private readonly TimeSpan executionTime;
+        private readonly TimeSpan executionTimeSpan;
+
+        private readonly string actionDescription;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ExecutionTimeAssertions"/> class.
+        /// Initializes a new instance of the <see cref="ExecutionTime"/> class.
         /// </summary>
-        /// <param name="action">The action of which the execution time must be asserted.</param>
-        public ExecutionTimeAssertions(Action action)
+        /// <param name="executionTime">The execution on which time must be asserted.</param>
+        public ExecutionTimeAssertions(ExecutionTime executionTime)
         {
-            ActionDescription = "the action";
-
-            var stopwatch = Stopwatch.StartNew();
-            action();
-            stopwatch.Stop();
-
-            executionTime = stopwatch.Elapsed;
+            executionTimeSpan = executionTime.ExecutionTimeSpan;
+            actionDescription = executionTime.ActionDescription;
         }
 
-        protected string ActionDescription { get; set; }
-
         /// <summary>
-        /// Asserts that the execution time of the operation does not exceed a specified amount of time.
+        /// Asserts that the execution time of the operation is less or equal to a specified amount of time.
         /// </summary>
         /// <param name="maxDuration">
         /// The maximum allowed duration.
         /// </param>
         /// <param name="because">
-        /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not 
+        /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public void ShouldNotExceed(TimeSpan maxDuration, string because = "", params object[] becauseArgs)
+        public void BeLessOrEqualTo(TimeSpan maxDuration, string because = "", params object[] becauseArgs)
         {
-            if (executionTime > maxDuration)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Execution of " + ActionDescription + " should not exceed {0}{reason}, but it required {1}",
-                        maxDuration, executionTime);
-            }
+            Execute.Assertion
+                .ForCondition(executionTimeSpan.CompareTo(maxDuration) <= 0)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Execution of " + actionDescription + " should be less or equal to {0}{reason}, but it required {1}",
+                    maxDuration, executionTimeSpan);
+        }
+
+        /// <summary>
+        /// Asserts that the execution time of the operation is less than a specified amount of time.
+        /// </summary>
+        /// <param name="maxDuration">
+        /// The maximum allowed duration.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not
+        /// start with the word <i>because</i>, it is prepended to the message.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
+        /// </param>
+        public void BeLessThan(TimeSpan maxDuration, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(executionTimeSpan.CompareTo(maxDuration) < 0)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Execution of " + actionDescription + " should be less than {0}{reason}, but it required {1}",
+                    maxDuration, executionTimeSpan);
+        }
+
+        /// <summary>
+        /// Asserts that the execution time of the operation is greater or equal to a specified amount of time.
+        /// </summary>
+        /// <param name="minDuration">
+        /// The minimum allowed duration.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not
+        /// start with the word <i>because</i>, it is prepended to the message.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
+        /// </param>
+        public void BeGreaterOrEqualTo(TimeSpan minDuration, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(executionTimeSpan.CompareTo(minDuration) >= 0)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Execution of " + actionDescription + " should be greater or equal to {0}{reason}, but it required {1}",
+                    minDuration, executionTimeSpan);
+        }
+
+        /// <summary>
+        /// Asserts that the execution time of the operation is greater than a specified amount of time.
+        /// </summary>
+        /// <param name="minDuration">
+        /// The minimum allowed duration.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not
+        /// start with the word <i>because</i>, it is prepended to the message.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
+        /// </param>
+        public void BeGreaterThan(TimeSpan minDuration, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(executionTimeSpan.CompareTo(minDuration) > 0)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Execution of " + actionDescription + " should be greater than {0}{reason}, but it required {1}",
+                    minDuration, executionTimeSpan);
+        }
+
+        /// <summary>
+        /// Asserts that the execution time of the operation is within the expected duration.
+        /// by a specified precision.
+        /// </summary>
+        /// <param name="expectedDuration">
+        /// The expected duration.
+        /// </param>
+        /// <param name="precision">
+        /// The maximum amount of time which the execution time may differ from the expected duration.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not
+        /// start with the word <i>because</i>, it is prepended to the message.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
+        /// </param>
+        public void BeCloseTo(TimeSpan expectedDuration, TimeSpan precision, string because = "", params object[] becauseArgs)
+        {
+            var minimumValue = expectedDuration - precision;
+            var maximumValue = expectedDuration + precision;
+
+            Execute.Assertion
+                .ForCondition((executionTimeSpan >= minimumValue) && (executionTimeSpan <= maximumValue))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Execution of " + actionDescription + " should be within {0} from {1}{reason}, but it required {2}",
+                    precision, expectedDuration, executionTimeSpan);
         }
     }
 
-    /// <summary>
-    /// Provides methods for asserting that the execution time of an object member satisfies certain conditions.
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    public class MemberExecutionTimeAssertions<T> : ExecutionTimeAssertions
+    public class ExecutionTime
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="MemberExecutionTimeAssertions&lt;T&gt;"/> class.
+        /// Initializes a new instance of the <see cref="ExecutionTime"/> class.
+        /// </summary>
+        /// <param name="action">The action of which the execution time must be asserted.</param>
+        public ExecutionTime(Action action)
+            : this(action, "the action")
+        {
+        }
+
+        protected ExecutionTime(Action action, string actionDescription)
+        {
+            ActionDescription = actionDescription;
+
+            var stopwatch = Stopwatch.StartNew();
+            action();
+            stopwatch.Stop();
+
+            ExecutionTimeSpan = stopwatch.Elapsed;
+        }
+
+        internal TimeSpan ExecutionTimeSpan { get; }
+
+        internal string ActionDescription { get; }
+    }
+
+    public class MemberExecutionTime<T> : ExecutionTime
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemberExecutionTime&lt;T&gt;"/> class.
         /// </summary>
         /// <param name="subject">The object that exposes the method or property.</param>
         /// <param name="action">A reference to the method or property to measure the execution time of.</param>
-        public MemberExecutionTimeAssertions(T subject, Expression<Action<T>> action) :
-            base(() => action.Compile()(subject))
+        public MemberExecutionTime(T subject, Expression<Action<T>> action) :
+            base(() => action.Compile()(subject), "(" + action.Body + ")")
         {
-            ActionDescription = "(" + action.Body + ")";
         }
     }
 }

--- a/Tests/Shared.Specs/ExecutionTimeAssertionsSpecs.cs
+++ b/Tests/Shared.Specs/ExecutionTimeAssertionsSpecs.cs
@@ -3,15 +3,13 @@ using System.Threading;
 using Xunit;
 using Xunit.Sdk;
 
-
-
 namespace FluentAssertions.Specs
 {
-    
     public class ExecutionTimeAssertionsSpecs
     {
+        #region BeLessOrEqualTo
         [Fact]
-        public void When_the_execution_time_of_a_member_exceeds_the_maximum_it_should_throw()
+        public void When_the_execution_time_of_a_member_is_not_less_or_equal_to_a_limit_it_should_throw()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -21,7 +19,8 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(610)).ShouldNotExceed(500.Milliseconds(), "we like speed");
+            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(610)).Should().BeLessOrEqualTo(500.Milliseconds(),
+                "we like speed");
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -29,11 +28,11 @@ namespace FluentAssertions.Specs
             act
                 .Should().Throw<XunitException>()
                 .And.Message.Should().Match(
-                    "Execution of (s.Sleep(610)) should not exceed 0.500s because we like speed, but it required*");
+                    "Execution of (s.Sleep(610)) should be less or equal to 0.500s because we like speed, but it required*");
         }
 
         [Fact]
-        public void When_the_execution_time_of_a_meber_stays_within_the_maximum_it_should_not_throw()
+        public void When_the_execution_time_of_a_member_is_less_or_equal_to_a_limit_it_should_not_throw()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -43,7 +42,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(0)).ShouldNotExceed(500.Milliseconds());
+            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(0)).Should().BeLessOrEqualTo(500.Milliseconds());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -52,7 +51,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_the_execution_time_of_an_action_exceeds_the_maximum_it_should_throw()
+        public void When_the_execution_time_of_an_action_is_not_less_or_equal_to_a_limit_it_should_throw()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -63,7 +62,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => someAction.ExecutionTime().ShouldNotExceed(100.Milliseconds());
+            Action act = () => someAction.ExecutionTime().Should().BeLessOrEqualTo(100.Milliseconds());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -71,11 +70,11 @@ namespace FluentAssertions.Specs
             act
                 .Should().Throw<XunitException>()
                 .And.Message.Should().StartWith(
-                    "Execution of the action should not exceed 0.100s, but it required");
+                    "Execution of the action should be less or equal to 0.100s, but it required");
         }
 
         [Fact]
-        public void When_the_execution_time_of_an_action_stays_within_the_limits_it_should_not_throw()
+        public void When_the_execution_time_of_an_action_is_less_or_equal_to_a_limit_it_should_not_throw()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -83,11 +82,54 @@ namespace FluentAssertions.Specs
 
             Action someAction = () => Thread.Sleep(100);
 
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => someAction.ExecutionTime().Should().BeLessOrEqualTo(1.Seconds());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
+        }
+        #endregion
+
+        #region BeLessThan
+        [Fact]
+        public void When_the_execution_time_of_a_member_is_not_less_than_a_limit_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new SleepingClass();
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => someAction.ExecutionTime().ShouldNotExceed(1.Seconds());
+            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(610)).Should().BeLessThan(500.Milliseconds(),
+                "we like speed");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .Should().Throw<XunitException>()
+                .And.Message.Should().Match(
+                    "Execution of (s.Sleep(610)) should be less than 0.500s because we like speed, but it required*");
+        }
+
+        [Fact]
+        public void When_the_execution_time_of_a_member_is_less_than_a_limit_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new SleepingClass();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(0)).Should().BeLessThan(500.Milliseconds());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -95,13 +137,318 @@ namespace FluentAssertions.Specs
             act.Should().NotThrow();
         }
 
+        [Fact]
+        public void When_the_execution_time_of_an_action_is_not_less_than_a_limit__it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+
+            Action someAction = () => Thread.Sleep(510);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => someAction.ExecutionTime().Should().BeLessThan(100.Milliseconds());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .Should().Throw<XunitException>()
+                .And.Message.Should().StartWith(
+                    "Execution of the action should be less than 0.100s, but it required");
+        }
+
+        [Fact]
+        public void When_the_execution_time_of_an_action_is_less_than_a_limit_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+
+            Action someAction = () => Thread.Sleep(100);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => someAction.ExecutionTime().Should().BeLessThan(1.Seconds());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
+        }
+        #endregion
+
+        #region BeGreaterOrEqualTo
+        [Fact]
+        public void When_the_execution_time_of_a_member_is_not_greater_or_equal_to_a_limit_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new SleepingClass();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(200)).Should().BeGreaterOrEqualTo(500.Milliseconds(),
+                "we like speed");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .Should().Throw<XunitException>()
+                .And.Message.Should().Match(
+                    "Execution of (s.Sleep(200)) should be greater or equal to 0.500s because we like speed, but it required*");
+        }
+
+        [Fact]
+        public void When_the_execution_time_of_a_member_is_greater_or_equal_to_a_limit_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new SleepingClass();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(100)).Should().BeGreaterOrEqualTo(50.Milliseconds());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_the_execution_time_of_an_action_is_not_greater_or_equal_to_a_limit_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+
+            Action someAction = () => Thread.Sleep(200);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => someAction.ExecutionTime().Should().BeGreaterOrEqualTo(300.Milliseconds());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .Should().Throw<XunitException>()
+                .And.Message.Should().StartWith(
+                    "Execution of the action should be greater or equal to 0.300s, but it required");
+        }
+
+        [Fact]
+        public void When_the_execution_time_of_an_action_is_greater_or_equal_to_a_limit_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+
+            Action someAction = () => Thread.Sleep(100);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => someAction.ExecutionTime().Should().BeGreaterOrEqualTo(50.Milliseconds());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
+        }
+        #endregion
+
+        #region BeGreaterThan
+        [Fact]
+        public void When_the_execution_time_of_a_member_is_not_greater_than_a_limit_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new SleepingClass();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(200)).Should().BeGreaterThan(500.Milliseconds(),
+                "we like speed");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .Should().Throw<XunitException>()
+                .And.Message.Should().Match(
+                    "Execution of (s.Sleep(200)) should be greater than 0.500s because we like speed, but it required*");
+        }
+
+        [Fact]
+        public void When_the_execution_time_of_a_member_is_greater_than_a_limit_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new SleepingClass();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(200)).Should().BeGreaterThan(100.Milliseconds());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_the_execution_time_of_an_action_is_not_greater_than_a_limit__it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+
+            Action someAction = () => Thread.Sleep(100);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => someAction.ExecutionTime().Should().BeGreaterThan(300.Milliseconds());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .Should().Throw<XunitException>()
+                .And.Message.Should().StartWith(
+                    "Execution of the action should be greater than 0.300s, but it required");
+        }
+
+        [Fact]
+        public void When_the_execution_time_of_an_action_is_greater_than_a_limit_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+
+            Action someAction = () => Thread.Sleep(200);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => someAction.ExecutionTime().Should().BeGreaterThan(100.Milliseconds());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
+        }
+        #endregion
+
+        #region BeCloseTo
+        [Fact]
+        public void When_the_execution_time_of_a_member_is_not_close_to_a_limit_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new SleepingClass();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(560)).Should().BeCloseTo(500.Milliseconds(),
+                50.Milliseconds(),
+                "we like speed");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .Should().Throw<XunitException>()
+                .And.Message.Should().Match(
+                    "Execution of (s.Sleep(560)) should be within 0.050s from 0.500s because we like speed, but it required*");
+        }
+
+        [Fact]
+        public void When_the_execution_time_of_a_member_is_close_to_a_limit_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new SleepingClass();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(510)).Should().BeCloseTo(500.Milliseconds(),
+                50.Milliseconds());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_the_execution_time_of_an_action_is_not_close_to_a_limit__it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+
+            Action someAction = () => Thread.Sleep(560);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => someAction.ExecutionTime().Should().BeCloseTo(500.Milliseconds(), 50.Milliseconds());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act
+                .Should().Throw<XunitException>()
+                .And.Message.Should().StartWith(
+                    "Execution of the action should be within 0.050s from 0.500s, but it required");
+        }
+
+        [Fact]
+        public void When_the_execution_time_of_an_action_is_close_to_a_limit_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+
+            Action someAction = () => Thread.Sleep(510);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => someAction.ExecutionTime().Should().BeCloseTo(500.Milliseconds(), 50.Milliseconds());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
+        }
+        #endregion
+
         internal class SleepingClass
         {
             public void Sleep(int milliseconds)
             {
-
                 Thread.Sleep(milliseconds);
-
             }
         }
     }

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -938,14 +938,14 @@ public class SomePotentiallyVerySlowClass
       }
     }
 var subject = new SomePotentiallyVerySlowClass();
-subject.ExecutionTimeOf(s => s.ExpensiveMethod()).ShouldNotExceed(500.Milliseconds());
+subject.ExecutionTimeOf(s => s.ExpensiveMethod()).Should().BeLessOrEqualTo(500.Milliseconds());
 ```
 
 Alternatively, to verify the execution time of an arbitrary action, use this syntax:
 
 ```csharp
 Action someAction = () => Thread.Sleep(510);
-someAction.ExecutionTime().ShouldNotExceed(100.Milliseconds());
+someAction.ExecutionTime().Should().BeLessOrEqualTo(100.Milliseconds());
 ```
 
 Since it doesn’t make sense to do something like that in Silverlight, it is only available in the .NET 3.5 and .NET 4.0 versions of Fluent Assertions.


### PR DESCRIPTION
This PR aligns `ExecutionTime[Of]` with the rest of the v5.0.0 API by using `Should().` to assert.
In order to that I introduced the `ExecutionTime` as a sort of DTO object which could be asserted on.

Removed:
* `ShouldNotExceed`

Added:
* `BeLessOrEqualTo`
* `BeLessThan`
* `BeGreaterOrEqualTo`
* `BeGreaterThan`
* `BeCloseTo`