### PR TITLE
Adds support for .NET Core 2.0 and restricts event assertion API.

### DIFF
--- a/Src/FluentAssertions.nuspec
+++ b/Src/FluentAssertions.nuspec
@@ -7,12 +7,12 @@
     <owners>Dennis Doomen</owners>
     <authors>Dennis Doomen</authors>
     <summary>
-      Fluent API for asserting the results of unit tests that targets .NET Framework 4.5 and 4.7, as well as .NET Standard 1.3, 1.6 and 2.0.
+      Fluent API for asserting the results of unit tests that targets .NET Framework 4.5 and 4.7, as well as .NET Core 2.0, .NET Standard 1.3, 1.6 and 2.0.
       Supports the unit test frameworks MSTest, MSTest2, Gallio, NUnit, XUnit, MBunit, MSpec, and NSpec.
     </summary>
     <description>
       A very extensive set of extension methods that allow you to more naturally specify the expected outcome of a TDD or
-      BDD-style unit tests. Targets .NET Framework 4.5 and 4.7, as well as .NET Standard 1.3, 1.6 and 2.0.
+      BDD-style unit tests. Targets .NET Framework 4.5 and 4.7, as well as .NET Core 2.0, .NET Standard 1.3, 1.6 and 2.0.
       Supports the unit test frameworks MSTest, MSTest2, Gallio, NUnit, XUnit, MBUnit, MSpec, and NSpec.
     </description>
     <language>en-US</language>
@@ -37,19 +37,18 @@
       <group targetFramework="netstandard1.3">
         <dependency id="NETStandard.Library" version="1.6.1" />
         <dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
-        <dependency id="System.Reflection.Emit.Lightweight" version="4.3.0" />
         <dependency id="System.ValueTuple" version="4.4.0" />
       </group>
       <group targetFramework="netstandard1.6">
         <dependency id="NETStandard.Library" version="1.6.1" />
         <dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
-        <dependency id="System.Reflection.Emit.Lightweight" version="4.3.0" />
-          <dependency id="System.ValueTuple" version="4.4.0" />
+        <dependency id="System.ValueTuple" version="4.4.0" />
+      </group>
+      <group targetFramework="netcoreapp2.0">
+          <dependency id="System.Configuration.ConfigurationManager" version="4.4.0" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="System.Configuration.ConfigurationManager" version="4.4.0" />
-        <dependency id="System.Reflection.Emit" version="4.3.0" />
-        <dependency id="System.Reflection.Emit.Lightweight" version="4.3.0" />
       </group>
     </dependencies>
   </metadata>
@@ -59,5 +58,6 @@
     <file src="..\Artifacts\Release\netstandard1.3\FluentAssertions.*" exclude="**\*.json" target="lib\netstandard1.3" />
     <file src="..\Artifacts\Release\netstandard1.6\FluentAssertions*.*" exclude="**\*.json" target="lib\netstandard1.6" />
     <file src="..\Artifacts\Release\netstandard2.0\FluentAssertions*.*" exclude="**\*.json" target="lib\netstandard2.0" />
+    <file src="..\Artifacts\Release\netcoreapp2.0\FluentAssertions*.*" exclude="**\*.json" target="lib\netcoreapp2.0" />
   </files>
 </package>

