### PR TITLE
Reworking failure messages

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -259,7 +259,7 @@ namespace FluentAssertions.Collections
                 Execute.Assertion
                     .ForCondition(unordered.SequenceEqual(expectation))
                     .BecauseOf(because, args)
-                    .FailWith("Expected collection {0} to be ordered{1}{reason} and result in {2}.",
+                    .FailWith("Expected {context:collection} {0} to be ordered{1}{reason} and result in {2}.",
                         Subject, orderString, expectation);
             }
 
@@ -277,7 +277,7 @@ namespace FluentAssertions.Collections
             return Execute.Assertion
                 .ForCondition(!ReferenceEquals(Subject, null))
                 .BecauseOf(because, args)
-                .FailWith("Expected collection to be ordered by {0}{reason} but found <null>.",
+                .FailWith("Expected {context:collection} to be ordered by {0}{reason} but found <null>.",
                     propertyExpression.GetMemberPath());
         }
 

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -614,7 +614,7 @@ namespace FluentAssertions.Collections
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("{context:Dictionary} {0} should not contain key {1}{reason}, but found it anyhow.", Subject, unexpected);
+                    .FailWith("Expected {context:dictionary} {0} not to contain key {1}{reason}, but found it anyhow.", Subject, unexpected);
             }
 
             return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
@@ -832,7 +832,7 @@ namespace FluentAssertions.Collections
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("{context:Dictionary} {0} should not contain value {1}{reason}, but found it anyhow.", Subject, unexpected);
+                    .FailWith("Expected {context:dictionary} {0} not to contain value {1}{reason}, but found it anyhow.", Subject, unexpected);
             }
 
             return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);

--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -458,7 +458,7 @@ namespace FluentAssertions.Collections
             Execute.Assertion
                 .ForCondition(Subject.Any(func))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("{context:Collection} {0} should have an item matching {1}{reason}.", Subject, predicate.Body);
+                .FailWith("Expected {context:collection} {0} to have an item matching {1}{reason}.", Subject, predicate.Body);
 
             return new AndWhichConstraint<TAssertions, T>((TAssertions)this, Subject.Where(func));
         }
@@ -568,7 +568,7 @@ namespace FluentAssertions.Collections
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:Collection} {0} to not have any items matching {1}{reason}, but found {2}.",
+                    .FailWith("Expected {context:collection} {0} to not have any items matching {1}{reason}, but found {2}.",
                         Subject, predicate.Body, unexpectedItems);
             }
 

--- a/Src/FluentAssertions/Equivalency/ConversionSelector.cs
+++ b/Src/FluentAssertions/Equivalency/ConversionSelector.cs
@@ -30,7 +30,7 @@ namespace FluentAssertions.Equivalency
         public void Exclude(Expression<Func<ISubjectInfo, bool>> predicate)
         {
             exclusions.Add(predicate.Compile());
-            description.Append("Don't convert member ").Append(predicate.Body).Append(". ");
+            description.Append("Do not convert member ").Append(predicate.Body).Append(". ");
         }
         
         public bool RequiresConversion(ISubjectInfo info)

--- a/Src/FluentAssertions/Equivalency/DictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DictionaryEquivalencyStep.cs
@@ -74,7 +74,7 @@ namespace FluentAssertions.Equivalency
         {
             return AssertionScope.Current
                 .ForCondition(subject != null)
-                .FailWith("Expected {context:subject} to be a dictionary, but it isn't");
+                .FailWith("Expected {context:subject} to be a dictionary, but it is not.");
         }
 
         private static bool AssertSameLength(IDictionary expectation, IDictionary subject)

--- a/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
+++ b/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
@@ -47,7 +47,7 @@ namespace FluentAssertions.Equivalency
                     break;
 
                 default:
-                    throw new InvalidOperationException(string.Format("Don't know how to handle {0}",
+                    throw new InvalidOperationException(string.Format("Do not know how to handle {0}",
                         config.EnumEquivalencyHandling));
             }
 

--- a/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
@@ -62,10 +62,10 @@ namespace FluentAssertions.Equivalency
         {
             return AssertionScope.Current
                 .ForCondition(!ReferenceEquals(type, null))
-                .FailWith("Can't compare a multi-dimensional array to {0}.", new object[] {null})
+                .FailWith("Cannot compare a multi-dimensional array to {0}.", new object[] {null})
                 .Then
                 .ForCondition(type is Array)
-                .FailWith("Can't compare a multi-dimensional array to something else.");
+                .FailWith("Cannot compare a multi-dimensional array to something else.");
         }
 
         private static bool HaveSameDimensions(object subject, Array expectation)

--- a/Src/FluentAssertions/Equivalency/StringEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/StringEqualityEquivalencyStep.cs
@@ -80,7 +80,7 @@ namespace FluentAssertions.Equivalency
             return 
                 AssertionScope.Current
                     .ForCondition(context.Subject.GetType().IsSameOrInherits(typeof (T)))
-                    .FailWith($"Expected {GetSubjectDescription(context)} to be {{0}}, but found {{1}}",
+                    .FailWith($"Expected {GetSubjectDescription(context)} to be {{0}}, but found {{1}}.",
                         context.RuntimeType, context.Subject.GetType());
 
         }

--- a/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
@@ -36,7 +36,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(ReferenceEquals(Subject, expected) || (Subject.CompareTo(expected) == Equal))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {0}{reason}, but found {1}.", expected, Subject);
+                .FailWith("Expected {context:object} to be equal to {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
         }
@@ -59,7 +59,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) != Equal)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect object to be equal to {0}{reason}.", expected);
+                .FailWith("Did not expect {context:object} to be equal to {0}{reason}.", expected);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
         }
@@ -82,7 +82,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) < Equal)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected object {0} to be less than {1}{reason}.", Subject, expected);
+                .FailWith("Expected {context:object} {0} to be less than {1}{reason}.", Subject, expected);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
         }
@@ -105,7 +105,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) <= Equal)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected object {0} to be less or equal to {1}{reason}.", Subject, expected);
+                .FailWith("Expected {context:object} {0} to be less or equal to {1}{reason}.", Subject, expected);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
         }
@@ -128,7 +128,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) > Equal)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected object {0} to be greater than {1}{reason}.", Subject, expected);
+                .FailWith("Expected {context:object} {0} to be greater than {1}{reason}.", Subject, expected);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
         }
@@ -151,7 +151,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) >= Equal)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected object {0} to be greater or equal to {1}{reason}.", Subject, expected);
+                .FailWith("Expected {context:object} {0} to be greater or equal to {1}{reason}.", Subject, expected);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
         }
@@ -181,7 +181,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition((Subject.CompareTo(minimumValue) >= Equal) && (Subject.CompareTo(maximumValue) <= Equal))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected object to be between {0} and {1}{reason}, but found {2}.",
+                .FailWith("Expected {context:object} to be between {0} and {1}{reason}, but found {2}.",
                     minimumValue, maximumValue, Subject);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
