### PR TITLE
Cleanups

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -480,7 +480,8 @@ namespace FluentAssertions
         }
 
         /// <summary>
-        /// Returns a <see cref="MethodBaseAssertions"/> object that can be used to assert the current <see cref="MethodInfo"/>.
+        /// Returns a <see cref="FluentAssertions.Types.MethodBaseAssertions{TSubject, TAssertions}"/> object
+        /// that can be used to assert the current <see cref="MethodInfo"/>.
         /// </summary>
         /// <seealso cref="TypeAssertions"/>
         [Pure]

--- a/Src/FluentAssertions/AssertionOptions.cs
+++ b/Src/FluentAssertions/AssertionOptions.cs
@@ -33,9 +33,9 @@ namespace FluentAssertions
         /// Returns <c>true</c> if the object should be treated as a value type and its <see cref="object.Equals(object)"/>
         /// must be used during a structural equivalency check.
         /// </returns>
-        public static Func<Type, bool> IsValueType = type => 
-            (type.Namespace == typeof (int).Namespace) && 
-            !type.IsSameOrInherits(typeof(Exception));
+        public static Func<Type, bool> IsValueType { get; set; } = type =>
+              (type.Namespace == typeof(int).Namespace) &&
+              !type.IsSameOrInherits(typeof(Exception));
 
         /// <summary>
         /// Allows configuring the defaults used during a structural equivalency assertion.

--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -14,8 +14,8 @@ namespace FluentAssertions.Collections
     /// Contains a number of methods to assert that an <see cref="IEnumerable"/> is in the expected state.
     /// </summary>
     public abstract class CollectionAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<TSubject, TAssertions>
-        where TAssertions : CollectionAssertions<TSubject, TAssertions>
         where TSubject : IEnumerable
