### PR TITLE
Do not assume test classes to be inside a namespace

### DIFF
--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -53,7 +53,7 @@ namespace FluentAssertions
         private static bool IsDotNet(StackFrame frame)
         {
             return frame.GetMethod().DeclaringType.Namespace
-                .StartsWith("system", StringComparison.InvariantCultureIgnoreCase);
+                ?.StartsWith("system", StringComparison.InvariantCultureIgnoreCase) == true;
         }
 
         private static string ExtractVariableNameFrom(StackFrame frame)

--- a/Tests/Shared.Specs/AssertionScopeSpecs.cs
+++ b/Tests/Shared.Specs/AssertionScopeSpecs.cs
@@ -1,9 +1,44 @@
 using System;
 using System.Text.RegularExpressions;
 
+using FluentAssertions;
 using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
+
+public class AssertionScopeSpecsWithoutNamespace
+{
+#if NET45 || NET47 || NETCOREAPP2_0
+    [Fact]
+    public void This_class_should_not_be_inside_a_namespace()
+    {
+        //-----------------------------------------------------------------------------------------------------------
+        // Arrange
+        //-----------------------------------------------------------------------------------------------------------
+        Type type = typeof(AssertionScopeSpecsWithoutNamespace);
+
+        //-----------------------------------------------------------------------------------------------------------
+        // Act / Assert
+        //-----------------------------------------------------------------------------------------------------------
+        type.Assembly.Should().DefineType(null, type.Name, "this class should not be inside a namespace");
+    }
+#endif
+
+    [Fact]
+    public void When_the_test_method_is_not_inside_a_namespace_it_should_not_throw_a_NullReferenceException()
+    {
+        //-----------------------------------------------------------------------------------------------------------
+        // Act
+        //-----------------------------------------------------------------------------------------------------------
+        Action act = () => 1.Should().Be(2, "we don't want a NullReferenceException");
+
+        //-----------------------------------------------------------------------------------------------------------
+        // Assert
+        //-----------------------------------------------------------------------------------------------------------
+        act.Should().ThrowExactly<XunitException>()
+            .WithMessage("*we don't want a NullReferenceException*");
+    }
+}
 
 namespace FluentAssertions.Specs
 {


### PR DESCRIPTION
This PR fixes a NullReferenceException, when the declaring type of a test method is not inside a namespace.

This fixes #772 