@@ -212,7 +212,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(!((Subject.CompareTo(minimumValue) >= Equal) && (Subject.CompareTo(maximumValue) <= Equal)))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected object to not be between {0} and {1}{reason}, but found {2}.",
+                .FailWith("Expected {context:object} to not be between {0} and {1}{reason}, but found {2}.",
                     minimumValue, maximumValue, Subject);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -86,7 +86,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(unexpected) != 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {0}{reason}.", unexpected);
+                .FailWith("Did not expect {context:value} to be {0}{reason}.", unexpected);
 
             return new AndConstraint<NumericAssertions<T>>(this);
         }
@@ -107,7 +107,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(unexpected) != 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {0}{reason}.", unexpected);
+                .FailWith("Did not expect {context:value} to be {0}{reason}.", unexpected);
 
             return new AndConstraint<NumericAssertions<T>>(this);
         }
@@ -127,7 +127,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(default(T)) > 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected positive value{reason}, but found {0}", Subject);
+                .FailWith("Expected {context:value} to be positive{reason}, but found {0}.", Subject);
             
             return new AndConstraint<NumericAssertions<T>>(this);
         }
@@ -147,7 +147,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(default(T)) < 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected negative value{reason}, but found {0}", Subject);
+                .FailWith("Expected {context:value} to be negative{reason}, but found {0}.", Subject);
 
             return new AndConstraint<NumericAssertions<T>>(this);
         }
@@ -168,7 +168,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) < 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected a value less than {0}{reason}, but found {1}.", expected, Subject);
+                .FailWith("Expected {context:value} to be less than {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<NumericAssertions<T>>(this);
         }
@@ -190,7 +190,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) <= 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected a value less or equal to {0}{reason}, but found {1}.", expected, Subject);
+                .FailWith("Expected {context:value} to be less or equal to {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<NumericAssertions<T>>(this);
         }
@@ -212,7 +212,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) > 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected a value greater than {0}{reason}, but found {1}.", expected, Subject);
+                .FailWith("Expected {context:value} to be greater than {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<NumericAssertions<T>>(this);
         }
@@ -234,7 +234,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) >= 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected a value greater or equal to {0}{reason}, but found {1}.", expected, Subject);
+                .FailWith("Expected {context:value} to be greater or equal to {0}{reason}, but found {1}.", expected, Subject);
             
             return new AndConstraint<NumericAssertions<T>>(this);
         }
@@ -264,7 +264,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition((Subject.CompareTo(minimumValue) >= 0) && (Subject.CompareTo(maximumValue) <= 0))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value to be between {0} and {1}{reason}, but found {2}.",
+                .FailWith("Expected {context:value} to be between {0} and {1}{reason}, but found {2}.",
                     minimumValue, maximumValue, Subject);
 
             return new AndConstraint<NumericAssertions<T>>(this);
@@ -295,7 +295,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(!((Subject.CompareTo(minimumValue) >= 0) && (Subject.CompareTo(maximumValue) <= 0)))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value to not be between {0} and {1}{reason}, but found {2}.",
+                .FailWith("Expected {context:value} to not be between {0} and {1}{reason}, but found {2}.",
                     minimumValue, maximumValue, Subject);
 
             return new AndConstraint<NumericAssertions<T>>(this);
@@ -331,7 +331,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(validValues.Contains((T)Subject))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value to be one of {0}{reason}, but found {1}.", validValues, Subject);
+                .FailWith("Expected {context:value} to be one of {0}{reason}, but found {1}.", validValues, Subject);
 
             return new AndConstraint<NumericAssertions<T>>(this);
         }

