### PR TITLE
Add ThatAre[Not]DecoratedWithOrInherit

### DIFF
--- a/Src/FluentAssertions/TypeEnumerableExtensions.cs
+++ b/Src/FluentAssertions/TypeEnumerableExtensions.cs
@@ -20,12 +20,30 @@ namespace FluentAssertions
         }
 
         /// <summary>
+        /// Filters to only include types decorated with, or inherits from a parent class, a particular attribute.
+        /// </summary>
+        public static IEnumerable<Type> ThatAreDecoratedWithOrInherit<TAttribute>(this IEnumerable<Type> types)
+            where TAttribute : Attribute
+        {
+            return new TypeSelector(types).ThatAreDecoratedWithOrInherit<TAttribute>();
+        }
+
+        /// <summary>
         /// Filters to only include types not decorated with a particular attribute.
         /// </summary>
         public static IEnumerable<Type> ThatAreNotDecoratedWith<TAttribute>(this IEnumerable<Type> types)
             where TAttribute : Attribute
         {
             return new TypeSelector(types).ThatAreNotDecoratedWith<TAttribute>();
+        }
+
+        /// <summary>
+        /// Filters to only include types not decorated with and does not inherit from a parent class, a particular attribute.
+        /// </summary>
+        public static IEnumerable<Type> ThatAreNotDecoratedWithOrInherit<TAttribute>(this IEnumerable<Type> types)
+            where TAttribute : Attribute
+        {
+            return new TypeSelector(types).ThatAreNotDecoratedWithOrInherit<TAttribute>();
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -98,12 +98,32 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
+        /// Only select the methods that are decorated with, or inherits from a parent class, an attribute of the specified type.
+        /// </summary>
+        public MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : Attribute
+        {
+            selectedMethods = selectedMethods.Where(method => method.GetCustomAttributes(true).OfType<TAttribute>().Any());
+            return this;
+        }
+
+        /// <summary>
         /// Only select the methods that are not decorated with an attribute of the specified type.
         /// </summary>
         public MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : Attribute
         {
             selectedMethods = selectedMethods.Where(method => !method.GetCustomAttributes(false).OfType<TAttribute>().Any());
+            return this;
+        }
+
+        /// <summary>
+        /// Only select the methods that are not decorated with and does not inherit from a parent class, an attribute of the specified type.
+        /// </summary>
+        public MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : Attribute
+        {
+            selectedMethods = selectedMethods.Where(method => !method.GetCustomAttributes(true).OfType<TAttribute>().Any());
             return this;
         }
 

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -55,7 +55,17 @@ namespace FluentAssertions.Types
         public PropertyInfoSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : Attribute
         {
-            selectedProperties = selectedProperties.Where(property => property.GetCustomAttributes(false).OfType<TAttribute>().Any());
+            selectedProperties = selectedProperties.Where(property => CustomAttributeExtensions.GetCustomAttributes(property, false).OfType<TAttribute>().Any());
+            return this;
+        }
+
+        /// <summary>
+        /// Only select the properties that are decorated with, or inherits from a parent class, an attribute of the specified type.
+        /// </summary>
+        public PropertyInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : Attribute
+        {
+            selectedProperties = selectedProperties.Where(property => CustomAttributeExtensions.GetCustomAttributes(property, true).OfType<TAttribute>().Any());
             return this;
         }
 
@@ -66,6 +76,16 @@ namespace FluentAssertions.Types
             where TAttribute : Attribute
         {
             selectedProperties = selectedProperties.Where(property => !property.GetCustomAttributes(false).OfType<TAttribute>().Any());
+            return this;
+        }
+
+        /// <summary>
+        /// Only select the properties that are not decorated with and does not inherit from a parent class an attribute of the specified type.
+        /// </summary>
+        public PropertyInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : Attribute
+        {
+            selectedProperties = selectedProperties.Where(property => !CustomAttributeExtensions.GetCustomAttributes(property, true).OfType<TAttribute>().Any());
             return this;
         }
 

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -81,6 +81,20 @@ namespace FluentAssertions.Types
         {
             types = types
 
+                .Where(t => t.GetTypeInfo().GetCustomAttributes(typeof(TAttribute), false).Any())
+                .ToList();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Determines whether a type is decorated with, or inherits from a parent class, a particular attribute.
+        /// </summary>
+        public TypeSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : Attribute
+        {
+            types = types
+
                 .Where(t => t.GetTypeInfo().GetCustomAttributes(typeof(TAttribute), true).Any())
                 .ToList();
 
@@ -91,6 +105,20 @@ namespace FluentAssertions.Types
         /// Determines whether a type is not decorated with a particular attribute.
         /// </summary>
         public TypeSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : Attribute
+        {
+            types = types
+
+                .Where(t => !t.GetTypeInfo().GetCustomAttributes(typeof(TAttribute), false).Any())
+                .ToList();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Determines whether a type is not decorated with and does not inherit from a parent class, a particular attribute.
+        /// </summary>
+        public TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : Attribute
         {
             types = types

--- a/Tests/Shared.Specs/MethodInfoSelectorSpecs.cs
+++ b/Tests/Shared.Specs/MethodInfoSelectorSpecs.cs
@@ -195,6 +195,158 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             methods.Should().HaveCount(2);
         }
+
+        [Fact]
+        public void When_selecting_methods_decorated_with_an_inheritable_attribute_it_should_only_return_the_applicable_methods()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForMethodSelectorWithInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<MethodInfo> methods = type.Methods().ThatAreDecoratedWith<DummyMethodAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            methods.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void When_selecting_methods_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_methods()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForMethodSelectorWithInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<MethodInfo> methods = type.Methods().ThatAreDecoratedWithOrInherit<DummyMethodAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            methods.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void When_selecting_methods_not_decorated_with_an_inheritable_attribute_it_should_only_return_the_applicable_methods()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForMethodSelectorWithInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<MethodInfo> methods = type.Methods().ThatAreNotDecoratedWith<DummyMethodAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            methods.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void When_selecting_methods_not_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_methods()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForMethodSelectorWithInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<MethodInfo> methods = type.Methods().ThatAreNotDecoratedWithOrInherit<DummyMethodAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            methods.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void When_selecting_methods_decorated_with_a_noninheritable_attribute_it_should_only_return_the_applicable_methods()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForMethodSelectorWithNonInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<MethodInfo> methods = type.Methods().ThatAreDecoratedWith<DummyMethodNonInheritableAttributeAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            methods.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void When_selecting_methods_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_methods()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForMethodSelectorWithNonInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<MethodInfo> methods = type.Methods().ThatAreDecoratedWithOrInherit<DummyMethodNonInheritableAttributeAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            methods.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void When_selecting_methods_not_decorated_with_a_noninheritable_attribute_it_should_only_return_the_applicable_methods()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForMethodSelectorWithNonInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<MethodInfo> methods = type.Methods().ThatAreNotDecoratedWith<DummyMethodNonInheritableAttributeAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            methods.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void When_selecting_methods_not_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_methods()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForMethodSelectorWithNonInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<MethodInfo> methods = type.Methods().ThatAreNotDecoratedWithOrInherit<DummyMethodNonInheritableAttributeAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            methods.Should().ContainSingle();
+        }
     }
 
     #region Internal classes used in unit tests
@@ -239,7 +391,35 @@ namespace FluentAssertions.Specs
         }
     }
 
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    internal class TestClassForMethodSelectorWithInheritableAttribute
+    {
+        [DummyMethod]
+        public virtual void PublicVirtualVoidMethodWithAttribute() { }
+    }
+
+    internal class TestClassForMethodSelectorWithNonInheritableAttribute
+    {
+        [DummyMethodNonInheritableAttribute]
+        public virtual void PublicVirtualVoidMethodWithAttribute() { }
+    }
+
+    internal class TestClassForMethodSelectorWithInheritableAttributeDerived : TestClassForMethodSelectorWithInheritableAttribute
+    {
+        public override void PublicVirtualVoidMethodWithAttribute() { }
+    }
+
+    internal class TestClassForMethodSelectorWithNonInheritableAttributeDerived : TestClassForMethodSelectorWithNonInheritableAttribute
+    {
+        public override void PublicVirtualVoidMethodWithAttribute() { }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class DummyMethodNonInheritableAttributeAttribute : Attribute
+    {
+        public bool Filter { get; set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
     public class DummyMethodAttribute : Attribute
     {
         public bool Filter { get; set; }

--- a/Tests/Shared.Specs/PropertyInfoSelectorSpecs.cs
+++ b/Tests/Shared.Specs/PropertyInfoSelectorSpecs.cs
@@ -158,6 +158,158 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             properties.Should().HaveCount(1);
         }
+
+        [Fact]
+        public void When_selecting_properties_decorated_with_an_inheritable_attribute_it_should_only_return_the_applicable_properties()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForPropertySelectorWithInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<PropertyInfo> properties = type.Properties().ThatAreDecoratedWith<DummyPropertyAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            properties.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void When_selecting_properties_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_properties()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForPropertySelectorWithInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<PropertyInfo> properties = type.Properties().ThatAreDecoratedWithOrInherit<DummyPropertyAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            properties.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void When_selecting_properties_not_decorated_with_an_inheritable_attribute_it_should_only_return_the_applicable_properties()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForPropertySelectorWithInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<PropertyInfo> properties = type.Properties().ThatAreNotDecoratedWith<DummyPropertyAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            properties.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void When_selecting_properties_not_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_properties()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForPropertySelectorWithInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<PropertyInfo> properties = type.Properties().ThatAreNotDecoratedWithOrInherit<DummyPropertyAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            properties.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void When_selecting_properties_decorated_with_a_noninheritable_attribute_it_should_only_return_the_applicable_properties()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForPropertySelectorWithNonInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<PropertyInfo> properties = type.Properties().ThatAreDecoratedWith<DummyPropertyNonInheritableAttributeAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            properties.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void When_selecting_properties_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_properties()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForPropertySelectorWithNonInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<PropertyInfo> properties = type.Properties().ThatAreDecoratedWithOrInherit<DummyPropertyNonInheritableAttributeAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            properties.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void When_selecting_properties_not_decorated_with_a_noninheritable_attribute_it_should_only_return_the_applicable_properties()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForPropertySelectorWithNonInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<PropertyInfo> properties = type.Properties().ThatAreNotDecoratedWith<DummyPropertyNonInheritableAttributeAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            properties.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void When_selecting_properties_not_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_properties()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(TestClassForPropertySelectorWithNonInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<PropertyInfo> properties = type.Properties().ThatAreNotDecoratedWithOrInherit<DummyPropertyNonInheritableAttributeAttribute>().ToArray();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            properties.Should().ContainSingle();
+        }
     }
 
     #region Internal classes used in unit tests
@@ -179,7 +331,44 @@ namespace FluentAssertions.Specs
         private int PrivateIntProperty { get; set; }
     }
 
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
+    internal class TestClassForPropertySelectorWithInheritableAttribute
+    {
+        [DummyProperty]
+        public virtual string PublicVirtualStringPropertyWithAttribute { get; set; }
+    }
+
+    internal class TestClassForPropertySelectorWithNonInheritableAttribute
+    {
+        [DummyPropertyNonInheritableAttribute]
+        public virtual string PublicVirtualStringPropertyWithAttribute { get; set; }
+    }
+
+    internal class TestClassForPropertySelectorWithInheritableAttributeDerived : TestClassForPropertySelectorWithInheritableAttribute
+    {
+        public override string PublicVirtualStringPropertyWithAttribute { get; set; }
+    }
+
+    internal class TestClassForPropertySelectorWithNonInheritableAttributeDerived : TestClassForPropertySelectorWithNonInheritableAttribute
+    {
+        public override string PublicVirtualStringPropertyWithAttribute { get; set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+    public class DummyPropertyNonInheritableAttributeAttribute : Attribute
+    {
+        public DummyPropertyNonInheritableAttributeAttribute()
+        {
+        }
+
+        public DummyPropertyNonInheritableAttributeAttribute(string value)
+        {
+            Value = value;
+        }
+
+        public string Value { get; private set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true, Inherited = true)]
     public class DummyPropertyAttribute : Attribute
     {
         public DummyPropertyAttribute()

--- a/Tests/Shared.Specs/TypeSelectorSpecs.cs
+++ b/Tests/Shared.Specs/TypeSelectorSpecs.cs
@@ -79,7 +79,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             types.Should()
-                .HaveCount(8);
+                .HaveCount(12);
         }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             types.ToArray().Should()
-                .HaveCount(8);
+                .HaveCount(12);
         }
 
         [Fact]
@@ -147,7 +147,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             types.Should()
-                .HaveCount(6);
+                .HaveCount(10);
         }
 
         [Fact]
@@ -339,6 +339,158 @@ namespace FluentAssertions.Specs
                 .ContainSingle()
                     .Which.Should().Be(type);
         }