--- a/Src/FluentAssertions/AssemblyInfo.cs
+++ b/Src/FluentAssertions/AssemblyInfo.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("FluentAssertions")]
-[assembly: AssemblyDescription("Fluent API for asserting the results of unit tests that targets .NET Framework 4.5 and 4.7, as well as .NET Standard 1.3, 1.6 and 2.0. " +
+[assembly: AssemblyDescription("Fluent API for asserting the results of unit tests that targets .NET Framework 4.5 and 4.7, as well as .NET Core 2.0, .NET Standard 1.3, 1.6 and 2.0. " +
 "Supports the unit test frameworks MSTest, MSTest2, Gallio, NUnit, XUnit, MBunit, MSpec, and NSpec..")]
 [assembly: AssemblyCopyright("Copyright Dennis Doomen 2010-2018")]
 

--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -629,6 +629,8 @@ namespace FluentAssertions
             return new AsyncFunctionAssertions(action, extractor);
         }
 
+#if NET45 || NET47 || NETCOREAPP2_0
+
         /// <summary>
         ///   Starts monitoring <paramref name="eventSource"/> for its events.
         /// </summary>
@@ -642,6 +644,8 @@ namespace FluentAssertions
         {
             return new EventMonitor<T>(eventSource, utcNow ?? (() => DateTime.UtcNow));
         }
+
+#endif
 
         /// <summary>
         /// Safely casts the specified object to the type specified through <typeparamref name="TTo"/>.

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -15,7 +15,7 @@ namespace FluentAssertions
     {
         public static Action<string> logger = str => { };
 
-#if NET45 || NET47 || NETSTANDARD2_0
+#if NET45 || NET47 || NETSTANDARD2_0 || NETCOREAPP2_0
         public static string DetermineCallerIdentity()
         {
             string caller = null;

--- a/Src/FluentAssertions/Common/AppSettingsConfigurationStore.cs
+++ b/Src/FluentAssertions/Common/AppSettingsConfigurationStore.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NET47 || NETSTANDARD2_0
+﻿#if NET45 || NET47 || NETSTANDARD2_0 || NETCOREAPP2_0
 
 using System.Configuration;
 

--- a/Src/FluentAssertions/Common/FullFrameworkReflector.cs
+++ b/Src/FluentAssertions/Common/FullFrameworkReflector.cs
@@ -1,11 +1,10 @@
-﻿#if NET45 || NET47 || NETSTANDARD2_0
+﻿#if NET45 || NET47 || NETSTANDARD2_0 || NETCOREAPP2_0
 
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Reflection.Emit;
 
 namespace FluentAssertions.Common
 {
@@ -33,7 +32,7 @@ namespace FluentAssertions.Common
 
         private static bool IsDynamic(Assembly assembly)
         {
-            return (assembly is AssemblyBuilder) ||
+            return (assembly.GetType().FullName  == "System.Reflection.Emit.AssemblyBuilder") ||
                    (assembly.GetType().FullName == "System.Reflection.Emit.InternalAssemblyBuilder");
         }
 

--- a/Src/FluentAssertions/Common/Services.cs
+++ b/Src/FluentAssertions/Common/Services.cs
@@ -64,7 +64,7 @@ namespace FluentAssertions.Common
 
         public static void ResetToDefaults()
         {
-#if NET45 || NET47 || NETSTANDARD2_0
+#if NET45 || NET47 || NETSTANDARD2_0 || NETCOREAPP2_0
             reflector = new FullFrameworkReflector();
             configurationStore = new AppSettingsConfigurationStore();
 #elif NETSTANDARD1_6

--- a/Src/FluentAssertions/Events/EventAssertions.cs
+++ b/Src/FluentAssertions/Events/EventAssertions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if NET45 || NET47 || NETCOREAPP2_0
+
+using System;
 using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
@@ -161,3 +163,5 @@ namespace FluentAssertions.Events
         protected override string Identifier => "subject";
     }
 }
+
+#endif

--- a/Src/FluentAssertions/Events/EventHandlerFactory.cs
+++ b/Src/FluentAssertions/Events/EventHandlerFactory.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6 && !NETSTANDARD2_0
+#if NET45 || NET47 || NETCOREAPP2_0
 
 using System;
 using System.Reflection;

--- a/Src/FluentAssertions/Events/EventHandlerFactory.cs
+++ b/Src/FluentAssertions/Events/EventHandlerFactory.cs
@@ -1,3 +1,5 @@
+#if !NETSTANDARD1_3 && !NETSTANDARD1_6 && !NETSTANDARD2_0
+
 using System;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -151,3 +153,5 @@ namespace FluentAssertions.Events
         }
     }
 }
+
+#endif

--- a/Src/FluentAssertions/Events/EventMonitor.cs
+++ b/Src/FluentAssertions/Events/EventMonitor.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if !NETSTANDARD1_3 && !NETSTANDARD1_6 && !NETSTANDARD2_0
+
+using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
@@ -126,3 +128,5 @@ namespace FluentAssertions.Events
         }
     }
 }
+
+#endif