--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -33,7 +33,7 @@ namespace FluentAssertions
             Execute.Assertion
                 .ForCondition(parent.Subject != null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
+                .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
             var nonNullableAssertions = new NumericAssertions<float>((float) parent.Subject);
             nonNullableAssertions.BeApproximately(expectedValue, precision, because, becauseArgs);
@@ -67,7 +67,7 @@ namespace FluentAssertions
             Execute.Assertion
                 .ForCondition(actualDifference <= precision)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value {0} to approximate {1} +/- {2}{reason}, but it differed by {3}.",
+                .FailWith("Expected {context:value} {0} to approximate {1} +/- {2}{reason}, but it differed by {3}.",
                     parent.Subject, expectedValue, precision, actualDifference);
 
             return new AndConstraint<NumericAssertions<float>>(parent);
@@ -97,7 +97,7 @@ namespace FluentAssertions
             Execute.Assertion
                 .ForCondition(parent.Subject != null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
+                .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
             var nonNullableAssertions = new NumericAssertions<double>((double) parent.Subject);
             BeApproximately(nonNullableAssertions, expectedValue, precision, because, becauseArgs);
@@ -131,7 +131,7 @@ namespace FluentAssertions
             Execute.Assertion
                 .ForCondition(actualDifference <= precision)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value {0} to approximate {1} +/- {2}{reason}, but it differed by {3}.",
+                .FailWith("Expected {context:value} {0} to approximate {1} +/- {2}{reason}, but it differed by {3}.",
                     parent.Subject, expectedValue, precision, actualDifference);
 
             return new AndConstraint<NumericAssertions<double>>(parent);
@@ -161,7 +161,7 @@ namespace FluentAssertions
             Execute.Assertion
                 .ForCondition(parent.Subject != null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
+                .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
             var nonNullableAssertions = new NumericAssertions<decimal>((decimal)parent.Subject);
             BeApproximately(nonNullableAssertions, expectedValue, precision, because, becauseArgs);
@@ -195,7 +195,7 @@ namespace FluentAssertions
             Execute.Assertion
                 .ForCondition(actualDifference <= precision)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value {0} to approximate {1} +/- {2}{reason}, but it differed by {3}.",
+                .FailWith("Expected {context:value} {0} to approximate {1} +/- {2}{reason}, but it differed by {3}.",
                     parent.Subject, expectedValue, precision, actualDifference);
 
             return new AndConstraint<NumericAssertions<decimal>>(parent);
@@ -225,7 +225,7 @@ namespace FluentAssertions
             Execute.Assertion
                 .ForCondition(parent.Subject != null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value to not approximate {0} +/- {1}{reason}, but it was <null>.", unexpectedValue, precision);
+                .FailWith("Expected {context:value} to not approximate {0} +/- {1}{reason}, but it was <null>.", unexpectedValue, precision);
 
             var nonNullableAssertions = new NumericAssertions<float>((float)parent.Subject);
             nonNullableAssertions.NotBeApproximately(unexpectedValue, precision, because, becauseArgs);
@@ -259,7 +259,7 @@ namespace FluentAssertions
             Execute.Assertion
                 .ForCondition(actualDifference > precision)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value {0} to not approximate {1} +/- {2}{reason}, but it only differed by {3}.",
+                .FailWith("Expected {context:value} {0} to not approximate {1} +/- {2}{reason}, but it only differed by {3}.",
                     parent.Subject, unexpectedValue, precision, actualDifference);
 
             return new AndConstraint<NumericAssertions<float>>(parent);
@@ -289,7 +289,7 @@ namespace FluentAssertions
             Execute.Assertion
                 .ForCondition(parent.Subject != null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value to not approximate {0} +/- {1}{reason}, but it was <null>.", unexpectedValue, precision);
+                .FailWith("Expected {context:value} to not approximate {0} +/- {1}{reason}, but it was <null>.", unexpectedValue, precision);
 
             var nonNullableAssertions = new NumericAssertions<double>((double)parent.Subject);
             NotBeApproximately(nonNullableAssertions, unexpectedValue, precision, because, becauseArgs);
@@ -323,7 +323,7 @@ namespace FluentAssertions
             Execute.Assertion
                 .ForCondition(actualDifference > precision)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value {0} to not approximate {1} +/- {2}{reason}, but it only differed by {3}.",
+                .FailWith("Expected {context:value} {0} to not approximate {1} +/- {2}{reason}, but it only differed by {3}.",
                     parent.Subject, unexpectedValue, precision, actualDifference);
 
             return new AndConstraint<NumericAssertions<double>>(parent);
@@ -353,7 +353,7 @@ namespace FluentAssertions
             Execute.Assertion
                 .ForCondition(parent.Subject != null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value to not approximate {0} +/- {1}{reason}, but it was <null>.", unexpectedValue, precision);
+                .FailWith("Expected {context:value} to not approximate {0} +/- {1}{reason}, but it was <null>.", unexpectedValue, precision);
 
             var nonNullableAssertions = new NumericAssertions<decimal>((decimal)parent.Subject);
             NotBeApproximately(nonNullableAssertions, unexpectedValue, precision, because, becauseArgs);
@@ -387,7 +387,7 @@ namespace FluentAssertions
             Execute.Assertion
                 .ForCondition(actualDifference > precision)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value {0} to not approximate {1} +/- {2}{reason}, but it only differed by {3}.",
+                .FailWith("Expected {context:value} {0} to not approximate {1} +/- {2}{reason}, but it only differed by {3}.",
                     parent.Subject, unexpectedValue, precision, actualDifference);
 
             return new AndConstraint<NumericAssertions<decimal>>(parent);

--- a/Src/FluentAssertions/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ObjectAssertionsExtensions.cs
@@ -58,7 +58,7 @@ namespace FluentAssertions
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {0} to be serializable{reason}, but serialization failed with:{1}{1}{2}",
+                    .FailWith("Expected {0} to be serializable{reason}, but serialization failed with:{1}{1}{2}.",
                         assertions.Subject,
                         Environment.NewLine,
                         exc.Message);
@@ -111,7 +111,7 @@ namespace FluentAssertions
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {0} to be serializable{reason}, but serialization failed with:{1}{1}{2}",
+                    .FailWith("Expected {0} to be serializable{reason}, but serialization failed with:{1}{1}{2}.",
                         assertions.Subject,
                         Environment.NewLine,
                         exc.Message);
@@ -189,7 +189,7 @@ namespace FluentAssertions
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {0} to be serializable{reason}, but serialization failed with:{1}{1}{2}",
+                    .FailWith("Expected {0} to be serializable{reason}, but serialization failed with:{1}{1}{2}.",
                         assertions.Subject,
                         Environment.NewLine,
                         exc.Message);

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -850,7 +850,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(validValues.Contains(Subject))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value to be one of {0}{reason}, but found {1}.", validValues, Subject);
+                .FailWith("Expected {context:date and time} to be one of {0}{reason}, but found {1}.", validValues, Subject);
 
             return new AndConstraint<DateTimeAssertions>(this);
         }

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -909,7 +909,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(validValues.Contains(Subject))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value to be one of {0}{reason}, but found {1}.", validValues, Subject);
+                .FailWith("Expected {context:date and time} to be one of {0}{reason}, but found {1}.", validValues, Subject);
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }

--- a/Src/FluentAssertions/Primitives/GuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/GuidAssertions.cs
@@ -37,7 +37,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition((Subject.HasValue) && (Subject.Value == Guid.Empty))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected empty Guid{reason}, but found {0}.", Subject);
+                .FailWith("Expected {context:Guid} to be empty{reason}, but found {0}.", Subject);
 
             return new AndConstraint<GuidAssertions>(this);
         }
@@ -57,7 +57,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition((Subject.HasValue) && (Subject.Value != Guid.Empty))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect empty Guid{reason}.");
+                .FailWith("Did not expect {context:Guid} to be empty{reason}.");
 
             return new AndConstraint<GuidAssertions>(this);
         }

--- a/Src/FluentAssertions/Primitives/NullableBooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableBooleanAssertions.cs
@@ -121,7 +121,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(!Subject.HasValue || Subject.Value)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected nullable boolean not to be {0}{reason}, but found {1}.", false, Subject);
+                .FailWith("Expected {context:nullable boolean} not to be {0}{reason}, but found {1}.", false, Subject);
 
             return new AndConstraint<BooleanAssertions>(this);
         }
@@ -141,7 +141,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(!Subject.HasValue || !Subject.Value)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected nullable boolean not to be {0}{reason}, but found {1}.", true, Subject);
+                .FailWith("Expected {context:nullable boolean} not to be {0}{reason}, but found {1}.", true, Subject);
 
             return new AndConstraint<BooleanAssertions>(this);
         }

--- a/Src/FluentAssertions/Primitives/NullableDateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateTimeAssertions.cs
@@ -33,7 +33,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected variable to have a value{reason}, but found {0}", Subject);
+                .FailWith("Expected {context:nullable date and time} to have a value{reason}, but found {0}.", Subject);
 
             return new AndConstraint<NullableDateTimeAssertions>(this);
         }
@@ -68,7 +68,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(!Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect variable to have a value{reason}, but found {0}", Subject);
+                .FailWith("Did not expect {context:nullable date and time} to have a value{reason}, but found {0}.", Subject);
 
             return new AndConstraint<NullableDateTimeAssertions>(this);
         }

--- a/Src/FluentAssertions/Primitives/NullableDateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateTimeOffsetAssertions.cs
@@ -33,7 +33,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected variable to have a value{reason}, but found {0}", Subject);
+                .FailWith("Expected {context:nullable date and time} to have a value{reason}, but found {0}.", Subject);
 
             return new AndConstraint<NullableDateTimeOffsetAssertions>(this);
         }
@@ -69,7 +69,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(!Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect variable to have a value{reason}, but found {0}", Subject);
+                .FailWith("Did not expect {context:date and time} to have a value{reason}, but found {0}.", Subject);
 
             return new AndConstraint<NullableDateTimeOffsetAssertions>(this);
         }

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -102,7 +102,7 @@ namespace FluentAssertions.Primitives
                 .UsingLineBreaks
                 .ForCondition(!ReferenceEquals(Subject, unexpected))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect reference to object {0}{reason}.", unexpected);
