### PR TITLE
Some threadsafety for Configuration

### DIFF
--- a/Src/FluentAssertions/Common/Configuration.cs
+++ b/Src/FluentAssertions/Common/Configuration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FluentAssertions.Formatting;
+using System.Threading;
 
 namespace FluentAssertions.Common
 {
@@ -11,6 +12,7 @@ namespace FluentAssertions.Common
         private string valueFormatterAssembly;
         private ValueFormatterDetectionMode? valueFormatterDetectionMode;
         private string testFrameworkName;
+        private object propertiesAccessLock = new object();
 
         #endregion
 
@@ -35,12 +37,17 @@ namespace FluentAssertions.Common
         {
             get
             {
+                Monitor.Enter(propertiesAccessLock);
                 if (!valueFormatterDetectionMode.HasValue)
                 {
                     valueFormatterDetectionMode = DetermineFormatterDetectionMode();
                 }
 
-                return valueFormatterDetectionMode.Value;
+                var value = valueFormatterDetectionMode.Value;
+
+                Monitor.Exit(propertiesAccessLock);
+
+                return value;
             }
             set { valueFormatterDetectionMode = value; }
         }
@@ -91,8 +98,10 @@ namespace FluentAssertions.Common
             }
             set
             {
+                Monitor.Enter(propertiesAccessLock);
                 valueFormatterAssembly = value;
                 valueFormatterDetectionMode = null;
+                Monitor.Exit(propertiesAccessLock);
             }
         }
 

--- a/Src/FluentAssertions/Common/Configuration.cs
+++ b/Src/FluentAssertions/Common/Configuration.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using FluentAssertions.Formatting;
-using System.Threading;
 
 namespace FluentAssertions.Common
 {
@@ -37,17 +36,16 @@ namespace FluentAssertions.Common
         {
             get
             {
-                Monitor.Enter(propertiesAccessLock);
-                if (!valueFormatterDetectionMode.HasValue)
+                lock(propertiesAccessLock)
                 {
-                    valueFormatterDetectionMode = DetermineFormatterDetectionMode();
+                    if (!valueFormatterDetectionMode.HasValue)
+                    {
+                        valueFormatterDetectionMode = DetermineFormatterDetectionMode();
+                    }
+
+                    return valueFormatterDetectionMode.Value;
                 }
-
-                var value = valueFormatterDetectionMode.Value;
-
-                Monitor.Exit(propertiesAccessLock);
-
-                return value;
+                
             }
             set { valueFormatterDetectionMode = value; }
         }
@@ -98,10 +96,11 @@ namespace FluentAssertions.Common
             }
             set
             {
-                Monitor.Enter(propertiesAccessLock);
-                valueFormatterAssembly = value;
-                valueFormatterDetectionMode = null;
-                Monitor.Exit(propertiesAccessLock);
+                lock(propertiesAccessLock)
+                {
+                    valueFormatterAssembly = value;
+                    valueFormatterDetectionMode = null;
+                }
             }
         }
 

--- a/Tests/Shared.Specs/ConfigurationSpecs.cs
+++ b/Tests/Shared.Specs/ConfigurationSpecs.cs
@@ -1,0 +1,36 @@
+﻿using FluentAssertions.Common;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace FluentAssertions.Specs
+{
+    public class ConfigurationSpecs
+    {
+        [Fact]
+        public void When_concurrently_accessing_current_Configuration_no_exception_should_be_thrown()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => Parallel.For(
+                0,
+                10000,
+                new ParallelOptions
+                {
+                    MaxDegreeOfParallelism = 8
+                },
+                e =>
+                {
+                    Configuration.Current.ValueFormatterAssembly = string.Empty;
+                    var mode = Configuration.Current.ValueFormatterDetectionMode;
+                }
+            );
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
+        }
+    }
+}

--- a/Tests/Shared.Specs/Shared.Specs.projitems
+++ b/Tests/Shared.Specs/Shared.Specs.projitems
@@ -20,6 +20,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionAssertionSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionEquivalencySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ComparableSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ConfigurationSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DateTimeAssertionSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DateTimeOffsetAssertionSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DateTimeOffsetValueFormatterSpecs.cs" />


### PR DESCRIPTION
Configuration.Current.ValueFormatterAssembly and Configuration.Current.ValueFormatterDetectionMode can be accessed in concurrent execution safely. Spotted in #664.