### PR TITLE
Expose more tests to netcore2

### DIFF
--- a/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Reflection
             Subject = assembly;
         }
 
-#if NET45 // TODO :: Should be able to remove based on: https://github.com/dotnet/corefx/issues/1784#issuecomment-218803619
+#if NET45 || NETSTANDARD2_0 // TODO :: Should be able to remove based on: https://github.com/dotnet/corefx/issues/1784#issuecomment-218803619
 
         /// <summary>
         /// Asserts that an assembly does not reference the specified assembly.

--- a/Tests/Shared.Specs/AssemblyAssertionSpecs.cs
+++ b/Tests/Shared.Specs/AssemblyAssertionSpecs.cs
@@ -1,4 +1,4 @@
-﻿#if NET45
+﻿#if NET45 || NETCOREAPP2_0
 
 using System;
 using System.Reflection;

--- a/Tests/Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/BasicEquivalencySpecs.cs
@@ -3090,7 +3090,7 @@ With configuration:*");
             act.Should().NotThrow();
         }
 
-#if NET45
+#if NET45 || NETCOREAPP2_0
         [Fact]
         public void When_asserting_types_with_infinite_oject_graphs_are_equivilent_it_should_not_overflow_the_stack()
         {

--- a/Tests/Shared.Specs/ObjectAssertionSpecs.cs
+++ b/Tests/Shared.Specs/ObjectAssertionSpecs.cs
@@ -872,7 +872,7 @@ namespace FluentAssertions.Specs
 
         #endregion
 
-#if NET45
+#if NET45 || NETCOREAPP2_0
 
         #region BeBinarySerializable
 


### PR DESCRIPTION
20 tests were not consumed by the netcore2.0 test application even though the assertions are exposed to .net standard 2.0.