### PR TITLE
Custom analysis rules

### DIFF
--- a/Rules.ruleset
+++ b/Rules.ruleset
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Rules for Fluent Assertions" Description="Code analysis rules for Fluent Assertions." ToolsVersion="15.0">
+  <IncludeAll Action="Warning" />
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
+    <Rule Id="CS0162" Action="Error" />
+    <Rule Id="CS0183" Action="Error" />
+    <Rule Id="CS0184" Action="Error" />
+    <Rule Id="CS0464" Action="Error" />
+    <Rule Id="CS0472" Action="Error" />
+    <Rule Id="CS0652" Action="Error" />
+    <Rule Id="CS0659" Action="Error" />
+    <Rule Id="CS0728" Action="Error" />
+    <Rule Id="CS1717" Action="Error" />
+    <Rule Id="CS1718" Action="Error" />
+    <Rule Id="CS1720" Action="Error" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+    <Rule Id="IDE0035" Action="Error" />
+	<Rule Id="IDE0007" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Features" RuleNamespace="Microsoft.CodeAnalysis.Features">
+    <Rule Id="IDE0010" Action="Warning" />
+    <Rule Id="IDE0033" Action="Info" />
+  </Rules>
+  <Rules AnalyzerId="Roslynator.CSharp.Analyzers" RuleNamespace="Roslynator.CSharp.Analyzers">
+    <Rule Id="RCS1080" Action="None" />
+    <Rule Id="RCS1102" Action="None" />
+    <Rule Id="RCS1119" Action="None" />
+    <Rule Id="RCS1141" Action="None" />
+    <Rule Id="RCS1142" Action="None" />
+	<Rule Id="RCS1171" Action="Hidden" />
+  </Rules>
+  <Rules AnalyzerId="U2UConsult.CodeAnalyzers" RuleNamespace="U2UConsult.CodeAnalyzers">
+    <Rule Id="U2U1000" Action="None" />
+    <Rule Id="U2U1001" Action="None" />
+	<Rule Id="U2U1002" Action="None" />
+	<Rule Id="U2U1003" Action="None" />
+    <Rule Id="U2U1010" Action="None" />
+	<Rule Id="U2U1022" Action="None" />
+	<Rule Id="U2U1101" Action="None" />
+    <Rule Id="U2U1103" Action="None" />
+    <Rule Id="U2U1104" Action="None" />
+    <Rule Id="U2U1105" Action="None" />
+    <Rule Id="U2U1108" Action="None" />
+    <Rule Id="U2U1201" Action="Hidden" />
+    <Rule Id="U2U1202" Action="None" />
+  </Rules>
+</RuleSet>