+                .FailWith("Did not expect {context:" + Context + "} to refer to {0}{reason}.", unexpected);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -39,7 +39,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(new TimeSpan()) > 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected positive value{reason}, but found {0}", Subject.Value);
+                .FailWith("Expected {context:time} to be positive{reason}, but found {0}.", Subject.Value);
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
         }
@@ -59,7 +59,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(new TimeSpan()) < 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected negative value{reason}, but found {0}", Subject.Value);
+                .FailWith("Expected {context:time} to be negative{reason}, but found {0}.", Subject.Value);
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
         }
@@ -125,7 +125,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(expected) < 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected a value less than {0}{reason}, but found {1}.", expected, Subject.Value);
+                .FailWith("Expected {context:time} to be less than {0}{reason}, but found {1}.", expected, Subject.Value);
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
         }
@@ -147,7 +147,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(expected) <= 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected a value less or equal to {0}{reason}, but found {1}.", expected, Subject.Value);
+                .FailWith("Expected {context:time} to be less or equal to {0}{reason}, but found {1}.", expected, Subject.Value);
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
         }
@@ -169,7 +169,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(expected) > 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected a value greater than {0}{reason}, but found {1}.", expected, Subject.Value);
+                .FailWith("Expected {context:time} to be greater than {0}{reason}, but found {1}.", expected, Subject.Value);
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
         }
@@ -192,7 +192,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(expected) >= 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected a value greater or equal to {0}{reason}, but found {1}.", expected, Subject.Value);
+                .FailWith("Expected {context:time} to be greater or equal to {0}{reason}, but found {1}.", expected, Subject.Value);
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
         }

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -70,7 +70,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(validValues.Contains(Subject))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value to be one of {0}{reason}, but found {1}.", validValues, Subject);
+                .FailWith("Expected {context:string} to be one of {0}{reason}, but found {1}.", validValues, Subject);
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -117,7 +117,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject != unexpected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected string not to be {0}{reason}.", unexpected);
+                .FailWith("Expected {context:string} not to be {0}{reason}.", unexpected);
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -244,7 +244,7 @@ namespace FluentAssertions.Primitives
               .ForCondition(!ReferenceEquals(Subject, null))
               .UsingLineBreaks
               .BecauseOf(because, becauseArgs)
-              .FailWith("Expected string to match regex {0}{reason}, but it was <null>.", regularExpression);
+              .FailWith("Expected {context:string} to match regex {0}{reason}, but it was <null>.", regularExpression);
 
           bool isMatch;
           try
@@ -264,7 +264,7 @@ namespace FluentAssertions.Primitives
               .ForCondition(isMatch)
               .BecauseOf(because, becauseArgs)
               .UsingLineBreaks
-              .FailWith("Expected string to match regex {0}{reason}, but {1} does not match.", regularExpression, Subject);
+              .FailWith("Expected {context:string} to match regex {0}{reason}, but {1} does not match.", regularExpression, Subject);
 
           return new AndConstraint<StringAssertions>(this);
         }
@@ -293,7 +293,7 @@ namespace FluentAssertions.Primitives
               .ForCondition(!ReferenceEquals(Subject, null))
               .UsingLineBreaks
               .BecauseOf(because, becauseArgs)
-              .FailWith("Expected string to not match regex {0}{reason}, but it was <null>.", regularExpression);
+              .FailWith("Expected {context:string} to not match regex {0}{reason}, but it was <null>.", regularExpression);
           
           bool isMatch;
           try
@@ -313,7 +313,7 @@ namespace FluentAssertions.Primitives
               .ForCondition(!isMatch)
               .BecauseOf(because, becauseArgs)
               .UsingLineBreaks
-              .FailWith("Did not expect string to match regex {0}{reason}, but {1} matches.", regularExpression, Subject);
+              .FailWith("Did not expect {context:string} to match regex {0}{reason}, but {1} matches.", regularExpression, Subject);
 
           return new AndConstraint<StringAssertions>(this);
         }
@@ -463,20 +463,20 @@ namespace FluentAssertions.Primitives
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected string {0} to end with {1}{reason}.", Subject, expected);
+                    .FailWith("Expected {context:string} {0} to end with {1}{reason}.", Subject, expected);
             }
 
             if (Subject.Length < expected.Length)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected string to end with {0}{reason}, but {1} is too short.", expected, Subject);
+                    .FailWith("Expected {context:string} to end with {0}{reason}, but {1} is too short.", expected, Subject);
             }
 
             Execute.Assertion
                 .ForCondition(Subject.EndsWith(expected))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected string {0} to end with {1}{reason}.", Subject, expected);
+                .FailWith("Expected {context:string} {0} to end with {1}{reason}.", Subject, expected);
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -509,13 +509,13 @@ namespace FluentAssertions.Primitives
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected string that does not end with {1}, but found {0}.", Subject, unexpected);
+                    .FailWith("Expected {context:string} that does not end with {1}, but found {0}.", Subject, unexpected);
             }
 
             Execute.Assertion
                 .ForCondition(!Subject.EndsWith(unexpected))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected string {0} not to end with {1}{reason}.", Subject, unexpected);
+                .FailWith("Expected {context:string} {0} not to end with {1}{reason}.", Subject, unexpected);
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -548,20 +548,20 @@ namespace FluentAssertions.Primitives
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected string that ends with equivalent of {0}{reason}, but found {1}.", expected, Subject);
+                    .FailWith("Expected {context:string} that ends with equivalent of {0}{reason}, but found {1}.", expected, Subject);
             }
 
             if (Subject.Length < expected.Length)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected string to end with equivalent of {0}{reason}, but {1} is too short.", expected, Subject);
+                    .FailWith("Expected {context:string} to end with equivalent of {0}{reason}, but {1} is too short.", expected, Subject);
             }
 
             Execute.Assertion
                 .ForCondition(Subject.EndsWith(expected, StringComparison.CurrentCultureIgnoreCase))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected string that ends with equivalent of {0}{reason}, but found {1}.", expected, Subject);
+                .FailWith("Expected {context:string} that ends with equivalent of {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -594,13 +594,13 @@ namespace FluentAssertions.Primitives
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected string that does not end with equivalent of {0}, but found {1}.", unexpected, Subject);
+                    .FailWith("Expected {context:string} that does not end with equivalent of {0}, but found {1}.", unexpected, Subject);
             }
 
             Execute.Assertion
                 .ForCondition(!Subject.EndsWith(unexpected, StringComparison.CurrentCultureIgnoreCase))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected string that does not end with equivalent of {0}{reason}, but found {1}.", unexpected, Subject);
