### PR TITLE
Update documentation with target frameworks

### DIFF
--- a/Src/FluentAssertions.nuspec
+++ b/Src/FluentAssertions.nuspec
@@ -7,12 +7,12 @@
     <owners>Dennis Doomen</owners>
     <authors>Dennis Doomen</authors>
     <summary>
-      Fluent API for asserting the results of unit tests that targets .NET Framework 4.5, .NET Standard 1.3, 1.6 and 2.0.
+      Fluent API for asserting the results of unit tests that targets .NET Framework 4.5 and 4.7, as well as .NET Standard 1.3, 1.6 and 2.0.
       Supports the unit test frameworks MSTest, MSTest2, Gallio, NUnit, XUnit, MBunit, MSpec, and NSpec.
     </summary>
     <description>
       A very extensive set of extension methods that allow you to more naturally specify the expected outcome of a TDD or
-      BDD-style unit tests. Targets .NET Framework 4.5, .NET Standard 1.3, 1.6 and 2.0.
+      BDD-style unit tests. Targets .NET Framework 4.5 and 4.7, as well as .NET Standard 1.3, 1.6 and 2.0.
       Supports the unit test frameworks MSTest, MSTest2, Gallio, NUnit, XUnit, MBUnit, MSpec, and NSpec.
     </description>
     <language>en-US</language>

--- a/Src/FluentAssertions/AssemblyInfo.cs
+++ b/Src/FluentAssertions/AssemblyInfo.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("FluentAssertions")]
-[assembly: AssemblyDescription("Fluent API for asserting the results of unit tests that targets .NET Framework 4.5, .NET Standard 1.4, 1.6 and 2.0. " +
+[assembly: AssemblyDescription("Fluent API for asserting the results of unit tests that targets .NET Framework 4.5 and 4.7, as well as .NET Standard 1.3, 1.6 and 2.0. " +
 "Supports the unit test frameworks MSTest, MSTest2, Gallio, NUnit, XUnit, MBunit, MSpec, and NSpec..")]
 [assembly: AssemblyCopyright("Copyright Dennis Doomen 2010-2018")]
 

--- a/docs/_pages/about.md
+++ b/docs/_pages/about.md
@@ -39,7 +39,7 @@ will fail with:
 
 ## Supported Frameworks and Libraries
 
-Fluent Assertions cross-compiles to .NET Framework 4.5, as well as .NET Standard 1.4, 1.6 and 2.0. Because of that it supports the following minimum platforms.
+Fluent Assertions cross-compiles to .NET Framework 4.5 and 4.7, as well as .NET Standard 1.3, 1.6 and 2.0. Because of that it supports the following minimum platforms.
 *   .NET Core 1.0 and 2.0
 *   .NET Framework 4.5
 *   Mono, Xamarin.iOS 10.0, Xamarin.Mac 3.0 and Xamarin.Android 7.0


### PR DESCRIPTION
I noticed a few places where the documentation about which frameworks we target where out of date.