### PR TITLE
(Not)Be(Abstract|Sealed|Static) class assertions implemented

### DIFF
--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -289,6 +289,39 @@ namespace FluentAssertions.Common
             return getMethod != null && !getMethod.IsPrivate && !getMethod.IsFamily;
         }
 
+        /// <summary>
+        /// Check if the type is declared as abstract. 
+        /// </summary>
+        /// <param name="type">Type to be checked</param>
+        /// <returns></returns>
+        public static bool IsCSharpAbstract(this Type type)
+        {
+            var typeInfo = type.GetTypeInfo();
+            return typeInfo.IsAbstract && !typeInfo.IsSealed;
+        }
+
+        /// <summary>
+        /// Check if the type is declared as sealed. 
+        /// </summary>
+        /// <param name="type">Type to be checked</param>
+        /// <returns></returns>
+        public static bool IsCSharpSealed(this Type type)
+        {
+            var typeInfo = type.GetTypeInfo();
+            return typeInfo.IsSealed && !typeInfo.IsAbstract;
+        }
+
+        /// <summary>
+        /// Check if the type is declared as static. 
+        /// </summary>
+        /// <param name="type">Type to be checked</param>
+        /// <returns></returns>
+        public static bool IsCSharpStatic(this Type type)
+        {
+            var typeInfo = type.GetTypeInfo();
+            return typeInfo.IsSealed && typeInfo.IsAbstract;
+        }
+
         public static MethodInfo GetMethod(this Type type, string methodName, IEnumerable<Type> parameterTypes)
         {
             return type.GetMethods(AllMembersFlag)

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -531,6 +531,8 @@ namespace FluentAssertions.Types
         /// <returns></returns>
         public AndConstraint<TypeAssertions> BeSealed(string because = "", params object[] becauseArgs)
         {
+            AssertThatSubjectIsClass();
+
             Execute.Assertion
                 .ForCondition(Subject.IsCSharpSealed())
                 .BecauseOf(because, becauseArgs)
@@ -548,6 +550,8 @@ namespace FluentAssertions.Types
         /// <returns></returns>
         public AndConstraint<TypeAssertions> NotBeSealed(string because = "", params object[] becauseArgs)
         {
+            AssertThatSubjectIsClass();
+
             Execute.Assertion
                 .ForCondition(!Subject.IsCSharpSealed())
                 .BecauseOf(because, becauseArgs)
@@ -565,6 +569,8 @@ namespace FluentAssertions.Types
         /// <returns></returns>
         public AndConstraint<TypeAssertions> BeAbstract(string because = "", params object[] becauseArgs)
         {
+            AssertThatSubjectIsClass();
+
             Execute.Assertion
                 .ForCondition(Subject.IsCSharpAbstract())
                 .BecauseOf(because, becauseArgs)
@@ -582,6 +588,8 @@ namespace FluentAssertions.Types
         /// <returns></returns>
         public AndConstraint<TypeAssertions> NotBeAbstract(string because = "", params object[] becauseArgs)
         {
+            AssertThatSubjectIsClass();
+
             Execute.Assertion
                 .ForCondition(!Subject.IsCSharpAbstract())
                 .BecauseOf(because, becauseArgs)
@@ -599,6 +607,8 @@ namespace FluentAssertions.Types
         /// <returns></returns>
         public AndConstraint<TypeAssertions> BeStatic(string because = "", params object[] becauseArgs)
         {
+            AssertThatSubjectIsClass();
+
             Execute.Assertion
                 .ForCondition(Subject.IsCSharpStatic())
                 .BecauseOf(because, becauseArgs)
@@ -616,6 +626,8 @@ namespace FluentAssertions.Types
         /// <returns></returns>
         public AndConstraint<TypeAssertions> NotBeStatic(string because = "", params object[] becauseArgs)
         {
+            AssertThatSubjectIsClass();
+
             Execute.Assertion
                 .ForCondition(!Subject.IsCSharpStatic())
                 .BecauseOf(because, becauseArgs)
@@ -1203,6 +1215,15 @@ namespace FluentAssertions.Types
         protected override string Identifier
         {
             get { return "type"; }
+        }
+
+        private void AssertThatSubjectIsClass()
+        {
+            var typeInfo = Subject.GetTypeInfo();
+            if (typeInfo.IsInterface || typeInfo.IsValueType || typeof(Delegate).IsAssignableFrom(typeInfo.BaseType))
+            {
+               throw new ArgumentException($"{Subject} must be a class.");
+            }
         }
     }
 }

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -551,7 +551,7 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .ForCondition(!Subject.IsCSharpSealed())
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected type {0} to not be sealed{reason}.", Subject);
+                .FailWith("Expected type {0} not to be sealed{reason}.", Subject);
 
             return new AndConstraint<TypeAssertions>(this);
         }

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -523,6 +523,108 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
+        /// Asserts that the current <see cref="System.Type"/> is sealed.
+        /// </summary>
+        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <returns></returns>
+        public AndConstraint<TypeAssertions> BeSealed(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(Subject.IsCSharpSealed())
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected type {0} to be sealed{reason}.", Subject);
+
+            return new AndConstraint<TypeAssertions>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="System.Type"/> is not sealed.
+        /// </summary>
+        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <returns></returns>
+        public AndConstraint<TypeAssertions> NotBeSealed(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(!Subject.IsCSharpSealed())
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected type {0} to not be sealed{reason}.", Subject);
+
+            return new AndConstraint<TypeAssertions>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="System.Type"/> is abstract.
+        /// </summary>
+        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <returns></returns>
+        public AndConstraint<TypeAssertions> BeAbstract(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(Subject.IsCSharpAbstract())
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected type {0} to be abstract{reason}.", Subject);
+
+            return new AndConstraint<TypeAssertions>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="System.Type"/> is not abstract.
+        /// </summary>
+        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <returns></returns>
+        public AndConstraint<TypeAssertions> NotBeAbstract(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(!Subject.IsCSharpAbstract())
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected type {0} not to be abstract{reason}.", Subject);
+
+            return new AndConstraint<TypeAssertions>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="System.Type"/> is static.
+        /// </summary>
+        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <returns></returns>
+        public AndConstraint<TypeAssertions> BeStatic(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(Subject.IsCSharpStatic())
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected type {0} to be static{reason}.", Subject);
+
+            return new AndConstraint<TypeAssertions>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="System.Type"/> is not static.
+        /// </summary>
+        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <returns></returns>
+        public AndConstraint<TypeAssertions> NotBeStatic(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(!Subject.IsCSharpStatic())
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected type {0} not to be static{reason}.", Subject);
+
+            return new AndConstraint<TypeAssertions>(this);
+        }
+
+        /// <summary>
         /// Asserts that the current type has a property of type <paramref name="propertyType"/> named <paramref name="name"/>.
         /// </summary>
         /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -1222,7 +1222,7 @@ namespace FluentAssertions.Types
             var typeInfo = Subject.GetTypeInfo();
             if (typeInfo.IsInterface || typeInfo.IsValueType || typeof(Delegate).IsAssignableFrom(typeInfo.BaseType))
             {
-               throw new ArgumentException($"{Subject} must be a class.");
+               throw new InvalidOperationException($"{Subject} must be a class.");
             }
         }
     }

--- a/Tests/Shared.Specs/TypeAssertionSpecs.cs
+++ b/Tests/Shared.Specs/TypeAssertionSpecs.cs
@@ -1579,6 +1579,24 @@ namespace FluentAssertions.Specs
                 .WithMessage("Expected type FluentAssertions.Specs.ClassWithoutMembers to be sealed because it's very important.");
         }
 
+        [Theory]
+        [InlineData(typeof(IDummyInterface), "FluentAssertions.Specs.IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "FluentAssertions.Specs.Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "FluentAssertions.Specs.ExampleDelegate must be a class.")]
+        public void When_type_is_not_valid_for_BeSealed_it_throws_exception(Type type, string exceptionMessage)
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange / Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().BeSealed();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<ArgumentException>()
+                .WithMessage(exceptionMessage);
+        }
+
         #endregion
 
         #region NotBeSealed
@@ -1635,6 +1653,24 @@ namespace FluentAssertions.Specs
                 .WithMessage("Expected type FluentAssertions.Specs.Sealed not to be sealed because it's very important.");
         }
 
+        [Theory]
+        [InlineData(typeof(IDummyInterface), "FluentAssertions.Specs.IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "FluentAssertions.Specs.Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "FluentAssertions.Specs.ExampleDelegate must be a class.")]
+        public void When_type_is_not_valid_for_NotBeSealed_it_throws_exception(Type type, string exceptionMessage)
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange / Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().NotBeSealed();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<ArgumentException>()
+                .WithMessage(exceptionMessage);
+        }
+
         #endregion
 
         #region BeAbstract
@@ -1684,6 +1720,24 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected type FluentAssertions.Specs.ClassWithoutMembers to be abstract because it's very important.");
+        }
+
+        [Theory]
+        [InlineData(typeof(IDummyInterface), "FluentAssertions.Specs.IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "FluentAssertions.Specs.Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "FluentAssertions.Specs.ExampleDelegate must be a class.")]
+        public void When_type_is_not_valid_for_BeAbstract_it_throws_exception(Type type, string exceptionMessage)
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange / Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().BeAbstract();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<ArgumentException>()
+                .WithMessage(exceptionMessage);
         }
 
         #endregion
@@ -1742,6 +1796,24 @@ namespace FluentAssertions.Specs
                 .WithMessage("Expected type FluentAssertions.Specs.Abstract not to be abstract because it's very important.");
         }
 
