### PR TITLE
Improve message for unequal length collections in BeEquivalentTo

### DIFF
--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -30,7 +31,7 @@ namespace FluentAssertions.Equivalency
 
         public void Execute<T>(object[] subject, T[] expectation)
         {
-            if (AssertIsNotNull(expectation, subject) && AssertLengthEquality(subject.Length, expectation.Length))
+            if (AssertIsNotNull(expectation, subject) && EnumerableEquivalencyValidatorExtensions.AssertCollectionsHaveSameCount(subject, expectation))
             {
                 if (Recursive)
                 {
@@ -54,14 +55,6 @@ namespace FluentAssertions.Equivalency
             return AssertionScope.Current
                 .ForCondition(!ReferenceEquals(expectation, null))
                 .FailWith("Expected {context:subject} to be <null>, but found {0}.", new object[]{ subject});
-        }
-
-        private bool AssertLengthEquality(int subjectLength, int expectationLength)
-        {
-            return AssertionScope.Current
-                .ForCondition(subjectLength == expectationLength)
-                .FailWith("Expected {context:subject} to be a collection with {0} item(s){reason}, but found {1}.",
-                    expectationLength, subjectLength);
         }
 
         private void AssertElementGraphEquivalency<T>(object[] subjects, T[] expectations)

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidatorExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidatorExtensions.cs
@@ -1,0 +1,55 @@
+using System;
+
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Equivalency
+{
+    internal static class EnumerableEquivalencyValidatorExtensions
+    {
+        public static Continuation AssertCollectionsHaveSameCount<T>(object[] subject, T[] expectation)
+        {
+            return AssertionScope.Current
+                .WithExpectation("Expected {context:subject} to be a collection with {0} item(s){reason}", expectation.Length)
+                .AssertEitherCollectionIsNotEmpty(subject, expectation)
+                .Then
+                .AssertCollectionHasEnoughItems(subject, expectation)
+                .Then
+                .AssertCollectionHasNotTooManyItems(subject, expectation);
+        }
+
+        public static Continuation AssertEitherCollectionIsNotEmpty<T>(this AssertionScope scope, object[] subject, T[] expectation)
+        {
+            return scope
+                .ForCondition((subject.Length > 0) || (expectation.Length == 0))
+                .FailWith(", but found an empty collection.")
+                .Then
+                .ForCondition((subject.Length == 0) || (expectation.Length > 0))
+                .FailWith(", but {0}{2}contains {1} item(s).",
+                    subject,
+                    subject.Length,
+                    Environment.NewLine);
+        }
+
+        public static Continuation AssertCollectionHasEnoughItems<T>(this AssertionScope scope, object[] subject, T[] expectation)
+        {
+            return scope
+                .ForCondition(subject.Length >= expectation.Length)
+                .FailWith(", but {0}{3}contains {1} item(s) less than{3}{2}.",
+                    subject,
+                    expectation.Length - subject.Length,
+                    expectation,
+                    Environment.NewLine);
+        }
+
+        public static Continuation AssertCollectionHasNotTooManyItems<T>(this AssertionScope scope, object[] subject, T[] expectation)
+        {
+            return scope
+                .ForCondition(subject.Length <= expectation.Length)
+                .FailWith(", but {0}{3}contains {1} item(s) more than{3}{2}.",
+                    subject,
+                    subject.Length - expectation.Length,
+                    expectation,
+                    Environment.NewLine);
+        }
+    }
+}

--- a/Tests/Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/CollectionAssertionSpecs.cs
@@ -1847,7 +1847,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected*collection*2 item(s)*we treat all alike, but found 3*");
+                "Expected*collection*2 item(s)*we treat all alike, but *1 item(s) more than*");
         }
 
         [Fact]
@@ -1889,7 +1889,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject to be a collection with 0 item(s), but found 3*");
+                "Expected subject to be a collection with 0 item(s), but*contains 3 item(s)*");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
@@ -201,6 +201,28 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_a_collection_does_not_match_it_should_include_items_in_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new int[] { 1, 2 };
+
+            var expectation = new int[] { 3, 2, 1 };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => subject.Should().BeEquivalentTo(expectation);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected*but*{1, 2}*1 item(s) less than*{3, 2, 1}*");
+        }
+
+        [Fact]
         public void
             When_a_collection_contains_a_reference_to_an_object_that_is_also_in_its_parent_it_should_not_be_treated_as_a_cyclic_reference
             ()
@@ -297,7 +319,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "*member Customers to be a collection with 2 item(s), but found 1*");
+                    "*member Customers to be a collection with 2 item(s), but*contains 1 item(s) less than*");
         }
 
         [Fact]
@@ -350,7 +372,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "*member Customers to be a collection with 1 item(s), but found 2*");
+                    "*member Customers to be a collection with 1 item(s), but*contains 1 item(s) more than*");
         }
 
         [Fact]
@@ -825,7 +847,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>()
-                .WithMessage("*Expected item[0].UnorderedCollection*5 item(s)*0*");
+                .WithMessage("*Expected item[0].UnorderedCollection*5 item(s)*empty collection*");
         }
 
         [Fact]
@@ -877,7 +899,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "*Expected item[0].UnorderedCollection*5 item(s)*0*");
+                    "*Expected item[0].UnorderedCollection*5 item(s)*empty collection*");
         }
 
         [Fact]
@@ -1331,7 +1353,7 @@ namespace FluentAssertions.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*29*but found 6*");
+                .WithMessage("Expected*29*but*contains 23 item(s) less than*");
         }
 
         [Fact]
@@ -1448,9 +1470,9 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
 #if NETCOREAPP1_1
-                .WithMessage("Expected subject*2 item(s)*but found 6*");
+                .WithMessage("Expected subject*2 item(s)*but*contains 4 item(s) more than*");
 #else
-                .WithMessage("Expected actual*2 item(s)*but found 6*");
+                .WithMessage("Expected actual*2 item(s)*but*contains 4 item(s) more than*");
 #endif
         }
 
@@ -1597,7 +1619,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "*subject to be a collection with 2 item(s), but found 1*");
+                    "*subject to be a collection with 2 item(s), but*contains 1 item(s) less than*");
         }
 
         [Fact]
@@ -1645,7 +1667,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected subject to be a collection with 1 item(s), but found 2*");
+                    "Expected subject to be a collection with 1 item(s), but*contains 1 item(s) more than*");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
@@ -1738,7 +1738,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject to be a collection with 0 item(s), but found 3*");
+                "Expected subject to be a collection with 0 item(s), but*contains 3 item(s)*");
         }
 
         [Fact]


### PR DESCRIPTION
This PR improves the failure message when collections fail in `BeEquivalentTo` due to unequal length.
Before the failure message would only state the number of found items.
The failure message now includes:
* subject collection,
* expected collection,
* the difference in length, 
* and whether the subject had too many or too few items.