--- a/Src/FluentAssertions/Events/EventRecorder.cs
+++ b/Src/FluentAssertions/Events/EventRecorder.cs
@@ -1,4 +1,4 @@
-#if !NETSTANDARD1_3 && !NETSTANDARD1_6 && !NETSTANDARD2_0
+#if NET45 || NET47 || NETCOREAPP2_0
 
 using System;
 using System.Collections;

--- a/Src/FluentAssertions/Events/EventRecorder.cs
+++ b/Src/FluentAssertions/Events/EventRecorder.cs
@@ -1,3 +1,5 @@
+#if !NETSTANDARD1_3 && !NETSTANDARD1_6 && !NETSTANDARD2_0
+
 using System;
 using System.Collections;
 using System.Collections.Concurrent;
@@ -121,3 +123,5 @@ namespace FluentAssertions.Events
         }
     }
 }
+
+#endif

--- a/Src/FluentAssertions/Events/IMonitor.cs
+++ b/Src/FluentAssertions/Events/IMonitor.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if NET45 || NET47 || NETCOREAPP2_0
+
+using System;
 using System.Reflection;
 
 namespace FluentAssertions.Events
@@ -83,3 +85,5 @@ namespace FluentAssertions.Events
         }
     }
 }
+
+#endif

--- a/Src/FluentAssertions/Execution/AssertionFailedException.cs
+++ b/Src/FluentAssertions/Execution/AssertionFailedException.cs
@@ -1,6 +1,6 @@
 using System;
 
-#if NET45 || NET47 || NETSTANDARD2_0
+#if NET45 || NET47 || NETSTANDARD2_0 || NETCOREAPP2_0
 using System.Runtime.Serialization;
 #endif
 
@@ -9,7 +9,7 @@ namespace FluentAssertions.Execution
     /// <summary>
     /// Represents the default exception in case no test framework is configured.
     /// </summary>
-#if NET45 || NET47 || NETSTANDARD2_0
+#if NET45 || NET47 || NETSTANDARD2_0 || NETCOREAPP2_0
     [Serializable]
 #endif
 
@@ -20,7 +20,7 @@ namespace FluentAssertions.Execution
         {
         }
 
-#if NET45 || NET47 || NETSTANDARD2_0
+#if NET45 || NET47 || NETSTANDARD2_0 || NETCOREAPP2_0
         protected AssertionFailedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/Src/FluentAssertions/Execution/GallioTestFramework.cs