+
+        [Fact]
+        public void When_selecting_types_decorated_with_an_inheritable_attribute_it_should_only_return_the_applicable_types()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(ClassWithSomeAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<Type> types = type.Types().ThatAreDecoratedWith<SomeAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            types.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void When_selecting_types_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_types()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(ClassWithSomeAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<Type> types = type.Types().ThatAreDecoratedWithOrInherit<SomeAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            types.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void When_selecting_types_not_decorated_with_an_inheritable_attribute_it_should_only_return_the_applicable_types()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(ClassWithSomeAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<Type> types = type.Types().ThatAreNotDecoratedWith<SomeAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            types.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void When_selecting_types_not_decorated_with_or_inheriting_an_inheritable_attribute_it_should_only_return_the_applicable_types()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(ClassWithSomeAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<Type> types = type.Types().ThatAreNotDecoratedWithOrInherit<SomeAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            types.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void When_selecting_types_decorated_with_a_noninheritable_attribute_it_should_only_return_the_applicable_types()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(ClassWithSomeNonInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<Type> types = type.Types().ThatAreDecoratedWith<SomeAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            types.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void When_selecting_types_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_types()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(ClassWithSomeNonInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<Type> types = type.Types().ThatAreDecoratedWithOrInherit<SomeAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            types.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void When_selecting_types_not_decorated_with_a_noninheritable_attribute_it_should_only_return_the_applicable_types()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(ClassWithSomeNonInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<Type> types = type.Types().ThatAreNotDecoratedWith<SomeAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            types.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void When_selecting_types_not_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_types()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            Type type = typeof(ClassWithSomeNonInheritableAttributeDerived);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            IEnumerable<Type> types = type.Types().ThatAreNotDecoratedWithOrInherit<SomeAttribute>();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            types.Should().ContainSingle();
+        }
     }
 }
 
@@ -371,8 +523,13 @@ namespace Internal.Main.Test
     {
     }
 
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, Inherited = true)]
     internal class SomeAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    internal class SomeNonInheritableAttribute : Attribute
     {
     }
 
@@ -384,6 +541,24 @@ namespace Internal.Main.Test
         public void Method1()
         {
         }
+    }
+
+    internal class ClassWithSomeAttributeDerived : ClassWithSomeAttribute
+    {
+    }
+
+    [SomeNonInheritable]
+    internal class ClassWithSomeNonInheritableAttribute
+    {
+        public string Property1 { get; set; }
+
+        public void Method1()
+        {
+        }
+    }
+
+    internal class ClassWithSomeNonInheritableAttributeDerived : ClassWithSomeNonInheritableAttribute
+    {
     }
 
     [Some]


### PR DESCRIPTION
This PR adds new selector for type, property and method selectors in order to align the API with the new assertions introduced in #727 .

`CustomAttributes.GetCustomAttributes(property, true)` is used instead of `property.GetCustomAttributes(true)` to workaround a bug in [corefx](https://github.com/dotnet/corefx/issues/8220) where `PropertyInfo` ignores the `inherit` parameter when overriding `GetCustomAttributes(bool inherit)`.