+                .FailWith("Expected {context:string} that does not end with equivalent of {0}{reason}, but found {1}.", unexpected, Subject);
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -633,7 +633,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Contains(Subject, expected, StringComparison.Ordinal))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected string {0} to contain {1}{reason}.", Subject, expected);
+                .FailWith("Expected {context:string} {0} to contain {1}{reason}.", Subject, expected);
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -665,7 +665,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Contains(Subject, expected, StringComparison.CurrentCultureIgnoreCase))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected string to contain equivalent of {0}{reason} but found {1}", expected, Subject);
+                .FailWith("Expected {context:string} to contain equivalent of {0}{reason} but found {1}.", expected, Subject);
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -786,7 +786,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(!Contains(Subject, expected, StringComparison.Ordinal))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect string {0} to contain {1}{reason}.", Subject, expected);
+                .FailWith("Did not expect {context:string} {0} to contain {1}{reason}.", Subject, expected);
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -815,7 +815,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(matches != values.Count())
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect the {context:string} {0} to contain all of the strings: {1}{reason}.", Subject, values);
+                .FailWith("Did not expect {context:string} {0} to contain all of the strings: {1}{reason}.", Subject, values);
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -862,7 +862,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(!matches.Any())
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect the {context:string} {0} to contain any of the strings: {1}{reason}.", Subject, matches);
+                .FailWith("Did not expect {context:string} {0} to contain any of the strings: {1}{reason}.", Subject, matches);
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -903,7 +903,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(!Contains(Subject, unexpected, StringComparison.CurrentCultureIgnoreCase))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect string to contain equivalent of {0}{reason} but found {1}", unexpected, Subject);
+                .FailWith("Did not expect {context:string} to contain equivalent of {0}{reason} but found {1}.", unexpected, Subject);
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -928,7 +928,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject?.Length == 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected empty string{reason}, but found {0}.", Subject);
+                .FailWith("Expected {context:string} to be empty{reason}, but found {0}.", Subject);
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -948,7 +948,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject.Length > 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect empty string{reason}.");
+                .FailWith("Did not expect {context:string} to be empty{reason}.");
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -969,7 +969,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject.Length == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected string with length {0}{reason}, but found string {1} with length {2}.",
+                .FailWith("Expected {context:string} with length {0}{reason}, but found string {1} with length {2}.",
                     expected, Subject, Subject.Length);
 
             return new AndConstraint<StringAssertions>(this);
@@ -990,7 +990,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(!string.IsNullOrEmpty(Subject))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected string not to be <null> or empty{reason}, but found {0}.", Subject);
+                .FailWith("Expected {context:string} not to be <null> or empty{reason}, but found {0}.", Subject);
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -1010,7 +1010,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(string.IsNullOrEmpty(Subject))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected string to be <null> or empty{reason}, but found {0}.", Subject);
+                .FailWith("Expected {context:string} to be <null> or empty{reason}, but found {0}.", Subject);
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -1030,7 +1030,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(!string.IsNullOrWhiteSpace(Subject))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected string not to be <null> or whitespace{reason}, but found {0}.", Subject);
+                .FailWith("Expected {context:string} not to be <null> or whitespace{reason}, but found {0}.", Subject);
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -1050,7 +1050,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(string.IsNullOrWhiteSpace(Subject))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected string to be <null> or whitespace{reason}, but found {0}.", Subject);
+                .FailWith("Expected {context:string} to be <null> or whitespace{reason}, but found {0}.", Subject);
 
             return new AndConstraint<StringAssertions>(this);
         }

--- a/Src/FluentAssertions/Specialized/ActionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ActionAssertions.cs
@@ -100,7 +100,7 @@ namespace FluentAssertions.Specialized
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Did not expect any exception{reason}, but found {0}", exception);
+                    .FailWith("Did not expect any exception{reason}, but found {0}.", exception);
             }
         }
 

--- a/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
@@ -51,7 +51,7 @@ namespace FluentAssertions.Reflection
             Execute.Assertion
                    .BecauseOf(because, becauseArgs)
                    .ForCondition(references.All(x => x != assemblyName))
-                   .FailWith("Assembly {0} should not reference assembly {1}{reason}", subjectName, assemblyName);
+                   .FailWith("Expected assembly {0} not to reference assembly {1}{reason}.", subjectName, assemblyName);
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace FluentAssertions.Reflection
             Execute.Assertion
                    .BecauseOf(because, becauseArgs)
                    .ForCondition(references.Any(x => x == assemblyName))
-                   .FailWith("Assembly {0} should reference assembly {1}{reason}, but it does not", subjectName, assemblyName);
+                   .FailWith("Expected assembly {0} to reference assembly {1}{reason}, but it does not.", subjectName, assemblyName);
         }
 #endif
         /// <summary>

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -165,7 +165,7 @@ namespace FluentAssertions.Specialized
             Execute.Assertion
                 .ForCondition(condition(SingleSubject))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected exception where {0}{reason}, but the condition was not met by:{1}{1}{2}",
+                .FailWith("Expected exception where {0}{reason}, but the condition was not met by:{1}{1}{2}.",
                     exceptionExpression.Body, Environment.NewLine, Subject);
 
             return this;

--- a/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
@@ -42,7 +42,7 @@ namespace FluentAssertions.Specialized
             Execute.Assertion
                 .ForCondition(executionTimeSpan.CompareTo(maxDuration) <= 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Execution of " + actionDescription + " should be less or equal to {0}{reason}, but it required {1}",
+                .FailWith("Execution of " + actionDescription + " should be less or equal to {0}{reason}, but it required {1}.",
                     maxDuration, executionTimeSpan);
         }
 
@@ -64,7 +64,7 @@ namespace FluentAssertions.Specialized
             Execute.Assertion
                 .ForCondition(executionTimeSpan.CompareTo(maxDuration) < 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Execution of " + actionDescription + " should be less than {0}{reason}, but it required {1}",
+                .FailWith("Execution of " + actionDescription + " should be less than {0}{reason}, but it required {1}.",
                     maxDuration, executionTimeSpan);
         }
 
@@ -86,7 +86,7 @@ namespace FluentAssertions.Specialized
             Execute.Assertion
                 .ForCondition(executionTimeSpan.CompareTo(minDuration) >= 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Execution of " + actionDescription + " should be greater or equal to {0}{reason}, but it required {1}",
+                .FailWith("Execution of " + actionDescription + " should be greater or equal to {0}{reason}, but it required {1}.",
                     minDuration, executionTimeSpan);
         }
 
@@ -108,7 +108,7 @@ namespace FluentAssertions.Specialized
             Execute.Assertion
                 .ForCondition(executionTimeSpan.CompareTo(minDuration) > 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Execution of " + actionDescription + " should be greater than {0}{reason}, but it required {1}",
+                .FailWith("Execution of " + actionDescription + " should be greater than {0}{reason}, but it required {1}.",
                     minDuration, executionTimeSpan);
         }
 
@@ -137,7 +137,7 @@ namespace FluentAssertions.Specialized
             Execute.Assertion
                 .ForCondition((executionTimeSpan >= minimumValue) && (executionTimeSpan <= maximumValue))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Execution of " + actionDescription + " should be within {0} from {1}{reason}, but it required {2}",
