### PR TITLE
Fix wrong exception message text of HaveOffset assertion

### DIFF
--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -710,7 +710,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Offset == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("but it was {0}.", Subject.Value.Second);
+                .FailWith("but it was {0}.", Subject.Value.Offset);
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }

--- a/Tests/Shared.Specs/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/Shared.Specs/DateTimeOffsetAssertionSpecs.cs
@@ -2464,7 +2464,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 00), TimeSpan.Zero);
+            DateTimeOffset subject = new DateTimeOffset(new DateTime(2009, 12, 31, 23, 59, 10), TimeSpan.Zero);
             TimeSpan expectation = TimeSpan.FromHours(3);
 
             //-----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## IMPORTANT 

* [ ] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [ ] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).
