### PR TITLE
Re-add nunit.runner for NUnit2

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -2,6 +2,7 @@
 #tool "nuget:?package=nspec&version=1.0.13"
 #tool "nuget:?package=nspec&version=2.0.1"
 #tool "nuget:?package=nspec&version=3.1.0"
+#tool "nuget:?package=nunit.runners&version=2.6.6"
 #tool "nuget:?package=GitVersion.CommandLine"
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I broke NUnit2 testing in fbf4b17718be39bf71c575ec0fe0a1dc82bcf1c7 👎 

nunit.runners is still required to run from console/Cake. 
NUnitTestAdapter is just for running through Visual Studio.

Apparently AppVeyor skipped the test, while locally it failed as it could not find the required runner.