+                .FailWith("Execution of " + actionDescription + " should be within {0} from {1}{reason}, but it required {2}.",
                     precision, expectedDuration, executionTimeSpan);
         }
     }

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -50,10 +50,10 @@ namespace FluentAssertions.Types
                 .ForCondition(!typesWithoutAttribute.Any())
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected all types to be decorated with {0}{reason}," +
-                    " but the attribute was not found on the following types:" +
-                    Environment.NewLine +
-                    GetDescriptionsFor(typesWithoutAttribute),
-                    typeof(TAttribute));
+                    " but the attribute was not found on the following types:{1}{2}.",
+                    typeof(TAttribute),
+                    Environment.NewLine,
+                    GetDescriptionsFor(typesWithoutAttribute));
 
             return new AndConstraint<TypeSelectorAssertions>(this);
         }
@@ -84,10 +84,11 @@ namespace FluentAssertions.Types
                 .ForCondition(!typesWithoutMatchingAttribute.Any())
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected all types to be decorated with {0} that matches {1}{reason}," +
-                    " but no matching attribute was found on the following types:" +
-                    Environment.NewLine +
-                    GetDescriptionsFor(typesWithoutMatchingAttribute),
-                    typeof(TAttribute), isMatchingAttributePredicate.Body);
+                    " but no matching attribute was found on the following types:{2}{3}.",
+                    typeof(TAttribute),
+                    isMatchingAttributePredicate.Body,
+                    Environment.NewLine,
+                    GetDescriptionsFor(typesWithoutMatchingAttribute));
 
             return new AndConstraint<TypeSelectorAssertions>(this);
         }
@@ -113,10 +114,10 @@ namespace FluentAssertions.Types
                 .ForCondition(!typesWithAttribute.Any())
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected all types to not be decorated with {0}{reason}," +
-                    " but the attribute was found on the following types:" +
-                    Environment.NewLine +
-                    GetDescriptionsFor(typesWithAttribute),
-                    typeof(TAttribute));
+                    " but the attribute was found on the following types:{1}{2}.",
+                    typeof(TAttribute),
+                    Environment.NewLine,
+                    GetDescriptionsFor(typesWithAttribute));
 
             return new AndConstraint<TypeSelectorAssertions>(this);
         }
@@ -147,10 +148,11 @@ namespace FluentAssertions.Types
                 .ForCondition(!typesWithMatchingAttribute.Any())
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected all types to not be decorated with {0} that matches {1}{reason}," +
-                    " but a matching attribute was found on the following types:" +
-                    Environment.NewLine +
-                    GetDescriptionsFor(typesWithMatchingAttribute),
-                    typeof(TAttribute), isMatchingAttributePredicate.Body);
+                    " but a matching attribute was found on the following types:{2}{3}.",
+                    typeof(TAttribute),
+                    isMatchingAttributePredicate.Body,
+                    Environment.NewLine,
+                    GetDescriptionsFor(typesWithMatchingAttribute));
 
             return new AndConstraint<TypeSelectorAssertions>(this);
         }

--- a/Src/FluentAssertions/Xml/XAttributeAssertions.cs
+++ b/Src/FluentAssertions/Xml/XAttributeAssertions.cs
@@ -44,7 +44,7 @@ namespace FluentAssertions.Xml
             Execute.Assertion
                 .ForCondition(Subject.Name.Equals(expected.Name) && Subject.Value.Equals(expected.Value))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected XML attribute to be {0}{reason}, but found {1}", expected, Subject);
+                .FailWith("Expected XML attribute to be {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<XAttributeAssertions>(this);
         }

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -49,7 +49,7 @@ namespace FluentAssertions.Xml
             Execute.Assertion
                 .ForCondition(Subject.IsSameOrEqualTo(expected))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected XML document to be {0}{reason}, but found {1}", expected, Subject);
+                .FailWith("Expected XML document to be {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<XDocumentAssertions>(this);
         }

--- a/Src/FluentAssertions/Xml/XmlReaderValidator.cs
+++ b/Src/FluentAssertions/Xml/XmlReaderValidator.cs
@@ -168,7 +168,7 @@ namespace FluentAssertions.Xml
 
                 if (expectedAttribute == null)
                 {
-                    return new ValidationResult("Didn't expect to find attribute {0} at {1}{reason}.",
+                    return new ValidationResult("Did not expect to find attribute {0} at {1}{reason}.",
                         subjectAttribute.QualifiedName, CurrentLocation);
                 }
 

--- a/Tests/Shared.Specs/DateTimeAssertionSpecs.cs
+++ b/Tests/Shared.Specs/DateTimeAssertionSpecs.cs
@@ -2519,7 +2519,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected value to be one of {<2016-12-31 23:58:57>, <2016-12-30 23:58:57.001>}, but found <2016-12-30 23:58:57>.");
+                .WithMessage("Expected date and time to be one of {<2016-12-31 23:58:57>, <2016-12-30 23:58:57.001>}, but found <2016-12-30 23:58:57>.");
         }
 
         [Fact]
@@ -2539,7 +2539,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected value to be one of {<2016-12-31 23:58:57>, <2016-12-30 23:58:57.001>} because it's true, but found <2016-12-30 23:58:57>.");
+                .WithMessage("Expected date and time to be one of {<2016-12-31 23:58:57>, <2016-12-30 23:58:57.001>} because it's true, but found <2016-12-30 23:58:57>.");
         }
 
         [Fact]
@@ -2580,7 +2580,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected value to be one of {<2216-01-30 00:05:07>, <1116-04-10 02:45:07>}, but found <null>.");
+                .WithMessage("Expected date and time to be one of {<2216-01-30 00:05:07>, <1116-04-10 02:45:07>}, but found <null>.");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/Shared.Specs/DateTimeOffsetAssertionSpecs.cs
@@ -2582,7 +2582,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected value to be one of {<2017-01-01 +1h>, <2016-12-31 04:00:00 +1h>}, but found <2016-12-31 +1h>.");
+                .WithMessage("Expected date and time to be one of {<2017-01-01 +1h>, <2016-12-31 04:00:00 +1h>}, but found <2016-12-31 +1h>.");
         }
 
         [Fact]
@@ -2602,7 +2602,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected value to be one of {<2017-01-01 +1h>, <2017-01-31 +1h>} because it's true, but found <2016-12-31 +1h>.");
+                .WithMessage("Expected date and time to be one of {<2017-01-01 +1h>, <2017-01-31 +1h>} because it's true, but found <2016-12-31 +1h>.");
         }
 
         [Fact]
@@ -2641,7 +2641,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected value to be one of {<2216-01-30 00:05:07 +1h>, <2016-02-10 02:45:07 +2h>}, but found <null>.");
+                .WithMessage("Expected date and time to be one of {<2216-01-30 00:05:07 +1h>, <2016-02-10 02:45:07 +2h>}, but found <null>.");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/Shared.Specs/GenericCollectionAssertionsSpecs.cs
@@ -48,7 +48,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
-                "Collection {1, 2, 3} should have an item matching (item > 3) because at least 1 item should be larger than 3.");
+                "Expected collection {1, 2, 3} to have an item matching (item > 3) because at least 1 item should be larger than 3.");
         }
 
         [Fact]
