### PR TITLE
Handle an edge case that seem to happen under NCrunch

### DIFF
--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -64,9 +64,9 @@ namespace FluentAssertions
             int column = frame.GetFileColumnNumber();
             string line = GetSourceCodeLineFrom(frame);
 
-            if ((line != null) && (column != 0))
+            if ((line != null) && (column != 0) && (line.Length > 0))
             {
-                string statement = line.Substring(column - 1);
+                string statement = line.Substring(Math.Min(column - 1, line.Length -1));
 
                 logger(statement);
 


### PR DESCRIPTION
See https://stackoverflow.com/questions/50120792/fluentassertions-throws-argumentoutofrangeexception-when-assertion-fails-possib?noredirect=1#50120792