+        [Theory]
+        [InlineData(typeof(IDummyInterface), "FluentAssertions.Specs.IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "FluentAssertions.Specs.Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "FluentAssertions.Specs.ExampleDelegate must be a class.")]
+        public void When_type_is_not_valid_for_NotBeAbstract_it_throws_exception(Type type, string exceptionMessage)
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange / Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().NotBeAbstract();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<ArgumentException>()
+                .WithMessage(exceptionMessage);
+        }
+
         #endregion
 
         #region BeStatic
@@ -1791,6 +1863,24 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected type FluentAssertions.Specs.ClassWithoutMembers to be static because it's very important.");
+        }
+
+        [Theory]
+        [InlineData(typeof(IDummyInterface), "FluentAssertions.Specs.IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "FluentAssertions.Specs.Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "FluentAssertions.Specs.ExampleDelegate must be a class.")]
+        public void When_type_is_not_valid_for_BeStatic_it_throws_exception(Type type, string exceptionMessage)
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange / Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().BeStatic();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<ArgumentException>()
+                .WithMessage(exceptionMessage);
         }
 
         #endregion
@@ -1847,6 +1937,24 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected type FluentAssertions.Specs.Static not to be static because it's very important.");
+        }
+
+        [Theory]
+        [InlineData(typeof(IDummyInterface), "FluentAssertions.Specs.IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "FluentAssertions.Specs.Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "FluentAssertions.Specs.ExampleDelegate must be a class.")]
+        public void When_type_is_not_valid_for_NotBeStatic_it_throws_exception(Type type, string exceptionMessage)
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange / Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().NotBeStatic();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<ArgumentException>()
+                .WithMessage(exceptionMessage);
         }
 
         #endregion
