### PR TITLE
Removed redudant cast from the TimeSpan#Nanosecond extension

### DIFF
--- a/Src/FluentAssertions/Extensions/FluentTimeSpanExtensions.cs
+++ b/Src/FluentAssertions/Extensions/FluentTimeSpanExtensions.cs
@@ -65,7 +65,7 @@ namespace FluentAssertions.Extensions
         /// </remarks>
         public static TimeSpan Nanoseconds(this int nanoseconds)
         {
-            return ((long)Math.Round((double)(nanoseconds * TicksPerNanosecond))).Ticks();
+            return ((long)Math.Round(nanoseconds * TicksPerNanosecond)).Ticks();
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace FluentAssertions.Extensions
         /// </remarks>
         public static TimeSpan Nanoseconds(this long nanoseconds)
         {
-            return ((long)Math.Round((double)(nanoseconds * TicksPerNanosecond))).Ticks();
+            return ((long)Math.Round(nanoseconds * TicksPerNanosecond)).Ticks();
         }
 
         /// <summary>


### PR DESCRIPTION
Mistakenly introduced a redundant cast in PR #675. Removed the cast and restored the original method body.