### PR TITLE
Constraining of generic types to exceptions

### DIFF
--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -97,7 +97,7 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+        public void NotThrow<TException>(string because = "", params object[] becauseArgs) where TException : Exception
         {
             try
             {

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -92,7 +92,7 @@ namespace FluentAssertions.Specialized
         ///   Asserts that the thrown exception contains an inner exception of type <typeparamref name = "TInnerException" />.
         /// </summary>
         /// <typeparam name = "TInnerException">The expected type of the inner exception.</typeparam>
-        public ExceptionAssertions<TException> WithInnerException<TInnerException>()
+        public ExceptionAssertions<TException> WithInnerException<TInnerException>() where TInnerException : Exception
         {
             return WithInnerException<TInnerException>(null, null);
         }
@@ -113,7 +113,7 @@ namespace FluentAssertions.Specialized
         /// <param name = "because">The reason why the inner exception should be of the supplied type.</param>
         /// <param name = "becauseArgs">The parameters used when formatting the <paramref name = "because" />.</param>
         public virtual ExceptionAssertions<TException> WithInnerException<TInnerException>(string because,
-            params object[] becauseArgs)
+            params object[] becauseArgs) where TInnerException : Exception
         {
             Execute.Assertion
                 .ForCondition(Subject != null)


### PR DESCRIPTION
Found a few places where we should constrain the generic type to be an exception.