### PR TITLE
Make tests more cross-platform

### DIFF
--- a/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Xml.Linq;
 
@@ -46,7 +46,7 @@ namespace FluentAssertions.Formatting
             string firstLine = lines.First().RemoveNewLines();
             string lastLine = lines.Last().RemoveNewLines();
 
-            string formattedElement = firstLine + "�" + lastLine;
+            string formattedElement = firstLine + "…" + lastLine;
             return formattedElement.Escape(escapePlaceholders: true);
         }
 

--- a/Tests/Shared.Specs/AndWhichConstraintSpecs.cs
+++ b/Tests/Shared.Specs/AndWhichConstraintSpecs.cs
@@ -30,7 +30,7 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "More than one object found.  FluentAssertions cannot determine which object is meant.*")
-                .WithMessage("*Found objects:\r\n\t\"hello\"\r\n\t\"world\"");
+                .WithMessage("*Found objects:*\"hello\"*\"world\"");
         }
     }
 }

--- a/Tests/Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/BasicEquivalencySpecs.cs
@@ -3037,7 +3037,7 @@ namespace FluentAssertions.Specs
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected member Level.Level.Text to be *A wrong text value*but \r\n\"Level2\"*length*");
+                    "Expected member Level.Level.Text to be *A wrong text value*but*\"Level2\"*length*");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/CollectionAssertionSpecs.cs
@@ -1649,7 +1649,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot compare collection with <null>.\r\nParameter name: expectation");
+                "Cannot compare collection with <null>.*Parameter name: expectation");
         }
 
         [Fact]
@@ -1975,7 +1975,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot compare collection with <null>.\r\nParameter name: unexpected");
+                "Cannot compare collection with <null>.*Parameter name: unexpected");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
@@ -807,7 +807,7 @@ namespace FluentAssertions.Specs
             //// Assert
             ////-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>().WithMessage(
-                "Expected item[1] to be 1, but found 2.\r\nExpected item[2] to be 1, but found 3*");
+                "Expected item[1] to be 1, but found 2.*Expected item[2] to be 1, but found 3*");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/ExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/ExceptionAssertionSpecs.cs
@@ -94,8 +94,8 @@ namespace FluentAssertions.Specs
                 //-----------------------------------------------------------------------------------------------------------
                 // Assert
                 //-----------------------------------------------------------------------------------------------------------
-                ex.Message.Should().StartWith(
-                    "Expected exception message to match the equivalent of \r\n\"some message\", but \r\n\"some\" does not.");
+                ex.Message.Should().Match(
+                    "Expected exception message to match the equivalent of*\"some message\", but*\"some\" does not*");
             }
         }
 
@@ -141,7 +141,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<Exception>()
-                .WithMessage("Expected exception message to match the equivalent of \r\n\"Expected mes*\", but \r\n\"OxpectOd message\" does not*");
+                .WithMessage("Expected exception message to match the equivalent of*\"Expected mes*\", but*\"OxpectOd message\" does not*");
         }
 
         [Fact]
@@ -186,7 +186,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<Exception>()
-                .WithMessage("Expected exception message to match the equivalent of \r\n\"expected mes*\", but \r\n\"OxpectOd message\" does not*");
+                .WithMessage("Expected exception message to match the equivalent of*\"expected mes*\", but*\"OxpectOd message\" does not*");
         }
 
         [Fact]
@@ -279,7 +279,7 @@ namespace FluentAssertions.Specs
                 // Assert
                 //-----------------------------------------------------------------------------------------------------------
                 ex.Message.Should().Match(
-                    "Expected exception message to match the equivalent of \r\n\"message2\", but \r\n\"message2\r\nParameter name: someParam\"*");
+                    "Expected exception message to match the equivalent of*\"message2\", but*\"message2*Parameter name: someParam\"*");
             }
         }
 