@@ -4491,6 +4599,10 @@ namespace FluentAssertions.Specs
     internal abstract class Abstract { }
 
     internal static class Static { }
+
+    internal struct Struct { }
+
+    public delegate void ExampleDelegate();
 
     #endregion
 }

--- a/Tests/Shared.Specs/TypeAssertionSpecs.cs
+++ b/Tests/Shared.Specs/TypeAssertionSpecs.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Common;
@@ -1527,6 +1526,327 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all types to not be decorated with or inherit*DummyClassAttribute" +
                     "*because we do*attribute was found*ClassWithInheritedAttribute*");
+        }
+
+        #endregion
+
+        #region BeSealed
+
+        [Fact]
+        public void When_type_is_sealed_it_succeeds()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange / Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            typeof(Sealed).Should().BeSealed();
+        }
+
+        [Theory]
+        [InlineData(typeof(ClassWithoutMembers), "Expected type FluentAssertions.Specs.ClassWithoutMembers to be sealed.")]
+        [InlineData(typeof(Abstract), "Expected type FluentAssertions.Specs.Abstract to be sealed.")]
+        [InlineData(typeof(Static), "Expected type FluentAssertions.Specs.Static to be sealed.")]
+        public void When_type_is_not_sealed_it_fails(Type type, string exceptionMessage)
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange / Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().BeSealed();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage(exceptionMessage);
+        }
+
+        [Fact]
+        public void When_type_is_not_sealed_it_fails_with_a_meaningful_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(ClassWithoutMembers);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().BeSealed("it's {0} important", "very");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type FluentAssertions.Specs.ClassWithoutMembers to be sealed because it's very important.");
+        }
+
+        #endregion
+
+        #region NotBeSealed
+
+        [Theory]
+        [InlineData(typeof(ClassWithoutMembers))]
+        [InlineData(typeof(Abstract))]
+        [InlineData(typeof(Static))]
+        public void When_type_is_not_sealed_it_succeeds(Type type)
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange / Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            type.Should().NotBeSealed();
+        }
+
+        [Fact]
+        public void When_type_is_sealed_it_fails()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(Sealed);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().NotBeSealed();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type FluentAssertions.Specs.Sealed to not be sealed.");
+        }
+
+        [Fact]
+        public void When_type_is_sealed_it_fails_with_a_meaningful_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(Sealed);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().NotBeSealed("it's {0} important", "very");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type FluentAssertions.Specs.Sealed to not be sealed because it's very important.");
+        }
+
+        #endregion
+
+        #region BeAbstract
+
+        [Fact]
+        public void When_type_is_abstract_it_succeeds()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange / Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            typeof(Abstract).Should().BeAbstract();
+        }
+
+        [Theory]
+        [InlineData(typeof(ClassWithoutMembers), "Expected type FluentAssertions.Specs.ClassWithoutMembers to be abstract.")]
+        [InlineData(typeof(Sealed), "Expected type FluentAssertions.Specs.Sealed to be abstract.")]
+        [InlineData(typeof(Static), "Expected type FluentAssertions.Specs.Static to be abstract.")]
+        public void When_type_is_not_abstract_it_fails(Type type, string exceptionMessage)
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange / Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().BeAbstract();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage(exceptionMessage);
+        }
+
+        [Fact]
+        public void When_type_is_not_abstract_it_fails_with_a_meaningful_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(ClassWithoutMembers);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().BeAbstract("it's {0} important", "very");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type FluentAssertions.Specs.ClassWithoutMembers to be abstract because it's very important.");
+        }
+
+        #endregion
+
+        #region NotBeAbstract
+
+        [Theory]
+        [InlineData(typeof(ClassWithoutMembers))]
+        [InlineData(typeof(Sealed))]
+        [InlineData(typeof(Static))]
+        public void When_type_is_not_abstract_it_succeeds(Type type)
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange / Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            type.Should().NotBeAbstract();
+        }
+
+        [Fact]
+        public void When_type_is_abstract_it_fails()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(Abstract);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().NotBeAbstract();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type FluentAssertions.Specs.Abstract not to be abstract.");
+        }
+
+        [Fact]
+        public void When_type_is_abstract_it_fails_with_a_meaningful_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(Abstract);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().NotBeAbstract("it's {0} important", "very");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type FluentAssertions.Specs.Abstract not to be abstract because it's very important.");
+        }
+
+        #endregion
+
+        #region BeStatic
+
+        [Fact]
+        public void When_type_is_static_it_succeeds()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange / Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            typeof(Static).Should().BeStatic();
+        }
+
+        [Theory]
+        [InlineData(typeof(ClassWithoutMembers), "Expected type FluentAssertions.Specs.ClassWithoutMembers to be static.")]
+        [InlineData(typeof(Sealed), "Expected type FluentAssertions.Specs.Sealed to be static.")]
+        [InlineData(typeof(Abstract), "Expected type FluentAssertions.Specs.Abstract to be static.")]
+        public void When_type_is_not_static_it_fails(Type type, string exceptionMessage)
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange / Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().BeStatic();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage(exceptionMessage);
+        }
+
+        [Fact]
+        public void When_type_is_not_static_it_fails_with_a_meaningful_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(ClassWithoutMembers);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().BeStatic("it's {0} important", "very");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type FluentAssertions.Specs.ClassWithoutMembers to be static because it's very important.");
+        }
+
+        #endregion
+
+        #region NotBeStatic
+
+        [Theory]
+        [InlineData(typeof(ClassWithoutMembers))]
+        [InlineData(typeof(Sealed))]
+        [InlineData(typeof(Abstract))]
+        public void When_type_is_not_static_it_succeeds(Type type)
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange / Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            type.Should().NotBeStatic();
+        }
+
+        [Fact]
+        public void When_type_is_static_it_fails()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(Static);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().NotBeStatic();
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type FluentAssertions.Specs.Static not to be static.");
+        }
+
+        [Fact]
+        public void When_type_is_static_it_fails_with_a_meaningful_message()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            var type = typeof(Static);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () => type.Should().NotBeStatic("it's {0} important", "very");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type FluentAssertions.Specs.Static not to be static because it's very important.");
         }
 
         #endregion
