### PR TITLE
Fixes a FormatException when a bad string is included in the 'because' clause

### DIFF
--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -115,18 +115,26 @@ namespace FluentAssertions.Execution
         /// <param name="because">
         /// A formatted phrase compatible with <see cref="string.Format(string,object[])"/> explaining why 
         /// the condition should be satisfied. If the phrase does not start with the word <i>because</i>, 
-        /// it is prepended to the message. 
+        /// it is prepended to the message. If the format of <paramref name="because"/> or 
+        /// <paramref name="becauseArgs"/> is not compatible with <see cref="string.Format(string,object[])"/>,
+        /// then a warning message is returned instead.
         /// </param>
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        /// <exception cref="System.FormatException">
-        /// Thrown if the format of <paramref name="because"/> or <paramref name="becauseArgs"/> is not 
-        /// compatible with <see cref="string.Format(string,object[])"/>.
-        /// </exception>
         public AssertionScope BecauseOf(string because, params object[] becauseArgs)
         {
-            reason = () => string.Format(because ?? "", becauseArgs ?? new object[0]);
+            reason = () =>
+            {
+                try
+                {
+                    return string.Format(because ?? "", becauseArgs ?? new object[0]);
+                }
+                catch (FormatException formatException)
+                {
+                    return $"**WARNING** because message '{because}' could not be formatted with string.Format{Environment.NewLine}{formatException.StackTrace}";
+                }
+            };
             return this;
         }
 

--- a/Tests/Shared.Specs/AssertionScopeSpecs.cs
+++ b/Tests/Shared.Specs/AssertionScopeSpecs.cs
@@ -193,6 +193,21 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_invalid_format_is_used_in_because_parameter_it_should_render_default_text()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => 1.Should().Be(2, "use of {} is considered invalid in because parameter");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("*because message 'use of {} is considered invalid in because parameter' could not be formatted with string.Format*");
+        }
+
+        [Fact]
         public void When_an_assertion_fails_in_a_scope_with_braces_it_should_use_the_name_as_the_assertion_context()
         {
             //-----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## IMPORTANT 
SINCE FLUENT ASSERTIONS IS CURRENTLY UNDER HEAVY REFACTORING FOR [VERSION 5.0](https://github.com/fluentassertions/fluentassertions/issues/463), WE CURRENTLY ONLY ACCEPT BUGFIX REQUESTS. SORRY FOR THE INCONVENIENCE

* [ ] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [ ] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/)/.
* [ ] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).

Fixes #756.