@@ -372,7 +372,7 @@ namespace FluentAssertions.Specs
                 // Assert
                 //-----------------------------------------------------------------------------------------------------------
                 ex.Message.Should().Match(
-                    "Expected exception message to match the equivalent of \r\n\"message without\"*, but \r\n\"message with {}*");
+                    "Expected exception message to match the equivalent of*\"message without\"*, but*\"message with {}*");
             }
         }
 

--- a/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/Shared.Specs/GenericCollectionAssertionOfStringSpecs.cs
@@ -825,7 +825,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot compare collection with <null>.\r\nParameter name: unexpected");
+                "Cannot compare collection with <null>.*Parameter name: unexpected");
         }
 
         [Fact]
@@ -895,7 +895,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot compare collection with <null>.\r\nParameter name: expectation");
+                "Cannot compare collection with <null>.*Parameter name: expectation");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
@@ -1167,7 +1167,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot compare dictionary with <null>.\r\nParameter name: expected");
+                "Cannot compare dictionary with <null>.*Parameter name: expected");
         }
 
         [Fact]
@@ -1352,7 +1352,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot compare dictionary with <null>.\r\nParameter name: unexpected");
+                "Cannot compare dictionary with <null>.*Parameter name: unexpected");
         }
 
         [Fact]
@@ -2494,7 +2494,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot compare dictionary with <null>.\r\nParameter name: expected");
+                "Cannot compare dictionary with <null>.*Parameter name: expected");
         }
 
         [Fact]
@@ -2570,7 +2570,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot compare dictionary with <null>.\r\nParameter name: items");
+                "Cannot compare dictionary with <null>.*Parameter name: items");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/MethodInfoSelectorAssertionSpecs.cs
+++ b/Tests/Shared.Specs/MethodInfoSelectorAssertionSpecs.cs
@@ -67,9 +67,9 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected methods" +
                              " to be virtual because we want to test the error message," +
-                             " but the following methods are not virtual:\r\n" +
-                             "Void FluentAssertions.Specs.ClassWithNonVirtualPublicMethods.PublicDoNothing\r\n" +
-                             "Void FluentAssertions.Specs.ClassWithNonVirtualPublicMethods.InternalDoNothing\r\n" +
+                             " but the following methods are not virtual:*" +
+                             "Void FluentAssertions.Specs.ClassWithNonVirtualPublicMethods.PublicDoNothing*" +
+                             "Void FluentAssertions.Specs.ClassWithNonVirtualPublicMethods.InternalDoNothing*" +
                              "Void FluentAssertions.Specs.ClassWithNonVirtualPublicMethods.ProtectedDoNothing");
         }
 
@@ -201,9 +201,9 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected methods to be decorated with" +
                              " FluentAssertions.Specs.DummyMethodAttribute because we want to test the error message," +
-                             " but the following methods are not:\r\n" +
-                             "Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing\r\n" +
-                             "Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.ProtectedDoNothing\r\n" +
+                             " but the following methods are not:*" +
+                             "Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing*" +
+                             "Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.ProtectedDoNothing*" +
                              "Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PrivateDoNothing");
         }
 

--- a/Tests/Shared.Specs/PropertyInfoSelectorAssertionSpecs.cs
+++ b/Tests/Shared.Specs/PropertyInfoSelectorAssertionSpecs.cs
@@ -69,9 +69,9 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>()
                .WithMessage("Expected all selected properties" +
                    " to be virtual because we want to test the error message," +
-                   " but the following properties are not virtual:\r\n" +
-                   "String FluentAssertions.Specs.ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty\r\n" +
-                   "String FluentAssertions.Specs.ClassWithNonVirtualPublicProperties.InternalNonVirtualProperty\r\n" +
+                   " but the following properties are not virtual:*" +
+                   "String FluentAssertions.Specs.ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty*" +
+                   "String FluentAssertions.Specs.ClassWithNonVirtualPublicProperties.InternalNonVirtualProperty*" +
                    "String FluentAssertions.Specs.ClassWithNonVirtualPublicProperties.ProtectedNonVirtualProperty");
         }
 