@@ -565,7 +565,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            const string expectedMessage = "Expected a value greater than 4, but found 3.";
+            const string expectedMessage = "Expected value to be greater than 4, but found 3.";
 
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }

--- a/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
@@ -1364,7 +1364,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
-                "Dictionary {[1, One], [2, Two]} should not contain key 1 because we don't like it, but found it anyhow.");
+                "Expected dictionary {[1, One], [2, Two]} not to contain key 1 because we don't like it, but found it anyhow.");
         }
 
         [Fact]
@@ -1681,7 +1681,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
-                "Dictionary {[1, One], [2, Two]} should not contain value \"One\" because we don't like it, but found it anyhow.");
+                "Expected dictionary {[1, One], [2, Two]} not to contain value \"One\" because we don't like it, but found it anyhow.");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/GuidAssertionSpecs.cs
+++ b/Tests/Shared.Specs/GuidAssertionSpecs.cs
@@ -32,7 +32,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected empty Guid because we want to test the failure message, but found {12345678-1234-1234-1234-123456789012}.");
+                "Expected Guid to be empty because we want to test the failure message, but found {12345678-1234-1234-1234-123456789012}.");
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect empty Guid because we want to test the failure message.");
+                "Did not expect Guid to be empty because we want to test the failure message.");
         }
 
         #endregion

--- a/Tests/Shared.Specs/NumericAssertionSpecs.cs
+++ b/Tests/Shared.Specs/NumericAssertionSpecs.cs
@@ -87,7 +87,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected positive value because we want to test the failure message, but found -1");
+                .WithMessage("Expected value to be positive because we want to test the failure message, but found -1.");
         }
 
         [Fact]
@@ -165,7 +165,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected negative value because we want to test the failure message, but found 1");
+                .WithMessage("Expected value to be negative because we want to test the failure message, but found 1.");
         }
 
         #endregion
@@ -357,7 +357,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Did not expect 1 because we want to test the failure message.");
+                .WithMessage("Did not expect value to be 1 because we want to test the failure message.");
         }
 
         #endregion
@@ -443,7 +443,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected a value greater than 3 because we want to test the failure message, but found 2.");
+                .WithMessage("Expected value to be greater than 3 because we want to test the failure message, but found 2.");
         }
 
         [Fact]
@@ -526,7 +526,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected a value greater or equal to 3 because we want to test the failure message, but found 2.");
+                .WithMessage("Expected value to be greater or equal to 3 because we want to test the failure message, but found 2.");
         }
 
         #endregion
@@ -612,7 +612,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected a value less than 1 because we want to test the failure message, but found 2.");
+                .WithMessage("Expected value to be less than 1 because we want to test the failure message, but found 2.");
         }
 
         [Fact]
@@ -694,7 +694,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected a value less or equal to 1 because we want to test the failure message, but found 2.");
+                .WithMessage("Expected value to be less or equal to 1 because we want to test the failure message, but found 2.");
         }
 
         #endregion

--- a/Tests/Shared.Specs/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/Shared.Specs/ReferenceTypeAssertionsSpecs.cs
@@ -90,7 +90,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect reference to object \r\nClassWithCustomEqualMethod(1) because they are the same.");
+                .WithMessage("Did not expect object to refer to \r\nClassWithCustomEqualMethod(1) because they are the same.");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/SimpleTimeSpanAssertionSpecs.cs
+++ b/Tests/Shared.Specs/SimpleTimeSpanAssertionSpecs.cs
@@ -33,7 +33,7 @@ namespace FluentAssertions.Specs
             var assertions = 1.Seconds().Negate().Should();
             assertions.Invoking(x => x.BePositive("because we want to test the failure {0}", "message"))
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected positive value because we want to test the failure message, but found -1s");
+                .WithMessage("Expected time to be positive because we want to test the failure message, but found -1s.");
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace FluentAssertions.Specs
             var assertions = 1.Seconds().Should();
             assertions.Invoking(x => x.BeNegative("because we want to test the failure {0}", "message"))
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected negative value because we want to test the failure message, but found 1s");
+                .WithMessage("Expected time to be negative because we want to test the failure message, but found 1s.");
         }
 
         [Fact]
@@ -136,7 +136,7 @@ namespace FluentAssertions.Specs
             var assertions = 1.Seconds().Should();
             assertions.Invoking(x => x.BeGreaterThan(2.Seconds(), "because we want to test the failure {0}", "message"))
                 .Should().Throw<XunitException>()
-                .WithMessage(@"Expected a value greater than 2s because we want to test the failure message, but found 1s.");
+                .WithMessage("Expected time to be greater than 2s because we want to test the failure message, but found 1s.");
         }
 
         [Fact]
@@ -166,7 +166,7 @@ namespace FluentAssertions.Specs
             var assertions = 1.Seconds().Should();
             assertions.Invoking(x => x.BeGreaterOrEqualTo(2.Seconds(), "because we want to test the failure {0}", "message"))
                 .Should().Throw<XunitException>()
-                .WithMessage(@"Expected a value greater or equal to 2s because we want to test the failure message, but found 1s.");
+                .WithMessage("Expected time to be greater or equal to 2s because we want to test the failure message, but found 1s.");
         }
 
         [Fact]
@@ -198,7 +198,7 @@ namespace FluentAssertions.Specs
             var assertions = 2.Seconds().Should();
             assertions.Invoking(x => x.BeLessThan(1.Seconds(), "because we want to test the failure {0}", "message"))
                 .Should().Throw<XunitException>()
-                .WithMessage(@"Expected a value less than 1s because we want to test the failure message, but found 2s.");
+                .WithMessage("Expected time to be less than 1s because we want to test the failure message, but found 2s.");
         }
 
         [Fact]
@@ -228,7 +228,7 @@ namespace FluentAssertions.Specs
             var assertions = 2.Seconds().Should();
             assertions.Invoking(x => x.BeLessOrEqualTo(1.Seconds(), "because we want to test the failure {0}", "message"))
                 .Should().Throw<XunitException>()
-                .WithMessage(@"Expected a value less or equal to 1s because we want to test the failure message, but found 2s.");
+                .WithMessage("Expected time to be less or equal to 1s because we want to test the failure message, but found 2s.");
         }
 
         #region Be Close To

--- a/Tests/Shared.Specs/StringAssertionSpecs.cs
+++ b/Tests/Shared.Specs/StringAssertionSpecs.cs
@@ -301,7 +301,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected value to be one of {\"def\", \"xyz\"}, but found \"abc\".");
+                .WithMessage("Expected string to be one of {\"def\", \"xyz\"}, but found \"abc\".");
         }
 
         [Fact]
@@ -321,7 +321,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected value to be one of {\"def\", \"xyz\"} because those are the valid values, but found \"abc\".");
+                .WithMessage("Expected string to be one of {\"def\", \"xyz\"} because those are the valid values, but found \"abc\".");
         }
 
         [Fact]
