### PR TITLE
Removed WithInnerMessage as chaining WithInnerException with WithMessage gives the same result.

### DIFF
--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -92,27 +92,9 @@ namespace FluentAssertions.Specialized
         ///   Asserts that the thrown exception contains an inner exception of type <typeparamref name = "TInnerException" />.
         /// </summary>
         /// <typeparam name = "TInnerException">The expected type of the inner exception.</typeparam>
-        public ExceptionAssertions<TException> WithInnerException<TInnerException>() where TInnerException : Exception
-        {
-            return WithInnerException<TInnerException>(null, null);
-        }
-
-        /// <summary>
-        ///   Asserts that the thrown exception contains an inner exception of the exact type <typeparamref name = "TInnerException" /> (and not a derived exception type).
-        /// </summary>
-        /// <typeparam name = "TInnerException">The expected type of the inner exception.</typeparam>
-        public ExceptionAssertions<TInnerException> WithInnerExceptionExactly<TInnerException>() where TInnerException : Exception
-        {
-            return WithInnerExceptionExactly<TInnerException>(null, null);
-        }
-
-        /// <summary>
-        ///   Asserts that the thrown exception contains an inner exception of type <typeparamref name = "TInnerException" />.
-        /// </summary>
-        /// <typeparam name = "TInnerException">The expected type of the inner exception.</typeparam>
         /// <param name = "because">The reason why the inner exception should be of the supplied type.</param>
         /// <param name = "becauseArgs">The parameters used when formatting the <paramref name = "because" />.</param>
-        public virtual ExceptionAssertions<TException> WithInnerException<TInnerException>(string because,
+        public virtual ExceptionAssertions<TInnerException> WithInnerException<TInnerException>(string because = null,
             params object[] becauseArgs) where TInnerException : Exception
         {
             Execute.Assertion
@@ -126,12 +108,17 @@ namespace FluentAssertions.Specialized
                 .FailWith("Expected inner {0}{reason}, but the thrown exception has no inner exception.",
                     typeof(TInnerException));
 
+            TInnerException[] expectedInnerExceptions = Subject
+                .Select(e => e.InnerException)
+                .OfType<TInnerException>()
+                .ToArray();
+
             Execute.Assertion
-                .ForCondition(Subject.Any(e => e.InnerException is TInnerException))
+                .ForCondition(expectedInnerExceptions.Any())
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected inner {0}{reason}, but found {1}.", typeof(TInnerException), SingleSubject.InnerException);
 
-            return this;
+            return new ExceptionAssertions<TInnerException>(expectedInnerExceptions);
         }
 
         /// <summary>
@@ -140,7 +127,7 @@ namespace FluentAssertions.Specialized
         /// <typeparam name = "TInnerException">The expected type of the inner exception.</typeparam>
         /// <param name = "because">The reason why the inner exception should be of the supplied type.</param>
         /// <param name = "becauseArgs">The parameters used when formatting the <paramref name = "because" />.</param>
-        public virtual ExceptionAssertions<TInnerException> WithInnerExceptionExactly<TInnerException>(string because,
+        public virtual ExceptionAssertions<TInnerException> WithInnerExceptionExactly<TInnerException>(string because = null,
             params object[] becauseArgs) where TInnerException : Exception
         {
             WithInnerException<TInnerException>(because, becauseArgs);
@@ -156,36 +143,6 @@ namespace FluentAssertions.Specialized
                 .FailWith("Expected inner {0}{reason}, but found {1}.", typeof(TInnerException), SingleSubject.InnerException);
 
             return new ExceptionAssertions<TInnerException>(expectedExceptions);
-        }
-
-        /// <summary>
-        ///   Asserts that the thrown exception contains an inner exception with the <paramref name = "expectedInnerMessage" />.
-        /// </summary>
-        /// <param name = "expectedInnerMessage">The expected message of the inner exception.</param>
-        /// <param name = "because">
-        ///   The reason why the message of the inner exception should match <paramref name = "expectedInnerMessage" />.
-        /// </param>
-        /// <param name = "becauseArgs">The parameters used when formatting the <paramref name = "because" />.</param>
-        public virtual ExceptionAssertions<TException> WithInnerMessage(string expectedInnerMessage, string because = "",
-            params object[] becauseArgs)
-        {
-            AssertionScope assertion = Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .UsingLineBreaks;
-
-            assertion
-                .ForCondition(Subject.Any())
-                .FailWith("Expected inner exception{reason}, but no exception was thrown.");
-
-            assertion
-                .ForCondition(Subject.Any(e => e.InnerException != null))
-                .FailWith("Expected inner exception{reason}, but the thrown exception has no inner exception.");
-
-            string[] subjectInnerMessage = Subject.Select(e => e.InnerException.Message).ToArray();
-
-            innerMessageAssertion.Execute(subjectInnerMessage, expectedInnerMessage, because, becauseArgs);
-
-            return this;
         }
 
         /// <summary>

--- a/Tests/Shared.Specs/ExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/ExceptionAssertionSpecs.cs
@@ -395,7 +395,7 @@ namespace FluentAssertions.Specs
             act.Should().Throw<AggregateException>()
                 .WithMessage("Outer Message*")
                 .WithInnerException<Exception>()
-                .WithInnerMessage("Inner Message");
+                .WithMessage("Inner Message");
         }
 
         #endregion
@@ -595,218 +595,7 @@ namespace FluentAssertions.Specs
                     "Expected inner System.InvalidOperationException because IFoo.Do should do that, but the thrown exception has no inner exception.");
             }
         }
