### PR TITLE
Explicitly set offset in DateTimeOffset test

### DIFF
--- a/Tests/Shared.Specs/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/Shared.Specs/DateTimeOffsetAssertionSpecs.cs
@@ -414,13 +414,13 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             var specificDate = 1.May(2008).At(6, 32);
 
-            var dateWithFiveHourOffset = new DateTimeOffset(specificDate);
-            var dateWithSixHourOffset = new DateTimeOffset(specificDate, 1.Hours());
+            var dateWithZeroHourOffset = new DateTimeOffset(specificDate, TimeSpan.Zero);
+            var dateWithOneHourOffset = new DateTimeOffset(specificDate, 1.Hours());
 
             //-----------------------------------------------------------------------------------------------------------
             // Act / Assert
             //-----------------------------------------------------------------------------------------------------------
-            dateWithFiveHourOffset.Should().NotBe(dateWithSixHourOffset);
+            dateWithZeroHourOffset.Should().NotBe(dateWithOneHourOffset);
         }
 
         #endregion


### PR DESCRIPTION
When not providing an `offset` to the `DateTimeOffset` constructor [it picks the local offset](http://referencesource.microsoft.com/#mscorlib/system/datetimeoffset.cs,69)

This PR explicitly sets the offset to `TimeSpan.Zero`.

Thanks to @alexangas for pointing this out. 