+++ b/Src/FluentAssertions/Execution/GallioTestFramework.cs
@@ -59,7 +59,7 @@ namespace FluentAssertions.Execution
         {
             get
             {
-#if !NET45 && !NET47 && !NETSTANDARD2_0
+#if !NET45 && !NET47 && !NETSTANDARD2_0 && !NETCOREAPP2_0
                 // For .NET Standard < 2.0, we need to attempt to load the assembly
                 try
                 {

--- a/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
+++ b/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
@@ -25,7 +25,7 @@ namespace FluentAssertions.Execution
         {
             get
             {
-#if !NET45 && !NET47 && !NETSTANDARD2_0
+#if !NET45 && !NET47 && !NETSTANDARD2_0 && !NETCOREAPP2_0
                 // For .NET Standard < 2.0, we need to attempt to load the assembly
                 try
                 {

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;net47;netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net47;netstandard1.3;netstandard1.6;netstandard2.0;netcoreapp2.0</TargetFrameworks>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>FluentAssertions.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -25,19 +25,18 @@
     <Compile Include="..\JetBrainsAnnotations.cs" Link="JetBrainsAnnotations.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.2" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Formatting
 
         private static readonly List<IValueFormatter> defaultFormatters = new List<IValueFormatter>
         {
-#if NET45 || NET47 || NETSTANDARD2_0
+#if NET45 || NET47 || NETSTANDARD2_0 || NETCOREAPP2_0
             new XmlNodeFormatter(),
 #endif
             new AttributeBasedFormatter(),

--- a/Src/FluentAssertions/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ObjectAssertionsExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NET47 || NETSTANDARD2_0
+﻿#if NET45 || NET47 || NETSTANDARD2_0 || NETCOREAPP2_0
 
 using System;
 using System.IO;

--- a/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Reflection
             Subject = assembly;
         }
 
-#if NET45 || NET47 || NETSTANDARD2_0 // TODO :: Should be able to remove based on: https://github.com/dotnet/corefx/issues/1784#issuecomment-218803619
+#if NET45 || NET47 || NETCOREAPP2_0 // TODO :: Should be able to remove based on: https://github.com/dotnet/corefx/issues/1784#issuecomment-218803619
 
         /// <summary>
         /// Asserts that an assembly does not reference the specified assembly.

--- a/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Reflection
             Subject = assembly;
         }
 
-#if NET45 || NET47 || NETCOREAPP2_0 // TODO :: Should be able to remove based on: https://github.com/dotnet/corefx/issues/1784#issuecomment-218803619
+#if NET45 || NET47 || NETSTANDARD2_0 || NETCOREAPP2_0 // TODO :: Should be able to remove based on: https://github.com/dotnet/corefx/issues/1784#issuecomment-218803619
 
         /// <summary>
         /// Asserts that an assembly does not reference the specified assembly.

--- a/Src/FluentAssertions/Xml/XmlAssertionExtensions.cs
+++ b/Src/FluentAssertions/Xml/XmlAssertionExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NET47 || NETSTANDARD2_0
+﻿#if NET45 || NET47 || NETSTANDARD2_0 || NETCOREAPP2_0
 
 using System.Diagnostics;
 using System.Xml;

--- a/Src/FluentAssertions/Xml/XmlElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XmlElementAssertions.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NET47 || NETSTANDARD2_0
+﻿#if NET45 || NET47 || NETSTANDARD2_0 || NETCOREAPP2_0
 
 using System.Diagnostics;
 using System.Xml;

--- a/Src/FluentAssertions/Xml/XmlNodeAssertions.cs
+++ b/Src/FluentAssertions/Xml/XmlNodeAssertions.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NET47 || NETSTANDARD2_0
+﻿#if NET45 || NET47 || NETSTANDARD2_0 || NETCOREAPP2_0
 
 using System.Diagnostics;
 using System.Xml;

--- a/Src/FluentAssertions/Xml/XmlNodeAssertionsofTSubjectTAssertions.cs
+++ b/Src/FluentAssertions/Xml/XmlNodeAssertionsofTSubjectTAssertions.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NET47 || NETSTANDARD2_0
+﻿#if NET45 || NET47 || NETSTANDARD2_0 || NETCOREAPP2_0
 
 using System.Diagnostics;
 using System.Xml;

--- a/Src/FluentAssertions/Xml/XmlNodeFormatter.cs
+++ b/Src/FluentAssertions/Xml/XmlNodeFormatter.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NET47 || NETSTANDARD2_0
+﻿#if NET45 || NET47 || NETSTANDARD2_0 || NETCOREAPP2_0
 
 using System.Xml;
 using FluentAssertions.Common;

--- a/Tests/NetCore20.Specs/NetCore20.Specs.csproj
+++ b/Tests/NetCore20.Specs/NetCore20.Specs.csproj
@@ -6,8 +6,9 @@
     <CodeAnalysisRuleSet>..\..\TestRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Chill" Version="3.2.0" />
     <PackageReference Include="FakeItEasy" Version="4.5.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />

--- a/Tests/Shared.Specs/AssertionOptionSpecs.cs
+++ b/Tests/Shared.Specs/AssertionOptionSpecs.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NET47
+﻿#if NET45 || NET47 || NETCOREAPP2_0
 
 using System;
 using System.Linq;

--- a/Tests/Shared.Specs/EnumAssertionSpecs.cs
+++ b/Tests/Shared.Specs/EnumAssertionSpecs.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Reflection.Emit;
-using System.Text;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/Shared.Specs/EventAssertionSpecs.cs
+++ b/Tests/Shared.Specs/EventAssertionSpecs.cs
@@ -9,7 +9,7 @@ using Xunit;
 using Xunit.Sdk;
 
 // ReSharper disable AccessToDisposedClosure
-#if NET45 || NET47 || NETSTANDARD2_0
+#if NET45 || NET47 || NETCOREAPP2_0
 using System.Reflection;
 using System.Reflection.Emit;
 

--- a/Tests/Shared.Specs/EventAssertionSpecs.cs
+++ b/Tests/Shared.Specs/EventAssertionSpecs.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if NET45 || NET47 || NETCOREAPP2_0
+
+using System;
 using System.ComponentModel;
 using System.Linq;
 
@@ -8,12 +10,8 @@ using FluentAssertions.Formatting;
 using Xunit;
 using Xunit.Sdk;
 
-// ReSharper disable AccessToDisposedClosure
-#if NET45 || NET47 || NETCOREAPP2_0
 using System.Reflection;
 using System.Reflection.Emit;
-
-#endif
 
 namespace FluentAssertions.Specs
 {
@@ -745,7 +743,7 @@ namespace FluentAssertions.Specs
             }
         }
 
-#if NET45 || NET47 || NETSTANDARD2_0
+#if NET45 || NET47
 
         [Fact]
         public void When_an_object_doesnt_expose_any_events_it_should_throw()
@@ -823,6 +821,7 @@ namespace FluentAssertions.Specs
         }
 
 #endif
+
 
         [Fact]
         public void When_event_exists_on_class_but_not_on_monitored_interface_it_should_not_allow_monitoring_it()
@@ -958,3 +957,5 @@ namespace FluentAssertions.Specs
         }
     }
 }
