### PR TITLE
Use method instead of property to avoid mistakes

### DIFF
--- a/Src/FluentAssertions/Equivalency/AssertionResultSet.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionResultSet.cs
@@ -30,25 +30,27 @@ namespace FluentAssertions.Equivalency
         /// </remarks>
         public string[] SelectClosestMatchFor(object key = null)
         {
-            if (!ContainsSuccessfulSet)
+            if (ContainsSuccessfulSet)
             {
-                KeyValuePair<object, string[]> bestMatch = BestResultSets.Any(r => r.Key.Equals(key))
-                    ? BestResultSets.Single(r => r.Key.Equals(key))
-                    : BestResultSets.First();
-
-                return bestMatch.Value;
+                return new string[0];
             }
 
-            return new string[0];
+            KeyValuePair<object, string[]>[] bestResultSets = GetBestResultSets();
+
+            KeyValuePair<object, string[]> bestMatch = bestResultSets.FirstOrDefault(r => r.Key.Equals(key));
+
+            if(bestMatch.Equals(default(KeyValuePair<object, string[]>)))
+            {
+                return bestResultSets[0].Value;
+            }
+
+            return bestMatch.Value;
         }
 
-        private KeyValuePair<object, string[]>[] BestResultSets
+        private KeyValuePair<object, string[]>[] GetBestResultSets()
         {
-            get
-            {
-                int fewestFailures = set.Values.Min(r => r.Count());
-                return set.Where(r => r.Value.Count() == fewestFailures).ToArray();
-            }
+            int fewestFailures = set.Values.Min(r => r.Length);
+            return set.Where(r => r.Value.Length == fewestFailures).ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION
The `BestResults` property violates the [MS guidelines](https://msdn.microsoft.com/en-us/library/ms229054%28v=vs.100%29.aspx) about when to prefer methods over properties.

> Do use a method, rather than a property, in the following situations.`
> The operation returns an array.

Probably because the use of a property made it look like a cheap operation, it was called twice, causing double enumeration and array allocation.

This is almost identical to the second example in the link above.