@@ -2490,7 +2490,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect string to contain equivalent of <null> but found \"a\"");
+                .WithMessage("Did not expect string to contain equivalent of <null> but found \"a\".");
         }
 
         [Fact]
@@ -2506,7 +2506,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect string to contain equivalent of \"\" but found \"a\"");
+                .WithMessage("Did not expect string to contain equivalent of \"\" but found \"a\".");
         }
 
         [Fact]
@@ -2522,7 +2522,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect string to contain equivalent of \", worLD!\" but found \"Hello, world!\"");
+                .WithMessage("Did not expect string to contain equivalent of \", worLD!\" but found \"Hello, world!\".");
         }
 
         [Fact]
@@ -2564,7 +2564,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected string to contain equivalent of \"aa\" but found \"a\"");
+                .WithMessage("Expected string to contain equivalent of \"aa\" but found \"a\".");
         }
 
         [Fact]
@@ -2623,7 +2623,7 @@ namespace FluentAssertions.Specs
             var assertions = "ABC".Should();
             assertions.Invoking(x => x.BeEmpty("because we want to test the failure {0}", "message"))
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected empty string because we want to test the failure message, but found \"ABC\".");
+                .WithMessage("Expected string to be empty because we want to test the failure message, but found \"ABC\".");
         }
 
         [Fact]
@@ -2643,7 +2643,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected empty string because strings should never be null, but found <null>.");
+                "Expected string to be empty because strings should never be null, but found <null>.");
         }
 
         [Fact]
@@ -2666,7 +2666,7 @@ namespace FluentAssertions.Specs
             var assertions = "".Should();
             assertions.Invoking(x => x.NotBeEmpty("because we want to test the failure {0}", "message"))
                 .Should().Throw<XunitException>()
-                .WithMessage("Did not expect empty string because we want to test the failure message.");
+                .WithMessage("Did not expect string to be empty because we want to test the failure message.");
         }
 
         #endregion

--- a/Tests/Shared.Specs/TypeAssertionSpecs.cs
+++ b/Tests/Shared.Specs/TypeAssertionSpecs.cs
@@ -941,10 +941,10 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be decorated with FluentAssertions.Specs.DummyClassAttribute" +
+                .WithMessage("Expected all types to be decorated with *DummyClassAttribute*" +
                     " because we do, but the attribute was not found on the following types:\r\n" +
-                    "FluentAssertions.Specs.ClassWithoutAttribute\r\n" +
-                    "FluentAssertions.Specs.OtherClassWithoutAttribute");
+                    "*ClassWithoutAttribute*\r\n" +
+                    "*OtherClassWithoutAttribute*.");
         }
 
 
@@ -972,11 +972,11 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be decorated with FluentAssertions.Specs.DummyClassAttribute" +
+                .WithMessage("Expected all types to be decorated with *DummyClassAttribute*" +
                     " that matches ((a.Name == \"Expected\")*a.IsEnabled) because we do," +
                     " but no matching attribute was found on the following types:\r\n" +
-                    "FluentAssertions.Specs.ClassWithoutAttribute\r\n" +
-                    "FluentAssertions.Specs.OtherClassWithoutAttribute");
+                    "*ClassWithoutAttribute*\r\n" +
+                    "*OtherClassWithoutAttribute*.");
         }
 
         #endregion
@@ -1139,7 +1139,7 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all types to not be decorated*DummyClassAttribute" +
-                    "*because we do*attribute was found*ClassWithAttribute");
+                    "*because we do*attribute was found*ClassWithAttribute*");
         }
 
 
@@ -1166,9 +1166,9 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to not be decorated*DummyClassAttribute" +
+                .WithMessage("Expected all types to not be decorated with *DummyClassAttribute" +
                     "*((a.Name == \"Expected\")*a.IsEnabled) because we do" +
-                    "*matching attribute was found*FluentAssertions.Specs.ClassWithAttribute");
+                    "*matching attribute was found*ClassWithAttribute*.");
         }
 
         #endregion

--- a/Tests/Shared.Specs/XAttributeAssertionSpecs.cs
+++ b/Tests/Shared.Specs/XAttributeAssertionSpecs.cs
@@ -51,7 +51,7 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             string expectedMessage = string.Format("Expected XML attribute to be {0}" +
                 " because we want to test the failure message," +
-                    " but found {1}", otherXAttribute, attribute);
+                    " but found {1}.", otherXAttribute, attribute);
 
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }

--- a/Tests/Shared.Specs/XDocumentAssertionSpecs.cs
+++ b/Tests/Shared.Specs/XDocumentAssertionSpecs.cs
@@ -97,7 +97,7 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected XML document to be <data></data>" +
                     " because we want to test the failure message," +
-                        " but found <configuration></configuration>");
+                        " but found <configuration></configuration>.");
         }
 
         [Fact]
@@ -572,7 +572,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().
-                WithMessage("Didn't expect to find attribute \"a\" at \"/xml/element\" because we want to test the failure message.");
+                WithMessage("Did not expect to find attribute \"a\" at \"/xml/element\" because we want to test the failure message.");
         }
 
         [Fact]
@@ -616,7 +616,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().
-                WithMessage("Didn't expect to find attribute \"ns:a\" at \"/xml/element\" because we want to test the failure message.");
+                WithMessage("Did not expect to find attribute \"ns:a\" at \"/xml/element\" because we want to test the failure message.");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/XElementAssertionSpecs.cs
+++ b/Tests/Shared.Specs/XElementAssertionSpecs.cs
@@ -725,7 +725,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().
-                WithMessage("Didn't expect to find attribute \"a\" at \"/xml/element\" because we want to test the failure message.");
+                WithMessage("Did not expect to find attribute \"a\" at \"/xml/element\" because we want to test the failure message.");
         }
 
         [Fact]
@@ -769,7 +769,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().
-                WithMessage("Didn't expect to find attribute \"ns:a\" at \"/xml/element\" because we want to test the failure message.");
+                WithMessage("Did not expect to find attribute \"ns:a\" at \"/xml/element\" because we want to test the failure message.");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/XmlNodeAssertionSpecs.cs
+++ b/Tests/Shared.Specs/XmlNodeAssertionSpecs.cs
@@ -562,7 +562,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().
-                WithMessage("Didn't expect to find attribute \"a\" at \"/xml/element\" because we want to test the failure message.");
+                WithMessage("Did not expect to find attribute \"a\" at \"/xml/element\" because we want to test the failure message.");
         }
 
         [Fact]
@@ -610,7 +610,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().
-                WithMessage("Didn't expect to find attribute \"ns:a\" at \"/xml/element\" because we want to test the failure message.");
+                WithMessage("Did not expect to find attribute \"ns:a\" at \"/xml/element\" because we want to test the failure message.");
         }
 
         [Fact]


### PR DESCRIPTION
Contents of this PR:

* Use `context` in failure messages. This fixes #707 
* Reword "Did not expect" to "Expected*not to"