### PR TITLE
Fix substitution of contextual tags

### DIFF
--- a/Src/FluentAssertions/Execution/MessageBuilder.cs
+++ b/Src/FluentAssertions/Execution/MessageBuilder.cs
@@ -72,7 +72,7 @@ namespace FluentAssertions.Execution
 
         private string SubstituteContextualTags(string message, ContextDataItems contextData)
         {
-            string pattern = @"[^\{]\{(?<key>[a-z|A-Z]+)(?:\:(?<default>[a-z|A-Z|\s]+))?\}";
+            string pattern = @"(?<!\{)\{(?<key>[a-z|A-Z]+)(?:\:(?<default>[a-z|A-Z|\s]+))?\}(?!\})";
 
             return Regex.Replace(message, pattern, match =>
             {

--- a/Tests/Shared.Specs/AssertionScopeSpecs.cs
+++ b/Tests/Shared.Specs/AssertionScopeSpecs.cs
@@ -250,5 +250,52 @@ namespace FluentAssertions.Specs
             act.Should().ThrowExactly<XunitException>()
                 .WithMessage("*empty*");
         }
+
+        [Fact]
+        public void When_message_starts_with_single_braces_they_should_be_replaced_with_context()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var scope = new AssertionScope();
+            scope.AddReportable("MyKey", "MyValue");
+
+            AssertionScope.Current.FailWith("{MyKey}");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = scope.Dispose;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().ThrowExactly<XunitException>()
+                .WithMessage("*MyValue*");
+        }
+
+        [Fact]
+        public void When_message_starts_with_two_single_braces_they_should_be_replaced_with_context()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var scope = new AssertionScope();
+            scope.AddReportable("SomeKey", "SomeValue");
+            scope.AddReportable("AnotherKey", "AnotherValue");
+
+            AssertionScope.Current.FailWith("{SomeKey}{AnotherKey}");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = scope.Dispose;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().ThrowExactly<XunitException>()
+                .WithMessage("*SomeValue*AnotherValue*");
+        }
     }
 }


### PR DESCRIPTION
I noticed that my changes in #715 were overwritten by #705.

That turned out to be a blessing in disguise, as my previous PR was wrong.
(The last `\}` in the regex was `\{` ).

Now I've done it right and added more tests.

I assume this is a corner case, so no pressure from me to get it pushed out.