### PR TITLE
Make GetEqualityStrategy thread-safe again

### DIFF
--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -47,7 +48,7 @@ namespace FluentAssertions.Equivalency
 
         private bool includeFields;
 
-        private readonly Dictionary<Type, bool> hasValueSemanticsMap = new Dictionary<Type, bool>();
+        private readonly ConcurrentDictionary<Type, bool> hasValueSemanticsMap = new ConcurrentDictionary<Type, bool>();
 
         private readonly List<Type> referenceTypes = new List<Type>();
         private readonly List<Type> valueTypes = new List<Type>();
@@ -176,11 +177,7 @@ namespace FluentAssertions.Equivalency
                 }
                 else
                 {
-                    if(!hasValueSemanticsMap.TryGetValue(type, out bool hasValueSemantics))
-                    {
-                        hasValueSemantics = type.HasValueSemantics();
-                        hasValueSemanticsMap[type] = hasValueSemantics;
-                    }
+                    bool hasValueSemantics = hasValueSemanticsMap.GetOrAdd(type, t => t.HasValueSemantics());
 
                     if (hasValueSemantics)
                     {

--- a/Tests/Shared.Specs/AssertionOptionSpecs.cs
+++ b/Tests/Shared.Specs/AssertionOptionSpecs.cs
@@ -1,18 +1,50 @@
-﻿#if NET45 || NET47 || NETCOREAPP2_0
+﻿using System;
+using System.Collections;
+using System.Threading.Tasks;
+using FluentAssertions.Equivalency;
+using Xunit;
 
-using System;
+#if NET45 || NET47 || NETCOREAPP2_0
 using System.Linq;
 using System.Net;
 using Chill;
-using FluentAssertions.Equivalency;
 using FluentAssertions.Execution;
-using Xunit;
 using Xunit.Sdk;
+#endif
 
 namespace FluentAssertions.Specs
 {
-    namespace AssertionOptionsSpecs
+    public class AssertionOptionsSpecs
     {
+        [Fact]
+        public void When_concurrently_getting_equality_strategy_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Type type = typeof(IEnumerable);
+            IEquivalencyAssertionOptions equivalencyAssertionOptions = new EquivalencyAssertionOptions();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => Parallel.For(
+                0,
+                10_000,
+                new ParallelOptions
+                {
+                    MaxDegreeOfParallelism = 8
+                },
+                e => equivalencyAssertionOptions.GetEqualityStrategy(type)
+            );
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
+        }
+
+#if NET45 || NET47 || NETCOREAPP2_0
         public abstract class Given_temporary_global_assertion_options : GivenWhenThen
         {
             protected override void Dispose(bool disposing)
@@ -260,7 +292,6 @@ namespace FluentAssertions.Specs
                 return true;
             }
         }
+#endif
     }
 }
-
-#endif


### PR DESCRIPTION
The current approach from 8af4abe9313be62391065d8b0cbf9b9f3ded9001 is not thread-safe.
Using a `ConcurrentDictionary` should make it thread-safe again.
From the benchmark results below, it still seems beneficial to cache the result of `HasValueSemantics()`.

A specially crafted test suite *might* suffer from the introduced locking by using `ConcurrentDictionary`, but I couldn't find a measurable difference when running the tests. 

This fixes #862.

Current approach with `Dictionary`
```
         Method |     N |         Mean |       Error |       StdDev |       Median |      Gen 0 |    Allocated |
--------------- |------ |-------------:|------------:|-------------:|-------------:|-----------:|-------------:|
 BeEquivalentTo |    10 |     663.7 us |    10.25 us |     9.584 us |     668.1 us |    54.6875 |    170.92 KB |
 BeEquivalentTo |   100 |   4,080.2 us |    79.61 us |    78.184 us |   4,076.7 us |   500.0000 |   1558.08 KB |
 BeEquivalentTo |  1000 |  38,073.6 us |    98.61 us |    65.225 us |  38,097.4 us |  5000.0000 |  15402.22 KB |
 BeEquivalentTo |  5000 | 185,843.2 us | 3,630.97 us | 3,566.098 us | 188,087.6 us | 25125.0000 |   77342.1 KB |
 BeEquivalentTo | 10000 | 384,217.0 us | 7,089.79 us | 6,631.796 us | 379,016.1 us | 50375.0000 | 154757.25 KB |
```

With `ConcurrentDictionary`
```
         Method |     N |         Mean |        Error |       StdDev |      Gen 0 |    Allocated |
--------------- |------ |-------------:|-------------:|-------------:|-----------:|-------------:|
 BeEquivalentTo |    10 |     671.6 us |     3.429 us |     2.863 us |    55.6641 |     171.6 KB |
 BeEquivalentTo |   100 |   4,191.7 us |    10.730 us |    10.037 us |   500.0000 |   1558.71 KB |
 BeEquivalentTo |  1000 |  37,693.7 us |   719.533 us |   738.907 us |  5000.0000 |  15402.71 KB |
 BeEquivalentTo |  5000 | 185,306.4 us |   181.597 us |   151.642 us | 25125.0000 |  77342.59 KB |
 BeEquivalentTo | 10000 | 389,597.7 us | 5,440.486 us | 4,822.849 us | 50375.0000 | 154757.73 KB |
```

Without caching of `HasValueSemantics`
```
         Method |     N |         Mean |        Error |        StdDev |      Gen 0 |    Allocated |
--------------- |------ |-------------:|-------------:|--------------:|-----------:|-------------:|
 BeEquivalentTo |    10 |     763.5 us |     1.128 us |     0.8803 us |    57.6172 |    177.71 KB |
 BeEquivalentTo |   100 |   5,244.8 us |    16.158 us |    13.4924 us |   523.4375 |    1619.4 KB |
 BeEquivalentTo |  1000 |  47,498.1 us |   854.129 us |   798.9523 us |  5187.5000 |  16010.21 KB |
 BeEquivalentTo |  5000 | 234,690.8 us | 4,678.781 us | 4,376.5341 us | 26125.0000 |  80405.65 KB |
 BeEquivalentTo | 10000 | 473,366.9 us | 8,201.216 us | 7,671.4219 us | 52312.5000 | 160845.33 KB |
```