### PR TITLE
Fix ContainKey and ContainSingle for AssertionScope

### DIFF
--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -513,7 +513,9 @@ namespace FluentAssertions.Collections
         {
             AndConstraint<GenericDictionaryAssertions<TKey, TValue>> andConstraint = ContainKeys(new[] { expected }, because, becauseArgs);
 
-            return new WhichValueConstraint<TKey, TValue>(andConstraint.And, Subject[expected]);
+            _ = Subject.TryGetValue(expected, out TValue value);
+
+            return new WhichValueConstraint<TKey, TValue>(andConstraint.And, value);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -606,7 +606,7 @@ namespace FluentAssertions.Collections
                     break;
             }
 
-            return new AndWhichConstraint<TAssertions, T>((TAssertions)this, Subject.Single());
+            return new AndWhichConstraint<TAssertions, T>((TAssertions)this, Subject.SingleOrDefault());
         }
 
         /// <summary>

--- a/Tests/Shared.Specs/AssertionScopeSpecs.cs
+++ b/Tests/Shared.Specs/AssertionScopeSpecs.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 using FluentAssertions;
@@ -209,6 +210,53 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected foo to be equal to*");
+        }
+
+        [Fact]
+        public void When_an_assertion_fails_on_ContainKey_succeeding_message_should_be_included()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () =>
+            {
+                using (new AssertionScope())
+                {
+                    var values = new Dictionary<int, int>();
+                    values.Should().ContainKey(0);
+                    values.Should().ContainKey(1);
+                }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected*to contain key 0*Expected*to contain key 1*");
+        }
+
+        [Fact]
+        public void When_an_assertion_fails_on_ContainSingle_succeeding_message_should_be_included()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () =>
+            {
+                using (new AssertionScope())
+                {
+                    var values = new List<int>();
+                    values.Should().ContainSingle();
+                    values.Should().ContainSingle();
+                }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected*to contain a single item, but the collection is empty*" +
+                "Expected*to contain a single item, but the collection is empty*");
         }
 
         [Fact]


### PR DESCRIPTION
`ContainKey` and `ContainSingle` could throw a `KeyNotFoundException` or `InvalidOperationException` respectively.
That prevented the inclusion failure messages of succeeding assertions inside an `AssertionScope`.

This fixes #835 