@@ -205,9 +205,9 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected properties to be decorated with" +
                    " FluentAssertions.Specs.DummyPropertyAttribute because we want to test the error message," +
-                   " but the following properties are not:\r\n" +
-                   "String FluentAssertions.Specs.ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty\r\n" +
-                   "String FluentAssertions.Specs.ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.InternalProperty\r\n" +
+                   " but the following properties are not:*" +
+                   "String FluentAssertions.Specs.ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty*" +
+                   "String FluentAssertions.Specs.ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.InternalProperty*" +
                    "String FluentAssertions.Specs.ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.ProtectedProperty");
         }
 
@@ -300,8 +300,8 @@ namespace FluentAssertions.Specs
                 .Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected all selected properties to have a setter because we want to test the error message, " +
-                    "but the following properties do not:\r\n" +
-                    "String FluentAssertions.Specs.ClassWithReadOnlyProperties.ReadOnlyProperty\r\n" +
+                    "but the following properties do not:*" +
+                    "String FluentAssertions.Specs.ClassWithReadOnlyProperties.ReadOnlyProperty*" +
                     "String FluentAssertions.Specs.ClassWithReadOnlyProperties.ReadOnlyProperty2");
         }
 

--- a/Tests/Shared.Specs/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/Shared.Specs/ReferenceTypeAssertionsSpecs.cs
@@ -53,11 +53,11 @@ namespace FluentAssertions.Specs
                 .Should().Throw<XunitException>()
                 .WithMessage(
 #if NETCOREAPP1_1
-                    "Expected object to refer to \r\n{ UserName = JohnDoe } because " +
-                    "they are the same, but found \r\n{ Name = John Doe }.");
+                    "Expected object to refer to*{ UserName = JohnDoe } because " +
+                    "they are the same, but found*{ Name = John Doe }.");
 #else
-                    "Expected subject to refer to \r\n{ UserName = JohnDoe } because " +
-                    "they are the same, but found \r\n{ Name = John Doe }.");
+                    "Expected subject to refer to*{ UserName = JohnDoe } because " +
+                    "they are the same, but found*{ Name = John Doe }.");
 #endif
         }
 
@@ -95,9 +95,9 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
 #if NETCOREAPP1_1
-                .WithMessage("Did not expect object to refer to \r\nClassWithCustomEqualMethod(1) because they are the same.");
+                .WithMessage("Did not expect object to refer to*ClassWithCustomEqualMethod(1) because they are the same.");
 #else
-                .WithMessage("Did not expect someObject to refer to \r\nClassWithCustomEqualMethod(1) because they are the same.");
+                .WithMessage("Did not expect someObject to refer to*ClassWithCustomEqualMethod(1) because they are the same.");
 #endif
         }
 
@@ -404,13 +404,13 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
 #if NETCOREAPP1_1
-                "Expected object to be \r\n\r\nFluentAssertions.Specs.SomeDto\r\n{\r\n   Age = 2\r\n   Birthdate = <2009-02-22>\r\n" +
-                "   Name = \"Teddie\"\r\n}, but found \r\n\r\nFluentAssertions.Specs.SomeDto\r\n{\r\n   Age = 37\r\n" +
-                "   Birthdate = <1973-09-20>\r\n   Name = \"Dennis\"\r\n}.");
+                "Expected object to be*FluentAssertions.Specs.SomeDto*{*Age = 2*Birthdate = <2009-02-22>*" +
+                "   Name = \"Teddie\"*}, but found*FluentAssertions.Specs.SomeDto*{*Age = 37*" +
+                "   Birthdate = <1973-09-20>*Name = \"Dennis\"*}.");
 #else
-                "Expected subject to be \r\n\r\nFluentAssertions.Specs.SomeDto\r\n{\r\n   Age = 2\r\n   Birthdate = <2009-02-22>\r\n" +
-                    "   Name = \"Teddie\"\r\n}, but found \r\n\r\nFluentAssertions.Specs.SomeDto\r\n{\r\n   Age = 37\r\n" +
-                        "   Birthdate = <1973-09-20>\r\n   Name = \"Dennis\"\r\n}.");
+                "Expected subject to be*FluentAssertions.Specs.SomeDto*{*Age = 2*Birthdate = <2009-02-22>*" +
+                    "   Name = \"Teddie\"*}, but found*FluentAssertions.Specs.SomeDto*{*Age = 37*" +
+                        "   Birthdate = <1973-09-20>*Name = \"Dennis\"*}.");
 #endif
         }
 

