### PR TITLE
Use methods instead of mutating properties

### DIFF
--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -36,37 +36,28 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Only select the methods that are public or internal.
         /// </summary>
-        public MethodInfoSelector ThatArePublicOrInternal
+        public MethodInfoSelector ThatArePublicOrInternal()
         {
-            get
-            {
-                selectedMethods = selectedMethods.Where(method => method.IsPublic || method.IsAssembly);
-                return this;
-            }
+            selectedMethods = selectedMethods.Where(method => method.IsPublic || method.IsAssembly);
+            return this;
         }
 
         /// <summary>
         /// Only select the methods without a return value
         /// </summary>
-        public MethodInfoSelector ThatReturnVoid
+        public MethodInfoSelector ThatReturnVoid()
         {
-            get
-            {
-                selectedMethods = selectedMethods.Where(method => method.ReturnType == typeof (void));
-                return this;
-            }
+            selectedMethods = selectedMethods.Where(method => method.ReturnType == typeof(void));
+            return this;
         }
 
         /// <summary>
         /// Only select the methods with a return value
         /// </summary>
-        public MethodInfoSelector ThatDoNotReturnVoid
+        public MethodInfoSelector ThatDoNotReturnVoid()
         {
-            get
-            {
-                selectedMethods = selectedMethods.Where(method => method.ReturnType != typeof(void));
-                return this;
-            }
+            selectedMethods = selectedMethods.Where(method => method.ReturnType != typeof(void));
+            return this;
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -35,18 +35,15 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Only select the properties that have a public or internal getter.
         /// </summary>
-        public PropertyInfoSelector ThatArePublicOrInternal
+        public PropertyInfoSelector ThatArePublicOrInternal()
         {
-            get
+            selectedProperties = selectedProperties.Where(property =>
             {
-                selectedProperties = selectedProperties.Where(property =>
-                {
-                    MethodInfo getter = property.GetGetMethod(true);
-                    return ((getter != null) && (getter.IsPublic || getter.IsAssembly));
-                });
+                MethodInfo getter = property.GetGetMethod(true);
+                return ((getter != null) && (getter.IsPublic || getter.IsAssembly));
+            });
 
-                return this;
-            }
+            return this;
         }
 
         /// <summary>

--- a/Tests/Shared.Specs/MethodInfoSelectorAssertionSpecs.cs
+++ b/Tests/Shared.Specs/MethodInfoSelectorAssertionSpecs.cs
@@ -168,7 +168,7 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             MethodInfoSelector methodSelector =
                 new MethodInfoSelector(typeof(ClassWithMethodsThatAreNotDecoratedWithDummyAttribute))
-                    .ThatArePublicOrInternal;
+                    .ThatArePublicOrInternal();
 
             //-------------------------------------------------------------------------------------------------------------------
             // Act
@@ -236,7 +236,7 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             MethodInfoSelector methodSelector =
                 new MethodInfoSelector(typeof(ClassWithAllMethodsDecoratedWithDummyAttribute))
-                    .ThatArePublicOrInternal;
+                    .ThatArePublicOrInternal();
 
             //-------------------------------------------------------------------------------------------------------------------
             // Act

--- a/Tests/Shared.Specs/MethodInfoSelectorSpecs.cs
+++ b/Tests/Shared.Specs/MethodInfoSelectorSpecs.cs
@@ -47,7 +47,7 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             // Act
             //-------------------------------------------------------------------------------------------------------------------
-            IEnumerable<MethodInfo> methods = type.Methods().ThatArePublicOrInternal;
+            IEnumerable<MethodInfo> methods = type.Methods().ThatArePublicOrInternal();
 
             //-------------------------------------------------------------------------------------------------------------------
             // Assert
@@ -147,7 +147,7 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             // Act
             //-------------------------------------------------------------------------------------------------------------------
-            IEnumerable<MethodInfo> methods = type.Methods().ThatReturnVoid.ToArray();
+            IEnumerable<MethodInfo> methods = type.Methods().ThatReturnVoid().ToArray();
 
             //-------------------------------------------------------------------------------------------------------------------
             // Assert
@@ -166,7 +166,7 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             // Act
             //-------------------------------------------------------------------------------------------------------------------
-            IEnumerable<MethodInfo> methods = type.Methods().ThatDoNotReturnVoid.ToArray();
+            IEnumerable<MethodInfo> methods = type.Methods().ThatDoNotReturnVoid().ToArray();
 
             //-------------------------------------------------------------------------------------------------------------------
             // Assert
@@ -186,8 +186,8 @@ namespace FluentAssertions.Specs
             // Act
             //-------------------------------------------------------------------------------------------------------------------
             IEnumerable<MethodInfo> methods = type.Methods()
-                .ThatArePublicOrInternal
-                .ThatReturnVoid
+                .ThatArePublicOrInternal()
+                .ThatReturnVoid()
                 .ToArray();
 
             //-------------------------------------------------------------------------------------------------------------------

--- a/Tests/Shared.Specs/PropertyInfoSelectorAssertionSpecs.cs
+++ b/Tests/Shared.Specs/PropertyInfoSelectorAssertionSpecs.cs
@@ -170,7 +170,7 @@ namespace FluentAssertions.Specs
             // Arrange
             //-------------------------------------------------------------------------------------------------------------------
             var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute))
-                .ThatArePublicOrInternal;
+                .ThatArePublicOrInternal();
 
             //-------------------------------------------------------------------------------------------------------------------
             // Act
@@ -239,7 +239,7 @@ namespace FluentAssertions.Specs
             // Arrange
             //-------------------------------------------------------------------------------------------------------------------
             var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute))
-                .ThatArePublicOrInternal;
+                .ThatArePublicOrInternal();
 
             //-------------------------------------------------------------------------------------------------------------------
             // Act

--- a/Tests/Shared.Specs/PropertyInfoSelectorSpecs.cs
+++ b/Tests/Shared.Specs/PropertyInfoSelectorSpecs.cs
@@ -47,7 +47,7 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             // Act
             //-------------------------------------------------------------------------------------------------------------------
-            IEnumerable<PropertyInfo> properties = type.Properties().ThatArePublicOrInternal.ToArray();
+            IEnumerable<PropertyInfo> properties = type.Properties().ThatArePublicOrInternal().ToArray();
 
             //-------------------------------------------------------------------------------------------------------------------
             // Assert
@@ -148,7 +148,7 @@ namespace FluentAssertions.Specs
             // Act
             //-------------------------------------------------------------------------------------------------------------------
             IEnumerable<PropertyInfo> properties = type.Properties()
-                .ThatArePublicOrInternal
+                .ThatArePublicOrInternal()
                 .OfType<string>()
                 .ThatAreDecoratedWith<DummyPropertyAttribute>()
                 .ToArray();


### PR DESCRIPTION
`ThatArePublicOrInternal`, `ThatReturnVoid` and `ThatDoNotReturnVoid` are properties even though they have observable side-effects.

Changing them to methods also aligns them with all other type/method/property selectors