### PR TITLE
Add an Extensions namespace for helper extension methods.

### DIFF
--- a/Src/FluentAssertions/Extensions/FluentDateTimeExtensions.cs
+++ b/Src/FluentAssertions/Extensions/FluentDateTimeExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 
-namespace FluentAssertions
+namespace FluentAssertions.Extensions
 {
     /// <summary>
     /// Extension methods on <see cref="int"/> to allow for a more fluent way of specifying a <see cref="DateTime"/>.

--- a/Src/FluentAssertions/Extensions/FluentDateTimeExtensions.cs
+++ b/Src/FluentAssertions/Extensions/FluentDateTimeExtensions.cs
@@ -17,7 +17,7 @@ namespace FluentAssertions.Extensions
     /// <br />
     /// 3.March(2011).At(09, 30)
     /// </example>
-    /// <seealso cref="TimeSpanConversionExtensions"/>
+    /// <seealso cref="FluentTimeSpanExtensions"/>
     [DebuggerNonUserCode]
     public static class FluentDateTimeExtensions
     {

--- a/Src/FluentAssertions/Extensions/FluentTimeSpanExtensions.cs
+++ b/Src/FluentAssertions/Extensions/FluentTimeSpanExtensions.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Extensions
     /// 12.Hours().And(30.Minutes()).
     /// </example>
     /// <seealso cref="FluentDateTimeExtensions"/>
-    public static class TimeSpanConversionExtensions
+    public static class FluentTimeSpanExtensions
     {
         /// <summary>
         /// Represents the number of ticks that are in 1 microsecond.

--- a/Src/FluentAssertions/Extensions/TimeSpanConversionExtensions.cs
+++ b/Src/FluentAssertions/Extensions/TimeSpanConversionExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace FluentAssertions
+namespace FluentAssertions.Extensions
 {
     /// <summary>
     /// Extension methods on <see cref="int"/> to allow for a more fluent way of specifying a <see cref="TimeSpan"/>.
@@ -65,7 +65,7 @@ namespace FluentAssertions
         /// </remarks>
         public static TimeSpan Nanoseconds(this int nanoseconds)
         {
-            return ((long)Math.Round(nanoseconds * TicksPerNanosecond)).Ticks();
+            return ((long)Math.Round((double)(nanoseconds * TicksPerNanosecond))).Ticks();
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace FluentAssertions
         /// </remarks>
         public static TimeSpan Nanoseconds(this long nanoseconds)
         {
-            return ((long)Math.Round(nanoseconds * TicksPerNanosecond)).Ticks();
+            return ((long)Math.Round((double)(nanoseconds * TicksPerNanosecond))).Ticks();
         }
 
         /// <summary>

--- a/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/Shared.Specs/DateTimeAssertionSpecs.cs
+++ b/Tests/Shared.Specs/DateTimeAssertionSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using FluentAssertions.Extensions;
 using FluentAssertions.Primitives;
 using Xunit;
 using Xunit.Sdk;

--- a/Tests/Shared.Specs/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/Shared.Specs/DateTimeOffsetAssertionSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FluentAssertions.Common;
+using FluentAssertions.Extensions;
 using FluentAssertions.Primitives;
 using Xunit;
 using Xunit.Sdk;

--- a/Tests/Shared.Specs/DateTimeOffsetValueFormatterSpecs.cs
+++ b/Tests/Shared.Specs/DateTimeOffsetValueFormatterSpecs.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+
+using FluentAssertions.Extensions;
 using FluentAssertions.Formatting;
 using Xunit;
 

--- a/Tests/Shared.Specs/EventAssertionSpecs.cs
+++ b/Tests/Shared.Specs/EventAssertionSpecs.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Linq;
+
 using FluentAssertions.Events;
+using FluentAssertions.Extensions;
 using FluentAssertions.Formatting;
 using Xunit;
 using Xunit.Sdk;

--- a/Tests/Shared.Specs/ExecutionTimeAssertionsSpecs.cs
+++ b/Tests/Shared.Specs/ExecutionTimeAssertionsSpecs.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Threading;
+
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/Shared.Specs/ExtensibilityRelatedEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/ExtensibilityRelatedEquivalencySpecs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Equivalency;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/Shared.Specs/FluentDateTimeSpecs.cs
+++ b/Tests/Shared.Specs/FluentDateTimeSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentAssertions.Extensions;
 using Xunit;
 
 namespace FluentAssertions.Specs

--- a/Tests/Shared.Specs/NullableSimpleTimeSpanAssertionSpecs.cs
+++ b/Tests/Shared.Specs/NullableSimpleTimeSpanAssertionSpecs.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 
 using FluentAssertions.Common;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/Shared.Specs/ObjectAssertionSpecs.cs
+++ b/Tests/Shared.Specs/ObjectAssertionSpecs.cs
@@ -4,6 +4,7 @@ using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
+using FluentAssertions.Extensions;
 using FluentAssertions.Primitives;
 using Xunit;
 using Xunit.Sdk;

--- a/Tests/Shared.Specs/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/Shared.Specs/ReferenceTypeAssertionsSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 
 using FluentAssertions.Common;
+using FluentAssertions.Extensions;
 using FluentAssertions.Formatting;
 using Xunit;
 using Xunit.Sdk;

--- a/Tests/Shared.Specs/SimpleTimeSpanAssertionSpecs.cs
+++ b/Tests/Shared.Specs/SimpleTimeSpanAssertionSpecs.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 
 using FluentAssertions.Common;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/Shared.Specs/TimeSpanConversionExtensionSpecs.cs
+++ b/Tests/Shared.Specs/TimeSpanConversionExtensionSpecs.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-
 using FluentAssertions.Common;
+using FluentAssertions.Extensions;
 using Xunit;
 
 namespace FluentAssertions.Specs


### PR DESCRIPTION
Fix for Issue #674, 

Moves DateTime and TimeSpan extensions into the "FluentAssertions.Extensions" namespace. I've also renamed the `TimeSpanConversionExtensions` to `FluentTimeSpanExtensions` to follow the naming conventions used in other "helper" extensions. 