--- a/Tests/Shared.Specs/StringAssertionSpecs.cs
+++ b/Tests/Shared.Specs/StringAssertionSpecs.cs
@@ -176,7 +176,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected string to be \r\n\"0987654321\", but \r\n\"1234567890\" differs near \"123\" (index 0).");
+                "Expected string to be*\"0987654321\", but*\"1234567890\" differs near \"123\" (index 0).");
         }
 
         [Fact]
@@ -416,9 +416,9 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
 #if NETCOREAPP1_1
-                .WithMessage("Expected string to match \r\n\"h*earth!\" because that's the universal greeting, but \r\n\"hello world!\" does not.");
+                .WithMessage("Expected string to match*\"h*earth!\" because that's the universal greeting, but*\"hello world!\" does not.");
 #else
-                .WithMessage("Expected subject to match \r\n\"h*earth!\" because that's the universal greeting, but \r\n\"hello world!\" does not.");
+                .WithMessage("Expected subject to match*\"h*earth!\" because that's the universal greeting, but*\"hello world!\" does not.");
 #endif
         }
 
@@ -459,9 +459,9 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
 #if NETCOREAPP1_1
-                .WithMessage("Expected string to match \r\n\"What\\? Are you deaf\\?\", but \r\n\"What! Are you deaf!\" does not.");
+                .WithMessage("Expected string to match*\"What\\? Are you deaf\\?\", but*\"What! Are you deaf!\" does not.");
 #else
-                .WithMessage("Expected subject to match \r\n\"What\\? Are you deaf\\?\", but \r\n\"What! Are you deaf!\" does not.");
+                .WithMessage("Expected subject to match*\"What\\? Are you deaf\\?\", but*\"What! Are you deaf!\" does not.");
 #endif
         }
 
@@ -483,9 +483,9 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
 #if NETCOREAPP1_1
-                .WithMessage("Expected string to match \r\n\"*World*\", but \r\n\"hello world\" does not.");
+                .WithMessage("Expected string to match*\"*World*\", but*\"hello world\" does not.");
 #else
-                .WithMessage("Expected subject to match \r\n\"*World*\", but \r\n\"hello world\" does not.");
+                .WithMessage("Expected subject to match*\"*World*\", but*\"hello world\" does not.");
 #endif
         }
 
@@ -531,9 +531,9 @@ namespace FluentAssertions.Specs
             act
                 .Should().Throw<XunitException>().WithMessage(
 #if NETCOREAPP1_1
-                    "Did not expect string to match \r\n\"*world*\" because that's illegal, but \r\n\"hello world\" matches.");
+                    "Did not expect string to match*\"*world*\" because that's illegal, but*\"hello world\" matches.");
 #else
-                    "Did not expect subject to match \r\n\"*world*\" because that's illegal, but \r\n\"hello world\" matches.");
+                    "Did not expect subject to match*\"*world*\" because that's illegal, but*\"hello world\" matches.");
 #endif
         }
 
@@ -559,11 +559,11 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
 #if NETCOREAPP1_1
-                "Expected string to match the equivalent of \r\n\"h*earth!\" " +
+                "Expected string to match the equivalent of*\"h*earth!\" " +
 #else
-                "Expected subject to match the equivalent of \r\n\"h*earth!\" " +
+                "Expected subject to match the equivalent of*\"h*earth!\" " +
 #endif
-                "because that's the universal greeting, but \r\n\"hello world!\" does not.");
+                "because that's the universal greeting, but*\"hello world!\" does not.");
         }
 
         [Fact]
