### PR TITLE
Include generic type in failure message

### DIFF
--- a/Src/FluentAssertions/Equivalency/AssertionRule.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionRule.cs
@@ -45,15 +45,23 @@ namespace FluentAssertions.Equivalency
         {
             if (predicate(context))
             {
-                bool expectationisNull = ReferenceEquals(context.Expectation, null);
+                bool subjectIsNull = ReferenceEquals(context.Subject, null);
 
-                bool succeeded =
+                bool subjectIsValidType =
                     AssertionScope.Current
-                        .ForCondition(expectationisNull || context.Expectation.GetType().IsSameOrInherits(typeof(TSubject)))
-                        .FailWith("Expected " + context.SelectedMemberDescription + " to be a {0}{reason}, but found a {1}",
-                            !expectationisNull ? context.Expectation.GetType() : null, context.SelectedMemberInfo.MemberType);
+                        .ForCondition(subjectIsNull || context.Subject.GetType().IsSameOrInherits(typeof(TSubject)))
+                        .FailWith("Expected " + context.SelectedMemberDescription + " from subject to be a {0}{reason}, but found a {1}.",
+                            typeof(TSubject), context.Subject?.GetType());
 
-                if (succeeded)
+                bool expectationIsNull = ReferenceEquals(context.Expectation, null);
+
+                bool expectationIsValidType =
+                    AssertionScope.Current
+                        .ForCondition(expectationIsNull || context.Expectation.GetType().IsSameOrInherits(typeof(TSubject)))
+                        .FailWith("Expected " + context.SelectedMemberDescription + " from expectation to be a {0}{reason}, but found a {1}.",
+                            typeof(TSubject), context.SelectedMemberInfo.MemberType);
+
+                if (subjectIsValidType && expectationIsValidType)
                 {
                     action(AssertionContext<TSubject>.CreateFromEquivalencyValidationContext(context));
                 }

--- a/Src/FluentAssertions/Equivalency/AssertionRuleEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionRuleEquivalencyStep.cs
@@ -27,17 +27,23 @@ namespace FluentAssertions.Equivalency
 
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
         {
-            bool expectationisNull = ReferenceEquals(context.Expectation, null);
+            bool subjectIsNull = ReferenceEquals(context.Subject, null);
 
-            bool succeeded =
-                AssertionScope.Current.ForCondition(
-                    expectationisNull || context.Expectation.GetType().IsSameOrInherits(typeof(TSubject)))
-                    .FailWith(
-                        "Expected " + context.SelectedMemberDescription + " to be a {0}{reason}, but found a {1}",
-                        !expectationisNull ? context.Expectation.GetType() : null,
-                        context.SelectedMemberInfo.MemberType);
+            bool subjectIsValidType =
+                AssertionScope.Current
+                    .ForCondition(context.Subject.GetType().IsSameOrInherits(typeof(TSubject)))
+                    .FailWith("Expected " + context.SelectedMemberDescription + " from subject to be a {0}{reason}, but found a {1}.",
+                        typeof(TSubject), context.Subject?.GetType());
 
-            if (succeeded)
+            bool expectationIsNull = ReferenceEquals(context.Expectation, null);
+
+            bool expectationIsValidType =
+                AssertionScope.Current
+                    .ForCondition(expectationIsNull || context.Expectation.GetType().IsSameOrInherits(typeof(TSubject)))
+                    .FailWith("Expected " + context.SelectedMemberDescription + " from expectation to be a {0}{reason}, but found a {1}.",
+                        typeof(TSubject), context.SelectedMemberInfo.MemberType);
+
+            if (subjectIsValidType && expectationIsValidType)
             {
                 handle(AssertionContext<TSubject>.CreateFromEquivalencyValidationContext(context));
                 return true;

--- a/Tests/Shared.Specs/ExtensibilityRelatedEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/ExtensibilityRelatedEquivalencySpecs.cs
@@ -180,7 +180,191 @@ namespace FluentAssertions.Specs
         #endregion
 
         #region Assertion Rules
-        
+
+        [Fact]
+        public void When_property_of_other_is_incompatible_with_generic_type_the_message_should_include_generic_type()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new
+            {
+                Id = "foo",
+            };
+
+            var other = new
+            {
+                Id = 0.5d,
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.Should().BeEquivalentTo(other,
+                o => o
+                    .Using<string>(c => c.Subject.Should().Be(c.Expectation))
+                    .When(si => si.SelectedMemberPath == "Id"));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("*member Id from expectation*System.String*System.Double*");
+        }
+
+        [Fact]
+        public void When_property_of_subject_is_incompatible_with_generic_type_the_message_should_include_generic_type()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new
+            {
+                Id = 0.5d,
+            };
+
+            var other = new
+            {
+                Id = "foo",
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.Should().BeEquivalentTo(other,
+                o => o
+                    .Using<string>(c => c.Subject.Should().Be(c.Expectation))
+                    .When(si => si.SelectedMemberPath == "Id"));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("*member Id from subject*System.String*System.Double*");
+        }
+
+        [Fact]
+        public void When_equally_named_properties_are_both_incompatible_with_generic_type_the_message_should_include_generic_type()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new
+            {
+                Id = 0.5d,
+            };
+
+            var other = new
+            {
+                Id = 0.5d,
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.Should().BeEquivalentTo(other,
+                o => o
+                    .Using<string>(c => c.Subject.Should().Be(c.Expectation))
+                    .When(si => si.SelectedMemberPath == "Id"));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("*member Id from subject*System.String*System.Double*member Id from expectation*System.String*System.Double*");
+        }
+
+        [Fact]
+        public void When_property_of_other_is_null_the_failure_message_should_not_complain_about_its_type()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new
+            {
+                Id = "foo",
+            };
+
+            var other = new
+            {
+                Id = null as double?,
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.Should().BeEquivalentTo(other,
+                o => o
+                    .Using<string>(c => c.Subject.Should().Be(c.Expectation))
+                    .When(si => si.SelectedMemberPath == "Id"));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .Which.Message.Should()
+                .Contain("Expected member Id to be <null>, but found \"foo\"")
+                    .And.NotContain("from expectation");
+        }
+
+        [Fact]
+        public void When_property_of_subject_is_null_the_failure_message_should_not_complain_about_its_type()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new
+            {
+                Id = null as double?,
+            };
+
+            var other = new
+            {
+                Id = "bar",
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.Should().BeEquivalentTo(other,
+                o => o
+                    .Using<string>(c => c.Subject.Should().Be(c.Expectation))
+                    .When(si => si.SelectedMemberPath == "Id"));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .Which.Message.Should()
+                .Contain("Expected member Id to be \"bar\", but found <null>")
+                    .And.NotContain("from subject");
+        }
+
+        [Fact]
+        public void When_equally_named_properties_are_both_null_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new
+            {
+                Id = null as double?,
+            };
+
+            var other = new
+            {
+                Id = null as string,
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            subject.Should().BeEquivalentTo(other,
+                o => o
+                    .Using<string>(c => c.Subject.Should().Be(c.Expectation))
+                    .When(si => si.SelectedMemberPath == "Id"));
+        }
+
         [Fact]
         public void When_equally_named_properties_are_type_incompatible_and_assertion_rule_exists_it_should_not_throw()
         {


### PR DESCRIPTION
This PR changes the failure message, when the type of a property is not equal or assignable to `TSubject`, to say that the property was not convertible to `TSubject`.

This is the first time I touch the object comparison code in Fluent Assertions, but I hope I haven't overlooked any (obvious) case(s).
E.g. are there any usages of `Using<TSubject>()` where `context.Expectation` or `context.Subject` are allowed to not be equal or assignable to `TSubject`?

This fixes #687 