### PR TITLE
fix(ThrowAssertionsSpecs): typos in exception messages

### DIFF
--- a/Tests/Shared.Specs/ThrowAssertionsSpecs.cs
+++ b/Tests/Shared.Specs/ThrowAssertionsSpecs.cs
@@ -46,7 +46,7 @@ namespace FluentAssertions.Specs
 
                 testSubject.Invoking(x => x.Do()).Should().Throw<Exception>();
 
-                throw new XunitException("Should().Throw() dit not throw");
+                throw new XunitException("Should().Throw() did not throw");
             }
             catch (XunitException ex)
             {
@@ -64,7 +64,7 @@ namespace FluentAssertions.Specs
 
                 act.Should().Throw<Exception>();
 
-                throw new XunitException("Should().Throw() dit not throw");
+                throw new XunitException("Should().Throw() did not throw");
             }
             catch (XunitException ex)
             {


### PR DESCRIPTION
Change `dit` to `did`.

I was reading through the unit tests in this project to get a better idea of how to write my own tests and noticed some spelling typos.

## IMPORTANT 

* [x] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [x] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).