@@ -627,11 +627,11 @@ namespace FluentAssertions.Specs
             act
                 .Should().Throw<XunitException>()
 #if NETCOREAPP1_1
-                .WithMessage("Did not expect string to match the equivalent of \r\n\"*world*\" because that's illegal, " +
-                "but \r\n\"hello WORLD\" matches.");
+                .WithMessage("Did not expect string to match the equivalent of*\"*world*\" because that's illegal, " +
+                "but*\"hello WORLD\" matches.");
 #else
-                .WithMessage("Did not expect subject to match the equivalent of \r\n\"*world*\" because that's illegal, " +
-                "but \r\n\"hello WORLD\" matches.");
+                .WithMessage("Did not expect subject to match the equivalent of*\"*world*\" because that's illegal, " +
+                "but*\"hello WORLD\" matches.");
 #endif
         }
 
@@ -676,9 +676,9 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
 #if NETCOREAPP1_1
-                .WithMessage("Expected string to match regex \r\n\"h.*\\sworld?$\" because that's the universal greeting, but \r\n\"hello world!\" does not match.");
+                .WithMessage("Expected string to match regex*\"h.*\\sworld?$\" because that's the universal greeting, but*\"hello world!\" does not match.");
 #else
-              .WithMessage("Expected subject to match regex \r\n\"h.*\\sworld?$\" because that's the universal greeting, but \r\n\"hello world!\" does not match.");
+              .WithMessage("Expected subject to match regex*\"h.*\\sworld?$\" because that's the universal greeting, but*\"hello world!\" does not match.");
 #endif
         }
 
@@ -700,9 +700,9 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
 #if NETCOREAPP1_1
-                .WithMessage("Expected string to match regex \r\n\".*\" because it should be a string, but it was <null>.");
+                .WithMessage("Expected string to match regex*\".*\" because it should be a string, but it was <null>.");
 #else
-             .WithMessage("Expected subject to match regex \r\n\".*\" because it should be a string, but it was <null>.");
+             .WithMessage("Expected subject to match regex*\".*\" because it should be a string, but it was <null>.");
 #endif
         }
 
@@ -792,9 +792,9 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
 #if NETCOREAPP1_1
-              .WithMessage("Did not expect string to match regex \r\n\".*world.*\" because that's illegal, but \r\n\"hello world!\" matches.");
+              .WithMessage("Did not expect string to match regex*\".*world.*\" because that's illegal, but*\"hello world!\" matches.");
 #else
-              .WithMessage("Did not expect subject to match regex \r\n\".*world.*\" because that's illegal, but \r\n\"hello world!\" matches.");
+              .WithMessage("Did not expect subject to match regex*\".*world.*\" because that's illegal, but*\"hello world!\" matches.");
 #endif
         }
 
@@ -816,9 +816,9 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
 #if NETCOREAPP1_1
-                .WithMessage("Expected string to not match regex \r\n\".*\" because it should not be a string, but it was <null>.");
+                .WithMessage("Expected string to not match regex*\".*\" because it should not be a string, but it was <null>.");
 #else
-             .WithMessage("Expected subject to not match regex \r\n\".*\" because it should not be a string, but it was <null>.");
+             .WithMessage("Expected subject to not match regex*\".*\" because it should not be a string, but it was <null>.");
 #endif
         }
 
@@ -920,8 +920,8 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected string to start with " +
-                    "\r\n\"ABCDDFGHI\" because it should start, but " +
-                        "\r\n\"ABCDEFGHI\" differs near \"EFG\" (index 4).");
+                    "*\"ABCDDFGHI\" because it should start, but " +
+                        "*\"ABCDEFGHI\" differs near \"EFG\" (index 4).");
         }
 
         [Fact]
