### PR TITLE
Params overloads for dictionary assertions

### DIFF
--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -913,6 +913,16 @@ namespace FluentAssertions.Collections
         /// Keys and values are compared using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
         /// <param name="expected">The expected key/value pairs.</param>
+        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> Contain(params KeyValuePair<TKey, TValue>[] expected)
+        {
+            return Contain(expected, string.Empty);
+        }
+
+        /// <summary>
+        /// Asserts that the current dictionary contains the specified <paramref name="expected"/>.
+        /// Keys and values are compared using their <see cref="object.Equals(object)" /> implementation.
+        /// </summary>
+        /// <param name="expected">The expected key/value pairs.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -1053,6 +1063,16 @@ namespace FluentAssertions.Collections
         #endregion
 
         #region NotContain
+
+        /// <summary>
+        /// Asserts that the current dictionary does not contain the specified <paramref name="items"/>.
+        /// Keys and values are compared using their <see cref="object.Equals(object)" /> implementation.
+        /// </summary>
+        /// <param name="items">The unexpected key/value pairs</param>
+        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContain(params KeyValuePair<TKey, TValue>[] items)
+        {
+            return NotContain(items, string.Empty);
+        }
 
         /// <summary>
         /// Asserts that the current dictionary does not contain the specified <paramref name="items"/>.

--- a/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
@@ -1798,6 +1798,29 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void Should_succeed_when_asserting_dictionary_contains_multiple_key_value_pair()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" },
+                { 3, "Three" },
+                { 4, "Four" }
+            };
+
+            var expectedKeyValuePair1 = new KeyValuePair<int, string>(2, "Two");
+            var expectedKeyValuePair2 = new KeyValuePair<int, string>(3, "Three");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            dictionary.Should().Contain(expectedKeyValuePair1, expectedKeyValuePair2);
+        }
+
+        [Fact]
         public void Should_succeed_when_asserting_dictionary_does_not_contain_single_key_value_pair()
         {
             var dictionary = new Dictionary<int, string>
@@ -1812,6 +1835,27 @@ namespace FluentAssertions.Specs
             };
 
             dictionary.Should().NotContain(keyValuePairs);
+        }
+
+        [Fact]
+        public void Should_succeed_when_asserting_dictionary_does_not_contain_multiple_key_value_pair()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var dictionary = new Dictionary<int, string>
+            {
+                { 1, "One" },
+                { 2, "Two" }
+            };
+
+            var unexpectedKeyValuePair1 = new KeyValuePair<int, string>(3, "Three");
+            var unexpectedKeyValuePair2 = new KeyValuePair<int, string>(4, "Four");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            dictionary.Should().NotContain(unexpectedKeyValuePair1, unexpectedKeyValuePair2);
         }
 
         [Fact]


### PR DESCRIPTION
This PR adds two `params KeyValuePair<TKey, TValue>[]` overloads for:

* `GenericDictionaryAssertions.Contain` 
* `GenericDictionaryAssertions.NotContain`

