### PR TITLE
Fail when Should().[Not]Throw used on async void Action

### DIFF
--- a/Tests/Shared.Specs/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/AsyncFunctionExceptionAssertionSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Sdk;
@@ -311,6 +312,86 @@ namespace FluentAssertions.Net45.Specs
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>().WithMessage("*InvalidOperation*Argument*");
         }
+
+        [Fact]
+        public void When_asserting_async_void_method_should_throw_it_should_fail()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var asyncObject = new AsyncClass();
+            Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => asyncVoidMethod.Should().Throw<ArgumentException>();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.Should().Throw<InvalidOperationException>("*async*void*");
+        }
+
+        [Fact]
+        public void When_asserting_async_void_method_should_throw_exactly_it_should_fail()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var asyncObject = new AsyncClass();
+            Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => asyncVoidMethod.Should().ThrowExactly<ArgumentException>();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.Should().Throw<InvalidOperationException>("*async*void*");
+        }
+
+        [Fact]
+        public void When_asserting_async_void_method_should_not_throw_it_should_fail()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var asyncObject = new AsyncClass();
+            Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => asyncVoidMethod.Should().NotThrow();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.Should().Throw<InvalidOperationException>("*async*void*");
+        }
+
+        [Fact]
+        public void When_asserting_async_void_method_should_not_throw_specific_exception_it_should_fail()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var asyncObject = new AsyncClass();
+            Action asyncVoidMethod = async () => await asyncObject.IncompleteTask();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => asyncVoidMethod.Should().NotThrow<ArgumentException>();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.Should().Throw<InvalidOperationException>("*async*void*");
+        }
     }
 
     internal class AsyncClass
@@ -327,6 +408,11 @@ namespace FluentAssertions.Net45.Specs
         public async Task SucceedAsync()
         {
             await Task.FromResult(0);
+        }
+
+        public Task IncompleteTask()
+        {
+            return new TaskCompletionSource<bool>().Task;
         }
     }
 }


### PR DESCRIPTION
## IMPORTANT 
SINCE FLUENT ASSERTIONS IS CURRENTLY UNDER HEAVY REFACTORING FOR [VERSION 5.0](https://github.com/fluentassertions/fluentassertions/issues/463), WE CURRENTLY ONLY ACCEPT BUGFIX REQUESTS. SORRY FOR THE INCONVENIENCE

* [ ] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [ ] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/)/.
* [ ] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).

#711 
