### PR TITLE
Only attempt to format in BecauseOf if format parameters were supplied

### DIFF
--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -128,7 +128,8 @@ namespace FluentAssertions.Execution
             {
                 try
                 {
-                    return string.Format(because ?? "", becauseArgs ?? new object[0]);
+                    string becauseOrEmpty = because ?? "";
+                    return becauseArgs.Any() ? string.Format(becauseOrEmpty, becauseArgs) : becauseOrEmpty;
                 }
                 catch (FormatException formatException)
                 {

--- a/Tests/Shared.Specs/AssertionScopeSpecs.cs
+++ b/Tests/Shared.Specs/AssertionScopeSpecs.cs
@@ -193,18 +193,33 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_invalid_format_is_used_in_because_parameter_it_should_render_default_text()
+        public void When_invalid_format_is_used_in_because_parameter_without_becauseArgs_it_should_still_render_reason_correctly()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => 1.Should().Be(2, "use of {} is considered invalid in because parameter");
+        Action act = () => 1.Should().Be(2, "use of {} is okay if there are no because parameters");
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
-                .WithMessage("*because message 'use of {} is considered invalid in because parameter' could not be formatted with string.Format*");
+                .WithMessage("*because use of {} is okay if there are no because parameters*");
+        }
+
+        [Fact]
+        public void When_invalid_format_is_used_in_because_parameter_along_with_becauseArgs_it_should_render_default_text()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => 1.Should().Be(2, "use of {} is considered invalid in because parameter with becauseArgs", "additional becauseArgs parameter");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("*because message 'use of {} is considered invalid in because parameter with becauseArgs' could not be formatted with string.Format*");
         }
 
         [Fact]


### PR DESCRIPTION
This is admittedly a minor case, but we should only trigger the `FormatException`/warning message from attempting to use the `because` parameter in `string.Format` if we also include `becauseArgs`.