### PR TITLE
docs(CONTRIBUTING): fix typos, remove/correct old messaging, lint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,8 @@
-Contributing to Fluent Assertions
------------
+# Contributing to Fluent Assertions
 
-No open-source projection is going to be successful without contributions. After we decided to move to Github, the involvement of the .NET community has increased significantly. However, contributing to this project involves a few steps that will seriously increase the chance we will accept it.
+No open-source project is going to be successful without contributions. After we decided to move to Github, the involvement of the .NET community has increased significantly. However, contributing to this project involves a few steps that will seriously increase the chance we will accept it.
 
-* The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `develop` branch.
+* The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
 * The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://csharpguidelines.codeplex.com/)/.
-* The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33). 
+* The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
 * If the contribution affects the documentation, please update [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md), which is published on the [website](http://fluentassertions.com/documentation.html).
-
-**PLEASE NOTE:** FluentAssertions is currently under going some significant refactoring for version 5 so major/significant PRs may not be accepted. Sorry for any inconvenience.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,6 @@
 No open-source project is going to be successful without contributions. After we decided to move to Github, the involvement of the .NET community has increased significantly. However, contributing to this project involves a few steps that will seriously increase the chance we will accept it.
 
 * The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
-* The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://csharpguidelines.codeplex.com/)/.
+* The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](https://csharpcodingguidelines.com/)/.
 * The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
-* If the contribution affects the documentation, please update [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md), which is published on the [website](http://fluentassertions.com/documentation.html).
+* If the contribution affects the documentation, please update [**the documentation**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which is published on the [website](https://fluentassertions.com/documentation/).


### PR DESCRIPTION
Updates to the current `CONTRIBUTING.md`

* References changes coming in v5.0 which has been released for awhile
* Says to target the `develop` branch which doesn't exist now
* Spelling typo
* Lint according to [markdownlint for vscode](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) which recommended using a `# title` for the first line.

## IMPORTANT 

* [x] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [x] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).
