### PR TITLE
Assuming types that override Equals to have value semantics

### DIFF
--- a/Src/FluentAssertions.nuspec
+++ b/Src/FluentAssertions.nuspec
@@ -29,15 +29,20 @@
       <frameworkAssembly assemblyName="System.Xml.Linq" targetFramework="net45" />
     </frameworkAssemblies>
     <dependencies>
+      <group targetFramework="net45">
+        <dependency id="System.ValueType" version="4.3.0" />
+      </group>
       <group targetFramework="netstandard1.4">
         <dependency id="NETStandard.Library" version="1.6.1" />
         <dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
         <dependency id="System.Reflection.Emit.Lightweight" version="4.3.0" />
+        <dependency id="System.ValueType" version="4.3.0" />
       </group>
       <group targetFramework="netstandard1.6">
         <dependency id="NETStandard.Library" version="1.6.1" />
         <dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
         <dependency id="System.Reflection.Emit.Lightweight" version="4.3.0" />
+          <dependency id="System.ValueType" version="4.3.0" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="System.Configuration.ConfigurationManager" version="4.4.0" />
@@ -47,7 +52,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\Artifacts\Release\net45\*.*"  target="lib\net45" />
+    <file src="..\Artifacts\Release\net45\*.*"  target="lib\net45" exclude="**\System.*" />
     <file src="..\Artifacts\Release\netstandard1.4\FluentAssertions.*" exclude="**\*.json" target="lib\netstandard1.4" />
     <file src="..\Artifacts\Release\netstandard1.6\FluentAssertions*.*" exclude="**\*.json" target="lib\netstandard1.6" />
     <file src="..\Artifacts\Release\netstandard2.0\FluentAssertions*.*" exclude="**\*.json" target="lib\netstandard2.0" />

--- a/Src/FluentAssertions/AssertionOptions.cs
+++ b/Src/FluentAssertions/AssertionOptions.cs
@@ -26,18 +26,6 @@ namespace FluentAssertions
         }
 
         /// <summary>
-        /// Defines a predicate with which the <see cref="EquivalencyValidator"/> determines if it should process 
-        /// an object's properties or not. 
-        /// </summary>
-        /// <returns>
-        /// Returns <c>true</c> if the object should be treated as a value type and its <see cref="object.Equals(object)"/>
-        /// must be used during a structural equivalency check.
-        /// </returns>
-        public static Func<Type, bool> IsValueType { get; set; } = type =>
-              (type.Namespace == typeof(int).Namespace) &&
-              !type.IsSameOrInherits(typeof(Exception));
-
-        /// <summary>
         /// Allows configuring the defaults used during a structural equivalency assertion.
         /// </summary>
         /// <param name="defaultsConfigurer">
@@ -50,7 +38,7 @@ namespace FluentAssertions
         }
 
         /// <summary>
-        /// Represents a mutable collection of steps that are executed while asserting a (collection of) object(s) 
+        /// Represents a mutable collection of steps that are executed while asserting a (collection of) object(s)
         /// is structurally equivalent to another (collection of) object(s).
         /// </summary>
         public static EquivalencyStepCollection EquivalencySteps { get; private set; }

--- a/Src/FluentAssertions/Equivalency/CollectionMemberAssertionOptionsDecorator.cs
+++ b/Src/FluentAssertions/Equivalency/CollectionMemberAssertionOptionsDecorator.cs
@@ -82,9 +82,9 @@ namespace FluentAssertions.Equivalency
             get { return inner.IncludeFields; }
         }
 
-        public bool IsValueType(Type type)
+        public EqualityStrategy GetEqualityStrategy(Type type)
         {
-            return inner.IsValueType(type);
+            return inner.GetEqualityStrategy(type);
         }
 
         public ITraceWriter TraceWriter => inner.TraceWriter;

--- a/Src/FluentAssertions/Equivalency/CyclicReferenceDetector.cs
+++ b/Src/FluentAssertions/Equivalency/CyclicReferenceDetector.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 using FluentAssertions.Execution;
@@ -23,7 +24,7 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Determines whether the specified object reference is a cyclic reference to the same object earlier in the 
+        /// Determines whether the specified object reference is a cyclic reference to the same object earlier in the
         /// equivalency validation.
         /// </summary>
         /// <remarks>
@@ -57,7 +58,7 @@ namespace FluentAssertions.Equivalency
         /// <summary>
         /// Creates a new object that is a copy of the current instance.
         /// </summary>
-        /// 
+        ///
         /// <returns>
         /// A new object that is a copy of this instance.
         /// </returns>

--- a/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
@@ -76,8 +76,31 @@ namespace FluentAssertions.Equivalency
         ITraceWriter TraceWriter { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the <paramref name="type"/> should be treated as having value semantics.
+        /// Determines the right strategy for evaluating the equality of objects of this type.
         /// </summary>
-        bool IsValueType(Type type);
+        EqualityStrategy GetEqualityStrategy(Type type);
+    }
+
+    public enum EqualityStrategy
+    {
+        /// <summary>
+        /// The object overrides <see cref="object.Equals"/>, so use that.
+        /// </summary>
+        Equals,
+
+        /// <summary>
+        /// The object does not seem to override <see cref="object.Equals"/>, so compare by members
+        /// </summary>
+        Members,
+
+        /// <summary>
+        /// Compare using <see cref="object.Equals(object)"/>, whether or not the object overrides it.
+        /// </summary>
+        ForceEquals,
+
+        /// <summary>
+        /// Compare the members, regardless of an <see cref="object.Equals(object)"/> override exists or not.
+        /// </summary>
+        ForceMembers,
     }
 }

--- a/Src/FluentAssertions/Equivalency/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/ObjectReference.cs
@@ -43,7 +43,7 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Serves as a hash function for a particular type. 
+        /// Serves as a hash function for a particular type.
         /// </summary>
         /// <returns>
         /// A hash code for the current <see cref="T:System.Object"/>.