@@ -4165,6 +4485,12 @@ namespace FluentAssertions.Specs
         public static implicit operator int(TypeWithConversionOperators typeWithConversionOperators) => typeWithConversionOperators.value;
         public static explicit operator byte(TypeWithConversionOperators typeWithConversionOperators) => (byte)typeWithConversionOperators.value;
     }
+
+    internal sealed class Sealed { }
+
+    internal abstract class Abstract { }
+
+    internal static class Static { }
 
     #endregion
 }

--- a/Tests/Shared.Specs/TypeAssertionSpecs.cs
+++ b/Tests/Shared.Specs/TypeAssertionSpecs.cs
@@ -1612,7 +1612,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.Sealed to not be sealed.");
+                .WithMessage("Expected type FluentAssertions.Specs.Sealed not to be sealed.");
         }
 
         [Fact]
@@ -1632,7 +1632,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.Sealed to not be sealed because it's very important.");
+                .WithMessage("Expected type FluentAssertions.Specs.Sealed not to be sealed because it's very important.");
         }
 
         #endregion

--- a/Tests/Shared.Specs/TypeAssertionSpecs.cs
+++ b/Tests/Shared.Specs/TypeAssertionSpecs.cs
@@ -1593,7 +1593,7 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
-            act.Should().Throw<ArgumentException>()
+            act.Should().Throw<InvalidOperationException>()
                 .WithMessage(exceptionMessage);
         }
 
