### PR TITLE
add a target for .net 4.7 that doesn't include ValueTuple fix #757

### DIFF
--- a/Src/FluentAssertions.nuspec
+++ b/Src/FluentAssertions.nuspec
@@ -29,6 +29,8 @@
       <frameworkAssembly assemblyName="System.Xml.Linq" targetFramework="net45" />
     </frameworkAssemblies>
     <dependencies>
+      <group targetFramework="net47">
+      </group>
       <group targetFramework="net45">
         <dependency id="System.ValueTuple" version="4.3.0" />
       </group>
@@ -52,6 +54,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="..\Artifacts\Release\net47\*.*"  target="lib\net47" />
     <file src="..\Artifacts\Release\net45\*.*"  target="lib\net45" exclude="**\System.*" />
     <file src="..\Artifacts\Release\netstandard1.4\FluentAssertions.*" exclude="**\*.json" target="lib\netstandard1.4" />
     <file src="..\Artifacts\Release\netstandard1.6\FluentAssertions*.*" exclude="**\*.json" target="lib\netstandard1.6" />

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -14,7 +14,7 @@ namespace FluentAssertions
     public static class CallerIdentifier
     {
         public static Action<string>  logger = str => {};
-#if NET45 || NETSTANDARD2_0
+#if NET45 || NET47 || NETSTANDARD2_0
         public static string DetermineCallerIdentity()
         {
             string caller = null;

--- a/Src/FluentAssertions/Common/AppSettingsConfigurationStore.cs
+++ b/Src/FluentAssertions/Common/AppSettingsConfigurationStore.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NETSTANDARD2_0
+﻿#if NET45 || NET47 || NETSTANDARD2_0
 
 using System.Configuration;
 

--- a/Src/FluentAssertions/Common/FullFrameworkReflector.cs
+++ b/Src/FluentAssertions/Common/FullFrameworkReflector.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NETSTANDARD2_0
+﻿#if NET45 || NET47 || NETSTANDARD2_0
 
 using System;
 using System.Collections.Generic;

--- a/Src/FluentAssertions/Common/Services.cs
+++ b/Src/FluentAssertions/Common/Services.cs
@@ -66,7 +66,7 @@ namespace FluentAssertions.Common
 
         public static void ResetToDefaults()
         {
-#if NET45 || NETSTANDARD2_0
+#if NET45 || NET47 || NETSTANDARD2_0
             reflector = new FullFrameworkReflector();
             configurationStore = new AppSettingsConfigurationStore();
 #elif NETSTANDARD1_6

--- a/Src/FluentAssertions/Execution/AssertionFailedException.cs
+++ b/Src/FluentAssertions/Execution/AssertionFailedException.cs
@@ -1,6 +1,6 @@
 using System;
 
-#if NET45 || NETSTANDARD2_0
+#if NET45 || NET47 || NETSTANDARD2_0
 using System.Runtime.Serialization;
 #endif
 
@@ -9,7 +9,7 @@ namespace FluentAssertions.Execution
     /// <summary>
     /// Represents the default exception in case no test framework is configured.
     /// </summary>
-#if NET45 || NETSTANDARD2_0
+#if NET45 || NET47 || NETSTANDARD2_0
     [Serializable]
 #endif
 
@@ -19,7 +19,7 @@ namespace FluentAssertions.Execution
         {
         }
 
-#if NET45 || NETSTANDARD2_0
+#if NET45 || NET47 || NETSTANDARD2_0
         protected AssertionFailedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/Src/FluentAssertions/Execution/GallioTestFramework.cs
+++ b/Src/FluentAssertions/Execution/GallioTestFramework.cs
@@ -60,7 +60,7 @@ namespace FluentAssertions.Execution
             get
             {
 
-#if !NET45
+#if !NET45 && !NET47
                 // For CoreCLR, we need to attempt to load the assembly
                 try
                 {

--- a/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
+++ b/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
@@ -32,7 +32,7 @@ namespace FluentAssertions.Execution
             get
             {
 
-#if !NET45
+#if !NET45 && !NET47
                 // For CoreCLR, we need to attempt to load the assembly
                 try
                 {

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.4;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net47;netstandard1.4;netstandard1.6;netstandard2.0</TargetFrameworks>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>FluentAssertions.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -10,6 +10,9 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
     <DefineConstants>NET45</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net47'">
+    <DefineConstants>NET47</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\..\Artifacts\Debug\</OutputPath>
@@ -37,6 +40,10 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+    <Reference Include="System.Configuration">
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
     <Reference Include="System.Configuration">
     </Reference>
   </ItemGroup>

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Formatting
 
         private static readonly List<IValueFormatter> defaultFormatters = new List<IValueFormatter>
         {
-#if NET45 || NETSTANDARD2_0
+#if NET45 || NET47 || NETSTANDARD2_0
             new XmlNodeFormatter(),
 #endif
             new AttributeBasedFormatter(),

--- a/Src/FluentAssertions/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ObjectAssertionsExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NETSTANDARD2_0
+﻿#if NET45 || NET47 || NETSTANDARD2_0
 
 using System;
 using System.IO;

--- a/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Reflection
             Subject = assembly;
         }
 
-#if NET45 || NETSTANDARD2_0 // TODO :: Should be able to remove based on: https://github.com/dotnet/corefx/issues/1784#issuecomment-218803619
+#if NET45 || NET47 || NETSTANDARD2_0 // TODO :: Should be able to remove based on: https://github.com/dotnet/corefx/issues/1784#issuecomment-218803619
 
         /// <summary>
         /// Asserts that an assembly does not reference the specified assembly.

--- a/Src/FluentAssertions/Xml/XmlAssertionExtensions.cs
+++ b/Src/FluentAssertions/Xml/XmlAssertionExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NETSTANDARD2_0
+﻿#if NET45 || NET47 || NETSTANDARD2_0
 
 using FluentAssertions.Xml;
 using System.Diagnostics;

--- a/Src/FluentAssertions/Xml/XmlElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XmlElementAssertions.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NETSTANDARD2_0
+﻿#if NET45 || NET47 || NETSTANDARD2_0
 
 using FluentAssertions.Common;
 using FluentAssertions.Execution;

--- a/Src/FluentAssertions/Xml/XmlNodeAssertions.cs
+++ b/Src/FluentAssertions/Xml/XmlNodeAssertions.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NETSTANDARD2_0
+﻿#if NET45 || NET47 || NETSTANDARD2_0
 
 using System.Diagnostics;
 using System.Xml;

--- a/Src/FluentAssertions/Xml/XmlNodeAssertionsofTSubjectTAssertions.cs
+++ b/Src/FluentAssertions/Xml/XmlNodeAssertionsofTSubjectTAssertions.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NETSTANDARD2_0
+﻿#if NET45 || NET47 || NETSTANDARD2_0
 
 using FluentAssertions.Primitives;
 using System.Diagnostics;

--- a/Src/FluentAssertions/Xml/XmlNodeFormatter.cs
+++ b/Src/FluentAssertions/Xml/XmlNodeFormatter.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NETSTANDARD2_0
+﻿#if NET45 || NET47 || NETSTANDARD2_0
 
 using FluentAssertions.Common;
 using FluentAssertions.Formatting;


### PR DESCRIPTION
I hope this is the right way to do this. I did build using the script and it changed all the assembly info files - not sure if I was supposed to include those in this pull request - can do if necessary