@@ -1359,8 +1359,8 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected string to start with equivalent of " +
-                    "\r\n\"abcddfghi\" because it should start, but " +
-                        "\r\n\"ABCDEFGHI\" differs near \"EFG\" (index 4).");
+                    "*\"abcddfghi\" because it should start, but " +
+                        "*\"ABCDEFGHI\" differs near \"EFG\" (index 4).");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/TypeAssertionSpecs.cs
+++ b/Tests/Shared.Specs/TypeAssertionSpecs.cs
@@ -660,7 +660,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<ArgumentException>()
-                .WithMessage("Must not be an interface Type.\r\nParameter name: baseType");
+                .WithMessage("Must not be an interface Type.*Parameter name: baseType");
         }
 
         #endregion
@@ -751,7 +751,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<ArgumentException>()
-                .WithMessage("Must not be an interface Type.\r\nParameter name: baseType");
+                .WithMessage("Must not be an interface Type.*Parameter name: baseType");
         }
 
         #endregion
@@ -939,8 +939,8 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all types to be decorated with *DummyClassAttribute*" +
-                    " because we do, but the attribute was not found on the following types:\r\n" +
-                    "*ClassWithoutAttribute*\r\n" +
+                    " because we do, but the attribute was not found on the following types:*" +
+                    "*ClassWithoutAttribute*" +
                     "*OtherClassWithoutAttribute*.");
         }
 
@@ -970,8 +970,8 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all types to be decorated with *DummyClassAttribute*" +
                     " that matches ((a.Name == \"Expected\")*a.IsEnabled) because we do," +
-                    " but no matching attribute was found on the following types:\r\n" +
-                    "*ClassWithoutAttribute*\r\n" +
+                    " but no matching attribute was found on the following types:*" +
+                    "*ClassWithoutAttribute*" +
                     "*OtherClassWithoutAttribute*.");
         }
 
@@ -1136,8 +1136,8 @@ namespace FluentAssertions.Specs
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all types to be decorated with or inherit *DummyClassAttribute*" +
-                    " because we do, but the attribute was not found on the following types:\r\n" +
-                    "*ClassWithoutAttribute*\r\n" +
+                    " because we do, but the attribute was not found on the following types:*" +
+                    "*ClassWithoutAttribute*" +
                     "*OtherClassWithoutAttribute*.");
         }
 
@@ -1168,8 +1168,8 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all types to be decorated with or inherit *DummyClassAttribute*" +
                     " that matches ((a.Name == \"Expected\")*a.IsEnabled) because we do," +
-                    " but no matching attribute was found on the following types:\r\n" +
-                    "*ClassWithoutAttribute*\r\n" +
+                    " but no matching attribute was found on the following types:*" +
+                    "*ClassWithoutAttribute*" +
                     "*OtherClassWithoutAttribute*.");
         }
 
@@ -2021,7 +2021,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<ArgumentException>()
-                .WithMessage("Must be an interface Type.\r\nParameter name: interfaceType");
+                .WithMessage("Must be an interface Type.*Parameter name: interfaceType");
         }
 
         #endregion
@@ -2112,7 +2112,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-------------------------------------------------------------------------------------------------------------------
             act.Should().Throw<ArgumentException>()
-                .WithMessage("Must be an interface Type.\r\nParameter name: interfaceType");
+                .WithMessage("Must be an interface Type.*Parameter name: interfaceType");
         }
 
         #endregion

--- a/Tests/Shared.Specs/XElementFormatterSpecs.cs
+++ b/Tests/Shared.Specs/XElementFormatterSpecs.cs
@@ -1,4 +1,4 @@
-using System.Xml.Linq;
+﻿using System.Xml.Linq;
 
 using FluentAssertions.Formatting;
 using Xunit;
@@ -48,7 +48,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            result.Should().Be(@"<person name=\""Martin\"" age=\""36\"">�</person>");
+            result.Should().Be(@"<person name=\""Martin\"" age=\""36\"">…</person>");
         }
     }
 }


### PR DESCRIPTION
The first commit changes test to to match `*` instead of `\r\n` to make the pass on Linux.
The second commit fixes an encoding issue, where an ellipsis would not be rendered on Linux.

With this PR I can build NetStandard{1.3, 1.6, 2.0} targets and run all three NetCore unit tests projects on Linux.