### PR TITLE
Use GetAssemblies() for .NET Standard 2.0

### DIFF
--- a/Src/FluentAssertions/Execution/GallioTestFramework.cs
+++ b/Src/FluentAssertions/Execution/GallioTestFramework.cs
@@ -59,8 +59,8 @@ namespace FluentAssertions.Execution
         {
             get
             {
-#if !NET45 && !NET47
-                // For CoreCLR, we need to attempt to load the assembly
+#if !NET45 && !NET47 && !NETSTANDARD2_0
+                // For .NET Standard < 2.0, we need to attempt to load the assembly
                 try
                 {
                     assembly = Assembly.Load(new AssemblyName(AssemblyName) { Version = new Version(0, 0, 0, 0) });

--- a/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
+++ b/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
@@ -28,8 +28,8 @@ namespace FluentAssertions.Execution
         {
             get
             {
-#if !NET45 && !NET47
-                // For CoreCLR, we need to attempt to load the assembly
+#if !NET45 && !NET47 && !NETSTANDARD2_0
+                // For .NET Standard < 2.0, we need to attempt to load the assembly
                 try
                 {
                     assembly = Assembly.Load(new AssemblyName(AssemblyName) { Version = new Version(0,0,0,0)});


### PR DESCRIPTION
Since .NET Standard 2.0 `GetAssemblies()` is now available.

This fixes #823 