### PR TITLE
Add id to all examples

### DIFF
--- a/docs/_includes/assertion-comparison.html
+++ b/docs/_includes/assertion-comparison.html
@@ -1,7 +1,8 @@
 ### {{ include.caption }}
 
+{% assign idName = {{include.caption | replace: " ", "-"}} %}
 {% for example in include.examples %}
-<table class="code-table">
+<table class="code-table" id="{{ include.idPrefix }}{{ idName }}-{{ forloop.index }}">
 <thead>
 <tr>
 	<th>

--- a/docs/_pages/tips.md
+++ b/docs/_pages/tips.md
@@ -34,7 +34,7 @@ We think this is both a useful migration guide and a convincing argument for swi
 
 If you see something missing, please consider submitting a pull request.
 
-{% include assertion-comparison.html header1="MSTest" header2="Fluent Assertions" caption="Assert"            examples=site.data.mstest-migration.assert %}
-{% include assertion-comparison.html header1="MSTest" header2="Fluent Assertions" caption="CollectionAssert"  examples=site.data.mstest-migration.collectionAssert %}
-{% include assertion-comparison.html header1="MSTest" header2="Fluent Assertions" caption="StringAssert"      examples=site.data.mstest-migration.stringAssert %}
-{% include assertion-comparison.html header1="MSTest" header2="Fluent Assertions" caption="Exceptions"        examples=site.data.mstest-migration.exceptions %}
+{% include assertion-comparison.html header1="MSTest" header2="Fluent Assertions" idPrefix="mstest-" caption="Assert"            examples=site.data.mstest-migration.assert %}
+{% include assertion-comparison.html header1="MSTest" header2="Fluent Assertions" idPrefix="mstest-" caption="CollectionAssert"  examples=site.data.mstest-migration.collectionAssert %}
+{% include assertion-comparison.html header1="MSTest" header2="Fluent Assertions" idPrefix="mstest-" caption="StringAssert"      examples=site.data.mstest-migration.stringAssert %}
+{% include assertion-comparison.html header1="MSTest" header2="Fluent Assertions" idPrefix="mstest-" caption="Exceptions"        examples=site.data.mstest-migration.exceptions %}


### PR DESCRIPTION
From #866 
This PR adds an `id` to all examples on the website, such that one can link directly to them.

Pros:
* No need to add individual ids to each example

Cons:
* If the order of examples is mutated or new examples are not appended to the end, then the links become invalid.