@@ -59,12 +59,9 @@ namespace FluentAssertions.Equivalency
 
         public override string ToString()
         {
-            return string.Format("{{\"{0}\", {1}}}", path, @object);
+            return $"{{\"{path}\", {@object}}}";
         }
 
-        public bool IsComplexType
-        {
-            get { return !ReferenceEquals(@object, null) && @object.GetType().IsComplexType(); }
-        }
+        public bool IsComplexType => !ReferenceEquals(@object, null) && !@object.GetType().OverridesEquals();
     }
 }

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -12,7 +12,7 @@ using FluentAssertions.Equivalency.Selection;
 namespace FluentAssertions.Equivalency
 {
     /// <summary>
-    /// Represents the run-time behavior of a structural equivalency assertion.
+    ///     Represents the run-time behavior of a structural equivalency assertion.
     /// </summary>
     public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : IEquivalencyAssertionOptions
         where TSelf : SelfReferenceEquivalencyAssertionOptions<TSelf>
@@ -47,12 +47,10 @@ namespace FluentAssertions.Equivalency
 
         private bool includeFields;
 
+        private readonly List<Type> referenceTypes = new List<Type>();
         private readonly List<Type> valueTypes = new List<Type>();
 
-        private readonly Func<Type, bool> isValueType = _ => false;
-        private ITraceWriter traceWriter;
-
-        private readonly ConversionSelector conversionSelector = new ConversionSelector();
+        private readonly Func<Type, EqualityStrategy> getDefaultEqualityStrategy = null;
 
         #endregion
 
@@ -64,7 +62,7 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Creates an instance of the equivalency assertions options based on defaults previously configured by the caller.
+        ///     Creates an instance of the equivalency assertions options based on defaults previously configured by the caller.
         /// </summary>
         protected SelfReferenceEquivalencyAssertionOptions(IEquivalencyAssertionOptions defaults)
         {
@@ -80,17 +78,17 @@ namespace FluentAssertions.Equivalency
             userEquivalencySteps.AddRange(defaults.UserEquivalencySteps);
             matchingRules.AddRange(defaults.MatchingRules);
             orderingRules = new OrderingRuleCollection(defaults.OrderingRules);
-            conversionSelector = defaults.ConversionSelector.Clone();
+            ConversionSelector = defaults.ConversionSelector.Clone();
 
-            isValueType = defaults.IsValueType;
-            traceWriter = defaults.TraceWriter;
+            getDefaultEqualityStrategy = defaults.GetEqualityStrategy;
+            TraceWriter = defaults.TraceWriter;
 
             RemoveSelectionRule<AllPublicPropertiesSelectionRule>();
             RemoveSelectionRule<AllPublicFieldsSelectionRule>();
         }
 
         /// <summary>
-        /// Gets an ordered collection of selection rules that define what members are included.
+        ///     Gets an ordered collection of selection rules that define what members are included.
         /// </summary>
         IEnumerable<IMemberSelectionRule> IEquivalencyAssertionOptions.SelectionRules
         {
@@ -116,93 +114,87 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Gets an ordered collection of matching rules that determine which subject members are matched with which
-        /// expectation members.
+        ///     Gets an ordered collection of matching rules that determine which subject members are matched with which
+        ///     expectation members.
         /// </summary>
-        IEnumerable<IMemberMatchingRule> IEquivalencyAssertionOptions.MatchingRules
-        {
-            get { return matchingRules; }
-        }
+        IEnumerable<IMemberMatchingRule> IEquivalencyAssertionOptions.MatchingRules => matchingRules;
 
         /// <summary>
-        /// Gets an ordered collection of Equivalency steps how a subject is compared with the expectation.
+        ///     Gets an ordered collection of Equivalency steps how a subject is compared with the expectation.
         /// </summary>
-        IEnumerable<IEquivalencyStep> IEquivalencyAssertionOptions.UserEquivalencySteps
+        IEnumerable<IEquivalencyStep> IEquivalencyAssertionOptions.UserEquivalencySteps =>
+            userEquivalencySteps.Concat(new[] {new TryConversionStep(ConversionSelector)});
+
+        public ConversionSelector ConversionSelector { get; } = new ConversionSelector();
+
+        /// <summary>
+        ///     Gets an ordered collection of rules that determine whether or not the order of collections is important. By
+        ///     default,
+        ///     ordering is irrelevant.
+        /// </summary>
+        OrderingRuleCollection IEquivalencyAssertionOptions.OrderingRules => orderingRules;
+
+        /// <summary>
+        ///     Gets value indicating whether the equality check will include nested collections and complex types.
+        /// </summary>
+        bool IEquivalencyAssertionOptions.IsRecursive => isRecursive;
+
+        bool IEquivalencyAssertionOptions.AllowInfiniteRecursion => allowInfiniteRecursion;
+
+        /// <summary>
+        ///     Gets value indicating how cyclic references should be handled. By default, it will throw an exception.
+        /// </summary>
+        CyclicReferenceHandling IEquivalencyAssertionOptions.CyclicReferenceHandling => cyclicReferenceHandling;
+
+        EnumEquivalencyHandling IEquivalencyAssertionOptions.EnumEquivalencyHandling => enumEquivalencyHandling;
+
+        bool IEquivalencyAssertionOptions.UseRuntimeTyping => useRuntimeTyping;
+
+        bool IEquivalencyAssertionOptions.IncludeProperties => includeProperties;
+
+        bool IEquivalencyAssertionOptions.IncludeFields => includeFields;
+
+        EqualityStrategy IEquivalencyAssertionOptions.GetEqualityStrategy(Type type)
         {
-            get
+            EqualityStrategy strategy;
+
+            if (referenceTypes.Any(type.IsSameOrInherits))
             {
-                return userEquivalencySteps.Concat(new[] { new TryConversionStep(conversionSelector), });
+                strategy = EqualityStrategy.ForceMembers;
             }
+            else if (valueTypes.Any(type.IsSameOrInherits))
+            {
+                strategy = EqualityStrategy.ForceEquals;
+            }
+            else
+            {
+                if (getDefaultEqualityStrategy != null)
+                {
+                    strategy = getDefaultEqualityStrategy(type);
+                }
+                else
+                {
+                    if (type.OverridesEquals() && !type.IsAnonymousType() && !type.IsTuple())
+                    {
+                        strategy =  EqualityStrategy.Equals;
+                    }
+                    else
+                    {
+                        strategy = EqualityStrategy.Members;
+                    }
+                }
+            }
+
+            return strategy;
         }
 
-        public ConversionSelector ConversionSelector
-        {
-            get { return conversionSelector; }
-        }
-
-        /// <summary>
-        /// Gets an ordered collection of rules that determine whether or not the order of collections is important. By default,
-        /// ordering is irrelevant.
-        /// </summary>
-        OrderingRuleCollection IEquivalencyAssertionOptions.OrderingRules
-        {
-            get { return orderingRules; }
-        }
-
-        /// <summary>
-        /// Gets value indicating whether the equality check will include nested collections and complex types.
-        /// </summary>
-        bool IEquivalencyAssertionOptions.IsRecursive
-        {
-            get { return isRecursive; }
-        }
-
-        bool IEquivalencyAssertionOptions.AllowInfiniteRecursion
-        {
-            get { return allowInfiniteRecursion; }
-        }
-
-        /// <summary>
-        /// Gets value indicating how cyclic references should be handled. By default, it will throw an exception.
-        /// </summary>
-        CyclicReferenceHandling IEquivalencyAssertionOptions.CyclicReferenceHandling
-        {
-            get { return cyclicReferenceHandling; }
-        }
-
-        EnumEquivalencyHandling IEquivalencyAssertionOptions.EnumEquivalencyHandling
-        {
-            get { return enumEquivalencyHandling; }
-        }
-
-        bool IEquivalencyAssertionOptions.UseRuntimeTyping
-        {
-            get { return useRuntimeTyping; }
-        }
-
-        bool IEquivalencyAssertionOptions.IncludeProperties
-        {
-            get { return includeProperties; }
-        }
-
-        bool IEquivalencyAssertionOptions.IncludeFields
-        {
-            get { return includeFields; }
-        }
+        public ITraceWriter TraceWriter { get; private set; }
 
         /// <summary>
-        /// Gets a value indicating whether the <paramref name="type"/> should be treated as having value semantics.
-        /// </summary>
-        bool IEquivalencyAssertionOptions.IsValueType(Type type)
-        {
-            return valueTypes.Contains(type) || isValueType(type) || AssertionOptions.IsValueType(type);
-        }
-
-        /// <summary>
-        /// Causes inclusion of only public properties of the subject as far as they are defined on the declared type.
+        ///     Causes inclusion of only public properties of the subject as far as they are defined on the declared type.
         /// </summary>
         /// <remarks>
-        /// This clears all previously registered selection rules.
+        ///     This clears all previously registered selection rules.
         /// </remarks>
         public TSelf IncludingAllDeclaredProperties()
         {
@@ -217,10 +209,10 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        ///  Causes inclusion of only public properties of the subject based on its run-time type rather than its declared type.
+        ///     Causes inclusion of only public properties of the subject based on its run-time type rather than its declared type.
         /// </summary>
         /// <remarks>
-        ///  This clears all previously registered selection rules.
+        ///     This clears all previously registered selection rules.
         /// </remarks>
         public TSelf IncludingAllRuntimeProperties()
         {
@@ -235,10 +227,10 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        ///  Instructs the comparison to include fields.
+        ///     Instructs the comparison to include fields.
         /// </summary>
         /// <remarks>
-        ///  This is part of the default behavior.
+        ///     This is part of the default behavior.
         /// </remarks>
         public TSelf IncludingFields()
         {
@@ -247,10 +239,10 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        ///  Instructs the comparison to exclude fields.
+        ///     Instructs the comparison to exclude fields.
         /// </summary>
         /// <remarks>
-        ///  This does not preclude use of `Including`.
+        ///     This does not preclude use of `Including`.
         /// </remarks>
         public TSelf ExcludingFields()
         {
@@ -259,10 +251,10 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        ///  Instructs the comparison to include properties.
+        ///     Instructs the comparison to include properties.
         /// </summary>
         /// <remarks>
-        ///  This is part of the default behavior.
+        ///     This is part of the default behavior.
         /// </remarks>
         public TSelf IncludingProperties()
         {
@@ -271,10 +263,10 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        ///  Instructs the comparison to exclude properties.
+        ///     Instructs the comparison to exclude properties.
         /// </summary>
         /// <remarks>
-        ///  This does not preclude use of `Including`.
+        ///     This does not preclude use of `Including`.
         /// </remarks>
         public TSelf ExcludingProperties()
         {
@@ -283,7 +275,7 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Instructs the comparison to respect the subject's runtime type.
+        ///     Instructs the comparison to respect the expectation's runtime type.
         /// </summary>
         public TSelf RespectingRuntimeTypes()
         {
@@ -292,7 +284,7 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Instructs the comparison to respect the subject's declared type.
+        ///     Instructs the comparison to respect the expectation's declared type.
         /// </summary>
         public TSelf RespectingDeclaredTypes()
         {
@@ -301,7 +293,7 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Excludes a (nested) property based on a predicate from the structural equality check.
+        ///     Excludes a (nested) property based on a predicate from the structural equality check.
         /// </summary>
         public TSelf Excluding(Expression<Func<ISubjectInfo, bool>> predicate)
         {
@@ -310,8 +302,8 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Tries to match the members of the subject with equally named members on the expectation. Ignores those
-        /// members that don't exist on the expectation and previously registered matching rules.
+        ///     Tries to match the members of the subject with equally named members on the expectation. Ignores those
+        ///     members that don't exist on the expectation and previously registered matching rules.
         /// </summary>
         public TSelf ExcludingMissingMembers()
         {
@@ -321,7 +313,7 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Requires the expectation to have members which are equally named to members on the subject.
+        ///     Requires the expectation to have members which are equally named to members on the subject.
         /// </summary>
         /// <returns></returns>
         public TSelf ThrowingOnMissingMembers()
@@ -333,7 +325,7 @@ namespace FluentAssertions.Equivalency
 
         /// <summary></summary>
         /// <param name="action">
-        /// The assertion to execute when the predicate is met.
+        ///     The assertion to execute when the predicate is met.
         /// </param>
         public Restriction<TProperty> Using<TProperty>(Action<IAssertionContext<TProperty>> action)
         {
@@ -341,7 +333,7 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Causes the structural equality check to include nested collections and complex types.
+        ///     Causes the structural equality check to include nested collections and complex types.
         /// </summary>
         public TSelf IncludingNestedObjects()
         {
@@ -350,10 +342,10 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Causes the structural equality check to exclude nested collections and complex types.
+        ///     Causes the structural equality check to exclude nested collections and complex types.
         /// </summary>
         /// <remarks>
-        /// Behaves similarly to the old property assertions API.
+        ///     Behaves similarly to the old property assertions API.
         /// </remarks>
         public TSelf ExcludingNestedObjects()
         {
@@ -362,10 +354,10 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Causes the structural equality check to ignore any cyclic references.
+        ///     Causes the structural equality check to ignore any cyclic references.
         /// </summary>
         /// <remarks>
-        /// By default, cyclic references within the object graph will cause an exception to be thrown.
+        ///     By default, cyclic references within the object graph will cause an exception to be thrown.
         /// </remarks>
         public TSelf IgnoringCyclicReferences()
         {
@@ -373,9 +365,8 @@ namespace FluentAssertions.Equivalency
             return (TSelf)this;
         }
 
-
         /// <summary>
-        /// Disables limitations on recursion depth when the structural equality check is configured to include nested objects
+        ///     Disables limitations on recursion depth when the structural equality check is configured to include nested objects
         /// </summary>
         public TSelf AllowingInfiniteRecursion()
         {
@@ -384,7 +375,7 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Clears all selection rules, including those that were added by default.
+        ///     Clears all selection rules, including those that were added by default.
         /// </summary>
         public void WithoutSelectionRules()
         {
@@ -392,7 +383,7 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Clears all matching rules, including those that were added by default.
+        ///     Clears all matching rules, including those that were added by default.
         /// </summary>
         public void WithoutMatchingRules()
         {
@@ -400,7 +391,7 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Adds a selection rule to the ones already added by default, and which is evaluated after all existing rules.
+        ///     Adds a selection rule to the ones already added by default, and which is evaluated after all existing rules.
         /// </summary>
         public TSelf Using(IMemberSelectionRule selectionRule)
         {
@@ -408,7 +399,7 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Adds a matching rule to the ones already added by default, and which is evaluated before all existing rules.
+        ///     Adds a matching rule to the ones already added by default, and which is evaluated before all existing rules.
         /// </summary>
         public TSelf Using(IMemberMatchingRule matchingRule)
         {
@@ -416,16 +407,17 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Adds an assertion rule to the ones already added by default, and which is evaluated before all existing rules.
+        ///     Adds an assertion rule to the ones already added by default, and which is evaluated before all existing rules.
         /// </summary>
         public TSelf Using(IAssertionRule assertionRule)
         {
             userEquivalencySteps.Insert(0, new AssertionRuleEquivalencyStepAdapter(assertionRule));
-            return (TSelf) this;
+            return (TSelf)this;
         }
 
         /// <summary>
-        /// Adds an equivalency step rule to the ones already added by default, and which is evaluated before previous user-registered steps
+        ///     Adds an equivalency step rule to the ones already added by default, and which is evaluated before previous
+        ///     user-registered steps
         /// </summary>
         public TSelf Using(IEquivalencyStep equivalencyStep)
         {
@@ -433,7 +425,7 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Causes all collections to be compared in the order in which the items appear in the expectation.
+        ///     Causes all collections to be compared in the order in which the items appear in the expectation.
         /// </summary>
         public TSelf WithStrictOrdering()
         {
@@ -442,8 +434,8 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Causes the collection identified by the provided <paramref name="predicate"/> to be compared in the order
-        /// in which the items appear in the expectation.
+        ///     Causes the collection identified by the provided <paramref name="predicate" /> to be compared in the order
+        ///     in which the items appear in the expectation.
         /// </summary>
         public TSelf WithStrictOrderingFor(Expression<Func<ISubjectInfo, bool>> predicate)
         {
@@ -452,8 +444,8 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Causes the collection identified by the provided <paramref name="predicate"/> to be compared ignoring the order
-        /// in which the items appear in the expectation.
+        ///     Causes the collection identified by the provided <paramref name="predicate" /> to be compared ignoring the order
+        ///     in which the items appear in the expectation.
         /// </summary>
         public TSelf WithoutStrictOrderingFor(Expression<Func<ISubjectInfo, bool>> predicate)
         {
@@ -466,127 +458,114 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Causes to compare Enum properties using the result of their ToString method.
+        ///     Causes to compare Enum properties using the result of their ToString method.
         /// </summary>
         /// <remarks>
-        /// By default, enums are compared by value.
+        ///     By default, enums are compared by value.
         /// </remarks>
         public TSelf ComparingEnumsByName()
         {
             enumEquivalencyHandling = EnumEquivalencyHandling.ByName;
-            return (TSelf) this;
+            return (TSelf)this;
         }
 
         /// <summary>
-        /// Causes to compare Enum members using their underlying value only.
+        ///     Causes to compare Enum members using their underlying value only.
         /// </summary>
         /// <remarks>
-        /// This is the default.
+        ///     This is the default.
         /// </remarks>
         public TSelf ComparingEnumsByValue()
         {
             enumEquivalencyHandling = EnumEquivalencyHandling.ByValue;
-            return (TSelf) this;
+            return (TSelf)this;
         }
 
         /// <summary>
-        /// Marks the <typeparamref name="T"/> as a value type which must be compared using its
-        /// <see cref="object.Equals(object)"/> method.
+        ///     Marks the <typeparamref name="T" /> as a type that should be compared by its members even though it may override
+        ///     the <see cref="object.Equals(object)" /> method.
+        /// </summary>
+        public TSelf ComparingByMembers<T>()
+        {
+            if (valueTypes.Any(typeof(T).IsSameOrInherits))
+            {
+                throw new InvalidOperationException(
+                    $"Can't compare {typeof(T).Name} by its members if it already setup to be compared by value");
+            }
+
+            referenceTypes.Add(typeof(T));
+            return (TSelf)this;
+        }
+
+        /// <summary>
+        ///     Marks the <typeparamref name="T" /> as a value type which must be compared using its
+        ///     <see cref="object.Equals(object)" /> method, regardless of it overriding it or not.
         /// </summary>
         public TSelf ComparingByValue<T>()
         {
+            if (referenceTypes.Any(typeof(T).IsSameOrInherits))
+            {
+                throw new InvalidOperationException(
+                    $"Can't compare {typeof(T).Name} by value if it already setup to be compared by its members");
+            }
+
             valueTypes.Add(typeof(T));
-            return (TSelf) this;
+            return (TSelf)this;
         }
 
         /// <summary>
-        /// Enables tracing the steps the equivalency validation followed to compare two graphs.
+        ///     Enables tracing the steps the equivalency validation followed to compare two graphs.
         /// </summary>
         public TSelf WithTracing(ITraceWriter writer = null)
         {
-            traceWriter = writer ?? new StringBuilderTraceWriter();
+            TraceWriter = writer ?? new StringBuilderTraceWriter();
             return (TSelf)this;
         }
 
         /// <summary>
-        /// Instructs the equivalency comparison to try to convert the values of
-        /// matching properties before running any of the other steps.
+        ///     Instructs the equivalency comparison to try to convert the values of
+        ///     matching properties before running any of the other steps.
         /// </summary>
         public TSelf WithAutoConversion()
         {
-            conversionSelector.IncludeAll();
+            ConversionSelector.IncludeAll();
             return (TSelf)this;
         }
 
         /// <summary>
-        /// Instructs the equivalency comparison to try to convert the value of
-        /// a specific property on the expectation object before running any of the other steps.
+        ///     Instructs the equivalency comparison to try to convert the value of
+        ///     a specific property on the expectation object before running any of the other steps.
         /// </summary>
         public TSelf WithAutoConversionFor(Expression<Func<ISubjectInfo, bool>> predicate)
         {
-            conversionSelector.Include(predicate);
+            ConversionSelector.Include(predicate);
             return (TSelf)this;
         }
 
         /// <summary>
-        /// Instructs the equivalency comparison to prevent trying to convert the value of
-        /// a specific property on the expectation object before running any of the other steps.
+        ///     Instructs the equivalency comparison to prevent trying to convert the value of
+        ///     a specific property on the expectation object before running any of the other steps.
         /// </summary>
         public TSelf WithoutAutoConversionFor(Expression<Func<ISubjectInfo, bool>> predicate)
         {
-            conversionSelector.Exclude(predicate);
+            ConversionSelector.Exclude(predicate);
             return (TSelf)this;
         }
 
-        #region Non-fluent API
-
-        protected void RemoveSelectionRule<T>() where T : IMemberSelectionRule
-        {
-            foreach (T selectionRule in selectionRules.OfType<T>().ToArray())
-            {
-                selectionRules.Remove(selectionRule);
-            }
-        }
-
-        private void ClearMatchingRules()
-        {
-            matchingRules.Clear();
-        }
-
-        protected TSelf AddSelectionRule(IMemberSelectionRule selectionRule)
-        {
-            selectionRules.Add(selectionRule);
-            return (TSelf) this;
-        }
-
-        private TSelf AddMatchingRule(IMemberMatchingRule matchingRule)
-        {
-            matchingRules.Insert(0, matchingRule);
-            return (TSelf) this;
-        }
-
-        private TSelf AddEquivalencyStep(IEquivalencyStep equivalencyStep)
-        {
-            userEquivalencySteps.Add(equivalencyStep);
-            return (TSelf) this;
-        }
-
-        #endregion
-
         /// <summary>
-        /// Returns a string that represents the current object.
+        ///     Returns a string that represents the current object.
         /// </summary>
         /// <returns>
-        /// A string that represents the current object.
+        ///     A string that represents the current object.
         /// </returns>
         /// <filterpriority>2</filterpriority>
         public override string ToString()
         {
-            var builder = new StringBuilder();
+            StringBuilder builder = new StringBuilder();
 
             builder.Append("- Use ")
-                   .Append((useRuntimeTyping ? "runtime" : "declared"))
-                   .AppendLine(" types and members");
+                .Append(useRuntimeTyping ? "runtime" : "declared")
+                .AppendLine(" types and members");
 
             if (isRecursive)
             {
@@ -597,7 +576,7 @@ namespace FluentAssertions.Equivalency
             }
 
             builder.AppendFormat("- Compare enums by {0}" + Environment.NewLine,
-                (enumEquivalencyHandling == EnumEquivalencyHandling.ByName) ? "name" : "value");
+                enumEquivalencyHandling == EnumEquivalencyHandling.ByName ? "name" : "value");
 
             if (cyclicReferenceHandling == CyclicReferenceHandling.Ignore)
             {
@@ -627,10 +606,8 @@ namespace FluentAssertions.Equivalency
             return builder.ToString();
         }
 
-        public ITraceWriter TraceWriter => traceWriter;
-
         /// <summary>
-        /// Defines additional overrides when used with <see cref="EquivalencyAssertionOptions.When"/>
+        ///     Defines additional overrides when used with <see cref="EquivalencyAssertionOptions.When" />
         /// </summary>
         public class Restriction<TMember>
         {
@@ -644,7 +621,8 @@ namespace FluentAssertions.Equivalency
             }
 
             /// <summary>
-            /// Allows overriding the way structural equality is applied to (nested) objects of type <typeparamref name="TMemberType"/>
+            ///     Allows overriding the way structural equality is applied to (nested) objects of type
+            ///     <typeparamref name="TMemberType" />
             /// </summary>
             public TSelf WhenTypeIs<TMemberType>()
             {
@@ -653,11 +631,12 @@ namespace FluentAssertions.Equivalency
             }
 
             /// <summary>
-            /// Allows overriding the way structural equality is applied to particular members.
+            ///     Allows overriding the way structural equality is applied to particular members.
             /// </summary>
             /// <param name="predicate">
-            /// A predicate based on the <see cref="ISubjectInfo"/> of the subject that is used to identify the property for which the
-            /// override applies.
+            ///     A predicate based on the <see cref="ISubjectInfo" /> of the subject that is used to identify the property for which
+            ///     the
+            ///     override applies.
             /// </param>
             public TSelf When(Expression<Func<ISubjectInfo, bool>> predicate)
             {
@@ -665,5 +644,41 @@ namespace FluentAssertions.Equivalency
                 return options;
             }
         }
+
+
+        #region Non-fluent API
+
+        protected void RemoveSelectionRule<T>() where T : IMemberSelectionRule
+        {
+            foreach (T selectionRule in selectionRules.OfType<T>().ToArray())
+            {
+                selectionRules.Remove(selectionRule);
+            }
+        }
+
+        private void ClearMatchingRules()
+        {
+            matchingRules.Clear();
+        }
+
+        protected TSelf AddSelectionRule(IMemberSelectionRule selectionRule)
+        {
+            selectionRules.Add(selectionRule);
+            return (TSelf)this;
+        }
+
+        private TSelf AddMatchingRule(IMemberMatchingRule matchingRule)
+        {
+            matchingRules.Insert(0, matchingRule);
+            return (TSelf)this;
+        }
+
+        private TSelf AddEquivalencyStep(IEquivalencyStep equivalencyStep)
+        {
+            userEquivalencySteps.Add(equivalencyStep);
+            return (TSelf)this;
+        }
+
+        #endregion
     }
 }

--- a/Src/FluentAssertions/Equivalency/ValueTypeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/ValueTypeEquivalencyStep.cs
@@ -1,4 +1,5 @@
 using System;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency
 {
@@ -13,16 +14,18 @@ namespace FluentAssertions.Equivalency
         public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
         {
             Type type = config.GetExpectationType(context);
+            EqualityStrategy strategy = config.GetEqualityStrategy(type);
 
-            bool canHandle =
-                (type != null) && 
-                (type != typeof (object)) && 
-                config.IsValueType(type) && 
-                !type.IsArray;
-
+            bool canHandle = (strategy == EqualityStrategy.Equals) || (strategy == EqualityStrategy.ForceEquals);
             if (canHandle)
             {
-                context.TraceSingle(path => $"Treating {path} as a value type");
+                context.TraceSingle(path =>
+                {
+                    string strategyName = (strategy == EqualityStrategy.Equals)
+                        ? "Equals must be used" : "object overrides Equals";
+
+                    return $"Treating {path} as a value type because {strategyName}.";
+                });
             }
 
             return canHandle;

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -23,10 +23,12 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.2" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
@@ -35,6 +37,11 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <Reference Include="System.Configuration">
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\system.valuetuple\4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -83,9 +83,9 @@ namespace FluentAssertions.Formatting
                     throw new InvalidOperationException(
                         $"Use the {nameof(FormatChild)} delegate inside a {nameof(IValueFormatter)} to recursively format children");
                 }
-                
+
                 isRentry = true;
-                
+
                 var graph = new ObjectGraph(value);
 
                 return Format(value, new FormattingContext
@@ -162,7 +162,7 @@ namespace FluentAssertions.Formatting
         }
 
         /// <summary>
-        /// Tracks the objects that were formatted as well as the path in the object graph of 
+        /// Tracks the objects that were formatted as well as the path in the object graph of
         /// that object.
         /// </summary>
         /// <remarks>

--- a/Tests/Net45.Specs/Net45.Specs.csproj
+++ b/Tests/Net45.Specs/Net45.Specs.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Chill" Version="3.0.1.0" />
     <PackageReference Include="FakeItEasy" Version="3.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />

--- a/Tests/NetCore.Specs/NetCore.Specs.csproj
+++ b/Tests/NetCore.Specs/NetCore.Specs.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="3.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />

--- a/Tests/Shared.Specs/AssertionOptionSpecs.cs
+++ b/Tests/Shared.Specs/AssertionOptionSpecs.cs
@@ -15,17 +15,9 @@ namespace FluentAssertions.Specs
     {
         public abstract class Given_temporary_global_assertion_options : GivenWhenThen
         {
-            private readonly Func<Type, bool> defaultValueTypePredicate;
-
-            protected Given_temporary_global_assertion_options()
-            {
-                defaultValueTypePredicate = AssertionOptions.IsValueType;
-            }
-
             protected override void Dispose(bool disposing)
             {
                 AssertionOptions.AssertEquivalencyUsing(options => new EquivalencyAssertionOptions());
-                AssertionOptions.IsValueType = defaultValueTypePredicate;
 
                 base.Dispose(disposing);
             }
@@ -112,42 +104,6 @@ namespace FluentAssertions.Specs
                 };
 
                 Action act = () => actual.Should().BeEquivalentTo(expected);
-
-                act.Should().NotThrow();
-            }
-        }
-
-        [Collection("Equivalency")]
-        public class When_marking_a_specific_type_as_a_value_type_globally : Given_temporary_global_assertion_options
-        {
-            public When_marking_a_specific_type_as_a_value_type_globally()
-            {
-                When(() =>
-                {
-                    Func<Type, bool> defaultPredicate = AssertionOptions.IsValueType;
-
-                    AssertionOptions.IsValueType =
-                        type => defaultPredicate(type) || (type == typeof(IPAddress));
-                });
-            }
-
-            [Fact]
-            public void Then_this_should_not_throw()
-            {
-                var subject = new
-                {
-                    Address = IPAddress.Parse("1.2.3.4"),
-                    Word = "a"
-                };
-
-                var expected = new
-                {
-                    Address = IPAddress.Parse("1.2.3.4"),
-                    Word = "a"
-                };
-
-                Action act = () => subject.Should().BeEquivalentTo(expected,
-                    options => options.ComparingByValue<IPAddress>());
 
                 act.Should().NotThrow();
             }

--- a/Tests/Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/BasicEquivalencySpecs.cs
@@ -161,6 +161,170 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_an_object_hides_object_equals_it_should_be_compared_using_its_members()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var actual = new VirtualClassOverride
+            {
+                Property = "Value",
+                OtherProperty = "Actual"
+            };
+
+            var expected = new VirtualClassOverride
+            {
+                Property = "Value",
+                OtherProperty = "Expected"
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => actual.Should().BeEquivalentTo(expected);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>("*OtherProperty*Expected*Actual*");
+        }
+
+        public class VirtualClass
+        {
+            public string Property { get; set; }
+
+            public new virtual bool Equals(object obj)
+            {
+                return (obj is VirtualClass other) && other.Property.Equals(Property);
+            }
+        }
+
+        public class VirtualClassOverride : VirtualClass
+        {
+            public string OtherProperty { get; set;}
+        }
+
+        [Fact]
+        public void When_treating_a_value_type_in_a_collection_as_a_complex_type_it_should_compare_them_by_members()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new[] { new ClassWithValueSemanticsOnSingleProperty
+            {
+                Key = "SameKey",
+                NestedProperty = "SomeValue"
+            } };
+
+            var expected = new[] { new ClassWithValueSemanticsOnSingleProperty
+            {
+                Key = "SameKey",
+                NestedProperty = "OtherValue"
+            } };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.Should().BeEquivalentTo(expected,
+                options => options.ComparingByMembers<ClassWithValueSemanticsOnSingleProperty>());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>().WithMessage("*NestedProperty*OtherValue*SomeValue*");
+        }
+
+        [Fact]
+        public void When_treating_a_value_type_as_a_complex_type_it_should_compare_them_by_members()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new ClassWithValueSemanticsOnSingleProperty
+            {
+                Key = "SameKey",
+                NestedProperty = "SomeValue"
+            };
+
+            var expected = new ClassWithValueSemanticsOnSingleProperty
+            {
+                Key = "SameKey",
+                NestedProperty = "OtherValue"
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.Should().BeEquivalentTo(expected,
+                options => options.ComparingByMembers<ClassWithValueSemanticsOnSingleProperty>());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>().WithMessage("*NestedProperty*OtherValue*SomeValue*");
+        }
+
+        [Fact]
+        public void When_treating_a_type_as_value_type_but_it_was_already_marked_as_reference_type_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new ClassWithValueSemanticsOnSingleProperty
+            {
+                Key = "Don't care",
+            };
+
+            var expected = new ClassWithValueSemanticsOnSingleProperty
+            {
+                Key = "Don't care",
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = ()  => subject.Should().BeEquivalentTo(expected, options => options
+                .ComparingByMembers<ClassWithValueSemanticsOnSingleProperty>()
+                .ComparingByValue<ClassWithValueSemanticsOnSingleProperty>());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<InvalidOperationException>().WithMessage(
+                $"*compare {nameof(ClassWithValueSemanticsOnSingleProperty)}*value*already*members*");
+        }
+
+        [Fact]
+        public void When_treating_a_type_as_reference_type_but_it_was_already_marked_as_value_type_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new ClassWithValueSemanticsOnSingleProperty
+            {
+                Key = "Don't care",
+            };
+
+            var expected = new ClassWithValueSemanticsOnSingleProperty
+            {
+                Key = "Don't care",
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = ()  => subject.Should().BeEquivalentTo(expected, options => options
+                .ComparingByValue<ClassWithValueSemanticsOnSingleProperty>()
+                .ComparingByMembers<ClassWithValueSemanticsOnSingleProperty>());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<InvalidOperationException>().WithMessage(
+                $"*compare {nameof(ClassWithValueSemanticsOnSingleProperty)}*members*already*value*");
+        }
+
+        [Fact]
         public void When_treating_a_complex_type_in_a_collection_as_a_value_type_it_should_compare_them_by_value()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -219,6 +383,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().NotThrow();
         }
+
 
         [Fact]
         public void When_a_type_originates_from_the_System_namespace_it_should_be_treated_as_a_value_type()
@@ -333,7 +498,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_scenario_it_should_behavior()
+        public void When_nummer_values_are_convertible_it_should_treat_them_as_equivalent()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -350,15 +515,15 @@ namespace FluentAssertions.Specs
                 { "002", 2 }
             };
 
-            actual.Should().BeEquivalentTo(expected, x => x.WithTracing());
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-
+            Action act = () => actual.Should().BeEquivalentTo(expected, x => x.WithTracing());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
         }
 
         [Fact]
@@ -3215,6 +3380,37 @@ namespace FluentAssertions.Specs
 
         #endregion
 
+        #region Tuples
+
+        [Fact]
+        public void When_a_nested_member_is_a_tuple_it_should_compare_its_property_for_equivalence()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var actual = new
+            {
+                Tuple = (new[] {"string1"}, new[] {"string2"})
+            };
+
+            var expected = new
+            {
+                Tuple = (new[] {"string1"}, new[] {"string2"})
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => actual.Should().BeEquivalentTo(expected);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
+        }
+
+        #endregion
+
         #region Enums
 
         [Fact]
@@ -3463,20 +3659,6 @@ namespace FluentAssertions.Specs
             // Arrange / Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => new ClassWithNoMembers().Should().BeEquivalentTo(new ClassWithNoMembers());
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Assert
-            //-----------------------------------------------------------------------------------------------------------
-            act.Should().Throw<InvalidOperationException>();
-        }
-
-        [Fact]
-        public void When_asserting_instances_of_a_struct_having_no_memebers_are_equivilent_it_should_fail()
-        {
-            //-----------------------------------------------------------------------------------------------------------
-            // Arrange / Act
-            //-----------------------------------------------------------------------------------------------------------
-            Action act = () => new StructWithNoMembers().Should().BeEquivalentTo(new StructWithNoMembers());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert

--- a/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
@@ -1873,7 +1873,9 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => list1.Should().BeEquivalentTo(list2, config => config.Excluding(ctx => ctx.Key));
+            Action act = () => list1.Should().BeEquivalentTo(list2, config => config
+                .Excluding(ctx => ctx.Key)
+                .ComparingByMembers<KeyValuePair<int, int>>());
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert

--- a/Tests/Shared.Specs/DictionaryEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/DictionaryEquivalencySpecs.cs
@@ -511,8 +511,10 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             Action act =
                 () =>
-                    actual.Should().BeEquivalentTo(expectation,
-                        opts => opts.RespectingRuntimeTypes());
+                    actual.Should().BeEquivalentTo(expectation, opts => opts
+                        .RespectingRuntimeTypes()
+                        .ComparingByMembers<CustomerType>()
+                    );
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -754,13 +754,20 @@ orderDto.Should().BeEquivalentTo(order, options =>
 
 ### Value Types ###
 
-To determine whether Fluent Assertions should recurs into an object's properties or fields, it needs to understand what types have value semantics and what types should be treated as reference types. There's no easy way to look at a .NET type from the outside and conclude it should have value semantics. 
+To determine whether Fluent Assertions should recurs into an object's properties or fields, it needs to understand what types have value semantics and what types should be treated as reference types. The default behavior is to treat every type that overrides `Object.Equals` as on object that was designed to have value semantics. Unfortunately, anonymous types and tuples also override this method, but because we tend to use them quite often in equivalency comparison, we always compare them by their properties.
 
-Unless you've changed the predicate associated with `AssertionOptions.IsValueType`, it will ignore anything from the `System` namespace. To change that for individual assertions, use the `ComparingByValue<T>` option:
+You can easily override this by using the `ComparingByValue<T>` or `ComparingByMembers<T>` options for individual assertions:
 
 ```csharp
 subject.Should().BeEquivalentTo(expected,
    options => options.ComparingByValue<IPAddress>());
+```
+
+Or  do the same using the global options:
+
+```csharp
+AssertionOptions.AssertEquivalencyUsing(options => options
+    .ComparingByValue<DirectoryInfo`());
 ```
 
 ### Auto-Conversion ###
@@ -981,16 +988,11 @@ This is where the static class `AssertionOptions` comes into play.
 For instance, to always compare enumerations by name, use the following statement:
 
 ```csharp
-AssertionOptions.AssertEquivalencyUsing(options => options.ComparingEnumsByValue);
+AssertionOptions.AssertEquivalencyUsing(options => 
+   options.ComparingEnumsByValue);
 ``` 
 
-All the options available to an individual call to `Should().BeEquivalenTo` are supported, with the exception of some of the overloads that are specific to the type of the subject (for obvious reasons).
-You can even change the algorithm that Fluent Assertions uses to determine if an object should be treated as a value type.
-Simply replace the `AssertionOptions.IsValueType` predicate with your own:
-
-```csharp
-AssertionOptions.IsValueType = type => // a custom algorithm 
-```
+All the options available to an individual call to `Should().BeEquivalentTo` are supported, with the exception of some of the overloads that are specific to the type of the subject (for obvious reasons).
 
 ## Event Monitoring ##
 

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -123,13 +123,20 @@ public class DirectoryInfoValueFormatter : IValueFormatter
 
 ## To be or not to be a value type ##
 
-The structural equivalency API provided by `Should().BeEquivalentTo` and is arguably the most powerful, but also the most complicated part of Fluent Assertions. And to make things worse, you can extend and adapt the default behavior quite extensively. For instance, to determine whether FA needs to recursive into a complex object, it needs to know what object should be treated as a complex object. An object that has properties isn't necessarily a complex type that you want to recurse on. `DirectoryInfo` has properties, but you don't want FA to just traverse its properties. So, you need to tell what types should be treated as value types. The default (naive) behavior is to treat everything from the `System` namespace as a value type.
+The structural equivalency API provided by `Should().BeEquivalentTo` and is arguably the most powerful, but also the most complicated part of Fluent Assertions. And to make things worse, you can extend and adapt the default behavior quite extensively. 
 
-```charp
-public static Func<Type, bool> IsValueType = type => (type.Namespace == typeof(int).Namespace);
+For instance, to determine whether FA needs to recursive into a complex object, it needs to know whether or not a particular type has value semantics. An object that has properties isn't necessarily a complex type that you want to recurse on. `DirectoryInfo` has properties, but you don't want FA to just traverse its properties. So you need to tell what types should be treated as value types. 
+
+The default behavior is to treat every type that overrides `Object.Equals` as on object that was designed to have value semantics. Unfortunately, anonymous types and tuples also override this method, but because we tend to use them quite often in equivalency comparison, we always compare them by their properties.
+
+You can easily override this by using the `ComparingByValue<T>` options for individual assertion, or to do the same using the global options:
+
+```csharp
+AssertionOptions.AssertEquivalencyUsing(options => options
+    .ComparingByValue<DirectoryInfo`());
 ```
 
-But you can easily change that by setting the global `AssertionOption.IsValueType` function or temporarily using the `ComparingByValue<T>` options for individual assertions.
+Similarly, you can force comparing objects that do override `Equals` by their properties using `ComparingByMembers<T>`.
 
 ## Equivalency assertion step by step ##
 


### PR DESCRIPTION
Replaces all mechanisms and options to control whether or not an object has value semantics by a single algorithm: Any object that overrides object.Equals and is not an anonymous type is treated as a value type, unless ComparingByMembers<T>() is used. Also removes the global AssertionOptions.IsValueType. For those cases where this algorithm misbehaves, ComparingByValue<T> can be used.

#739 

* [x] Initial implementation
* [x] Also treat tuples specially
* [x] Update extensibility docs
* [x] Update main docs on value equality