### PR TITLE
Improve documentation for 5.0

### DIFF
--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -102,7 +102,7 @@ namespace FluentAssertions.Primitives
 
         /// <summary>
         /// Asserts that a string is not exactly the same as the specified <paramref name="unexpected"/>,
-        /// including any leading or trailing whitespace, with the exception of the casing.
+        /// including the casing and any leading or trailing whitespace.
         /// </summary>
         /// <param name="unexpected">The string that the subject is not expected to be equivalent to.</param>
         /// <param name="because">

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -5,7 +5,9 @@ title: Documentation
 **This is the documentation for v3.0 and higher. You can find the v2.2 documentation [here](v2/documentation.md).**
 
 ## Coding by Example ##
-As you may have noticed the purpose of this open-source project is to not only be the best assertion framework in the .NET realm, but to also demonstrate high-quality code. We heavily practice Test Driven Development and one of the promises TDD makes is that unit tests can be treated as your API's documentation. So although you are free to go through the many examples here, please consider to analyze the many [unit tests](https://github.com/fluentassertions/fluentassertions/tree/master/Tests/FluentAssertions.Shared.Specs).
+As you may have noticed the purpose of this open-source project is to not only be the best assertion framework in the .NET realm, but to also demonstrate high-quality code.
+We heavily practice Test Driven Development and one of the promises TDD makes is that unit tests can be treated as your API's documentation.
+So although you are free to go through the many examples here, please consider to analyze the many [unit tests](https://github.com/fluentassertions/fluentassertions/tree/master/Tests/FluentAssertions.Shared.Specs).
 
 ## Table of Contents ##
 * TOC
@@ -14,9 +16,12 @@ As you may have noticed the purpose of this open-source project is to not only b
 
 ## Supported Test Frameworks ##
 
-Fluent Assertions supports MSTest, MSTest2, NUnit, xUnit, xUnit2, MSpec, NSpec, MBUnit and the Gallio Framework as well as the Windows Store and Windows Phone unit testing frameworks. You can simply add a reference to the corresponding test framework assembly to the unit test project. Fluent Assertions will automatically find the corresponding assembly and use it for throwing the framework-specific exceptions. 
+Fluent Assertions supports MSTest, MSTest2, NUnit, xUnit, xUnit2, MSpec, NSpec, MBUnit and the Gallio Framework as well as the Windows Store and Windows Phone unit testing frameworks.
+You can simply add a reference to the corresponding test framework assembly to the unit test project.
+Fluent Assertions will automatically find the corresponding assembly and use it for throwing the framework-specific exceptions.
 
-If, for some unknown reason, Fluent Assertions fails to find the assembly, try specifying the framework explicitly using a configuration setting in the project’s app.config. If it cannot find any of the supported frameworks, it will fall back to using a custom `AssertFailedException` exception class.
+If, for some unknown reason, Fluent Assertions fails to find the assembly, try specifying the framework explicitly using a configuration setting in the project’s app.config.
+If it cannot find any of the supported frameworks, it will fall back to using a custom `AssertFailedException` exception class.
 
 ```xml
 <configuration>
@@ -26,10 +31,10 @@ If, for some unknown reason, Fluent Assertions fails to find the assembly, try s
   </appSettings>
 </configuration>
 ```
-Just add nuget package "fluentassertions" to your test project.
+Just add NuGet package "FluentAssertions" to your test project.
 
 ## Basic assertions ##
-The following assertions are available to all types of objects. 
+The following assertions are available to all types of objects.
 
 ```csharp
 object theObject = null;
@@ -38,13 +43,15 @@ theObject.Should().NotBeNull();
 
 theObject = "whatever";
 theObject.Should().BeOfType<string>("because a {0} is set", typeof(string));
-theObject.Should().BeOfType(typeof(string), "because a {0} is set", typeof(string));	
+theObject.Should().BeOfType(typeof(string), "because a {0} is set", typeof(string));
 ```
 
-Sometimes you might like to first assert that an object is of a certain type using `BeOfType` and then continue with additional assertions on the result of casting that object to the specified type. You can do that by chaining those assertions onto the `Which` property like this. 
+Sometimes you might like to first assert that an object is of a certain type using `BeOfType` and then continue with additional assertions on the result of casting that object to the specified type.
+You can do that by chaining those assertions onto the `Which` property like this.
 
 ```csharp
-someObject.Should().BeOfType<Exception>().Which.Message.Should().Be("Other Message");
+someObject.Should().BeOfType<Exception>()
+  .Which.Message.Should().Be("Other Message");
 ```
 
 To assert that two objects are equal (through their implementation of `Object.Equals`), use 
@@ -55,10 +62,10 @@ theObject.Should().Be(otherObject, "because they have the same values");
 theObject.Should().NotBe(otherObject);
 ```
  
-If you want to make sure two objects are not just functionally equal but refer to the exact same object in memory, use the following two methods. 
+If you want to make sure two objects are not just functionally equal but refer to the exact same object in memory, use the following two methods.
 
 ```csharp
-theObject = otherObject; 
+theObject = otherObject;
 theObject.Should().BeSameAs(otherObject);
 theObject.Should().NotBeSameAs(otherObject);
 ```
@@ -78,7 +85,7 @@ dummy.Should().Match((string d) => (d == "System.Object"));
 
 Some users requested the ability to easily downcast an object to one of its derived classes in a fluent way.
 
-```csharp	
+```csharp
 customer.Animals.First().As<Human>().Height.Should().Be(178);
 ```
 
@@ -93,7 +100,7 @@ Internally, `BeBinarySerializable` uses the [Object graph comparison](#object-gr
 
 ```csharp
 theObject.Should().BeBinarySerializable<MyClass>(
-	options => options.Excluding(s => s.SomeNonSerializableProperty));
+    options => options.Excluding(s => s.SomeNonSerializableProperty));
 ```
 
 Fluent Assertions has special support for `[Flags]` based enumerations, which allow you to do something like this:
@@ -145,7 +152,7 @@ string theString = "";
 theString.Should().NotBeNull();
 theString.Should().BeNull();
 theString.Should().BeEmpty();
-theString.Should().NotBeEmpty("because the string is not empty"); 
+theString.Should().NotBeEmpty("because the string is not empty");
 theString.Should().HaveLength(0);
 theString.Should().BeNullOrWhiteSpace(); // either null, empty or whitespace only
 theString.Should().NotBeNullOrWhiteSpace();
@@ -158,6 +165,11 @@ theString = "This is a String";
 theString.Should().Be("This is a String");
 theString.Should().NotBe("This is another String");
 theString.Should().BeEquivalentTo("THIS IS A STRING");
+
+theString.Should().BeOneOf(
+	"That is a String",
+	"This is a String",
+);
 
 theString.Should().Contain("is a");
 theString.Should().ContainAll("should", "contain", "all", "of", "these");
@@ -179,15 +191,17 @@ theString.Should().EndWithEquivalent("a string");
 theString.Should().NotEndWithEquivalentOf("a string");
 ```
 
-We even support wildcards. For instance, if you would like to assert that some email address is correct, use this:
+We even support wildcards.
+For instance, if you would like to assert that some email address is correct, use this:
 
 ```csharp
 emailAddress.Should().Match("*@*.com");
+homeAddress.Should().NotMatch("*@*.com");
 ```
 
 If the casing of the input string is irrelevant, use this:
 
-```csharp	
+```csharp
 emailAddress.Should().MatchEquivalentOf("*@*.COM");
 ```
 
@@ -204,13 +218,13 @@ subject.Should().NotMatchRegex(".*earth.*");
 int theInt = 5;
 theInt.Should().BeGreaterOrEqualTo(5);
 theInt.Should().BeGreaterOrEqualTo(3);
-theInt.Should().BeGreaterThan(4);     
+theInt.Should().BeGreaterThan(4);
 theInt.Should().BeLessOrEqualTo(5);
 theInt.Should().BeLessThan(6);
 theInt.Should().BePositive();
 theInt.Should().Be(5);
 theInt.Should().NotBe(10);
-theInt.Should().BeInRange(1,10);
+theInt.Should().BeInRange(1, 10);
 theInt.Should().NotBeInRange(6, 10);
 
 theInt = 0;
@@ -222,13 +236,15 @@ theInt.Should().BeNegative();
 int? nullableInt = 3;
 nullableInt.Should().Be(3);
 
-double theDouble = 5.1;     
+double theDouble = 5.1;
 theDouble.Should().BeGreaterThan(5);
 byte theByte = 2;
 theByte.Should().Be(2);
 ```
 
-Notice that `Should().Be()` and `Should().NotBe()` are not available for floats and  doubles. As explained in  this article, floating point variables are inheritably inaccurate and should never be compared for equality. Instead, either use the Should().BeInRange() method or the following method specifically designed for floating point or `decimal` variables.
+Notice that `Should().Be()` and `Should().NotBe()` are not available for floats and doubles.
+As explained in this article, floating point variables are inheritably inaccurate and should never be compared for equality.
+Instead, either use the Should().BeInRange() method or the following method specifically designed for floating point or `decimal` variables.
 
 ```csharp
 float value = 3.1415927F;
@@ -254,17 +270,25 @@ value.Should().BeOneOf(new[] { 3, 6});
 
 ## Dates and times ##
 
-For asserting a `DateTime` or a `DateTimeOffset` against various constraints, FA offers a bunch of methods that, provided that you use the extension methods for representinging dates and times, really help to keep your assertions readable.
+For asserting a `DateTime` or a `DateTimeOffset` against various constraints, FA offers a bunch of methods that, provided that you use the extension methods for representing dates and times, really help to keep your assertions readable.
 
 ```csharp
-var theDatetime = 1.March(2010).At(22,15);
-
-theDatetime.Should().BeAfter(1.February(2010));
-theDatetime.Should().BeBefore(2.March(2010));     
-theDatetime.Should().BeOnOrAfter(1.March(2010));
+var theDatetime = 1.March(2010).At(22, 15);
 
 theDatetime.Should().Be(1.March(2010).At(22, 15));
-theDatetime.Should().NotBe(1.March(2010).At(22, 16)); 
+theDatetime.Should().BeAfter(1.February(2010));
+theDatetime.Should().BeBefore(2.March(2010));
+theDatetime.Should().BeOnOrAfter(1.March(2010));
+theDatetime.Should().BeOnOrBefore(1.March(2010));
+theDatetime.Should().BeSameDateAs(1.March(2010).At(22, 16));
+theDatetime.Should().BeIn(DateTimeKind.Local);
+
+theDatetime.Should().NotBe(1.March(2010).At(22, 16));
+theDatetime.Should().NotBeAfter(2.March(2010));
+theDatetime.Should().NotBeBefore(1.February(2010));
+theDatetime.Should().NotBeOnOrAfter(2.March(2010));
+theDatetime.Should().NotBeOnOrBefore(1.February(2010));
+theDatetime.Should().NotBeSameDateAs(2.March(2010));
 
 theDatetime.Should().HaveDay(1);
 theDatetime.Should().HaveMonth(3);
@@ -273,80 +297,110 @@ theDatetime.Should().HaveHour(22);
 theDatetime.Should().HaveMinute(15);
 theDatetime.Should().HaveSecond(0);
 
-theDatetime.Should().BeSameDateAs(1.March(2010));
+theDatetime.Should().NotHaveDay(2);
+theDatetime.Should().NotHaveMonth(4);
+theDatetime.Should().NotHaveYear(2011);
+theDatetime.Should().NotHaveHour(23);
+theDatetime.Should().NotHaveMinute(16);
+theDatetime.Should().NotHaveSecond(1);
+
+theDatetime.Should().BeOneOf(
+	1.March(2010).At(21, 15),
+	1.March(2010).At(22, 15),
+	1.March(2010).At(23, 15)
+);
 ```
 
-We've added a whole set of methods for asserting that the difference between two DateTime objects match a certain time frame. All five methods support a Before and  After extension method.
+We've added a whole set of methods for asserting that the difference between two DateTime objects match a certain time frame.
+All five methods support a Before and After extension method.
 
 ```csharp
 theDatetime.Should().BeLessThan(10.Minutes()).Before(otherDatetime); // Equivalent to <
 theDatetime.Should().BeWithin(2.Hours()).After(otherDatetime);       // Equivalent to <=
 theDatetime.Should().BeMoreThan(1.Days()).Before(deadline);          // Equivalent to >
 theDatetime.Should().BeAtLeast(2.Days()).Before(deliveryDate);       // Equivalent to >=
-theDatetime.Should().BeExactly(24.Hours()).Before(appointement);     // Equivalent to ==
+theDatetime.Should().BeExactly(24.Hours()).Before(appointment);      // Equivalent to ==
 ```
 
-To assert that a date/time is within a specified number of milliseconds from another date/time value you can use this method.
+To assert that a date/time is (not) within a specified number of milliseconds from another date/time value you can use this method.
 
 ```csharp
-theDatetime.Should().BeCloseTo(1.March(2010).At(22,15), 2000); // 2000 milliseconds
-theDatetime.Should().BeCloseTo(1.March(2010).At(22,15));       // default is 20 milliseconds
+theDatetime.Should().BeCloseTo(1.March(2010).At(22, 15), 2000); // 2000 milliseconds
+theDatetime.Should().BeCloseTo(1.March(2010).At(22, 15));       // default is 20 milliseconds
+theDatetime.Should().BeCloseTo(1.March(2010).At(22, 15), 2000.Milliseconds());
+
+theDatetime.Should().NotBeCloseTo(2.March(2010), 1.Hours());
 ```
 
-This can be particularly useful if your database truncates date/time values. 
+This can be particularly useful if your database truncates date/time values.
 
 ## TimeSpans ##
 
 FA also support a few dedicated methods that apply to (nullable) TimeSpans directly:
 
 ```csharp
-var timeSpan = new TimeSpan(12, 59, 59); 
-timeSpan.Should().BePositive(); 
-timeSpan.Should().BeNegative(); 
-timeSpan.Should().Be(12.Hours()); 
-timeSpan.Should().NotBe(1.Days()); 
-timeSpan.Should().BeLessThan(someOtherTimeSpan); 
-timeSpan.Should().BeLessOrEqualTo(someOtherTimeSpan); 
-timeSpan.Should().BeGreaterThan(someOtherTimeSpan); 
+var timeSpan = new TimeSpan(12, 59, 59);
+timeSpan.Should().BePositive();
+timeSpan.Should().BeNegative();
+timeSpan.Should().Be(12.Hours());
+timeSpan.Should().NotBe(1.Days());
+timeSpan.Should().BeLessThan(someOtherTimeSpan);
+timeSpan.Should().BeLessOrEqualTo(someOtherTimeSpan);
+timeSpan.Should().BeGreaterThan(someOtherTimeSpan);
 timeSpan.Should().BeGreaterOrEqualTo(someOtherTimeSpan);
 ```
 
-Similarly to the [date and time assertions](#dates-and-times), `BeCloseTo` is also available for time spans:
+Similarly to the [date and time assertions](#dates-and-times), `BeCloseTo` and `NotBeCloseTo` are also available for time spans:
 
 ```csharp
 timeSpan.Should().BeCloseTo(new TimeSpan(13, 0, 0), 10.Ticks());
+timeSpan.Should().NotBeCloseTo(new TimeSpan(14, 0, 0), 10.Ticks());
 ```
 
 ## Collections ##
 
-A collection object in .NET is so versatile that the number of assertions on them require the same level of versatility. Most, if not all, are so self-explanatory that we'll just list them here.   
+A collection object in .NET is so versatile that the number of assertions on them require the same level of versatility.
+Most, if not all, are so self-explanatory that we'll just list them here.
 
 ```csharp
 IEnumerable collection = new[] { 1, 2, 5, 8 };
 
 collection.Should().NotBeEmpty()
-     .And.HaveCount(4)
-     .And.ContainInOrder(new[] { 2, 5 })
-     .And.ContainItemsAssignableTo<int>();
+    .And.HaveCount(4)
+    .And.ContainInOrder(new[] { 2, 5 })
+    .And.ContainItemsAssignableTo<int>();
 
 collection.Should().Equal(new List<int> { 1, 2, 5, 8 });
 collection.Should().Equal(1, 2, 5, 8);
+collection.Should().NotEqual(8, 2, 3, 5);
 collection.Should().BeEquivalentTo(8, 2, 1, 5);
 collection.Should().NotBeEquivalentTo(8, 2, 3, 5);
 
-collection.Should().HaveCount(c => c > 3).And.OnlyHaveUniqueItems();
-collection.Should().HaveSameCount(new[] {6, 2, 0, 5});
-collection.Should().NotHaveSameCount(new[] {6, 2, 0});
+collection.Should().HaveCount(c => c > 3)
+  .And.OnlyHaveUniqueItems();
 
-collection.Should().StartWith(element);
-collection.Should().EndWith(element);
+collection.Should().HaveCountGreaterThan(3);
+collection.Should().HaveCountGreaterOrEqualTo(4);
+collection.Should().HaveCountLessOrEqualTo(4);
+collection.Should().HaveCountLessThan(5);
+collection.Should().NotHaveCount(3);
+collection.Should().HaveSameCount(new[] { 6, 2, 0, 5 });
+collection.Should().NotHaveSameCount(new[] { 6, 2, 0 });
+
+collection.Should().StartWith(1);
+collection.Should().StartWith(new[] { 1, 2 });
+collection.Should().EndWith(8);
+collection.Should().EndWith(new[] { 5, 8 });
 
 collection.Should().BeSubsetOf(new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, });
 
 collection.Should().ContainSingle();
 collection.Should().ContainSingle(x => x > 3);
-collection.Should().Contain(8).And.HaveElementAt(2, 5).And.NotBeSubsetOf(new[] {11, 56});
-collection.Should().Contain(x => x > 3); 
+collection.Should().Contain(8)
+  .And.HaveElementAt(2, 5)
+  .And.NotBeSubsetOf(new[] {11, 56});
+
+collection.Should().Contain(x => x > 3);
 collection.Should().Contain(collection, "", 5, 6); // It should contain the original items, plus 5 and 6.
 
 collection.Should().OnlyContain(x => x < 10);
@@ -355,6 +409,7 @@ collection.Should().ContainItemsAssignableTo<int>();
 collection.Should().ContainInOrder(new[] { 1, 5, 8 });
 
 collection.Should().NotContain(82);
+collection.Should().NotContain(new[] { 82, 83 });
 collection.Should().NotContainNulls();
 collection.Should().NotContain(x => x > 10);
 
@@ -373,34 +428,59 @@ collection.Should().IntersectWith(otherCollection);
 collection.Should().NotIntersectWith(anotherCollection);
 
 collection.Should().BeInAscendingOrder();
-collection.Should().NotBeAscendingOrder();
+collection.Should().BeInDescendingOrder();
+collection.Should().NotBeAscendingInOrder();
+collection.Should().NotBeDescendingInOrder();
 ```
 
-Those last two methods can be used to assert a collection contains items in ascending or descending order.  For simple types that might be fine, but for more complex types, it requires you to implement `IComparable`, something that doesn't make a whole lot of sense in all cases. That's why we offer overloads that take an expression.
+Those last two methods can be used to assert a collection contains items in ascending or descending order.
+For simple types that might be fine, but for more complex types, it requires you to implement `IComparable`, something that doesn't make a whole lot of sense in all cases.
+That's why we offer overloads that take an expression.
 
 ```csharp
 collection.Should().BeInAscendingOrder(x => x.SomeProperty);
+collection.Should().BeInDescendingOrder(x => x.SomeProperty);
 ```
 
-A special overload of `Equal()` takes a lambda that is used for checking the equality of two collections without relying on the type’s Equals() method. Consider for instance two collections that contain some kind of domain entity persisted to a database and then reloaded. Since the actual object instance is different, if you want to make sure a particular property was properly persisted, you usually do something like this:
+When asserting on a projection of a collection the failure message will be less descriptive as it only knows about the projected value and not object containing that property.
+```csharp
+collection.Select(x => x.SomeProperty).Should().OnlyHaveUniqueItems();
+```
+
+Therefore we offer two overloads that takes an expression to select the property.
+```csharp
+collection.Should().OnlyHaveUniqueItems(x => x.SomeProperty);
+collection.Should().NotContainNulls(x => x.SomeProperty);
+```
+
+Special overloads of `Equal()`, `StartWith` and `EndWith` take a lambda that is used for checking the two collections without relying on the type’s Equals() method.
+Consider for instance two collections that contain some kind of domain entity persisted to a database and then reloaded.
+Since the actual object instance is different, if you want to make sure a particular property was properly persisted, you usually do something like this:
 
 ```csharp
 persistedCustomers.Select(c => c.Name).Should().Equal(customers.Select(c => c.Name);
+persistedCustomers.Select(c => c.Name).Should().StartWith(customers.Select(c => c.Name);
+persistedCustomers.Select(c => c.Name).Should().EndWith(customers.Select(c => c.Name);
 ```
 
-With this new overload, you can rewrite it into:
+With these new overloads, you can rewrite them into:
 
 ```csharp
 persistedCustomers.Should().Equal(customers, (c1, c2) => c1.Name == c2.Name);
+persistedCustomers.Should().StartWith(customers, (c1, c2) => c1.Name == c2.Name);
+persistedCustomers.Should().EndWith(customers, (c1, c2) => c1.Name == c2.Name);
 ```
 
 ## Dictionaries ##
 
-You can apply Fluent Assertions to your generic dictionaries as well. Of course you can assert any dictionary to be null or not null, and empty or not empty. Like this:
+You can apply Fluent Assertions to your generic dictionaries as well.
+Of course you can assert any dictionary to be null or not null, and empty or not empty.
+Like this:
 
 ```csharp
 Dictionary<int, string> dictionary;
 dictionary.Should().BeNull();
+
 dictionary = new Dictionary<int, string>();
 dictionary.Should().NotBeNull();
 dictionary.Should().BeEmpty();
@@ -408,7 +488,8 @@ dictionary.Add(1, "first element");
 dictionary.Should().NotBeEmpty();
 ```
 
-You can also assert the equality of the entire dictionary, where the equality of the keys and values will be validated using their Equals implementation. Like this:
+You can also assert the equality of the entire dictionary, where the equality of the keys and values will be validated using their Equals implementation.
+Like this:
 
 ```csharp
 var dictionary1 = new Dictionary<int, string>
@@ -436,36 +517,47 @@ Or you can assert that the dictionary contains a certain key or value:
 
 ```csharp
 dictionary.Should().ContainKey(1);
+dictionary.Should().ContainKeys(1, 2);
 dictionary.Should().NotContainKey(9);
+dictionary.Should().NotContainKeys(9, 10);
 dictionary.Should().ContainValue("One");
+dictionary.Should().ContainValues("One", "Two");
 dictionary.Should().NotContainValue("Nine");
+dictionary.Should().NotContainValues("Nine", "Ten");
 ```
 
 You can also assert that the dictionary has a certain number of items:
 
 ```csharp
 dictionary.Should().HaveCount(2);
+dictionary.Should().NotHaveCount(3);
 ```
 
 And finally you can assert that the dictionary contains a specific key/value pair or not:
 
 ```csharp
-KeyValuePair<int, string> item = new KeyValuePair<int, string>(1, "One");
+KeyValuePair<int, string> item1 = new KeyValuePair<int, string>(1, "One");
+KeyValuePair<int, string> item2 = new KeyValuePair<int, string>(2, "Two");
 
-dictionary.Should().Contain(item);
+dictionary.Should().Contain(item1);
+dictionary.Should().Contain(item1, item2);
 dictionary.Should().Contain(2, "Two");
+dictionary.Should().NotContain(item1);
+dictionary.Should().NotContain(item1, item2);
 dictionary.Should().NotContain(9, "Nine");
 ```
 
 Chaining additional assertion is supported as well.
 
 ```csharp
-dictionary.Should().ContainValue(myClass).Which.SomeProperty.Should().BeGreaterThan(0);
+dictionary.Should().ContainValue(myClass)
+  .Which.SomeProperty.Should().BeGreaterThan(0);
 ```
 
 ## Guids ##
 
-The assertions you can do on Guids are simple. You can assert their equality to another Guid, or you can assert that a Guid is empty.
+The assertions you can do on Guids are simple.
+You can assert their equality to another Guid, or you can assert that a Guid is empty.
 
 ```csharp
 Guid theGuid = Guid.NewGuid();
@@ -480,7 +572,8 @@ Guid.Empty.Should().BeEmpty();
 ```
 
 ## Enums ##
-With the standard `Should().Be()` method, Enums are compared using .NET's `Enum.Equals()` implementation. This means that the Enums must be of the same type, and have the same underlying value.
+With the standard `Should().Be()` method, Enums are compared using .NET's `Enum.Equals()` implementation.
+This means that the Enums must be of the same type, and have the same underlying value.
 
 ## Exceptions ##
 
@@ -488,8 +581,8 @@ The following example verifies that the `Foo()` method throws an `InvalidOperati
 
 ```csharp
 subject.Invoking(y => y.Foo("Hello"))
-     .ShouldThrow<InvalidOperationException>()
-     .WithMessage("Hello is not allowed at this moment");
+    .Should().Throw<InvalidOperationException>()
+    .WithMessage("Hello is not allowed at this moment");
 ```
 
 But if you, like me, prefer the arrange-act-assert syntax, you can also use an action in your act part.
@@ -497,17 +590,18 @@ But if you, like me, prefer the arrange-act-assert syntax, you can also use an a
 ```csharp
 Action act = () => subject.Foo2("Hello");
 
-act.ShouldThrow<InvalidOperationException>()
-     .WithInnerException<ArgumentException>()
-     .WithInnerMessage("whatever");
+act.Should().Throw<InvalidOperationException>()
+    .WithInnerException<ArgumentException>()
+    .WithInnerMessage("whatever");
 ```
 
-Notice that the example also verifies that the exception has a particular inner exception with a specific message. in fact, you can even check the individual properties of the exception instance using the And property.
+Notice that the example also verifies that the exception has a particular inner exception with a specific message.
+In fact, you can even check the individual properties of the exception instance using the And property.
 
 ```csharp
 Action act = () => subject.Foo(null);
 
-act.ShouldThrow<ArgumentNullException>()
+act.Should().Throw<ArgumentNullException>()
  .And.ParamName.Should().Be("message");
 ```
 
@@ -515,7 +609,7 @@ An alternative syntax for doing the same is by chaining one or more calls to the
 
 ```csharp
 Action act = () => subject.Foo(null);
-act.ShouldThrow<ArgumentNullException>().Where(e => e.Message.StartsWith("did"));
+act.Should().Throw<ArgumentNullException>().Where(e => e.Message.StartsWith("did"));
 ```
 
 However, we discovered that testing the exception message for a substring is so common, that we changed the default behavior of `WithMessage` to support wildcard expressions and match in a case-insensitive way.
@@ -523,7 +617,7 @@ However, we discovered that testing the exception message for a substring is so 
 ```csharp
 Action act = () => subject.Foo(null);
 act
-  .ShouldThrow<ArgumentNullException>()
+  .Should().Throw<ArgumentNullException>()
   .WithMessage("?did*");
 ```
 
@@ -531,60 +625,70 @@ On the other hand, you may want to verify that no exceptions were thrown.
 
 ```csharp
 Action act = () => subject.Foo("Hello");
-act.ShouldNotThrow();
+act.Should().NotThrow();
 ```
 
-I know that a unit test will fail anyhow if an exception was thrown, but this syntax returns a clearer description of the exception that was thrown and fits better to the AAA syntax. 
+I know that a unit test will fail anyhow if an exception was thrown, but this syntax returns a clearer description of the exception that was thrown and fits better to the AAA syntax.
 
 If you want to verify that a specific exception is not thrown, and want to ignore others, you can do that using an overload:
 
 ```csharp
 Action act = () => subject.Foo("Hello");
-act.ShouldNotThrow<InvalidOperationException>();
+act.Should().NotThrow<InvalidOperationException>();
 ```
 
-If the method you are testing returns an `IEnumerable` or `IEnumerable<T>` and it uses the `yield` keyword to construct that collection, just calling the method will not cause the effect you expected. Because the real work is not done until you actually iterate over that collection. you can use the Enumerating() extension method to force enumerating the collection like this.
+If the method you are testing returns an `IEnumerable` or `IEnumerable<T>` and it uses the `yield` keyword to construct that collection, just calling the method will not cause the effect you expected.
+Because the real work is not done until you actually iterate over that collection.
+You can use the Enumerating() extension method to force enumerating the collection like this.
 
 ```csharp
 Func<IEnumerable<char>> func = () => obj.SomeMethodThatUsesYield("blah");
-func.Enumerating().ShouldThrow<ArgumentException>();
+func.Enumerating().Should().Throw<ArgumentException>();
 ```
 
 You do have to use the `Func<T>` type instead of `Action<T>` then.
 
-The exception throwing API follows the same rules as the `try`...`catch`...construction does. In other words, if you're expecting a certain exception to be (not) thrown, and a more specific exception is thrown instead, it would still satisfy the assertion. So throwing an `ApplicationException` when an `Exception` was expected will not fail the assertion. However, if you really want to be explicit about the exact type of exception, you can use `ShouldThrowExactly` and `WithInnerExceptionExactly`.  
+The exception throwing API follows the same rules as the `try`...`catch`...construction does.
+In other words, if you're expecting a certain exception to be (not) thrown, and a more specific exception is thrown instead, it would still satisfy the assertion.
+So throwing an `ApplicationException` when an `Exception` was expected will not fail the assertion.
+However, if you really want to be explicit about the exact type of exception, you can use `ThrowExactly` and `WithInnerExceptionExactly`.
 
-.NET 4.0 and later includes the `AggregateException` which is typically thrown by code that runs through the Parallel Task Library or using the new `async` keyword. All of the above also works for exceptions that are aggregated, whether or not you are asserting on the actual `AggregateException` or any of its (nested) aggregated exceptions.
+.NET 4.0 and later includes the `AggregateException` which is typically thrown by code that runs through the Parallel Task Library or using the new `async` keyword.
+All of the above also works for exceptions that are aggregated, whether or not you are asserting on the actual `AggregateException` or any of its (nested) aggregated exceptions.
 
 Talking about the `async` keyword, you can also verify that an asynchronously executed method throws or doesn't throw an exception:
 
 ```csharp
 Func<Task> act = async () => { await asyncObject.ThrowAsync<ArgumentException>(); };
-act.ShouldThrow<InvalidOperationException>();
-act.ShouldNotThrow();
+act.Should().Throw<InvalidOperationException>();
+act.Should().NotThrow();
 ```
 
 Alternatively, you can use the `Awaiting` method like this:
 
 ```csharp
-Func<Task> act = () => asyncObject.Awaiting(async x => await x.ThrowAsync<ArgumentException>())
-act.ShouldThrow<ArgumentException>();
+Func<Task> act = () => asyncObject.Awaiting(async x => await x.ThrowAsync<ArgumentException>());
+act.Should().Throw<ArgumentException>();
 ```
 
-Both give you the same results, so it's just a matter of personal preference. 
+Both give you the same results, so it's just a matter of personal preference.
 
 ## Object graph comparison ##
 
-Consider the class `Order` and its wire-transfer equivalent `OrderDto` (a so-called [DTO](http://en.wikipedia.org/wiki/Data_transfer_object)). Suppose also that an order has one or more `Product`s and an associated `Customer`. Coincidentally, the `OrderDto` will have one or more `ProductDto`s and a corresponding `CustomerDto`. You may want to make sure that all exposed members of all the objects in the `OrderDto` object graph match the equally named members of the `Order` object graph.
+Consider the class `Order` and its wire-transfer equivalent `OrderDto` (a so-called [DTO](http://en.wikipedia.org/wiki/Data_transfer_object)).
+Suppose also that an order has one or more `Product`s and an associated `Customer`.
+Coincidentally, the `OrderDto` will have one or more `ProductDto`s and a corresponding `CustomerDto`.
+You may want to make sure that all exposed members of all the objects in the `OrderDto` object graph match the equally named members of the `Order` object graph.
 
-You may assert the structural equality of two object graphs with `ShouldbeEquivalentTo`:
+You may assert the structural equality of two object graphs with `ShouldBeEquivalentTo`:
 ```csharp
 orderDto.ShouldBeEquivalentTo(order);
 ```
 
 ### Recursion ###
 
-The comparison is recursive by default. To avoid infinite recursion, Fluent Assertions will recurse up to 10 levels deep by default, but if you want to force it to go as deep as possible, use the `AllowingInfiniteRecursion` option.
+The comparison is recursive by default.
+To avoid infinite recursion, Fluent Assertions will recurse up to 10 levels deep by default, but if you want to force it to go as deep as possible, use the `AllowingInfiniteRecursion` option.
 On the other hand, if you want to disable recursion, just use this option:
 
 ```csharp
@@ -594,23 +698,31 @@ orderDto.ShouldBeEquivalentTo(order, options =>
 
 ### Compile-time types vs. run-time types ###
 
-By default, Fluent Assertions respects an object's or member's declared (compile-time) type when selecting members to process during a recursive comparison. That is to say if the subject is a `OrderDto` but the variable it is assigned to has type `Dto` only the members defined by the latter class would be included. This behavior can be configured and you can choose to use run-time types if you prefer:
+By default, Fluent Assertions respects an object's or member's declared (compile-time) type when selecting members to process during a recursive comparison.
+That is to say if the subject is a `OrderDto` but the variable it is assigned to has type `Dto` only the members defined by the latter class would be included.
+This behavior can be configured and you can choose to use run-time types if you prefer:
 
 ```csharp
 // Use runtime type information
 orderDto.ShouldBeEquivalentTo(order, options => 
     options.RespectingRuntimeTypes());
-	
+
 // Use declared type information
 orderDto.ShouldBeEquivalentTo(order, options => 
-    options.RespectingDeclaredTypes());	
+    options.RespectingDeclaredTypes());
 ```
 
-One exception to this rule is when the declared type is `object`. Since `object` doesn't expose any properties, it makes no sense to respect the declared type. So if the subject or member's type is `object`, it will use the run-time type for that node in the graph. This will also work better with (multidimensional) arrays.
+One exception to this rule is when the declared type is `object`.
+Since `object` doesn't expose any properties, it makes no sense to respect the declared type.
+So if the subject or member's type is `object`, it will use the run-time type for that node in the graph.
+This will also work better with (multidimensional) arrays.
 
 ### Matching Members ###
 
-All public members of the `OrderDto` must be available on the `Order` having the same name.  If any members are missing, an exception will be thrown. However, you may customize this behavior. For instance, if you want to include only the members both object graphs have:
+All public members of the `OrderDto` must be available on the `Order` having the same name.
+If any members are missing, an exception will be thrown.
+However, you may customize this behavior.
+For instance, if you want to include only the members both object graphs have:
 
 ```csharp
 orderDto.ShouldBeEquivalentTo(order, options => 
@@ -630,88 +742,96 @@ The `Excluding()` method on the options object also takes a lambda expression th
 
 ```csharp
 orderDto.ShouldBeEquivalentTo(order, options => options 
-    .Excluding(ctx => ctx.SelectedMemberPath == "Level.Level.Text")); 
+    .Excluding(ctx => ctx.SelectedMemberPath == "Level.Level.Text"));
 ```
 
-Maybe far-fetched, but you may even decide to exclude a member on a particular nested object by its index. 
+Maybe far-fetched, but you may even decide to exclude a member on a particular nested object by its index.
 
 ```csharp
 orderDto.ShouldBeEquivalentTo(order, options => 
-    options.Excluding(o => o.Products[1].Status)); 
+    options.Excluding(o => o.Products[1].Status));
 ```
 
 Of course, `Excluding()` and `ExcludingMissingMembers()` can be combined.
 
-You can also take a different approach and explicitly tell Fluent Assertions which members to include. You can directly specify a property expression or use a predicate that acts on the provided `ISubjectInfo`.  
+You can also take a different approach and explicitly tell Fluent Assertions which members to include.
+You can directly specify a property expression or use a predicate that acts on the provided `ISubjectInfo`.
 
 ```csharp
 orderDto.ShouldBeEquivalentTo(order, options => options
     .Including(o => o.OrderNumber)
-	.Including(pi => pi.PropertyPath.EndsWith("Date")); 
+    .Including(pi => pi.PropertyPath.EndsWith("Date"));
 ```
 
 ### Including properties and/or fields ###
 
-You may also configure member inclusion more broadly. Barring other configuration, Fluent Assertions will include all `public` properties and fields. This behavior can be changed:
+You may also configure member inclusion more broadly.
+Barring other configuration, Fluent Assertions will include all `public` properties and fields.
+This behavior can be changed:
 
 ```csharp
 // Include Fields
 orderDto.ShouldBeEquivalentTo(order, options => options
-	.IncludingFields();
+    .IncludingFields();
 
 // Include Properties
 orderDto.ShouldBeEquivalentTo(order, options => options
-	.IncludingProperties();
-	
+    .IncludingProperties();
+
 // Exclude Fields
 orderDto.ShouldBeEquivalentTo(order, options => options
-	.ExcludingFields();
-	
+    .ExcludingFields();
+
 // Exclude Properties
 orderDto.ShouldBeEquivalentTo(order, options => options
-	.ExcludingProperties();
+    .ExcludingProperties();
 ```
 
-This configuration affects the initial inclusion of members and happens before any `Exclude`s or other `IMemberSelectionRule`s.  This configuration also affects matching.  For example, that if properties are excluded, properties will not be inspected when looking for a match on the expected object.
+This configuration affects the initial inclusion of members and happens before any `Exclude`s or other `IMemberSelectionRule`s.
+This configuration also affects matching.
+For example, that if properties are excluded, properties will not be inspected when looking for a match on the expected object.
 
 
 ### Equivalency Comparison Behavior ###
-In addition to influencing the members that are including in the comparison, you can also override the actual assertion operation that is executed on a particular member. 
+In addition to influencing the members that are including in the comparison, you can also override the actual assertion operation that is executed on a particular member.
 
 ```csharp
 orderDto.ShouldBeEquivalentTo(order, options => options
     .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1000))
-    .When(info => info.SelectedMemberPath.EndsWith("Date"))); 
+    .When(info => info.SelectedMemberPath.EndsWith("Date")));
 ```
 
-If you want to do this for all members of a certain type, you can shorten the above call like this. 
+If you want to do this for all members of a certain type, you can shorten the above call like this.
 
 ```csharp
 orderDto.ShouldBeEquivalentTo(order, options => options 
-    .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1000)) 
-    .WhenTypeIs<DateTime>(); 
+    .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1000))
+    .WhenTypeIs<DateTime>();
 ```
 
 ### Enums ###
 
-By default, ``ShouldBeEquivalentTo()`` compares Enum members by the Enum's underlying numeric value. An option to compare Enums only by name is also available, using the following configuration :
+By default, ``ShouldBeEquivalentTo()`` compares Enum members by the Enum's underlying numeric value.
+An option to compare Enums only by name is also available, using the following configuration :
 
 ```csharp
 orderDto.ShouldBeEquivalentTo(expectation, options => options.ComparingEnumsByName());
 ```
 
 ### Collections and Dictionaries ###
-The original `ShouldAllBeEquivalentTo()` extension method does support collections, but it doesn’t allow you to influence the comparison based on the actual collection type, nor does it support (nested) dictionaries. The new extension method `ShouldAllBeEquivalentTo()` supports this so you can configure comparisons on the type of items in the collection.
+The original `ShouldAllBeEquivalentTo()` extension method does support collections, but it doesn’t allow you to influence the comparison based on the actual collection type, nor does it support (nested) dictionaries.
+The new extension method `ShouldAllBeEquivalentTo()` supports this so you can configure comparisons on the type of items in the collection.
 
 Considering our running example, you could use the following against a collection of `OrderDto`s: 
 
 ```csharp
-orderDtos.ShouldAllBeEquivalentTo(orders, options => options.Excluding(o => o.Customer.Name)); 
+orderDtos.ShouldAllBeEquivalentTo(orders, options => options.Excluding(o => o.Customer.Name));
 ```
 
 ### Ordering ###
 
-Fluent Assertions will, by default, ignore the order of the items in the collections, regardless of whether the collection is at the root of the object graph or tucked away in a nested property or field. If the order is important, you can override the default behavior with the following option:
+Fluent Assertions will, by default, ignore the order of the items in the collections, regardless of whether the collection is at the root of the object graph or tucked away in a nested property or field.
+If the order is important, you can override the default behavior with the following option:
 
 ```csharp
 orderDto.ShouldBeEquivalentTo(expectation, options => options.WithStrictOrdering());
@@ -726,33 +846,41 @@ orderDto.ShouldBeEquivalentTo(expectation, options => options.WithStrictOrdering
 **Notice:** For performance reasons, collections of bytes are compared in exact order.
 
 ### Global Configuration ###
-Even though the structural equivalency API is pretty flexible, you might want to change some of these options on a global scale. This is where the static class `AssertionOptions` comes into play. For instance, to always compare enumerations by name, use the following statement:
+Even though the structural equivalency API is pretty flexible, you might want to change some of these options on a global scale.
+This is where the static class `AssertionOptions` comes into play.
+For instance, to always compare enumerations by name, use the following statement:
 
 ```csharp
 AssertionOptions.AssertEquivalencyUsing(options => options.ComparingEnumsByValue);
 ``` 
 
-All the options available to an individual call to `ShouldBeEquivalenTo` are supported, with the exception of some of the overloads that are specific to the type of the subject (for obvious reasons). You can even change the algorithm that Fluent Assertions uses to determine if an object should be treated as a value type. Simply replace the `AssertionOptions.IsValueType` predicate with your own:
+All the options available to an individual call to `ShouldBeEquivalenTo` are supported, with the exception of some of the overloads that are specific to the type of the subject (for obvious reasons).
+You can even change the algorithm that Fluent Assertions uses to determine if an object should be treated as a value type.
+Simply replace the `AssertionOptions.IsValueType` predicate with your own:
 
 ```csharp
 AssertionOptions.IsValueType = type => // a custom algorithm 
-```  
+```
 
 ### Extensibility ###
 Internally the structural comparison process consists of three phases which repeat as the comparison recurses:
 
-1. Select the members of the subject object to include in the comparison.  
-2. Find a matching member on the expectation object and decide what to do if it can’t find any.  
-3. Select the appropriate assertion method for the member’s type and execute it.  
+1. Select the members of the subject object to include in the comparison.
+2. Find a matching member on the expectation object and decide what to do if it can’t find any.
+3. Select the appropriate assertion method for the member’s type and execute it.
 
-Three main extension points exist: `IEquivalencyStep`, `IMemberSelectionRule`, `IMemberMatchingRule`.  You may add your own implementations using the `Using` method overloads on `EquivalencyAssertionOptions`, or if you want to make it a global change, to the `AssertionOptions.EquivalencySteps` collection. 
+Three main extension points exist: `IEquivalencyStep`, `IMemberSelectionRule`, `IMemberMatchingRule`.
+You may add your own implementations using the `Using` method overloads on `EquivalencyAssertionOptions`, or if you want to make it a global change, to the `AssertionOptions.EquivalencySteps` collection.
 
-Fluent Assertions uses these same interfaces to provide its  built-in functionality.  Internally, for example, `ExcludeMemberByPredicateSelectionRule`, is added to the collection of selection rules when you use the `Excluding(expression)` method on the options parameter of `ShouldBeEquivalentTo()`. Even the `Using().When()` construct in the previous section is doing nothing more than inserting an `IEquivalencyStep` in to the list of equivalency steps. Creating your own rules is quite straightforward.
-  
+Fluent Assertions uses these same interfaces to provide its built-in functionality.
+Internally, for example, `ExcludeMemberByPredicateSelectionRule`, is added to the collection of selection rules when you use the `Excluding(expression)` method on the options parameter of `ShouldBeEquivalentTo()`.
+Even the `Using().When()` construct in the previous section is doing nothing more than inserting an `IEquivalencyStep` in to the list of equivalency steps.
+Creating your own rules is quite straightforward.
+
 1. Choose the appropriate phase that the rule should influence 
 2. Select the corresponding interface 
 3. Create a class that implements this interface 
-4. Add it to the `ShouldBeEquivalentTo()` call using the `Using()` method on the options parameters. 
+4. Add it to the `ShouldBeEquivalentTo()` call using the `Using()` method on the options parameters.
 
 ```csharp
 subject.ShouldBeEquivalentTo(expected, options => options.Using(new ExcludeForeignKeysSelectionRule()));
@@ -760,7 +888,8 @@ subject.ShouldBeEquivalentTo(expected, options => options.Using(new ExcludeForei
 
 ## Event Monitoring ##
 
-Version 1.3.0 introduced a new set of extensions that allow you to verify that an object raised a particular event. Before you can invoke the assertion extensions, you must first tell Fluent Assertions that you want to monitor the object:
+Version 1.3.0 introduced a new set of extensions that allow you to verify that an object raised a particular event.
+Before you can invoke the assertion extensions, you must first tell Fluent Assertions that you want to monitor the object:
 
 ```csharp
 var subject = new EditCustomerViewModel();
@@ -776,7 +905,9 @@ subject
   .WithArgs<PropertyChangedEventArgs>(args => args.PropertyName == "SomeProperty");
 ```
 
-Notice that `WithSender()` verifies that all occurrences had its sender argument set to the specified object. `WithArgs()` just verifies that at least one occurrence had a matching `EventArgs` object. In other words, event monitoring only works for events that comply with the standard two-argument sender/args .NET pattern.
+Notice that `WithSender()` verifies that all occurrences had its sender argument set to the specified object.
+`WithArgs()` just verifies that at least one occurrence had a matching `EventArgs` object.
+In other words, event monitoring only works for events that comply with the standard two-argument sender/args .NET pattern.
 
 Since verifying for `PropertyChanged` events is so common, I’ve included a specialized shortcut to the example above:
 
@@ -791,23 +922,27 @@ subject.ShouldNotRaisePropertyChangeFor(x => x.SomeProperty);
 ```
 
 Or, if your project is .NET 3.5 or 4.0 based:
-	
+
 ```csharp
 subject.ShouldNotRaise("SomeOtherEvent");
 ```
 
-In version 4.1.2 we added a new generic version of `MonitorEvents()`. It is used to limit which events you want to listen to. You do that by providing a type which defines the events. 
+In version 4.1.2 we added a new generic version of `MonitorEvents()`.
+It is used to limit which events you want to listen to.
+You do that by providing a type which defines the events.
 
 ```csharp
 var subject = new ClassWithManyEvents();
 subject.MonitorEvents<IInterfaceWithFewEvents>();
 ```
 
-This generic version of `MonitorEvents()` is also very useful if you wish to monitor events of a dynamically generated class using `System.Reflection.Emit`. Since events are dynamically generated and are not present in parent class non-generic version of `MonitorEvents()` will not find the events. This way you can tell the event monitor which interface was implemented in the generated class.
+This generic version of `MonitorEvents()` is also very useful if you wish to monitor events of a dynamically generated class using `System.Reflection.Emit`.
+Since events are dynamically generated and are not present in parent class non-generic version of `MonitorEvents()` will not find the events.
+This way you can tell the event monitor which interface was implemented in the generated class.
 
 ```csharp
 POCOClass subject = EmitViewModelFromPOCOClass();
-subject.MonitorEvents<INotifyPropertyChanged>();  // POCO class doesn't have INotifyPropertyChanged implemented
+subject.MonitorEvents<INotifyPropertyChanged>(); // POCO class doesn't have INotifyPropertyChanged implemented
 subject.ShouldRaisePropertyChangeFor(x => x.SomeProperty);
 ```
 
@@ -815,7 +950,12 @@ subject.ShouldRaisePropertyChangeFor(x => x.SomeProperty);
 
 ## Type, Method, and Property assertions ##
 
-Recently, we have added a number of assertions on types and on methods and properties of types. These are rather technical assertions and, although we like our unit tests to read as functional specifications for the application, we still see a use for assertions on the members of a class. For example when you use policy injection on your classes and require its methods to be virtual. Forgetting to make a method virtual will avoid the policy injection mechanism from creating a proxy for it, but you will only notice the consequences at runtime. Therefore it can be useful to create a unit test that asserts such requirements on your classes. Some examples.
+We have added a number of assertions on types and on methods and properties of types.
+These are rather technical assertions and, although we like our unit tests to read as functional specifications for the application, we still see a use for assertions on the members of a class.
+For example when you use policy injection on your classes and require its methods to be virtual.
+Forgetting to make a method virtual will avoid the policy injection mechanism from creating a proxy for it, but you will only notice the consequences at runtime.
+Therefore it can be useful to create a unit test that asserts such requirements on your classes.
+Some examples.
 
 ```csharp
 typeof(MyPresentationModel).Should().BeDecoratedWith<SomeAttribute>();
@@ -824,10 +964,12 @@ MethodInfo method = GetMethod();
 method.Should().BeVirtual();
 
 PropertyInfo property = GetSomeProperty();
-property.Should().BeVirtual().And.BeDecoratedWith<SomeAttribute>();
+property.Should().BeVirtual()
+  .And.BeDecoratedWith<SomeAttribute>();
 ```
 
-You can also perform assertions on multiple methods or properties in a certain type by using the `Methods()` or `Properties()` extension methods and some optional filtering methods. Like this:
+You can also perform assertions on multiple methods or properties in a certain type by using the `Methods()` or `Properties()` extension methods and some optional filtering methods.
+Like this:
 
 ```csharp
 typeof(MyPresentationModel).Methods()
@@ -835,7 +977,16 @@ typeof(MyPresentationModel).Methods()
   .ThatReturnVoid
   .Should()
   .BeVirtual("because this is required to intercept exceptions")
-  .BeWritable();
+    .And.BeWritable()
+    .And.BeAsync();
+
+typeof(MyController).Methods()
+  .ThatDoNotReturn<ActionResult>()
+  .ThatAreNotDecoratedWith<HttpPostAttribute>()
+  .Should().NotBeVirtual()
+    .And.NotBeAsync()
+    .And.NotReturnVoid()
+    .And.NotReturn<ActionResult>();
 
 typeof(MyController).Methods()
   .ThatReturn<ActionResult>()
@@ -872,12 +1023,21 @@ AllTypes.From(assembly)
   .ThatImplement<ISomeInterface>()
   .ThatDeriveFrom<IDisposable>()
   .ThatAreUnderNamespace("Internal.Main.Test");
+
+AllTypes.From(assembly)
+  .ThatAreNotDecoratedWith<SomeAttribute>()
+  .ThatDoNotImplement<ISomeInterface>()
+  .ThatDoNotDeriveFrom<IDisposable>()
+  .ThatAreNotUnderNamespace("Internal.Main")
+  .ThatAreNotInNamespace("Internal.Main.Test");
 ```
 ## Assembly References ##
-New in version 3.1 are methods to assert an assembly does or does not reference another assembly. These are typically used to enforce layers within an application, such as for example, asserting the web layer does not reference the data layer. To assert the references, use the the following syntax:
+New in version 3.1 are methods to assert an assembly does or does not reference another assembly.
+These are typically used to enforce layers within an application, such as for example, asserting the web layer does not reference the data layer.
+To assert the references, use the the following syntax:
 
 ```csharp 
-assembly.Should().Reference(otherAssembly); 
+assembly.Should().Reference(otherAssembly);
 assembly.Should().NotReference(otherAssembly);
 ```
 
@@ -909,18 +1069,21 @@ You can also perform a deep comparison between two elements like this.
 
 ```csharp
 xDocument.Should().BeEquivalentTo(XDocument.Parse("<configuration><item>value</item></configuration>"));
-xElement.Should().BeEquivalentTo(XElement.Parse("<item>value</item>"));	
+xElement.Should().BeEquivalentTo(XElement.Parse("<item>value</item>"));
 ```
 
-Chaining additional assertions on top of a particular (root) element is possible through this syntax. 
+Chaining additional assertions on top of a particular (root) element is possible through this syntax.
 
 ```csharp
-xDocument.Should().HaveElement("child").Which.Should().BeOfType<XElement>().And.HaveAttribute("attr", "1");
+xDocument.Should().HaveElement("child")
+  .Which.Should().BeOfType<XElement>()
+    .And.HaveAttribute("attr", "1");
 ```
 
 ## Execution Time ##
 
-New in version 1.4 is a method to assert that the execution time of particular method or action does not exceed a predefined value. To verify the execution time of a method, use the following syntax:
+New in version 1.4 is a method to assert that the execution time of particular method or action does not exceed a predefined value.
+To verify the execution time of a method, use the following syntax:
 
 ```csharp
 public class SomePotentiallyVerySlowClass
@@ -952,24 +1115,29 @@ Since it doesn’t make sense to do something like that in Silverlight, it is on
 
 ## Extensibility ##
 
-**Custom assertions**  
-Adding your own assertion extensions is quite straightforward and happens in my projects quite often. You have a few options though.
+**Custom assertions**
+Adding your own assertion extensions is quite straightforward and happens in my projects quite often.
+You have a few options though.
 
-* Extend one of the built-in classes such as `CollectionAssertions<T>` or `ReferenceTypeAssertions<T>` and expose them through a custom static class with extension methods named `Should()`. 
+* Extend one of the built-in classes such as `CollectionAssertions<T>` or `ReferenceTypeAssertions<T>` and expose them through a custom static class with extension methods named `Should()`.
 
 * Create extension methods that extend an assertion class: 
 
 ```csharp
-	public static void BeWhatever<T>(this GenericCollectionAssertions<T> assertions, string because, params object[] becauseArgs)
-	{ 
-    	Execute.Assertion
-    	   .ForCondition(somecondition)
-    	   .BecauseOf(reason, reasonArgs)
-    	   .FailWith("Expected object not to be {0}{reason}", null);
-	}
+    public static void BeWhatever<T>(this GenericCollectionAssertions<T> assertions, string because, params object[] becauseArgs)
+    { 
+        Execute.Assertion
+           .ForCondition(somecondition)
+           .BecauseOf(reason, reasonArgs)
+           .FailWith("Expected object not to be {0}{reason}", null);
+    }
 ```
 
-* Create a custom assertions class and use the `Assertion` class to verify conditions and create comprehensive failure messages using the built-in formatters. Notice that error messages of custom assertion extensions can specify the `{context}` tag that is used to inject the property path in object graph comparisons. For instance, in the date/time assertions, this is used to display date and time. But when this assertion is used as part of a recursive object graph comparison, it will display the property path instead. You can use this special tag in your own extensions like this:
+* Create a custom assertions class and use the `Assertion` class to verify conditions and create comprehensive failure messages using the built-in formatters.
+Notice that error messages of custom assertion extensions can specify the `{context}` tag that is used to inject the property path in object graph comparisons.
+For instance, in the date/time assertions, this is used to display date and time.
+But when this assertion is used as part of a recursive object graph comparison, it will display the property path instead.
+You can use this special tag in your own extensions like this:
 
 ```csharp
 Execute.Assertion
@@ -979,22 +1147,27 @@ Execute.Assertion
 ```
 
 
-**Formatters**  
+**Formatters**
 In addition to writing your own extensions, you can influence the way data is formatted with these two techniques.
 
-* You can alter the list of `IValueFormatter` objects on the `Formatter` class with your own implementation of that interface using its methods `AddFormatter` and `RemoveFormatter`. 
+* You can alter the list of `IValueFormatter` objects on the `Formatter` class with your own implementation of that interface using its methods `AddFormatter` and `RemoveFormatter`.
 
-* You can override the way Fluent Assertions formats objects in an error message by annotating a static method with the `[ValueFormatter]` attribute. If a class doesn’t override `ToString()`, the built-in `DefaultValueFormatter` will render an object graph of that object. But you can now override that using a construct like this:
+* You can override the way Fluent Assertions formats objects in an error message by annotating a static method with the `[ValueFormatter]` attribute.
+If a class doesn’t override `ToString()`, the built-in `DefaultValueFormatter` will render an object graph of that object.
+But you can now override that using a construct like this:
 
 ```csharp
 public static class CustomFormatter
-{    
+{
     [ValueFormatter]
-    public static string Foo(SomeClassvalue value)    
+    public static string Foo(SomeClassvalue value)
     {
-        return "Property = " + value.Property;   
+        return "Property = " + value.Property;
     }
 }
 ```
 
-Since scanning for value formatters incurs a significant performance hit, you need to explicitly enable that using the `<appSetting>`  with key `valueFormatters`. Valid values include `Disabled` (the default), `Scan` and `Specific`, where `Scan` will scan all assemblies in the `AppDomain`. Option `Specific` also requires you to set the `valueFormattersAssembly` setting key with the (partial) name of an assembly FA should scan. Since Silverlight and Windows Phone apps do not support an `app.config` file, you'll need to set those settings through the `ValueFormatterDetectionMode` and `ValueFormatterAssembly` properties of the static `Configuration.Current` object.
+Since scanning for value formatters incurs a significant performance hit, you need to explicitly enable that using the `<appSetting>` with key `valueFormatters`.
+Valid values include `Disabled` (the default), `Scan` and `Specific`, where `Scan` will scan all assemblies in the `AppDomain`.
+Option `Specific` also requires you to set the `valueFormattersAssembly` setting key with the (partial) name of an assembly FA should scan.
+Since Silverlight and Windows Phone apps do not support an `app.config` file, you'll need to set those settings through the `ValueFormatterDetectionMode` and `ValueFormatterAssembly` properties of the static `Configuration.Current` object.


### PR DESCRIPTION
I've updated the documentation as a part of #592.

Stuff I have done:
* Adapting the `Should().` pattern most places
* Adding new assertions
* Fixing typos/mispellings

Stuff I _haven't_ touched:
* Archiving the current docs and link to them like we link to the 2.0 docs.
* The merging of `ShouldBeEquivalentTo` and `BeEquivalentTo`, `ShouldAllBeEquivalentTo`
* The gazillion new `Type` related assertions
* Events: `Should[Not]Raise`, `Should[Not]RaisePropertyChangeFor`