-
-        [Fact]
-        public void When_subject_throws_inner_exception_with_expected_message_it_should_not_throw()
-        {
-            //-----------------------------------------------------------------------------------------------------------
-            // Arrange
-            //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new Exception("", new InvalidOperationException("expected message")));
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Act
-            //-----------------------------------------------------------------------------------------------------------
-            Action action = testSubject.Do;
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Assert
-            //-----------------------------------------------------------------------------------------------------------
-            action.Should().Throw<Exception>()
-                .WithInnerMessage("*xpected messag*");
-        }
-        
-        [Fact]
-        public void When_subject_throws_inner_exception_with_message_starting_with_expected_message_it_should_not_throw()
-        {
-            //-----------------------------------------------------------------------------------------------------------
-            // Arrange
-            //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new Exception("", new InvalidOperationException("expected message")));
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Act
-            //-----------------------------------------------------------------------------------------------------------
-            Action action = testSubject.Do;
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Assert
-            //-----------------------------------------------------------------------------------------------------------
-            action.Should().Throw<Exception>()
-                .WithInnerMessage("expected mes*");
-        }
-        
-        [Fact]
-        public void When_subject_throws_inner_exception_with_message_that_does_not_start_with_expected_message_it_should_throw()
-        {
-            //-----------------------------------------------------------------------------------------------------------
-            // Arrange
-            //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new Exception("", new InvalidOperationException("OxpectOd message")));
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Act
-            //-----------------------------------------------------------------------------------------------------------
-            Action action = () => testSubject
-                    .Invoking(s => s.Do())
-                    .Should().Throw<Exception>()
-                    .WithInnerMessage("Expected mes*");
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Assert
-            //-----------------------------------------------------------------------------------------------------------
-            action.Should().Throw<Exception>()
-                .WithMessage("Expected inner exception message to match the equivalent of \r\n\"Expected mes*\", but \r\n\"OxpectOd message\" does not*");
-        }
-
-        [Fact]
-        public void When_subject_throws_inner_exception_with_message_starting_with_expected_equivalent_message_it_should_not_throw()
-        {
-            //-----------------------------------------------------------------------------------------------------------
-            // Arrange
-            //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new Exception("", new InvalidOperationException("Expected Message")));
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Act
-            //-----------------------------------------------------------------------------------------------------------
-            Action action = testSubject.Do;
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Assert
-            //-----------------------------------------------------------------------------------------------------------
-            action.Should().Throw<Exception>()
-                .WithInnerMessage("expected mes*");
-        }
-
-        [Fact]
-        public void When_subject_throws_inner_exception_with_message_that_does_not_start_with_equivalent_message_it_should_throw()
-        {
-            //-----------------------------------------------------------------------------------------------------------
-            // Arrange
-            //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new Exception("", new InvalidOperationException("OxpectOd message")));
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Act
-            //-----------------------------------------------------------------------------------------------------------
-            Action action = () => testSubject
-                    .Invoking(s => s.Do())
-                    .Should().Throw<Exception>()
-                    .WithInnerMessage("expected mes");
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Assert
-            //-----------------------------------------------------------------------------------------------------------
-            action.Should().Throw<Exception>()
-                .WithMessage("Expected inner exception message to match the equivalent of \r\n\"expected mes*\", but \r\n\"OxpectOd message\" does not*");
-        }
-
-        [Fact]
-        public void When_subject_throws_inner_exception_without_an_equivalent_message_it_should_throw()
-        {
-            //-----------------------------------------------------------------------------------------------------------
-            // Arrange
-            //-----------------------------------------------------------------------------------------------------------
-            var testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new Exception("", new InvalidOperationException("OxpectOd message")));
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Act
-            //-----------------------------------------------------------------------------------------------------------
-            Action action = () => testSubject
-                    .Invoking(s => s.Do())
-                    .Should().Throw<Exception>()
-                    .WithInnerMessage("Expected message");
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Assert
-            //-----------------------------------------------------------------------------------------------------------
-            action
-                .Should().Throw<XunitException>()
-                .WithMessage("Expected inner exception message to match the equivalent of \r\n\"Expected message\", but \r\n\"OxpectOd message\" does not*");
-        }
-
-        [Fact]
-        public void When_subject_throws_inner_exception_with_a_matching_message_with_different_casing_it_should_not_throw()
-        {
-            //-----------------------------------------------------------------------------------------------------------
-            // Arrange
-            //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new Exception("", new InvalidOperationException("Expected Message")));
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Act
-            //-----------------------------------------------------------------------------------------------------------
-            Action action = testSubject.Do;
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Assert
-            //-----------------------------------------------------------------------------------------------------------
-            action
-                .Should().Throw<Exception>()
-                .WithInnerMessage("EXPECTED*");
-        }
-
-        [Fact]
-        public void When_subject_throws_inner_exception_with_a_matching_message_it_should_not_throw()
-        {
-            //-----------------------------------------------------------------------------------------------------------
-            // Arrange
-            //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new Exception("", new InvalidOperationException("expected message")));
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Act
-            //-----------------------------------------------------------------------------------------------------------
-            Action action = testSubject.Do;
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Assert
-            //-----------------------------------------------------------------------------------------------------------
-            action
-                .Should().Throw<Exception>()
-                .WithInnerMessage("*ted*mes*");
-        }
-
-        [Fact]
-        public void When_subject_throws_inner_exception_with_unexpected_message_it_should_throw()
-        {
-            //-----------------------------------------------------------------------------------------------------------
-            // Arrange
-            //-----------------------------------------------------------------------------------------------------------
-            var testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new Exception("", new InvalidOperationException("unexpected message")));
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Act
-            //-----------------------------------------------------------------------------------------------------------
-            try
-            {
-                testSubject
-                    .Invoking(x => x.Do())
-                    .Should().Throw<Exception>()
-                    .WithInnerMessage("expected message", "because {0} should do just that", "IFoo.Do");
-
-                throw new XunitException("This point should not be reached");
-            }
-            catch (XunitException ex)
-            {
-                //-----------------------------------------------------------------------------------------------------------
-                // Assert
-                //-----------------------------------------------------------------------------------------------------------
-                ex.Message.Should().Match(
-                    "Expected inner*\r\n\"expected message\"*because IFoo.Do should do just that, but*");
-            }
-        }
-        
+                
         [Fact]
         public void When_an_inner_exception_matches_exactly_it_should_allow_chaining_more_asserts_on_that_exception_type()
         {
@@ -860,9 +649,8 @@ namespace FluentAssertions.Specs
             testSubject
                 .Invoking(x => x.Do())
                 .Should().Throw<InvalidOperationException>()
-                .WithInnerMessage("inner message")
                 .WithInnerException<ArgumentException>()
-                .WithInnerMessage("inner message");
+                .WithMessage("inner message");
         }
 
         [Fact]


### PR DESCRIPTION
#433 