### PR TITLE
Test that nullable enums are catched by ObjectAssertions

### DIFF
--- a/Tests/Shared.Specs/NullableEnumAssertionSpecs.cs
+++ b/Tests/Shared.Specs/NullableEnumAssertionSpecs.cs
@@ -1,0 +1,27 @@
+﻿using Xunit;
+
+namespace FluentAssertions.Specs
+{
+    public enum MyEnum
+    {
+        Dummy,
+    }
+
+    public class NullableEnumAssertionSpecs
+    {
+        [Fact]
+        public void When_a_nullable_enum_is_asserted_on_is_should_use_object_assertions()
+        {
+            // Arrange
+            MyEnum? myEnum = MyEnum.Dummy;
+            string expectedAssertionType = "FluentAssertions.Primitives.ObjectAssertions";
+
+            // Act
+            string assertionType = myEnum.Should().GetType().FullName;
+
+            // Assert
+            assertionType.Should().Be(expectedAssertionType,
+                "it is a breaking change, if nullable enums do not end up in ObjectAssertions");
+        }
+    }
+}

--- a/Tests/Shared.Specs/Shared.Specs.projitems
+++ b/Tests/Shared.Specs/Shared.Specs.projitems
@@ -26,6 +26,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DateTimeOffsetValueFormatterSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BasicEquivalencySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DictionaryEquivalencySpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NullableEnumAssertionSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EnumAssertionSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EventAssertionSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExceptionAssertionSpecs.cs" />


### PR DESCRIPTION
A regression test to ensure that "someone" does not break the API again regarding nullable enums.