@@ -1667,7 +1667,7 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
-            act.Should().Throw<ArgumentException>()
+            act.Should().Throw<InvalidOperationException>()
                 .WithMessage(exceptionMessage);
         }
 
@@ -1736,7 +1736,7 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
-            act.Should().Throw<ArgumentException>()
+            act.Should().Throw<InvalidOperationException>()
                 .WithMessage(exceptionMessage);
         }
 
@@ -1810,7 +1810,7 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
-            act.Should().Throw<ArgumentException>()
+            act.Should().Throw<InvalidOperationException>()
                 .WithMessage(exceptionMessage);
         }
 
@@ -1879,7 +1879,7 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
-            act.Should().Throw<ArgumentException>()
+            act.Should().Throw<InvalidOperationException>()
                 .WithMessage(exceptionMessage);
         }
 
@@ -1953,7 +1953,7 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
-            act.Should().Throw<ArgumentException>()
+            act.Should().Throw<InvalidOperationException>()
                 .WithMessage(exceptionMessage);
         }
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1105,6 +1105,9 @@ typeof(MyPresentationModel).Should().NotBeDecoratedWith<SomeAttribute>();
 typeof(MyPresentationModel)
   .Should().NotBeDecoratedWithOrInherit<SomeInheritedOrDirectlyDecoratedAttribute>();
 
+typeof(MyBaseClass).Should().BeAbstract();
+typeof(InjectedClass).Should().NotBeStatic();
+
 MethodInfo method = GetMethod();
 method.Should().BeVirtual();
 


### PR DESCRIPTION
For  #645
Assertions for types (abstract, sealed, static) added. They are based on C# understanding of those keywords, as in CLR they differ.