### PR TITLE
Report all matches when NotContain fails

### DIFF
--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -561,11 +561,15 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:collection} not to contain {0}{reason}, but found {1}.", predicate.Body, Subject);
             }
 
-            if (Subject.Any(item => predicate.Compile()(item)))
+            Func<T, bool> compiledPredicate = predicate.Compile();
+            IEnumerable<T> unexpectedItems = Subject.Where(item => compiledPredicate(item));
+
+            if (unexpectedItems.Any())
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:Collection} {0} to not have any items matching {1}{reason}.", Subject, predicate.Body);
+                    .FailWith("Expected {context:Collection} {0} to not have any items matching {1}{reason}, but found {2}.",
+                        Subject, predicate.Body, unexpectedItems);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Tests/Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/CollectionAssertionSpecs.cs
@@ -2395,7 +2395,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {1, 2, 3} to not have any items matching (item == 2) because 2s are evil.");
+                "Expected collection {1, 2, 3} to not have any items matching (item == 2) because 2s are evil,*{2}*");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
@@ -1282,7 +1282,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection {\"one\", \"two\", \"three\"} to not have any items matching (item == \"two\") because twos are evil.");
+                "Expected collection {\"one\", \"two\", \"three\"} to not have any items matching (item == \"two\") because twos are evil,*{\"two\"}*");
         }
 
         [Fact]


### PR DESCRIPTION
This PR includes all the unexpected matches in the failure message of `NotContain`.

This is useful when the predicate uses some (nested) property, then you will now know the entire structure of the object(s) which led to the failure.