### PR TITLE
Nullable properties of type `IEnumerable` should still be treated as enumerables

### DIFF
--- a/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptionsExtentions.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptionsExtentions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Linq;
+using System.Reflection;
 
 namespace FluentAssertions.Equivalency
 {
@@ -7,9 +9,24 @@ namespace FluentAssertions.Equivalency
         /// <summary>
         ///     Returns either the run-time or compile-time type of the subject based on the options provided by the caller.
         /// </summary>
+        /// <remarks>
+        /// If the expectation is a nullable type, it should return the type of the wrapped object.
+        /// </remarks>
         public static Type GetExpectationType(this IEquivalencyAssertionOptions config, IMemberInfo context)
         {
-            return config.UseRuntimeTyping ? context.RuntimeType : context.CompileTimeType;
+            Type type = config.UseRuntimeTyping ? context.RuntimeType : context.CompileTimeType;
+
+            return NullableOrActualType(type);;
+        }
+
+        private static Type NullableOrActualType(Type type)
+        {
+            if (type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                type = type.GetGenericArguments().First();
+            }
+
+            return type;
         }
     }
 }

--- a/Tests/Net45.Specs/Net45.Specs.csproj
+++ b/Tests/Net45.Specs/Net45.Specs.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Chill" Version="3.0.1.0" />
     <PackageReference Include="FakeItEasy" Version="3.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />

--- a/Tests/Net47.Specs/Net47.Specs.csproj
+++ b/Tests/Net47.Specs/Net47.Specs.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Chill" Version="3.0.1.0" />
     <PackageReference Include="FakeItEasy" Version="3.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />

--- a/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Linq;
 using FluentAssertions.Common;
@@ -178,8 +179,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void
-            When_a_byte_array_does_not_match_strictly_it_should_throw()
+        public void When_a_byte_array_does_not_match_strictly_it_should_throw()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -220,6 +220,31 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected*but*{1, 2}*1 item(s) less than*{3, 2, 1}*");
+        }
+
+        [Fact]
+        public void When_a_nullable_collection_does_not_match_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = new
+            {
+                Values = (ImmutableArray<int>?) ImmutableArray.Create<int>(1, 2, 3)
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.Should().BeEquivalentTo(new
+            {
+                Values = (ImmutableArray<int>?) ImmutableArray.Create<int>(1, 2, 4)
+            });
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>().WithMessage("Expected member Values[2] to be 4, but found 3*");
         }
 
         [Fact]


### PR DESCRIPTION
The `EnumerableEquivalencyStep` did not treat the expectation as an enumerable when the property type was a `Nullable<T>`. 

Fixes #777