+
+#endif

--- a/docs/_pages/about.md
+++ b/docs/_pages/about.md
@@ -39,7 +39,7 @@ will fail with:
 
 ## Supported Frameworks and Libraries
 
-Fluent Assertions cross-compiles to .NET Framework 4.5 and 4.7, as well as .NET Standard 1.3, 1.6 and 2.0. Because of that it supports the following minimum platforms.
+Fluent Assertions cross-compiles to .NET Framework 4.5 and 4.7, as well as .NET Core 2.0, .NET Standard 1.3, 1.6 and 2.0. Because of that it supports the following minimum platforms.
 *   .NET Core 1.0 and 2.0
 *   .NET Framework 4.5
 *   Mono, Xamarin.iOS 10.0, Xamarin.Mac 3.0 and Xamarin.Android 7.0

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@ intro:
      [<i class="fab fa-patreon"></i> Sponser Us](https://www.patreon.com/bePatron?u=9250052&redirect_uri=http%3A%2F%2Ffluentassertions.com%2F&utm_medium=widget){: .btn .btn--patreon}
      <br/>
      A very extensive set of extension methods that allow you to more naturally specify the expected outcome of a TDD or
-     BDD-style unit tests. Targets .NET Framework 4.5 and 4.7, as well as .NET Standard 1.3, 1.6 and 2.0.'
+     BDD-style unit tests. Targets .NET Framework 4.5 and 4.7, as well as .NET Core 2.0, .NET Standard 1.3, 1.6 and 2.0.'
 feature_row:
   - title: "Intention-Revealing Unit Tests"
     image_path: /assets/images/nugetlogo.svg
@@ -48,7 +48,7 @@ feature_row2:
   - title: "Feature Complete"
     image_path: /assets/images/nugetlogo.svg
     excerpt: '
-**Targets** .NET 4.5, .NET 4.7, .NET Standard 1.3, 1.6 and 2.0. 
+**Targets** .NET 4.5, .NET 4.7, .NET Core 2.0, .NET Standard 1.3, 1.6 and 2.0. 
 Supports **Supports** with MSTest, xUnit, NUnit, Gallio, MBUnit, MSpec and NSpec.  
 Parses the C# code to **identify** the subject-under-test. 
 Allows asserting the **equivalency** of (collections of ) deep object graphs.


### PR DESCRIPTION
Some features such as ILEmit didn't work in .NET Standard 2.0, but where available up until recently when microsoft pulled System.Reflection.Emit from NuGet. So it appeared the API worked, but only really worked under the runtime platforms. See also https://github.com/dotnet/corefx/issues/29365

* {New} Added support for .NET Core 2.0 in addition to .NET Standard 2.0
* {Fix) Restricted the event assertion API to the run-time .NET platforms only 

Fixes #859 