+        where TAssertions : CollectionAssertions<TSubject, TAssertions>
     {
         /// <summary>
         /// Asserts that the collection does not contain any items.

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -1018,8 +1018,8 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
-        /// Asserts that the current dictionary contains the specified <paramref name="value" /> for the supplied <paramref
-        /// name="key" />. Values are compared using their <see cref="object.Equals(object)" /> implementation.
+        /// Asserts that the current dictionary contains the specified <paramref name="value" /> for the supplied
+        /// <paramref name="key" />. Values are compared using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
         /// <param name="key">The key for which to validate the value</param>
         /// <param name="value">The value to validate</param>

--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -246,7 +246,7 @@ namespace FluentAssertions.Collections
 
         /// <summary>
         /// Expects the current collection to contain all the same elements in the same order as the collection identified by 
-        /// <paramref name="elements" />. Elements are compared using their <see cref="T.Equals(T)" /> method.
+        /// <paramref name="elements" />. Elements are compared using their <see cref="T.Equals(object)" /> method.
         /// </summary>
         /// <param name="elements">A params array with the expected elements.</param>
         public AndConstraint<TAssertions> Equal(params T[] elements)

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -17,7 +17,7 @@ namespace FluentAssertions.Collections
         /// Expects the current collection to contain all the same elements in the same order as the collection identified by 
         /// <paramref name="expected" />. Elements are compared using their <see cref="object.Equals(object)" />.
         /// </summary>
-        /// <param name="expected">An <see cref="IEnumerable"/> with the expected elements.</param>
+        /// <param name="expected">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
         public new AndConstraint<StringCollectionAssertions> Equal(params string[] expected)
         {
             return base.Equal(expected.AsEnumerable());
@@ -27,7 +27,7 @@ namespace FluentAssertions.Collections
         /// Expects the current collection to contain all the same elements in the same order as the collection identified by 
         /// <paramref name="expected" />. Elements are compared using their <see cref="object.Equals(object)" />.
         /// </summary>
-        /// <param name="expected">An <see cref="IEnumerable"/> with the expected elements.</param>
+        /// <param name="expected">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
         public AndConstraint<StringCollectionAssertions> Equal(IEnumerable<string> expected)
         {
             return base.Equal(expected);
@@ -112,7 +112,7 @@ namespace FluentAssertions.Collections
         /// Expects the current collection to contain the specified elements in the exact same order. Elements are compared
         /// using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
-        /// <param name="expected">An <see cref="IEnumerable"/> with the expected elements.</param>
+        /// <param name="expected">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
         public AndConstraint<StringCollectionAssertions> ContainInOrder(params string[] expected)
         {
             return base.ContainInOrder(expected.AsEnumerable());
@@ -122,7 +122,7 @@ namespace FluentAssertions.Collections
         /// Expects the current collection to contain the specified elements in the exact same order. Elements are compared
         /// using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
-        /// <param name="expected">An <see cref="IEnumerable"/> with the expected elements.</param>
+        /// <param name="expected">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -140,7 +140,7 @@ namespace FluentAssertions.Collections
         /// Expects the current collection to contain the specified elements in any order. Elements are compared
         /// using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
-        /// <param name="expected">An <see cref="IEnumerable"/> with the expected elements.</param>
+        /// <param name="expected">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
         public AndConstraint<StringCollectionAssertions> Contain(IEnumerable<string> expected)
         {
             return base.Contain(expected);
@@ -150,7 +150,7 @@ namespace FluentAssertions.Collections
         /// Expects the current collection to contain the specified elements in any order. Elements are compared
         /// using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
-        /// <param name="expected">An <see cref="IEnumerable"/> with the expected elements.</param>
+        /// <param name="expected">An <see cref="IEnumerable{T}" /> with the expected elements.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -171,7 +171,7 @@ namespace FluentAssertions.Collections
         /// Asserts that the current collection does not contain the supplied items. Elements are compared
         /// using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
-        /// <param name="unexpected">An <see cref="IEnumerable"/> with the unexpected elements.</param>
+        /// <param name="unexpected">An <see cref="IEnumerable{T}"/> with the unexpected elements.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion 
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.

--- a/Src/FluentAssertions/Common/Configuration.cs
+++ b/Src/FluentAssertions/Common/Configuration.cs
@@ -11,7 +11,7 @@ namespace FluentAssertions.Common
         private string valueFormatterAssembly;
         private ValueFormatterDetectionMode? valueFormatterDetectionMode;
         private string testFrameworkName;
-        private object propertiesAccessLock = new object();
+        private readonly object propertiesAccessLock = new object();
 
         #endregion
 

--- a/Src/FluentAssertions/Common/ValueFormatterDetectionMode.cs
+++ b/Src/FluentAssertions/Common/ValueFormatterDetectionMode.cs
@@ -1,8 +1,8 @@
 ﻿namespace FluentAssertions.Common
 {
     /// <summary>
-    /// Defines the modes in which custom implementations of <see cref="IValueFormatter"/> are detected as configured
-    /// through <see cref="Configuration.ValueFormatterDetectionMode"/>.
+    /// Defines the modes in which custom implementations of <see cref="FluentAssertions.Formatting.IValueFormatter"/>
+    /// are detected as configured through <see cref="Configuration.ValueFormatterDetectionMode"/>.
     /// </summary>
     public enum ValueFormatterDetectionMode
     {
@@ -18,7 +18,7 @@
         Specific,
         
         /// <summary>
-        /// All custom value formatters in any assembly loaded in the current <see cref="AppDomain"/> will be detected.
+        /// All custom value formatters in any assembly loaded in the current <see cref="System.AppDomain"/> will be detected.
         /// </summary>
         Scan,
     }

--- a/Src/FluentAssertions/Equivalency/AssertionRule.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionRule.cs
@@ -27,15 +27,6 @@ namespace FluentAssertions.Equivalency
         /// <summary>
         /// Defines how a subject's property is compared for equality with the same property of the expectation.
         /// </summary>
-        /// <param name="subjectProperty">
-        /// Provides details about the subject's property.
-        /// </param>
-        /// <param name="subject">
-        /// The value of the subject's property.
-        /// </param>
-        /// <param name="expectation">
-        /// The value of a property on expectation object that was identified 
-        /// </param>
         /// <returns>
         /// Returns <c>true</c> if the rule was applied correctly and the assertion didn't cause any exceptions. 
         /// Returns <c>false</c> if this rule doesn't support the subject's type.

--- a/Src/FluentAssertions/Equivalency/CollectionMemberSubjectInfo.cs
+++ b/Src/FluentAssertions/Equivalency/CollectionMemberSubjectInfo.cs
@@ -16,7 +16,7 @@ namespace FluentAssertions.Equivalency
 
         internal static string GetAdjustedPropertyPath(string propertyPath)
         {
-            return propertyPath.Substring(propertyPath.IndexOf(".", StringComparison.Ordinal) + 1);
+            return propertyPath.Substring(propertyPath.IndexOf('.') + 1);
         }
 
         public SelectedMemberInfo SelectedMemberInfo { get; private set; }

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
@@ -100,7 +100,7 @@ namespace FluentAssertions.Equivalency
             if (Tracer != null)
             {
                 string path = SelectedMemberDescription.Length > 0 ? SelectedMemberDescription : "root";
-                Tracer.AddSingle($"{getTraceMessage(path)}");
+                Tracer.AddSingle(getTraceMessage(path));
             }
         }
 

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -325,6 +325,7 @@ namespace FluentAssertions.Equivalency
             return (TSelf)this;
         }
 
+        /// <summary></summary>
         /// <param name="action">
         /// The assertion to execute when the predicate is met.
         /// </param>

--- a/Src/FluentAssertions/Events/EventAssertions.cs
+++ b/Src/FluentAssertions/Events/EventAssertions.cs
@@ -9,7 +9,7 @@ using FluentAssertions.Primitives;
 namespace FluentAssertions.Events
 {
     /// <summary>
-    /// Provides convenient assertion methods on a <see cref="IEventMonitor"/> that can be 
+    /// Provides convenient assertion methods on a <see cref="IMonitor{T}"/> that can be 
     /// used to assert that certain events have been raised. 
     /// </summary>
     public class EventAssertions<T> : ReferenceTypeAssertions<T, EventAssertions<T>>

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -38,7 +38,8 @@ namespace FluentAssertions.Execution
         }
 
         /// <summary>
-        /// Starts an unnamed scope within which multiple assertions can be executed and which will not throw until the scope is disposed.
+        /// Starts an unnamed scope within which multiple assertions can be executed
+        /// and which will not throw until the scope is disposed.
         /// </summary>
         public AssertionScope()
             : this(new CollectingAssertionStrategy())
@@ -143,7 +144,7 @@ namespace FluentAssertions.Execution
         /// If an expectation was set through a prior call to <see cref="WithExpectation"/>, then the failure message is appended to that
         /// expectation.
         /// </remarks>
-        ///  <param name="message">The format string that represents the failure message.</param>
+        ///  <param name="expectation">The format string that represents the failure message.</param>
         /// <param name="args">Optional arguments to any numbered placeholders.</param>
         public AssertionScope WithExpectation(string expectation, params object[] args)
         {
@@ -180,18 +181,20 @@ namespace FluentAssertions.Execution
 
         /// <summary>
         /// Sets the failure message when the assertion is not met, or completes the failure message set to a
-        /// prior call to to <see cref="WithExpectation"/>.
+        /// prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>.
         /// </summary>
         /// <remarks>
         /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a few
         /// specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as passed
-        /// to <see cref="BecauseOf"/>. Other named placeholders will be replaced with the <see cref="Current"/> scope data
-        /// passed through <see cref="AddNonReportable"/> and <see cref="AddReportable"/>. Finally, a description of the
+        /// to <see cref="FluentAssertions.Execution.AssertionScope.BecauseOf"/>. Other named placeholders will be replaced with
+        /// the <see cref="FluentAssertions.Execution.AssertionScope.Current"/> scope data passed through
+        /// <see cref="FluentAssertions.Execution.AssertionScope.AddNonReportable"/> and
+        /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable"/>. Finally, a description of the
         /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
         /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
         /// Note that only 10 <paramref name="args"/> are supported in combination with a {reason}.
-        /// If an expectation was set through a prior call to <see cref="WithExpectation"/>, then the failure message is appended to that
-        /// expectation.
+        /// If an expectation was set through a prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>,
+        /// then the failure message is appended to that expectation.
         /// </remarks>
         /// <param name="message">The format string that represents the failure message.</param>
         /// <param name="args">Optional arguments to any numbered placeholders.</param>

--- a/Src/FluentAssertions/Execution/GivenSelector.cs
+++ b/Src/FluentAssertions/Execution/GivenSelector.cs
@@ -28,12 +28,12 @@ namespace FluentAssertions.Execution
         /// <summary>
         /// Specify the condition that must be satisfied upon the subject selected through a prior selector.
         /// </summary>
-        /// <param name="condition">
+        /// <param name="predicate">
         /// If <c>true</c> the assertion will be treated as successful and no exceptions will be thrown.
         /// </param>
         /// <remarks>
-        /// The condition will not be evaluated if the prior assertion failed, nor will <see cref="FailWith(string,System.Func{T,object}[])"/>
-        /// throw any exceptions.
+        /// The condition will not be evaluated if the prior assertion failed,
+        /// nor will <see cref="FailWith(string, System.Func{T, object}[])"/> throw any exceptions.
         /// </remarks>
         public GivenSelector<T> ForCondition(Func<T, bool> predicate)
         {
@@ -52,8 +52,8 @@ namespace FluentAssertions.Execution
         /// Selector which result is passed to successive calls to <see cref="ForCondition"/>.
         /// </paramref>
         /// <remarks>
-        /// The selector will not be invoked if the prior assertion failed, nor will <see cref="FailWith(string,System.Func{T,object}[])"/>
-        /// throw any exceptions.
+        /// The selector will not be invoked if the prior assertion failed,
+        /// nor will <see cref="FailWith(string,System.Func{T,object}[])"/> throw any exceptions.
         /// </remarks>
         public GivenSelector<TOut> Given<TOut>(Func<T, TOut> selector)
         {
@@ -62,11 +62,11 @@ namespace FluentAssertions.Execution
 
         /// <summary>
         /// Sets the failure message when the assertion is not met, or completes the failure message set to a 
-        /// prior call to to <see cref="WithExpectation"/>.
+        /// prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>.
         /// </summary>
         /// <remarks>
-        /// If an expectation was set through a prior call to <see cref="WithExpectation"/>, then the failure message is appended to that
-        /// expectation. 
+        /// If an expectation was set through a prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>,
+        /// then the failure message is appended to that expectation. 
         /// </remarks>
         /// <param name="message">The format string that represents the failure message.</param>
         public ContinuationOfGiven<T> FailWith(string message)
@@ -76,18 +76,20 @@ namespace FluentAssertions.Execution
 
         /// <summary>
         /// Sets the failure message when the assertion is not met, or completes the failure message set to a 
-        /// prior call to to <see cref="WithExpectation"/>.
+        /// prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>.
         /// </summary>
         /// <remarks>
         /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a few 
         /// specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as passed 
-        /// to <see cref="BecauseOf"/>. Other named placeholders will be replaced with the <see cref="Current"/> scope data 
-        /// passed through <see cref="AddNonReportable"/> and <see cref="AddReportable"/>. Finally, a description of the 
-        /// current subject can be passed through the {context:description} placeholder. This is used in the message if no 
-        /// explicit context is specified through the <see cref="AssertionScope"/> constructor. 
+        /// to <see cref="FluentAssertions.Execution.AssertionScope.BecauseOf"/>. Other named placeholders will be replaced with
+        /// the <see cref="FluentAssertions.Execution.AssertionScope.Current"/> scope data passed through
+        /// <see cref="FluentAssertions.Execution.AssertionScope.AddNonReportable"/> and
+        /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable"/>. Finally, a description of the current subject
+        /// can be passed through the {context:description} placeholder. This is used in the message if no explicit context
+        /// is specified through the <see cref="AssertionScope"/> constructor. 
         /// Note that only 10 <paramref name="args"/> are supported in combination with a {reason}.
-        /// If an expectation was set through a prior call to <see cref="WithExpectation"/>, then the failure message is appended to that
-        /// expectation. 
+        /// If an expectation was set through a prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>,
+        /// then the failure message is appended to that expectation. 
         /// </remarks>
         /// <param name="message">The format string that represents the failure message.</param>
         /// <param name="args">Optional arguments to any numbered placeholders.</param>
@@ -98,18 +100,21 @@ namespace FluentAssertions.Execution
 
         /// <summary>
         /// Sets the failure message when the assertion is not met, or completes the failure message set to a 
-        /// prior call to to <see cref="WithExpectation"/>.
+        /// prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>.
         /// </summary>
         /// <remarks>
-        /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a few 
-        /// specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as passed 
-        /// to <see cref="BecauseOf"/>. Other named placeholders will be replaced with the <see cref="Current"/> scope data 
-        /// passed through <see cref="AddNonReportable"/> and <see cref="AddReportable"/>. Finally, a description of the 
+        /// In addition to the numbered <see cref="string.Format(string, object[])"/>-style placeholders, messages may contain
+        /// a few specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as
+        /// passed to <see cref="FluentAssertions.Execution.AssertionScope.BecauseOf"/>. Other named placeholders will be
+        /// replaced with the <see cref="FluentAssertions.Execution.AssertionScope.Current"/> scope data passed through
+        /// <see cref="FluentAssertions.Execution.AssertionScope.AddNonReportable"/> and
+        /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable"/>. Finally, a description of the 
         /// current subject can be passed through the {context:description} placeholder. This is used in the message if no 
         /// explicit context is specified through the <see cref="AssertionScope"/> constructor. 
         /// Note that only 10 <paramref name="args"/> are supported in combination with a {reason}.
-        /// If an expectation was set through a prior call to <see cref="WithExpectation"/>, then the failure message is appended to that
-        /// expectation. 
+        /// If an expectation was set through a prior call to
+        /// <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>, then the failure message is appended
+        /// to that expectation. 
         /// </remarks>
         /// <param name="message">The format string that represents the failure message.</param>
         /// <param name="args">Optional arguments to any numbered placeholders.</param>

--- a/Src/FluentAssertions/Execution/MessageBuilder.cs
+++ b/Src/FluentAssertions/Execution/MessageBuilder.cs
@@ -44,8 +44,9 @@ namespace FluentAssertions.Execution
 
         private string SubstituteIdentifier(string message, string identifier, string fallbackIdentifier)
         {
-            var regex = new Regex(@"(\s|^)\{context(?:\:(?<default>[a-z|A-Z|\s]+))?\}");
-            message = regex.Replace(message, match =>
+            string pattern = @"(\s|^)\{context(?:\:(?<default>[a-z|A-Z|\s]+))?\}";
+
+            message = Regex.Replace(message, pattern, match =>
             {
                 string defaultIdentifier = match.Groups["default"].Value;
                 string result = "object";
@@ -71,8 +72,9 @@ namespace FluentAssertions.Execution
 
         private string SubstituteContextualTags(string message, ContextDataItems contextData)
         {
-            var regex = new Regex(@"[^\{]\{(?<key>[a-z|A-Z]+)(?:\:(?<default>[a-z|A-Z|\s]+))?\}");
-            return regex.Replace(message, match =>
+            string pattern = @"[^\{]\{(?<key>[a-z|A-Z]+)(?:\:(?<default>[a-z|A-Z|\s]+))?\}";
+
+            return Regex.Replace(message, pattern, match =>
             {
                 string key = match.Groups["key"].Value;
                 return contextData.AsStringOrDefault(key)?.Replace("{", "{{").Replace("}", "}}") ?? match.Groups["default"].Value;

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -67,7 +67,7 @@ namespace FluentAssertions.Formatting
 
             var type = obj.GetType();
             builder.AppendLine(type.FullName);
-            builder.Append(CreateWhitespaceForLevel(context.Depth)).AppendLine("{");
+            builder.Append(CreateWhitespaceForLevel(context.Depth)).Append('{').AppendLine();
 
             IEnumerable<SelectedMemberInfo> properties = type.GetNonPrivateMembers();
             foreach (var propertyInfo in properties.OrderBy(pi => pi.Name))
@@ -75,7 +75,7 @@ namespace FluentAssertions.Formatting
                 builder.AppendLine(GetPropertyValueTextFor(obj, propertyInfo, context, formatChild));
             }
 
-            builder.Append(CreateWhitespaceForLevel(context.Depth)).Append("}");
+            builder.Append(CreateWhitespaceForLevel(context.Depth)).Append('}');
 
             return builder.ToString();
         }

--- a/Src/FluentAssertions/Formatting/ExceptionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ExceptionValueFormatter.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Formatting
         }
 
         /// <inheritdoc />
-        public string Format(object value, FormattingContext multiline, FormatChild formatChild)
+        public string Format(object value, FormattingContext context, FormatChild formatChild)
         {
             var exception = (Exception)value;
 

--- a/Src/FluentAssertions/Formatting/ExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ExpressionValueFormatter.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Formatting
 
 
         /// <inheritdoc />
-        public string Format(object value, FormattingContext multiline, FormatChild formatChild)
+        public string Format(object value, FormattingContext context, FormatChild formatChild)
         {
             return value.ToString().Replace(" = ", " == ");
         }

--- a/Src/FluentAssertions/Formatting/GuidValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/GuidValueFormatter.cs
@@ -18,7 +18,7 @@ namespace FluentAssertions.Formatting
         }
 
         /// <inheritdoc />
-        public string Format(object value, FormattingContext multiline, FormatChild formatChild)
+        public string Format(object value, FormattingContext context, FormatChild formatChild)
         {
             return "{" + value + "}";
         }

--- a/Src/FluentAssertions/Formatting/Int16ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/Int16ValueFormatter.cs
@@ -18,7 +18,7 @@ namespace FluentAssertions.Formatting
         }
 
         /// <inheritdoc />
-        public string Format(object value, FormattingContext multiline, FormatChild formatChild)
+        public string Format(object value, FormattingContext context, FormatChild formatChild)
         {
             return ((short)value).ToString(CultureInfo.InvariantCulture) + "s";
         }

--- a/Src/FluentAssertions/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ObjectAssertionsExtensions.cs
@@ -133,7 +133,7 @@ namespace FluentAssertions
 
         private class SimpleBinder : SerializationBinder
         {
-            private Type type;
+            private readonly Type type;
 
             public SimpleBinder(Type type)
             {

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -10,7 +10,8 @@ namespace FluentAssertions.Primitives
     /// Contains a number of methods to assert that a <see cref="DateTime"/> is in the expected state.
     /// </summary>
     /// <remarks>
-    /// You can use the <see cref="FluentDateTimeExtensions"/> for a more fluent way of specifying a <see cref="DateTime"/>.
+    /// You can use the <see cref="FluentAssertions.Extensions.FluentDateTimeExtensions"/>
+    /// for a more fluent way of specifying a <see cref="DateTime"/>.
     /// </remarks>
     [DebuggerNonUserCode]
     public class DateTimeAssertions

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -10,7 +10,8 @@ namespace FluentAssertions.Primitives
     /// Contains a number of methods to assert that a <see cref="DateTimeOffset"/> is in the expected state.
     /// </summary>
     /// <remarks>
-    /// You can use the <see cref="FluentDateTimeExtensions"/> for a more fluent way of specifying a <see cref="DateTimeOffset"/>.
+    /// You can use the <see cref="FluentAssertions.Extensions.FluentDateTimeExtensions"/>
+    /// for a more fluent way of specifying a <see cref="DateTimeOffset"/>.
     /// </remarks>
     [DebuggerNonUserCode]
     public class DateTimeOffsetAssertions

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
@@ -10,8 +10,8 @@ namespace FluentAssertions.Primitives
     /// Contains a number of methods to assert that two <see cref="DateTime"/> objects differ in the expected way.
     /// </summary>
     /// <remarks>
-    /// You can use the <see cref="FluentDateTimeExtensions"/> and <see cref="TimeSpanConversionExtensions"/> for a more fluent
-    /// way of specifying a <see cref="DateTime"/> or a <see cref="TimeSpan"/>.
+    /// You can use the <see cref="FluentDateTimeExtensions"/> and <see cref="TimeSpanConversionExtensions"/>
+    /// for a more fluent way of specifying a <see cref="DateTime"/> or a <see cref="TimeSpan"/>.
     /// </remarks>
     [DebuggerNonUserCode]
     public class DateTimeOffsetRangeAssertions

--- a/Src/FluentAssertions/Primitives/DateTimeRangeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeRangeAssertions.cs
@@ -9,7 +9,8 @@ namespace FluentAssertions.Primitives
     /// Contains a number of methods to assert that two <see cref="DateTime"/> objects differ in the expected way.
     /// </summary>
     /// <remarks>
-    /// You can use the <see cref="FluentDateTimeExtensions"/> and <see cref="TimeSpanConversionExtensions"/> for a more fluent
+    /// You can use the <see cref="FluentAssertions.Extensions.FluentDateTimeExtensions"/> and
+    /// <see cref="FluentAssertions.Extensions.FluentTimeSpanExtensions"/> for a more fluent
     /// way of specifying a <see cref="DateTime"/> or a <see cref="TimeSpan"/>.
     /// </remarks>
     [DebuggerNonUserCode]

--- a/Src/FluentAssertions/Primitives/NullableDateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateTimeAssertions.cs
@@ -5,7 +5,8 @@ using FluentAssertions.Execution;
 namespace FluentAssertions.Primitives
 {
     /// <summary>
-    /// Contains a number of methods to assert that a nullable <see cref="DateTime"/> or <see cref="DateTimeOffset"/> is in the expected state.
+    /// Contains a number of methods to assert that a nullable <see cref="DateTime"/> or
+    /// <see cref="DateTimeOffset"/> is in the expected state.
     /// </summary>
     /// <remarks>
     /// You can use the <see cref="FluentDateTimeExtensions"/> for a more fluent way of specifying a <see cref="DateTime"/>.

--- a/Src/FluentAssertions/Primitives/NullableDateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateTimeOffsetAssertions.cs
@@ -8,7 +8,8 @@ namespace FluentAssertions.Primitives
     /// Contains a number of methods to assert that a nullable <see cref="DateTimeOffset"/> is in the expected state.
     /// </summary>
     /// <remarks>
-    /// You can use the <see cref="FluentDateTimeExtensions"/> for a more fluent way of specifying a <see cref="DateTime"/>.
+    /// You can use the <see cref="FluentAssertions.Extensions.FluentDateTimeExtensions"/>
+    /// for a more fluent way of specifying a <see cref="DateTime"/>.
     /// </remarks>
     [DebuggerNonUserCode]
     public class NullableDateTimeOffsetAssertions : DateTimeOffsetAssertions

--- a/Src/FluentAssertions/Primitives/NullableSimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableSimpleTimeSpanAssertions.cs
@@ -9,7 +9,8 @@ namespace FluentAssertions.Primitives
     /// Contains a number of methods to assert that a nullable <see cref="TimeSpan"/> is in the expected state.
     /// </summary>
     /// <remarks>
-    /// You can use the <see cref="TimeSpanConversionExtensions"/> for a more fluent way of specifying a <see cref="TimeSpan"/>.
+    /// You can use the <see cref="FluentAssertions.Extensions.FluentTimeSpanExtensions"/>
+    /// for a more fluent way of specifying a <see cref="TimeSpan"/>.
     /// </remarks>
     [DebuggerNonUserCode]
     public class NullableSimpleTimeSpanAssertions : SimpleTimeSpanAssertions

--- a/Src/FluentAssertions/Primitives/ObjectAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ObjectAssertions.cs
@@ -92,7 +92,7 @@ namespace FluentAssertions.Primitives
         /// <remarks>
         /// Objects are equivalent when both object graphs have equally named properties with the same value, 
         /// irrespective of the type of those objects. Two properties are also equal if one type can be converted to another and the result is equal.
-        /// The type of a collection property is ignored as long as the collection implements <see cref="IEnumerable"/> and all
+        /// The type of a collection property is ignored as long as the collection implements <see cref="IEnumerable{T}"/> and all
         /// items in the collection are structurally equal. 
         /// </remarks>
         /// <param name="config">

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -696,13 +696,6 @@ namespace FluentAssertions.Primitives
         /// <param name="values">
         /// The values that should not be present in the string
         /// </param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="because" />.
-        /// </param>
         public AndConstraint<StringAssertions> ContainAll(params string[] values)
         {
             return ContainAll(values, because: string.Empty);
@@ -738,13 +731,6 @@ namespace FluentAssertions.Primitives
         /// </summary>
         /// <param name="values">
         /// The values that should will be tested against the string
-        /// </param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<StringAssertions> ContainAny(params string[] values)
         {
@@ -821,13 +807,6 @@ namespace FluentAssertions.Primitives
         /// <param name="values">
         /// The values that should not be present in the string
         /// </param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="because" />.
-        /// </param>
         public AndConstraint<StringAssertions> NotContainAll(params string[] values)
         {
             return NotContainAll(values, because: string.Empty);
@@ -866,13 +845,6 @@ namespace FluentAssertions.Primitives
         /// </summary>
         /// <param name="values">
         /// The values that should not be present in the string
-        /// </param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public AndConstraint<StringAssertions> NotContainAny(params string[] values)
         {

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -24,7 +24,7 @@ namespace FluentAssertions.Xml
         /// <summary>
         /// Asserts that the current <see cref="XElement"/> equals the 
         /// <paramref name="expected"/> element, by using 
-        /// <see cref="XElement.DeepEquals(XNode, XNode)"/>
+        /// <see cref="XNode.DeepEquals(XNode, XNode)"/>
         /// </summary>
         /// <param name="expected">The expected element</param>
         public AndConstraint<XElementAssertions> Be(XElement expected)
@@ -35,7 +35,7 @@ namespace FluentAssertions.Xml
         /// <summary>
         /// Asserts that the current <see cref="XElement"/> equals the 
         /// <paramref name="expected"/> element, by using 
-        /// <see cref="XElement.DeepEquals(XNode, XNode)"/>
+        /// <see cref="XNode.DeepEquals(XNode, XNode)"/>
         /// </summary>
         /// <param name="expected">The expected element</param>
         /// <param name="because">
@@ -58,7 +58,7 @@ namespace FluentAssertions.Xml
         /// <summary>
         /// Asserts that the current <see cref="XElement"/> does not equal the 
         /// <paramref name="unexpected"/> element, using 
-        /// <see cref="XElement.DeepEquals(XNode, XNode)" />.
+        /// <see cref="XNode.DeepEquals(XNode, XNode)" />.
         /// </summary>
         /// <param name="unexpected">The unexpected element</param>
         public AndConstraint<XElementAssertions> NotBe(XElement unexpected)
@@ -69,7 +69,7 @@ namespace FluentAssertions.Xml
         /// <summary>
         /// Asserts that the current <see cref="XElement"/> does not equal the 
         /// <paramref name="unexpected"/> element, using 
-        /// <see cref="XElement.DeepEquals(XNode, XNode)" />.
+        /// <see cref="XNode.DeepEquals(XNode, XNode)" />.
         /// </summary>
         /// <param name="unexpected">The unexpected element</param>
         /// <param name="because">

--- a/Src/FluentAssertions/Xml/XmlNodeAssertionsofTSubjectTAssertions.cs
+++ b/Src/FluentAssertions/Xml/XmlNodeAssertionsofTSubjectTAssertions.cs
@@ -11,8 +11,8 @@ namespace FluentAssertions.Xml
     /// </summary>
     [DebuggerNonUserCode]
     public class XmlNodeAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<TSubject, TAssertions>
-        where TAssertions : XmlNodeAssertions<TSubject, TAssertions>
         where TSubject : XmlNode
+        where TAssertions : XmlNodeAssertions<TSubject, TAssertions>
     {
         public XmlNodeAssertions(TSubject xmlNode)
         {

--- a/Src/FluentAssertions/Xml/XmlReaderValidator.cs
+++ b/Src/FluentAssertions/Xml/XmlReaderValidator.cs
@@ -10,16 +10,16 @@ namespace FluentAssertions.Xml
 {
     internal class XmlReaderValidator
     {
-        private AssertionScope assertion;
-        private XmlReader subjectReader;
-        private XmlReader otherReader;
+        private readonly AssertionScope assertion;
+        private readonly XmlReader subjectReader;
+        private readonly XmlReader otherReader;
 
         private string CurrentLocation
         {
             get { return "/" + string.Join("/", locationStack.Reverse()); }
         }
 
-        private Stack<string> locationStack = new Stack<string>();
+        private readonly Stack<string> locationStack = new Stack<string>();
 
         public XmlReaderValidator(XmlReader subjectReader, XmlReader otherReader, string because, object[] reasonArgs)
         {

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -779,7 +779,7 @@ You can directly specify a property expression or use a predicate that acts on t
 ```csharp
 orderDto.ShouldBeEquivalentTo(order, options => options
     .Including(o => o.OrderNumber)
-    .Including(pi => pi.PropertyPath.EndsWith("Date"));
+    .Including(pi => pi.SelectedMemberPath.EndsWith("Date"));
 ```
 
 ### Including properties and/or fields ###


### PR DESCRIPTION
Primarily cleanups in the XML summaries with missing/misspelled `paramref`s and fixing references to (generic) types.