--- a/Src/FluentAssertions/AssertionExtensions.Actions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.Actions.cs
@@ -71,9 +71,7 @@ namespace FluentAssertions
             {
                 if (typeof(T).IsSameOrInherits(typeof(AggregateException)))
                 {
-                    var exception = actualException as T;
-
-                    return (exception == null) ? Enumerable.Empty<T>() : new[] { exception };
+                    return (actualException is T exception) ? new[] { exception } : Enumerable.Empty<T>();
                 }
 
                 return GetExtractedExceptions<T>(actualException);
@@ -84,16 +82,15 @@ namespace FluentAssertions
             {
                 var exceptions = new List<T>();
 
-                var aggregateException = actualException as AggregateException;
-                if (aggregateException != null)
+                if (actualException is AggregateException aggregateException)
                 {
                     var flattenedExceptions = aggregateException.Flatten();
 
                     exceptions.AddRange(flattenedExceptions.InnerExceptions.OfType<T>());
                 }
-                else if (actualException is T)
+                else if (actualException is T genericException)
                 {
-                    exceptions.Add((T)actualException);
+                    exceptions.Add(genericException);
                 }
 
                 return exceptions;

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -102,7 +102,7 @@ namespace FluentAssertions
             {
                 using (StreamReader reader = new StreamReader(File.OpenRead(fileName)))
                 {
-                    string line = null;
+                    string line;
                     int currentLine = 1;
 
                     while ((line = reader.ReadLine()) != null && currentLine < expectedLineNumber)

--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -177,7 +177,7 @@ namespace FluentAssertions.Collections
             int[] indices = Subject
                 .Cast<object>()
                 .Select((item, index) => new { Item = item, Index = index })
-                .Where(e => ReferenceEquals(e.Item, null))
+                .Where(e => e.Item is null)
                 .Select(e => e.Index)
                 .ToArray();
 
@@ -233,7 +233,7 @@ namespace FluentAssertions.Collections
             string because = "", params object[] becauseArgs)
         {
             bool subjectIsNull = ReferenceEquals(Subject, null);
-            bool expectationIsNull = ReferenceEquals(expectation, null);
+            bool expectationIsNull = expectation is null;
             if (subjectIsNull && expectationIsNull)
             {
                 return;

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -34,7 +34,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<GenericCollectionAssertions<T>> NotContainNulls<TKey>(Expression<Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
             where TKey : class
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -44,7 +44,7 @@ namespace FluentAssertions.Collections
             Func<T, TKey> compiledPredicate = predicate.Compile();
 
             var values = Subject
-                .Where(e => ReferenceEquals(compiledPredicate(e), null))
+                .Where(e => compiledPredicate(e) is null)
                 .ToArray();
 
             if (values.Length > 0)
@@ -72,7 +72,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<GenericCollectionAssertions<T>> OnlyHaveUniqueItems<TKey>(Expression<Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -276,7 +276,7 @@ namespace FluentAssertions.Collections
             }
 
             return Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null))
+                .ForCondition(!(Subject is null))
                 .BecauseOf(because, args)
                 .FailWith("Expected {context:collection} to be ordered by {0}{reason} but found <null>.",
                     propertyExpression.GetMemberPath());

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -42,7 +42,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> HaveCount(int expected,
             string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -72,7 +72,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -102,7 +102,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -132,7 +132,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -162,7 +162,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -192,7 +192,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -228,7 +228,7 @@ namespace FluentAssertions.Collections
                 throw new ArgumentNullException(nameof(countPredicate), "Cannot compare dictionary count against a <null> predicate.");
             }
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -266,7 +266,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -294,7 +294,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotBeEmpty(string because = "",
             params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -329,7 +329,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> Equal(IDictionary<TKey, TValue> expected,
             string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -388,7 +388,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotEqual(IDictionary<TKey, TValue> unexpected,
             string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -555,7 +555,7 @@ namespace FluentAssertions.Collections
                 throw new ArgumentException("Cannot verify key containment against an empty sequence", nameof(expected));
             }
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -604,7 +604,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainKey(TKey unexpected,
             string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -658,7 +658,7 @@ namespace FluentAssertions.Collections
                 throw new ArgumentException("Cannot verify key containment against an empty sequence", nameof(unexpected));
             }
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -759,7 +759,7 @@ namespace FluentAssertions.Collections
                 throw new ArgumentException("Cannot verify value containment with an empty sequence", nameof(expected));
             }
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -822,7 +822,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainValue(TValue unexpected,
             string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -876,7 +876,7 @@ namespace FluentAssertions.Collections
                 throw new ArgumentException("Cannot verify value containment with an empty sequence", nameof(unexpected));
             }
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -947,7 +947,7 @@ namespace FluentAssertions.Collections
                     nameof(expected));
             }
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -1034,7 +1034,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value,
             string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -1102,7 +1102,7 @@ namespace FluentAssertions.Collections
                     nameof(items));
             }
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -1171,7 +1171,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContain(TKey key, TValue value,
             string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -988,7 +988,7 @@ namespace FluentAssertions.Collections
                 }
                 else
                 {
-                    var expectedKeyValuePair = keyValuePairsNotSameOrEqualInSubject.First();
+                    var expectedKeyValuePair = keyValuePairsNotSameOrEqualInSubject[0];
                     TValue actual = Subject[expectedKeyValuePair.Key];
 
                     Execute.Assertion
@@ -1125,7 +1125,7 @@ namespace FluentAssertions.Collections
                     }
                     else
                     {
-                        var keyValuePair = keyValuePairsSameOrEqualInSubject.First();
+                        var keyValuePair = keyValuePairsSameOrEqualInSubject[0];
 
                         Execute.Assertion
                             .BecauseOf(because, becauseArgs)

--- a/Src/FluentAssertions/Collections/NonGenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/NonGenericCollectionAssertions.cs
@@ -246,8 +246,7 @@ namespace FluentAssertions.Collections
 
         private int GetMostLocalCount()
         {
-            ICollection castSubject = Subject as ICollection;
-            if (castSubject != null)
+            if (Subject is ICollection castSubject)
             {
                 return castSubject.Count;
             }
@@ -272,9 +271,9 @@ namespace FluentAssertions.Collections
         public AndConstraint<NonGenericCollectionAssertions> Contain(object expected, string because = "",
             params object[] becauseArgs)
         {
-            if (expected is IEnumerable)
+            if (expected is IEnumerable enumerable)
             {
-                return base.Contain((IEnumerable)expected, because, becauseArgs);
+                return base.Contain(enumerable, because, becauseArgs);
             }
 
             return base.Contain(new[] { expected }, because, becauseArgs);
@@ -295,9 +294,9 @@ namespace FluentAssertions.Collections
         public AndConstraint<NonGenericCollectionAssertions> NotContain(object unexpected, string because = "",
             params object[] becauseArgs)
         {
-            if (unexpected is IEnumerable)
+            if (unexpected is IEnumerable enumerable)
             {
-                return base.NotContain((IEnumerable)unexpected, because, becauseArgs);
+                return base.NotContain(enumerable, because, becauseArgs);
             }
 
             return base.NotContain(new[] { unexpected }, because, becauseArgs);

--- a/Src/FluentAssertions/Collections/NonGenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/NonGenericCollectionAssertions.cs
@@ -36,7 +36,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<NonGenericCollectionAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -66,7 +66,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<NonGenericCollectionAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -96,7 +96,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<NonGenericCollectionAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -126,7 +126,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<NonGenericCollectionAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -156,7 +156,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<NonGenericCollectionAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -186,7 +186,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<NonGenericCollectionAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -222,7 +222,7 @@ namespace FluentAssertions.Collections
                 throw new ArgumentNullException(nameof(countPredicate), "Cannot compare collection count against a <null> predicate.");
             }
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)

--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -36,7 +36,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -72,7 +72,7 @@ namespace FluentAssertions.Collections
                 throw new ArgumentNullException(nameof(countPredicate), "Cannot compare collection count against a <null> predicate.");
             }
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -107,7 +107,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -137,7 +137,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -167,7 +167,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -197,7 +197,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -227,7 +227,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -400,7 +400,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -446,7 +446,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndWhichConstraint<TAssertions, T> Contain(Expression<Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -510,7 +510,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -554,7 +554,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> NotContain(Expression<Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -587,7 +587,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -626,7 +626,7 @@ namespace FluentAssertions.Collections
             string expectationPrefix =
                 string.Format("Expected {{context:collection}} to contain a single item matching {0}{{reason}}, ", predicate.Body);
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)

--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -12,7 +12,7 @@ namespace FluentAssertions.Common
     {
         public static SelectedMemberInfo GetSelectedMemberInfo<T, TValue>(this Expression<Func<T, TValue>> expression)
         {
-            if (ReferenceEquals(expression, null))
+            if (expression is null)
             {
                 throw new ArgumentNullException(nameof(expression), "Expected an expression, but found <null>.");
             }
@@ -42,7 +42,7 @@ namespace FluentAssertions.Common
 
         public static PropertyInfo GetPropertyInfo<T, TValue>(this Expression<Func<T, TValue>> expression)
         {
-            if (ReferenceEquals(expression, null))
+            if (expression is null)
             {
                 throw new ArgumentNullException(nameof(expression), "Expected a property expression, but found <null>.");
             }

--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -22,14 +22,12 @@ namespace FluentAssertions.Common
 
             if (memberInfo != null)
             {
-                var propertyInfo = memberInfo as PropertyInfo;
-                if (propertyInfo != null)
+                if (memberInfo is PropertyInfo propertyInfo)
                 {
                     return SelectedMemberInfo.Create(propertyInfo);
                 }
 
-                var fieldInfo = memberInfo as FieldInfo;
-                if (fieldInfo != null)
+                if (memberInfo is FieldInfo fieldInfo)
                 {
                     return SelectedMemberInfo.Create(fieldInfo);
                 }
@@ -50,9 +48,7 @@ namespace FluentAssertions.Common
             var memberInfo = AttemptToGetMemberInfoFromCastExpression(expression) ??
                              AttemptToGetMemberInfoFromMemberExpression(expression);
 
-            var propertyInfo = memberInfo as PropertyInfo;
-
-            if (propertyInfo == null)
+            if (!(memberInfo is PropertyInfo propertyInfo))
             {
                 throw new ArgumentException("Cannot use <" + expression.Body + "> when a property expression is expected.",
                     nameof(expression));
@@ -64,8 +60,7 @@ namespace FluentAssertions.Common
         private static MemberInfo AttemptToGetMemberInfoFromMemberExpression<T, TValue>(
             Expression<Func<T, TValue>> expression)
         {
-            var memberExpression = expression.Body as MemberExpression;
-            if (memberExpression != null)
+            if (expression.Body is MemberExpression memberExpression)
             {
                 return memberExpression.Member;
             }
@@ -75,8 +70,7 @@ namespace FluentAssertions.Common
 
         private static MemberInfo AttemptToGetMemberInfoFromCastExpression<T, TValue>(Expression<Func<T, TValue>> expression)
         {
-            var castExpression = expression.Body as UnaryExpression;
-            if (castExpression != null)
+            if (expression.Body is UnaryExpression castExpression)
             {
                 return ((MemberExpression)castExpression.Operand).Member;
             }

--- a/Src/FluentAssertions/Common/ObjectExtensions.cs
+++ b/Src/FluentAssertions/Common/ObjectExtensions.cs
@@ -6,17 +6,17 @@ namespace FluentAssertions.Common
     {
         public static bool IsSameOrEqualTo(this object actual, object expected)
         {
-            if (ReferenceEquals(actual, null) && ReferenceEquals(expected, null))
+            if (actual is null && expected is null)
             {
                 return true;
             }
 
-            if (ReferenceEquals(actual, null))
+            if (actual is null)
             {
                 return false;
             }
 
-            if (ReferenceEquals(expected, null))
+            if (expected is null)
             {
                 return false;
             }

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -155,12 +155,12 @@ namespace FluentAssertions.Common
         /// </returns>
         public static PropertyInfo FindProperty(this Type type, string propertyName, Type preferredType)
         {
-            IEnumerable<PropertyInfo> properties =
+            List<PropertyInfo> properties =
                 type.GetProperties(PublicMembersFlag)
                     .Where(pi => pi.Name == propertyName)
                     .ToList();
 
-            return properties.Count() > 1
+            return properties.Count > 1
                 ? properties.SingleOrDefault(p => p.PropertyType == preferredType)
                 : properties.SingleOrDefault();
         }
@@ -173,12 +173,12 @@ namespace FluentAssertions.Common
         /// </returns>
         public static FieldInfo FindField(this Type type, string fieldName, Type preferredType)
         {
-            IEnumerable<FieldInfo> properties =
+            List<FieldInfo> properties =
                 type.GetFields(PublicMembersFlag)
                     .Where(pi => pi.Name == fieldName)
                     .ToList();
 
-            return properties.Count() > 1
+            return properties.Count > 1
                 ? properties.SingleOrDefault(p => p.FieldType == preferredType)
                 : properties.SingleOrDefault();
         }
@@ -272,17 +272,17 @@ namespace FluentAssertions.Common
             return typeToReflect.GetTypeInfo().IsInterface;
         }
 
-        private static IEnumerable<Type> GetInterfaces(Type type)
+        private static Type[] GetInterfaces(Type type)
         {
             return type.GetInterfaces();
         }
 
-        private static IEnumerable<PropertyInfo> GetPublicProperties(Type type)
+        private static PropertyInfo[] GetPublicProperties(Type type)
         {
             return type.GetProperties(PublicMembersFlag);
         }
 
-        private static IEnumerable<FieldInfo> GetPublicFields(Type type)
+        private static FieldInfo[] GetPublicFields(Type type)
         {
             return type.GetFields(PublicMembersFlag);
         }

--- a/Src/FluentAssertions/Equivalency/AssertionRule.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionRule.cs
@@ -36,7 +36,7 @@ namespace FluentAssertions.Equivalency
         {
             if (predicate(context))
             {
-                bool subjectIsNull = ReferenceEquals(context.Subject, null);
+                bool subjectIsNull = context.Subject is null;
 
                 bool subjectIsValidType =
                     AssertionScope.Current
@@ -44,7 +44,7 @@ namespace FluentAssertions.Equivalency
                         .FailWith("Expected " + context.SelectedMemberDescription + " from subject to be a {0}{reason}, but found a {1}.",
                             typeof(TSubject), context.Subject?.GetType());
 
-                bool expectationIsNull = ReferenceEquals(context.Expectation, null);
+                bool expectationIsNull = context.Expectation is null;
 
                 bool expectationIsValidType =
                     AssertionScope.Current

--- a/Src/FluentAssertions/Equivalency/AssertionRuleEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionRuleEquivalencyStep.cs
@@ -27,7 +27,7 @@ namespace FluentAssertions.Equivalency
 
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
         {
-            bool subjectIsNull = ReferenceEquals(context.Subject, null);
+            bool subjectIsNull = context.Subject is null;
 
             bool subjectIsValidType =
                 AssertionScope.Current
@@ -35,7 +35,7 @@ namespace FluentAssertions.Equivalency
                     .FailWith("Expected " + context.SelectedMemberDescription + " from subject to be a {0}{reason}, but found a {1}.",
                         typeof(TSubject), context.Subject?.GetType());
 
-            bool expectationIsNull = ReferenceEquals(context.Expectation, null);
+            bool expectationIsNull = context.Expectation is null;
 
             bool expectationIsValidType =
                 AssertionScope.Current

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyStep.cs
@@ -48,7 +48,7 @@ namespace FluentAssertions.Equivalency
         private static bool AssertSubjectIsCollection(object subject)
         {
             bool conditionMet = AssertionScope.Current
-                .ForCondition(!ReferenceEquals(subject, null))
+                .ForCondition(!(subject is null))
                 .FailWith("Expected a collection, but {context:Subject} is <null>.");
 
             if (conditionMet)
@@ -68,7 +68,7 @@ namespace FluentAssertions.Equivalency
 
         internal static object[] ToArray(object value)
         {
-            return !ReferenceEquals(value, null) ? ((IEnumerable)value).Cast<object>().ToArray() : null;
+            return !(value is null) ? ((IEnumerable)value).Cast<object>().ToArray() : null;
         }
     }
 }

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
@@ -53,7 +53,7 @@ namespace FluentAssertions.Equivalency
         private bool AssertIsNotNull(object expectation, object[] subject)
         {
             return AssertionScope.Current
-                .ForCondition(!ReferenceEquals(expectation, null))
+                .ForCondition(!(expectation is null))
                 .FailWith("Expected {context:subject} to be <null>, but found {0}.", new object[] { subject });
         }
 

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
@@ -62,7 +62,7 @@ namespace FluentAssertions.Equivalency
         {
             get
             {
-                return ((compileTimeType != typeof(object)) || ReferenceEquals(Expectation, null)) ? compileTimeType : RuntimeType;
+                return ((compileTimeType != typeof(object)) || Expectation is null) ? compileTimeType : RuntimeType;
             }
             set => compileTimeType = value;
         }

--- a/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
@@ -52,7 +52,7 @@ namespace FluentAssertions.Equivalency
         private static bool AssertExpectationIsNotNull(object subject, object expectation)
         {
             return AssertionScope.Current
-                .ForCondition(!ReferenceEquals(expectation, null))
+                .ForCondition(!(expectation is null))
                 .FailWith("Expected {context:Subject} to be {0}, but found {1}.", null, subject);
         }
 

--- a/Src/FluentAssertions/Equivalency/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericEnumerableEquivalencyStep.cs
@@ -81,7 +81,7 @@ namespace FluentAssertions.Equivalency
         private static bool AssertSubjectIsCollection(object expectation, object subject)
         {
             bool conditionMet = AssertionScope.Current
-                .ForCondition(!ReferenceEquals(subject, null))
+                .ForCondition(!(subject is null))
                 .FailWith("Expected {context:Subject} not to be {0}.", new object[] { null });
 
             if (conditionMet)

--- a/Src/FluentAssertions/Equivalency/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericEnumerableEquivalencyStep.cs
@@ -54,7 +54,7 @@ namespace FluentAssertions.Equivalency
 
                 Type typeOfEnumeration = GetTypeOfEnumeration(expectedType);
 
-                Expression expectationAsArray = ToArray(context.Expectation, typeOfEnumeration);
+                MethodCallExpression expectationAsArray = ToArray(context.Expectation, typeOfEnumeration);
                 ConstantExpression subjectAsArray =
                     Expression.Constant(EnumerableEquivalencyStep.ToArray(context.Subject));
 

--- a/Src/FluentAssertions/Equivalency/MemberInfoSelectedMemberInfo.cs
+++ b/Src/FluentAssertions/Equivalency/MemberInfoSelectedMemberInfo.cs
@@ -26,7 +26,7 @@ namespace FluentAssertions.Equivalency
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
+            if (obj is null)
             {
                 return false;
             }

--- a/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
@@ -61,7 +61,7 @@ namespace FluentAssertions.Equivalency
         private static bool IsArray(object type)
         {
             return AssertionScope.Current
-                .ForCondition(!ReferenceEquals(type, null))
+                .ForCondition(!(type is null))
                 .FailWith("Cannot compare a multi-dimensional array to {0}.", new object[] { null })
                 .Then
                 .ForCondition(type is Array)

--- a/Src/FluentAssertions/Equivalency/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/ObjectReference.cs
@@ -29,9 +29,7 @@ namespace FluentAssertions.Equivalency
         /// <param name="obj">The <see cref="T:System.Object"/> to compare with the current <see cref="T:System.Object"/>. </param><filterpriority>2</filterpriority>
         public override bool Equals(object obj)
         {
-            var other = obj as ObjectReference;
-
-            if (other is null)
+            if (!(obj is ObjectReference other))
             {
                 return false;
             }

--- a/Src/FluentAssertions/Equivalency/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/ObjectReference.cs
@@ -31,7 +31,7 @@ namespace FluentAssertions.Equivalency
         {
             var other = obj as ObjectReference;
 
-            if (ReferenceEquals(other, null))
+            if (other is null)
             {
                 return false;
             }
@@ -64,6 +64,6 @@ namespace FluentAssertions.Equivalency
             return $"{{\"{path}\", {@object}}}";
         }
 
-        public bool IsComplexType => isComplexType ?? (!ReferenceEquals(@object, null) && !@object.GetType().OverridesEquals());
+        public bool IsComplexType => isComplexType ?? (!(@object is null) && !@object.GetType().OverridesEquals());
     }
 }

--- a/Src/FluentAssertions/Equivalency/StringEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/StringEqualityEquivalencyStep.cs
@@ -70,7 +70,7 @@ namespace FluentAssertions.Equivalency
 
         private static bool ValidateAgainstType<T>(IEquivalencyValidationContext context)
         {
-            bool subjectIsNull = ReferenceEquals(context.Subject, null);
+            bool subjectIsNull = context.Subject is null;
             if (subjectIsNull)
             {
                 // Do not know the declared type of the expectation.

--- a/Src/FluentAssertions/Equivalency/StructuralEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/StructuralEqualityEquivalencyStep.cs
@@ -18,14 +18,14 @@ namespace FluentAssertions.Equivalency
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
         {
             bool expectationIsNotNull = AssertionScope.Current
-                .ForCondition(!ReferenceEquals(context.Expectation, null))
+                .ForCondition(!(context.Expectation is null))
                 .FailWith(
                     "Expected {context:subject} to be <null>, but found {0}.",
                     context.Subject);
 
             bool subjectIsNotNull =
                 AssertionScope.Current.ForCondition(
-                    !ReferenceEquals(context.Subject, null))
+                    !(context.Subject is null))
                     .FailWith(
                         "Expected {context:object} to be {0}{reason}, but found {1}.",
                         context.Expectation,

--- a/Src/FluentAssertions/Equivalency/TryConversionStep.cs
+++ b/Src/FluentAssertions/Equivalency/TryConversionStep.cs
@@ -40,7 +40,7 @@ namespace FluentAssertions.Equivalency
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator structuralEqualityValidator,
             IEquivalencyAssertionOptions config)
         {
-            if (!ReferenceEquals(context.Expectation, null) && !ReferenceEquals(context.Subject, null)
+            if (!(context.Expectation is null) && !(context.Subject is null)
                 && !context.Subject.GetType().IsSameOrInherits(context.Expectation.GetType()))
             {
                 Type expectationType = context.Expectation.GetType();

--- a/Src/FluentAssertions/Events/EventRecorder.cs
+++ b/Src/FluentAssertions/Events/EventRecorder.cs
@@ -55,7 +55,7 @@ namespace FluentAssertions.Events
 
             cleanup = () =>
             {
-                if (!ReferenceEquals(subject.Target, null))
+                if (!(subject.Target is null))
                 {
                     eventInfo.RemoveEventHandler(subject.Target, handler);
                 }

--- a/Src/FluentAssertions/Events/RecordedEvent.cs
+++ b/Src/FluentAssertions/Events/RecordedEvent.cs
@@ -35,10 +35,7 @@ namespace FluentAssertions.Events
             get
             {
                 return parameters.Select(parameter =>
-                {
-                    var weakReference = parameter as WeakReference;
-                    return (weakReference != null) ? weakReference.Target : parameter;
-                }).ToArray();
+                    (parameter is WeakReference weakReference) ? weakReference.Target : parameter).ToArray();
             }
 
             private set { parameters = value.ToArray(); }

--- a/Src/FluentAssertions/Execution/ContextDataItems.cs
+++ b/Src/FluentAssertions/Execution/ContextDataItems.cs
@@ -82,8 +82,8 @@ namespace FluentAssertions.Execution
 
             public DataItem Clone()
             {
-                var cloneable = Value as ICloneable2;
-                return new DataItem(Key, (cloneable != null) ? cloneable.Clone() : Value, reportability);
+                object value = (Value is ICloneable2 cloneable) ? cloneable.Clone() : Value;
+                return new DataItem(Key, value, reportability);
             }
         }
     }

--- a/Src/FluentAssertions/Execution/GivenSelectorExtensions.cs
+++ b/Src/FluentAssertions/Execution/GivenSelectorExtensions.cs
@@ -11,7 +11,7 @@ namespace FluentAssertions.Execution
             this GivenSelector<IEnumerable<T>> givenSelector)
         {
             return givenSelector
-                .ForCondition(items => !ReferenceEquals(items, null))
+                .ForCondition(items => !(items is null))
                 .FailWith("but found collection is <null>.");
         }
 

--- a/Src/FluentAssertions/Execution/MessageBuilder.cs
+++ b/Src/FluentAssertions/Execution/MessageBuilder.cs
@@ -44,7 +44,7 @@ namespace FluentAssertions.Execution
 
         private string SubstituteIdentifier(string message, string identifier, string fallbackIdentifier)
         {
-            string pattern = @"(\s|^)\{context(?:\:(?<default>[a-z|A-Z|\s]+))?\}";
+            const string pattern = @"(\s|^)\{context(?:\:(?<default>[a-z|A-Z|\s]+))?\}";
 
             message = Regex.Replace(message, pattern, match =>
             {
@@ -72,7 +72,7 @@ namespace FluentAssertions.Execution
 
         private string SubstituteContextualTags(string message, ContextDataItems contextData)
         {
-            string pattern = @"(?<!\{)\{(?<key>[a-z|A-Z]+)(?:\:(?<default>[a-z|A-Z|\s]+))?\}(?!\})";
+            const string pattern = @"(?<!\{)\{(?<key>[a-z|A-Z]+)(?:\:(?<default>[a-z|A-Z|\s]+))?\}(?!\})";
 
             return Regex.Replace(message, pattern, match =>
             {

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -7,6 +7,7 @@
     <NoWarn>1701;1702;1705;1591;1574;1572;1573;419</NoWarn>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <CodeAnalysisRuleSet>..\..\Rules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
     <DefineConstants>NET45</DefineConstants>

--- a/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
@@ -24,59 +24,59 @@ namespace FluentAssertions.Formatting
         /// <inheritdoc />
         public string Format(object value, FormattingContext context, FormatChild formatChild)
         {
-            DateTimeOffset dateTime;
+            DateTimeOffset dateTimeOffset;
 
-            if (value is DateTime)
+            if (value is DateTime dateTime)
             {
-                dateTime = ((DateTime)value).ToDateTimeOffset();
+                dateTimeOffset = dateTime.ToDateTimeOffset();
             }
             else
             {
-                dateTime = (DateTimeOffset)value;
+                dateTimeOffset = (DateTimeOffset)value;
             }
 
             var fragments = new List<string>();
 
-            if (HasDate(dateTime))
+            if (HasDate(dateTimeOffset))
             {
-                fragments.Add(dateTime.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+                fragments.Add(dateTimeOffset.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
             }
 
-            if (HasTime(dateTime))
+            if (HasTime(dateTimeOffset))
             {
-                if (HasNanoSeconds(dateTime))
+                if (HasNanoSeconds(dateTimeOffset))
                 {
-                    fragments.Add(dateTime.ToString("HH:mm:ss.fffffff", CultureInfo.InvariantCulture));
+                    fragments.Add(dateTimeOffset.ToString("HH:mm:ss.fffffff", CultureInfo.InvariantCulture));
                 }
-                else if (HasMicroSeconds(dateTime))
+                else if (HasMicroSeconds(dateTimeOffset))
                 {
-                    fragments.Add(dateTime.ToString("HH:mm:ss.ffffff", CultureInfo.InvariantCulture));
+                    fragments.Add(dateTimeOffset.ToString("HH:mm:ss.ffffff", CultureInfo.InvariantCulture));
                 }
-                else if (HasMilliSeconds(dateTime))
+                else if (HasMilliSeconds(dateTimeOffset))
                 {
-                    fragments.Add(dateTime.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture));
+                    fragments.Add(dateTimeOffset.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture));
                 }
                 else
                 {
-                    fragments.Add(dateTime.ToString("HH:mm:ss", CultureInfo.InvariantCulture));
+                    fragments.Add(dateTimeOffset.ToString("HH:mm:ss", CultureInfo.InvariantCulture));
                 }
             }
 
-            if (dateTime.Offset > TimeSpan.Zero)
+            if (dateTimeOffset.Offset > TimeSpan.Zero)
             {
-                fragments.Add("+" + formatChild("offset", dateTime.Offset));
+                fragments.Add("+" + formatChild("offset", dateTimeOffset.Offset));
             }
 
-            if (dateTime.Offset < TimeSpan.Zero)
+            if (dateTimeOffset.Offset < TimeSpan.Zero)
             {
-                fragments.Add(formatChild("offset", dateTime.Offset));
+                fragments.Add(formatChild("offset", dateTimeOffset.Offset));
             }
 
             if (!fragments.Any())
             {
-                if (HasMilliSeconds(dateTime))
+                if (HasMilliSeconds(dateTimeOffset))
                 {
-                    fragments.Add("0001-01-01 00:00:00." + dateTime.ToString("fff", CultureInfo.InvariantCulture));
+                    fragments.Add("0001-01-01 00:00:00." + dateTimeOffset.ToString("fff", CultureInfo.InvariantCulture));
                 }
                 else
                 {

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -52,7 +52,7 @@ namespace FluentAssertions.Formatting
 
         private static bool HasDefaultToStringImplementation(object value)
         {
-            return ReferenceEquals(value.ToString(), null) || value.ToString().Equals(value.GetType().ToString());
+            return value.ToString() is null || value.ToString().Equals(value.GetType().ToString());
         }
 
         private static string GetTypeAndPublicPropertyValues(object obj, FormattingContext context, FormatChild formatChild)

--- a/Src/FluentAssertions/Formatting/EnumerableValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/EnumerableValueFormatter.cs
@@ -28,7 +28,7 @@ namespace FluentAssertions.Formatting
             {
                 string postfix = "";
 
-                int maxItems = 32;
+                const int maxItems = 32;
                 if (enumerable.Count > maxItems)
                 {
                     postfix = $", …{enumerable.Count - maxItems} more…";

--- a/Src/FluentAssertions/Formatting/NullValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/NullValueFormatter.cs
@@ -13,7 +13,7 @@ namespace FluentAssertions.Formatting
         /// </returns>
         public bool CanHandle(object value)
         {
-            return ReferenceEquals(value, null);
+            return value is null;
         }
 
         /// <inheritdoc />

--- a/Src/FluentAssertions/Formatting/TaskFormatter.cs
+++ b/Src/FluentAssertions/Formatting/TaskFormatter.cs
@@ -15,9 +15,7 @@ namespace FluentAssertions.Formatting
 
         public string Format(object value, FormattingContext context, FormatChild formatChild)
         {
-            var task = value as Task;
-
-            if (!(task is null))
+            if (value is Task task)
             {
                 return $"{formatChild("type", task.GetType())} {{Status={task.Status}}}";
             }

--- a/Src/FluentAssertions/Formatting/TaskFormatter.cs
+++ b/Src/FluentAssertions/Formatting/TaskFormatter.cs
@@ -17,7 +17,7 @@ namespace FluentAssertions.Formatting
         {
             var task = value as Task;
 
-            if (!ReferenceEquals(task, null))
+            if (!(task is null))
             {
                 return $"{formatChild("type", task.GetType())} {{Status={task.Status}}}";
             }

--- a/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
@@ -34,7 +34,7 @@ namespace FluentAssertions.Formatting
                 return "max time span";
             }
 
-            IEnumerable<string> fragments = GetNonZeroFragments(timeSpan);
+            List<string> fragments = GetNonZeroFragments(timeSpan);
 
             if (!fragments.Any())
             {
@@ -43,7 +43,7 @@ namespace FluentAssertions.Formatting
 
             string sign = (timeSpan.Ticks >= 0) ? "" : "-";
 
-            if (fragments.Count() == 1)
+            if (fragments.Count == 1)
             {
                 return sign + fragments.Single();
             }
@@ -53,7 +53,7 @@ namespace FluentAssertions.Formatting
             }
         }
 
-        private static IEnumerable<string> GetNonZeroFragments(TimeSpan timeSpan)
+        private static List<string> GetNonZeroFragments(TimeSpan timeSpan)
         {
             TimeSpan absoluteTimespan = timeSpan.Duration();
 

--- a/Src/FluentAssertions/Numeric/NullableNumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableNumericAssertions.cs
@@ -25,7 +25,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null))
+                .ForCondition(!(Subject is null))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value{reason}.");
 
@@ -60,7 +60,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(ReferenceEquals(Subject, null))
+                .ForCondition(Subject is null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect a value{reason}, but found {0}.", Subject);
 

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -17,7 +17,7 @@ namespace FluentAssertions.Numeric
     {
         public NumericAssertions(object value)
         {
-            if (!ReferenceEquals(value, null))
+            if (!(value is null))
             {
                 Subject = value as IComparable;
                 if (Subject == null)
@@ -43,7 +43,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null) && Subject.CompareTo(expected) == 0)
+                .ForCondition(!(Subject is null) && Subject.CompareTo(expected) == 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be {0}{reason}, but found {1}.", expected, Subject);
 
@@ -64,7 +64,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition((ReferenceEquals(Subject, null) && !expected.HasValue) || (!ReferenceEquals(Subject, null) && Subject.CompareTo(expected) == 0))
+                .ForCondition((Subject is null && !expected.HasValue) || (!(Subject is null) && Subject.CompareTo(expected) == 0))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be {0}{reason}, but found {1}.", expected, Subject);
 
@@ -85,7 +85,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<NumericAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(ReferenceEquals(Subject, null) || Subject.CompareTo(unexpected) != 0)
+                .ForCondition(Subject is null || Subject.CompareTo(unexpected) != 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:value} to be {0}{reason}.", unexpected);
 
@@ -106,7 +106,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<NumericAssertions<T>> NotBe(T? unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition((ReferenceEquals(Subject, null) == unexpected.HasValue) || (!ReferenceEquals(Subject, null) && Subject.CompareTo(unexpected) != 0))
+                .ForCondition((Subject is null == unexpected.HasValue) || (!(Subject is null) && Subject.CompareTo(unexpected) != 0))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:value} to be {0}{reason}.", unexpected);
 
@@ -126,7 +126,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<NumericAssertions<T>> BePositive(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null) && Subject.CompareTo(default(T)) > 0)
+                .ForCondition(!(Subject is null) && Subject.CompareTo(default(T)) > 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be positive{reason}, but found {0}.", Subject);
 
@@ -146,7 +146,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<NumericAssertions<T>> BeNegative(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null) && Subject.CompareTo(default(T)) < 0)
+                .ForCondition(!(Subject is null) && Subject.CompareTo(default(T)) < 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be negative{reason}, but found {0}.", Subject);
 
@@ -167,7 +167,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<NumericAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null) && Subject.CompareTo(expected) < 0)
+                .ForCondition(!(Subject is null) && Subject.CompareTo(expected) < 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be less than {0}{reason}, but found {1}.", expected, Subject);
 
@@ -189,7 +189,7 @@ namespace FluentAssertions.Numeric
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null) && Subject.CompareTo(expected) <= 0)
+                .ForCondition(!(Subject is null) && Subject.CompareTo(expected) <= 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be less or equal to {0}{reason}, but found {1}.", expected, Subject);
 
@@ -211,7 +211,7 @@ namespace FluentAssertions.Numeric
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null) && Subject.CompareTo(expected) > 0)
+                .ForCondition(!(Subject is null) && Subject.CompareTo(expected) > 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be greater than {0}{reason}, but found {1}.", expected, Subject);
 
@@ -233,7 +233,7 @@ namespace FluentAssertions.Numeric
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null) && Subject.CompareTo(expected) >= 0)
+                .ForCondition(!(Subject is null) && Subject.CompareTo(expected) >= 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be greater or equal to {0}{reason}, but found {1}.", expected, Subject);
 
@@ -263,7 +263,7 @@ namespace FluentAssertions.Numeric
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null) && (Subject.CompareTo(minimumValue) >= 0) && (Subject.CompareTo(maximumValue) <= 0))
+                .ForCondition(!(Subject is null) && (Subject.CompareTo(minimumValue) >= 0) && (Subject.CompareTo(maximumValue) <= 0))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be between {0} and {1}{reason}, but found {2}.",
                     minimumValue, maximumValue, Subject);
@@ -294,7 +294,7 @@ namespace FluentAssertions.Numeric
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null) && !((Subject.CompareTo(minimumValue) >= 0) && (Subject.CompareTo(maximumValue) <= 0)))
+                .ForCondition(!(Subject is null) && !((Subject.CompareTo(minimumValue) >= 0) && (Subject.CompareTo(maximumValue) <= 0)))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to not be between {0} and {1}{reason}, but found {2}.",
                     minimumValue, maximumValue, Subject);
@@ -330,7 +330,7 @@ namespace FluentAssertions.Numeric
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null) && validValues.Contains((T)Subject))
+                .ForCondition(!(Subject is null) && validValues.Contains((T)Subject))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be one of {0}{reason}, but found {1}.", validValues, Subject);
 

--- a/Src/FluentAssertions/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ObjectAssertionsExtensions.cs
@@ -123,8 +123,10 @@ namespace FluentAssertions
         private static object CreateCloneUsingBinarySerializer(object subject)
         {
             var stream = new MemoryStream();
-            var binaryFormatter = new BinaryFormatter();
-            binaryFormatter.Binder = new SimpleBinder(subject.GetType());
+            var binaryFormatter = new BinaryFormatter
+            {
+                Binder = new SimpleBinder(subject.GetType())
+            };
 
             binaryFormatter.Serialize(stream, subject);
             stream.Position = 0;

--- a/Src/FluentAssertions/Primitives/ObjectAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ObjectAssertions.cs
@@ -143,7 +143,7 @@ namespace FluentAssertions.Primitives
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(!ReferenceEquals(Subject, null))
+                .ForCondition(!(Subject is null))
                 .FailWith("Expected type to be {0}{reason}, but found <null>.", expectedFlag.GetType())
                 .Then
                 .ForCondition(Subject.GetType() == expectedFlag.GetType())
@@ -172,7 +172,7 @@ namespace FluentAssertions.Primitives
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(!ReferenceEquals(Subject, null))
+                .ForCondition(!(Subject is null))
                 .FailWith("Expected type to be {0}{reason}, but found <null>.", unexpectedFlag.GetType())
                 .Then
                 .ForCondition(Subject.GetType() == unexpectedFlag.GetType())

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -241,7 +241,7 @@ namespace FluentAssertions.Primitives
             }
 
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null))
+                .ForCondition(!(Subject is null))
                 .UsingLineBreaks
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} to match regex {0}{reason}, but it was <null>.", regularExpression);
@@ -287,7 +287,7 @@ namespace FluentAssertions.Primitives
             }
 
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null))
+                .ForCondition(!(Subject is null))
                 .UsingLineBreaks
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} to not match regex {0}{reason}, but it was <null>.", regularExpression);

--- a/Src/FluentAssertions/Types/MethodBaseAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodBaseAssertions.cs
@@ -64,9 +64,7 @@ namespace FluentAssertions.Types
         {
             var parameterTypes = methodBase.GetParameters().Select(p => p.ParameterType);
 
-            return !parameterTypes.Any()
-                ? string.Empty
-                : parameterTypes.Select(p => p.FullName).Aggregate((p, c) => p + ", " + c);
+            return string.Join(", ", parameterTypes.Select(p => p.FullName));
         }
     }
 }

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -1033,12 +1033,7 @@ namespace FluentAssertions.Types
 
         private string GetParameterString(IEnumerable<Type> parameterTypes)
         {
-            if (!parameterTypes.Any())
-            {
-                return string.Empty;
-            }
-
-            return parameterTypes.Select(p => p.FullName).Aggregate((p, c) => p + ", " + c);
+            return string.Join(", ", parameterTypes.Select(p => p.FullName));
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -161,7 +161,7 @@ namespace FluentAssertions.Types
         /// </summary>
         public TypeSelector ThatAreNotUnderNamespace(string @namespace)
         {
-            types = types.Where(t => !(t.Namespace?.StartsWith(@namespace) == true)).ToList();
+            types = types.Where(t => t.Namespace?.StartsWith(@namespace) != true).ToList();
             return this;
         }
 

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -42,7 +42,7 @@ namespace FluentAssertions.Types
         public AndConstraint<TypeSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
-            IEnumerable<Type> typesWithoutAttribute = Subject
+            Type[] typesWithoutAttribute = Subject
                 .Where(type => !type.IsDecoratedWith<TAttribute>())
                 .ToArray();
 
@@ -76,7 +76,7 @@ namespace FluentAssertions.Types
             Expression<Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
-            IEnumerable<Type> typesWithoutMatchingAttribute = Subject
+            Type[] typesWithoutMatchingAttribute = Subject
                 .Where(type => !type.HasMatchingAttribute(isMatchingAttributePredicate))
                 .ToArray();
 
@@ -106,7 +106,7 @@ namespace FluentAssertions.Types
         public AndConstraint<TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
-            IEnumerable<Type> typesWithoutAttribute = Subject
+            Type[] typesWithoutAttribute = Subject
                 .Where(type => !type.IsDecoratedWith<TAttribute>(true))
                 .ToArray();
 
@@ -140,7 +140,7 @@ namespace FluentAssertions.Types
             Expression<Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
-            IEnumerable<Type> typesWithoutMatchingAttribute = Subject
+            Type[] typesWithoutMatchingAttribute = Subject
                 .Where(type => !type.HasMatchingAttribute(isMatchingAttributePredicate, true))
                 .ToArray();
 
@@ -170,7 +170,7 @@ namespace FluentAssertions.Types
         public AndConstraint<TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
-            IEnumerable<Type> typesWithAttribute = Subject
+            Type[] typesWithAttribute = Subject
                 .Where(type => type.IsDecoratedWith<TAttribute>())
                 .ToArray();
 
@@ -204,7 +204,7 @@ namespace FluentAssertions.Types
             Expression<Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
-            IEnumerable<Type> typesWithMatchingAttribute = Subject
+            Type[] typesWithMatchingAttribute = Subject
                 .Where(type => type.HasMatchingAttribute(isMatchingAttributePredicate))
                 .ToArray();
 
@@ -234,7 +234,7 @@ namespace FluentAssertions.Types
         public AndConstraint<TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
-            IEnumerable<Type> typesWithAttribute = Subject
+            Type[] typesWithAttribute = Subject
                 .Where(type => type.IsDecoratedWith<TAttribute>(true))
                 .ToArray();
 
@@ -268,7 +268,7 @@ namespace FluentAssertions.Types
             Expression<Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
-            IEnumerable<Type> typesWithMatchingAttribute = Subject
+            Type[] typesWithMatchingAttribute = Subject
                 .Where(type => type.HasMatchingAttribute(isMatchingAttributePredicate, true))
                 .ToArray();
 

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -79,7 +79,7 @@ namespace FluentAssertions.Xml
         public AndConstraint<XDocumentAssertions> NotBe(XDocument unexpected, string because, params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null))
+                .ForCondition(!(Subject is null))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect XML document to be {0}, but found <null>.", unexpected);
 

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -82,7 +82,7 @@ namespace FluentAssertions.Xml
         public AndConstraint<XElementAssertions> NotBe(XElement unexpected, string because, params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition((ReferenceEquals(Subject, null) && !ReferenceEquals(unexpected, null)) || !XNode.DeepEquals(Subject, unexpected))
+                .ForCondition((Subject is null && !(unexpected is null)) || !XNode.DeepEquals(Subject, unexpected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected XML element not to be {0}{reason}.", unexpected);
 

--- a/Src/FluentAssertions/Xml/XmlNodeFormatter.cs
+++ b/Src/FluentAssertions/Xml/XmlNodeFormatter.cs
@@ -18,7 +18,7 @@ namespace FluentAssertions.Xml
         {
             string outerXml = ((XmlNode)value).OuterXml;
 
-            int maxLength = 20;
+            const int maxLength = 20;
 
             if (outerXml.Length > maxLength)
             {

--- a/TestRules.ruleset
+++ b/TestRules.ruleset
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Rules for Fluent Assertions" Description="Code analysis rules for Fluent Assertions." ToolsVersion="15.0">
+  <Include Path="Rules.ruleset" Action="Default" />
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Features" RuleNamespace="Microsoft.CodeAnalysis.Features">
+  </Rules>
+  <Rules AnalyzerId="Roslynator.CSharp.Analyzers" RuleNamespace="Roslynator.CSharp.Analyzers">
+    <Rule Id="RCS1079" Action="None" />
+    <Rule Id="RCS1118" Action="None" />
+    <Rule Id="RCS1163" Action="None" />
+    <Rule Id="RCS1170" Action="None" />
+    <Rule Id="RCS1194" Action="None" />
+    <Rule Id="RCS1213" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="U2UConsult.CodeAnalyzers" RuleNamespace="U2UConsult.CodeAnalyzers">
+    <Rule Id="U2U1005" Action="None" />
+    <Rule Id="U2U1018" Action="None" />
+    <Rule Id="U2U1019" Action="None" />
+    <Rule Id="U2U1020" Action="None" />
+    <Rule Id="U2U1200" Action="None" />
+  </Rules>
+</RuleSet>

--- a/Tests/AssemblyA/AssemblyA.csproj
+++ b/Tests/AssemblyA/AssemblyA.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <CodeAnalysisRuleSet>..\..\Rules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/Tests/AssemblyB/AssemblyB.csproj
+++ b/Tests/AssemblyB/AssemblyB.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <CodeAnalysisRuleSet>..\..\Rules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/Tests/Net45.Specs/Net45.Specs.csproj
+++ b/Tests/Net45.Specs/Net45.Specs.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>FluentAssertions.Net45.Specs</AssemblyName>
     <RootNamespace>FluentAssertions.Net45.Specs</RootNamespace>
     <DefineConstants>$(DefineConstants);NET45</DefineConstants>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\..\TestRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/Tests/Net47.Specs/Net47.Specs.csproj
+++ b/Tests/Net47.Specs/Net47.Specs.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>FluentAssertions.Net47.Specs</AssemblyName>
     <RootNamespace>FluentAssertions.Net47.Specs</RootNamespace>
     <DefineConstants>$(DefineConstants);NET47</DefineConstants>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\..\TestRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/Tests/NetCore.Specs/NetCore.Specs.csproj
+++ b/Tests/NetCore.Specs/NetCore.Specs.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <AssemblyName>FluentAssertions.NetCore.Specs</AssemblyName>
     <RootNamespace>FluentAssertions.NetCore.Specs</RootNamespace>
+    <CodeAnalysisRuleSet>..\..\TestRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="4.5.1" />

--- a/Tests/NetCore13.Specs/NetCore13.Specs.csproj
+++ b/Tests/NetCore13.Specs/NetCore13.Specs.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>FluentAssertions.NetCore13.Specs</AssemblyName>
     <RootNamespace>FluentAssertions.NetCore13.Specs</RootNamespace>
     <DefineConstants>NETSTANDARD1_3</DefineConstants>
+    <CodeAnalysisRuleSet>..\..\TestRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="4.5.1" />

--- a/Tests/NetCore20.Specs/NetCore20.Specs.csproj
+++ b/Tests/NetCore20.Specs/NetCore20.Specs.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>FluentAssertions.NetCore20.Specs</AssemblyName>
     <RootNamespace>FluentAssertions.NetCore20.Specs</RootNamespace>
+    <CodeAnalysisRuleSet>..\..\TestRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="4.5.1" />

--- a/Tests/Shared.Specs/AssertionScopeSpecs.cs
+++ b/Tests/Shared.Specs/AssertionScopeSpecs.cs
@@ -7,7 +7,9 @@ using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
+#pragma warning disable RCS1110 // Declare type inside namespace.
 public class AssertionScopeSpecsWithoutNamespace
+#pragma warning restore RCS1110 // Declare type inside namespace.
 {
 #if NET45 || NET47 || NETCOREAPP2_0
     [Fact]

--- a/Tests/Shared.Specs/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/AsyncFunctionExceptionAssertionSpecs.cs
@@ -20,7 +20,7 @@ namespace FluentAssertions.Net45.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action action = () => asyncObject
-                .Awaiting(async x => await x.ThrowAsync<ArgumentNullException>())
+                .Awaiting(x => x.ThrowAsync<ArgumentNullException>())
                 .Should().ThrowExactly<ArgumentException>("because {0} should do that", "IFoo.Do");
 
             //-----------------------------------------------------------------------------------------------------------
@@ -42,7 +42,7 @@ namespace FluentAssertions.Net45.Specs
             // Act / Assert
             //-----------------------------------------------------------------------------------------------------------
             asyncObject
-                .Awaiting(async x => await x.ThrowAsync<ArgumentNullException>())
+                .Awaiting(x => x.ThrowAsync<ArgumentNullException>())
                 .Should().ThrowExactly<ArgumentNullException>();
         }
 
@@ -58,7 +58,7 @@ namespace FluentAssertions.Net45.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action action = () => asyncObject
-                .Awaiting(async x => await x.ThrowAsync<ArgumentException>())
+                .Awaiting(x => x.ThrowAsync<ArgumentException>())
                 .Should().Throw<ArgumentException>();
 
             //-----------------------------------------------------------------------------------------------------------
@@ -79,7 +79,7 @@ namespace FluentAssertions.Net45.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action action = () => asyncObject
-                .Awaiting(async x => await x.SucceedAsync())
+                .Awaiting(x => x.SucceedAsync())
                 .Should().Throw<InvalidOperationException>("because {0} should do that", "IFoo.Do");
 
             //-----------------------------------------------------------------------------------------------------------
@@ -101,7 +101,7 @@ namespace FluentAssertions.Net45.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action action = () => asyncObject
-                .Awaiting(async x => await x.ThrowAsync<ArgumentException>())
+                .Awaiting(x => x.ThrowAsync<ArgumentException>())
                 .Should().Throw<InvalidOperationException>("because {0} should do that", "IFoo.Do");
 
             //-----------------------------------------------------------------------------------------------------------
@@ -123,7 +123,7 @@ namespace FluentAssertions.Net45.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action action = () => asyncObject
-                .Awaiting(async x => await x.SucceedAsync())
+                .Awaiting(x => x.SucceedAsync())
                 .Should().NotThrow();
 
             //-----------------------------------------------------------------------------------------------------------
@@ -144,7 +144,7 @@ namespace FluentAssertions.Net45.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action action = () => asyncObject
-                .Awaiting(async x => await x.ThrowAsync<ArgumentException>())
+                .Awaiting(x => x.ThrowAsync<ArgumentException>())
                 .Should().NotThrow();
 
             //-----------------------------------------------------------------------------------------------------------
@@ -166,7 +166,7 @@ namespace FluentAssertions.Net45.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action action = () => asyncObject
-                .Awaiting(async x => await x.ThrowAsync<ArgumentException>())
+                .Awaiting(x => x.ThrowAsync<ArgumentException>())
                 .Should().NotThrow<InvalidOperationException>();
 
             //-----------------------------------------------------------------------------------------------------------
@@ -187,7 +187,7 @@ namespace FluentAssertions.Net45.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action action = () => asyncObject
-                .Awaiting(async x => await asyncObject.SucceedAsync())
+                .Awaiting(x => asyncObject.SucceedAsync())
                 .Should().NotThrow<InvalidOperationException>();
 
             //-----------------------------------------------------------------------------------------------------------
@@ -208,7 +208,7 @@ namespace FluentAssertions.Net45.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action action = () => asyncObject
-                .Awaiting(async x => await x.ThrowAsync<ArgumentException>())
+                .Awaiting(x => x.ThrowAsync<ArgumentException>())
                 .Should().NotThrow<ArgumentException>();
 
             //-----------------------------------------------------------------------------------------------------------

--- a/Tests/Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/BasicEquivalencySpecs.cs
@@ -3986,7 +3986,7 @@ namespace FluentAssertions.Specs
 
         public override int GetHashCode()
         {
-            return (Code?.GetHashCode() ?? 0);
+            return Code?.GetHashCode() ?? 0;
         }
 
         public static bool operator ==(CustomerType a, CustomerType b)

--- a/Tests/Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/BasicEquivalencySpecs.cs
@@ -4166,7 +4166,7 @@ namespace FluentAssertions.Specs
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
+            if (obj is null)
             {
                 return false;
             }

--- a/Tests/Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/CollectionAssertionSpecs.cs
@@ -4993,6 +4993,7 @@ namespace FluentAssertions.Specs
         }
 
         public int GetEnumeratorCallCount { get; private set; }
+
         public IEnumerator GetEnumerator()
         {
             GetEnumeratorCallCount++;
@@ -5002,6 +5003,7 @@ namespace FluentAssertions.Specs
         public void CopyTo(Array array, int index) { throw new NotImplementedException(); }
 
         public int GetCountCallCount { get; private set; }
+
         public int Count
         {
             get
@@ -5025,6 +5027,7 @@ namespace FluentAssertions.Specs
         }
 
         public int GetEnumeratorCallCount { get; private set; }
+
         public IEnumerator<TElement> GetEnumerator()
         {
             GetEnumeratorCallCount++;
@@ -5043,6 +5046,7 @@ namespace FluentAssertions.Specs
         public bool Remove(TElement item) { throw new NotImplementedException(); }
 
         public int GetCountCallCount { get; private set; }
+
         public int Count
         {
             get
@@ -5068,25 +5072,21 @@ namespace FluentAssertions.Specs
 
     internal class TrackingTestEnumerable : IEnumerable
     {
-        private readonly TrackingEnumerator enumerator;
         private readonly int[] values;
 
         public TrackingTestEnumerable(params int[] values)
         {
             this.values = values;
-            enumerator = new TrackingEnumerator(this.values);
+            Enumerator = new TrackingEnumerator(this.values);
         }
 
-        public TrackingEnumerator Enumerator
-        {
-            get { return enumerator; }
-        }
+        public TrackingEnumerator Enumerator { get; }
 
         public IEnumerator GetEnumerator()
         {
-            enumerator.IncreaseEnumerationCount();
-            enumerator.Reset();
-            return enumerator;
+            Enumerator.IncreaseEnumerationCount();
+            Enumerator.Reset();
+            return Enumerator;
         }
     }
 

--- a/Tests/Shared.Specs/DictionaryEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/DictionaryEquivalencySpecs.cs
@@ -268,7 +268,7 @@ namespace FluentAssertions.Specs
 
             public bool Equals(SomeBaseKeyClass other)
             {
-                if (object.ReferenceEquals(other, null))
+                if (other is null)
                 {
                     return false;
                 }

--- a/Tests/Shared.Specs/EnumAssertionSpecs.cs
+++ b/Tests/Shared.Specs/EnumAssertionSpecs.cs
@@ -10,9 +10,9 @@ namespace FluentAssertions.Specs
 {
     public enum EnumULong : ulong
     {
-        UInt64Max = UInt64.MaxValue,
+        Int64Max = Int64.MaxValue,
         UInt64LessOne = UInt64.MaxValue - 1,
-        Int64Max = Int64.MaxValue
+        UInt64Max = UInt64.MaxValue
     }
 
     public enum EnumLong : long

--- a/Tests/Shared.Specs/EventAssertionSpecs.cs
+++ b/Tests/Shared.Specs/EventAssertionSpecs.cs
@@ -857,7 +857,15 @@ namespace FluentAssertions.Specs
             string typeName = baseType.Name + "_GeneratedForTest";
             TypeBuilder typeBuilder = moduleBuilder.DefineType(typeName, TypeAttributes.Public, baseType, new[] { interfaceType });
 
-            Func<string, MethodBuilder> emitAddRemoveEventHandler = methodName =>
+            MethodBuilder addHandler = emitAddRemoveEventHandler("add");
+            typeBuilder.DefineMethodOverride(addHandler, interfaceType.GetMethod("add_InterfaceEvent"));
+            MethodBuilder removeHandler = emitAddRemoveEventHandler("remove");
+            typeBuilder.DefineMethodOverride(removeHandler, interfaceType.GetMethod("remove_InterfaceEvent"));
+
+            Type generatedType = typeBuilder.CreateType();
+            return Activator.CreateInstance(generatedType);
+
+            MethodBuilder emitAddRemoveEventHandler(string methodName)
             {
                 MethodBuilder method =
                     typeBuilder.DefineMethod(string.Format("{0}.{1}_InterfaceEvent", interfaceType.FullName, methodName),
@@ -869,14 +877,7 @@ namespace FluentAssertions.Specs
                 ILGenerator gen = method.GetILGenerator();
                 gen.Emit(OpCodes.Ret);
                 return method;
-            };
-            MethodBuilder addHandler = emitAddRemoveEventHandler("add");
-            typeBuilder.DefineMethodOverride(addHandler, interfaceType.GetMethod("add_InterfaceEvent"));
-            MethodBuilder removeHandler = emitAddRemoveEventHandler("remove");
-            typeBuilder.DefineMethodOverride(removeHandler, interfaceType.GetMethod("remove_InterfaceEvent"));
-
-            Type generatedType = typeBuilder.CreateType();
-            return Activator.CreateInstance(generatedType);
+            }
         }
 
 #endif

--- a/Tests/Shared.Specs/ExtensibilityRelatedEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/ExtensibilityRelatedEquivalencySpecs.cs
@@ -165,15 +165,15 @@ namespace FluentAssertions.Specs
 
         internal class ForeignKeyMatchingRule : IMemberMatchingRule
         {
-            public SelectedMemberInfo Match(SelectedMemberInfo subjectMember, object expectation, string memberPath, IEquivalencyAssertionOptions config)
+            public SelectedMemberInfo Match(SelectedMemberInfo expectedMember, object subject, string memberPath, IEquivalencyAssertionOptions config)
             {
-                string name = subjectMember.Name;
+                string name = expectedMember.Name;
                 if (name.EndsWith("Id"))
                 {
                     name = name.Replace("Id", "");
                 }
 
-                return SelectedMemberInfo.Create(expectation.GetType().GetRuntimeProperty(name));
+                return SelectedMemberInfo.Create(subject.GetType().GetRuntimeProperty(name));
             }
         }
 

--- a/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
@@ -3003,19 +3003,15 @@ namespace FluentAssertions.Specs
 
     internal class TrackingTestDictionary : IDictionary<int, string>
     {
-        private readonly TrackingDictionaryEnumerator enumerator;
         private readonly IDictionary<int, string> entries;
 
         public TrackingTestDictionary(params KeyValuePair<int, string>[] entries)
         {
             this.entries = entries.ToDictionary(e => e.Key, e => e.Value);
-            enumerator = new TrackingDictionaryEnumerator(entries);
+            Enumerator = new TrackingDictionaryEnumerator(entries);
         }
 
-        public TrackingDictionaryEnumerator Enumerator
-        {
-            get { return enumerator; }
-        }
+        public TrackingDictionaryEnumerator Enumerator { get; }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
@@ -3024,9 +3020,9 @@ namespace FluentAssertions.Specs
 
         public IEnumerator<KeyValuePair<int, string>> GetEnumerator()
         {
-            enumerator.IncreaseEnumerationCount();
-            enumerator.Reset();
-            return enumerator;
+            Enumerator.IncreaseEnumerationCount();
+            Enumerator.Reset();
+            return Enumerator;
         }
 
         public void Add(KeyValuePair<int, string> item)

--- a/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
@@ -1502,7 +1502,7 @@ namespace FluentAssertions.Specs
 
             public override bool Equals(object obj)
             {
-                if (ReferenceEquals(null, obj))
+                if (obj is null)
                 {
                     return false;
                 }

--- a/Tests/Shared.Specs/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/Shared.Specs/ReferenceTypeAssertionsSpecs.cs
@@ -491,7 +491,7 @@ namespace FluentAssertions.Specs
 
         private bool Equals(ClassWithCustomEqualMethod other)
         {
-            if (ReferenceEquals(null, other))
+            if (other is null)
             {
                 return false;
             }
@@ -504,7 +504,7 @@ namespace FluentAssertions.Specs
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
+            if (obj is null)
             {
                 return false;
             }

--- a/Tests/Shared.Specs/TypeExtensionsSpecs.cs
+++ b/Tests/Shared.Specs/TypeExtensionsSpecs.cs
@@ -197,8 +197,10 @@ namespace FluentAssertions.Specs
                 this.value = value;
             }
 
+#pragma warning disable IDE1006 // Naming Styles
             public static int op_Implicit(TypeWithFakeConversionOperators typeWithFakeConversionOperators) => typeWithFakeConversionOperators.value;
             public static byte op_Explicit(TypeWithFakeConversionOperators typeWithFakeConversionOperators) => (byte)typeWithFakeConversionOperators.value;
+#pragma warning restore IDE1006 // Naming Styles
         }
     }
 }

--- a/Tests/TestFrameworks/MSTestV2.Specs/MSTestV2.Specs.csproj
+++ b/Tests/TestFrameworks/MSTestV2.Specs/MSTestV2.Specs.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <RootNamespace>MSTestV2.Specs</RootNamespace>
     <AssemblyName>MSTestV2.Specs</AssemblyName>
+    <CodeAnalysisRuleSet>..\..\..\TestRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Src\FluentAssertions\FluentAssertions.csproj" />

--- a/Tests/TestFrameworks/MSpec.Specs/FrameworkSpecs.cs
+++ b/Tests/TestFrameworks/MSpec.Specs/FrameworkSpecs.cs
@@ -12,6 +12,6 @@ namespace MSpec.Specs
         It should_fail = () => Exception.Should().NotBeNull().And.BeAssignableTo<Exception>();
         It should_have_a_specific_reason = () => Exception.GetType().FullName.Should().ContainEquivalentOf("Machine.Specifications.SpecificationException");
 
-        static Exception Exception;
+        private static Exception Exception;
     }
 }

--- a/Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj
+++ b/Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
     <RootNamespace>MSpec.Specs</RootNamespace>
     <AssemblyName>MSpec.Specs</AssemblyName>
+    <CodeAnalysisRuleSet>Rules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Src\FluentAssertions\FluentAssertions.csproj" />

--- a/Tests/TestFrameworks/MSpec.Specs/Rules.ruleset
+++ b/Tests/TestFrameworks/MSpec.Specs/Rules.ruleset
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Rules for Fluent Assertions" Description="Code analysis rules for Fluent Assertions." ToolsVersion="15.0">
+  <Include Path="..\..\..\TestRules.ruleset" Action="Default" />
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Features" RuleNamespace="Microsoft.CodeAnalysis.Features">
+  </Rules>
+  <Rules AnalyzerId="Roslynator.CSharp.Analyzers" RuleNamespace="Roslynator.CSharp.Analyzers">
+    <Rule Id="RCS1018" Action="None" />
+    <Rule Id="RCS1169" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="U2UConsult.CodeAnalyzers" RuleNamespace="U2UConsult.CodeAnalyzers">
+  </Rules>
+</RuleSet>

--- a/Tests/TestFrameworks/NSpec.Net45.Specs/NSpec.Net45.Specs.csproj
+++ b/Tests/TestFrameworks/NSpec.Net45.Specs/NSpec.Net45.Specs.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net451</TargetFramework>
     <RootNamespace>NSpec.Specs</RootNamespace>
     <AssemblyName>NSpec.Specs</AssemblyName>
+    <CodeAnalysisRuleSet>..\..\..\TestRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Src\FluentAssertions\FluentAssertions.csproj" />

--- a/Tests/TestFrameworks/NSpec2.Net45.Specs/NSpec2.Net45.Specs.csproj
+++ b/Tests/TestFrameworks/NSpec2.Net45.Specs/NSpec2.Net45.Specs.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net451</TargetFramework>
     <RootNamespace>NSpec2.Specs</RootNamespace>
     <AssemblyName>NSpec2.Specs</AssemblyName>
+    <CodeAnalysisRuleSet>..\..\..\TestRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Src\FluentAssertions\FluentAssertions.csproj" />

--- a/Tests/TestFrameworks/NSpec3.Net45.Specs/NSpec3.Net45.Specs.csproj
+++ b/Tests/TestFrameworks/NSpec3.Net45.Specs/NSpec3.Net45.Specs.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net451</TargetFramework>
     <RootNamespace>NSpec3.Specs</RootNamespace>
     <AssemblyName>NSpec3.Specs</AssemblyName>
+    <CodeAnalysisRuleSet>..\..\..\TestRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Src\FluentAssertions\FluentAssertions.csproj" />

--- a/Tests/TestFrameworks/NUnit2.Net45.Specs/NUnit2.Net45.Specs.csproj
+++ b/Tests/TestFrameworks/NUnit2.Net45.Specs/NUnit2.Net45.Specs.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net451</TargetFramework>
     <RootNamespace>NUnit2.Specs</RootNamespace>
     <AssemblyName>NUnit2.Specs</AssemblyName>
+    <CodeAnalysisRuleSet>..\..\..\TestRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Src\FluentAssertions\FluentAssertions.csproj" />

--- a/Tests/TestFrameworks/NUnit3.Specs/NUnit3.Specs.csproj
+++ b/Tests/TestFrameworks/NUnit3.Specs/NUnit3.Specs.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <RootNamespace>NUnit3.Specs</RootNamespace>
     <AssemblyName>NUnit3.Specs</AssemblyName>
+    <CodeAnalysisRuleSet>..\..\..\TestRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Src\FluentAssertions\FluentAssertions.csproj" />

--- a/Tests/TestFrameworks/XUnit.Net45.Specs/XUnit.Net45.Specs.csproj
+++ b/Tests/TestFrameworks/XUnit.Net45.Specs/XUnit.Net45.Specs.csproj
@@ -11,4 +11,7 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="1.9.2" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/Tests/TestFrameworks/XUnit.Net45.Specs/XUnit.Net45.Specs.csproj
+++ b/Tests/TestFrameworks/XUnit.Net45.Specs/XUnit.Net45.Specs.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net451</TargetFramework>
     <RootNamespace>XUnit.Specs</RootNamespace>
     <AssemblyName>XUnit.Specs</AssemblyName>
+    <CodeAnalysisRuleSet>..\..\..\TestRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Src\FluentAssertions\FluentAssertions.csproj" />

--- a/Tests/TestFrameworks/XUnit2.Specs/XUnit2.Specs.csproj
+++ b/Tests/TestFrameworks/XUnit2.Specs/XUnit2.Specs.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <RootNamespace>XUnit2.Specs</RootNamespace>
     <AssemblyName>XUnit2.Specs</AssemblyName>
+    <CodeAnalysisRuleSet>..\..\..\TestRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Src\FluentAssertions\FluentAssertions.csproj" />


### PR DESCRIPTION
This PR adds custom analysis rulesets to both Core and Test projects.
The ruleset for Tests is more relaxed, as we e.g. intentionally box an int to exercise specific code paths.

* Some standard rules are raised to errors, such as e.g. [CS0162 Unreachable code detected](https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs0162).
* Som rules from third-party analyzers are now ignored.
  * [Roslynator](https://github.com/JosefPihrt/Roslynator)
  * [U2U Consult Performance Analyzers for C# 7](https://github.com/u2uconsult/codeanalyzers).

This makes the warnings from analyzers that we actually care about more visible in the error list - at least to me.

Having a trimmed error list revealed some spots that could be improved with e.g. pattern matching.