### PR TITLE
 Allow marking custom assertions so they are ignored during caller identification

### DIFF
--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions
@@ -24,7 +25,7 @@ namespace FluentAssertions
             {
                 logger(frame.ToString());
 
-                if (!IsDynamic(frame) && !IsDotNet(frame) && !IsCurrentAssembly(frame))
+                if (!IsDynamic(frame) && !IsDotNet(frame) && !IsCurrentAssembly(frame) && !IsCustomAssertion(frame))
                 {
                     caller = ExtractVariableNameFrom(frame) ?? caller;
                     break;
@@ -32,6 +33,11 @@ namespace FluentAssertions
             }
 
             return caller;
+        }
+
+        private static bool IsCustomAssertion(StackFrame frame)
+        {
+            return frame.GetMethod().HasAttribute<CustomAssertionAttribute>();
         }
 
         private static bool IsDynamic(StackFrame frame)

--- a/Src/FluentAssertions/CustomAssertionAttribute.cs
+++ b/Src/FluentAssertions/CustomAssertionAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace FluentAssertions
+{
+    /// <summary>
+    /// Marks a method as an extension to Fluent Assertions that either uses the built-in assertions
+    /// internally, or directly uses the <c>Execute.Assertion</c>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class CustomAssertionAttribute : Attribute
+    {
+    }
+}

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -24,7 +24,7 @@ namespace FluentAssertions.Primitives
         /// Asserts that the value is <c>false</c>.
         /// </summary>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -35,7 +35,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject == false)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {0}{reason}, but found {1}.", false, Subject);
+                .FailWith("Expected {context:boolean} to be false{reason}, but found {1}.", true, Subject);
 
             return new AndConstraint<BooleanAssertions>(this);
         }
@@ -44,7 +44,7 @@ namespace FluentAssertions.Primitives
         /// Asserts that the value is <c>true</c>.
         /// </summary>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
@@ -55,7 +55,7 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject == true)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {0}{reason}, but found {1}.", true, Subject);
+                .FailWith("Expected {context:boolean} to be true{reason}, but found {1}.", true, Subject);
 
             return new AndConstraint<BooleanAssertions>(this);
         }
@@ -65,7 +65,7 @@ namespace FluentAssertions.Primitives
         /// </summary>
         /// <param name="expected">The expected value</param>
         /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">

--- a/Tests/Shared.Specs/BooleanAssertionSpecs.cs
+++ b/Tests/Shared.Specs/BooleanAssertionSpecs.cs
@@ -42,7 +42,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             action
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected True because we want to test the failure message, but found False.");
+                .WithMessage("Expected boolean to be true because we want to test the failure message, but found False.");
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected False because we want to test the failure message, but found True.");
+                .WithMessage("Expected boolean to be false because we want to test the failure message, but found True.");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/ExtensibilitySpecs.cs
+++ b/Tests/Shared.Specs/ExtensibilitySpecs.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using FluentAssertions.Execution;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Net45.Specs
+{
+    public class ExtensibilitySpecs
+    {
+        [Fact]
+        public void When_a_method_is_marked_as_custom_assertion_it_should_be_ignored_during_caller_identification()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var myClient = new Customer
+            {
+               Active = false
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => myClient.Should().BeActive("because we don't work with old clients");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>().WithMessage(
+#if NETCOREAPP1_1
+                "Expected boolean to be true because we don't work with old clients, but found False.");
+#else
+                "Expected myClient to be true because we don't work with old clients, but found False.");
+#endif
+        }
+    }
+
+    public class Customer
+    {
+        public bool Active { get; set; }
+    }
+
+    public static class CustomerExtensions
+    {
+        public static CustomerAssertions Should(this Customer customer)
+        {
+            return new CustomerAssertions(customer);
+        }
+    }
+
+    public class CustomerAssertions
+    {
+        private readonly Customer customer;
+
+        public CustomerAssertions(Customer customer)
+        {
+            this.customer = customer;
+        }
+
+        [CustomAssertion]
+        public void BeActive(string because = "", params object[] becauseArgs)
+        {
+            customer.Active.Should().BeTrue(because, becauseArgs);
+        }
+    }
+}

--- a/Tests/Shared.Specs/NullableBooleanAssertionSpecs.cs
+++ b/Tests/Shared.Specs/NullableBooleanAssertionSpecs.cs
@@ -127,7 +127,12 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected False because we want to test the failure message, but found <null>.");
+#if NETCOREAPP1_1
+                .WithMessage("Expected boolean to be false because we want to test the failure message, but found <null>.");
+#else
+                .WithMessage("Expected nullableBoolean to be false because we want to test the failure message, but found <null>.");
+#endif
+
         }
 
         [Fact]
@@ -148,7 +153,11 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected True because we want to test the failure message, but found <null>.");
+#if NETCOREAPP1_1
+                .WithMessage("Expected boolean to be true because we want to test the failure message, but found <null>.");
+#else
+                .WithMessage("Expected nullableBoolean to be true because we want to test the failure message, but found <null>.");
+#endif
         }
 
         [Fact]

--- a/Tests/Shared.Specs/Shared.Specs.projitems
+++ b/Tests/Shared.Specs/Shared.Specs.projitems
@@ -31,6 +31,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ExceptionAssertionSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExecutionTimeAssertionsSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExtensibilityRelatedEquivalencySpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ExtensibilitySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FindAssembly.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FluentDateTimeSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FormatterSpecs.cs" />


### PR DESCRIPTION
If a custom assertion (extension) method uses Fluent Assertions internally, you can mark it with the `[CustomAssertion]` attribute. This ensures that FA will ignore that method while traversing the stack frames looking for a call to `Should` as part of the caller identification process

#588