### PR TITLE
Fixed a StackOverflow while comparing a self-returning enumerable.

### DIFF
--- a/Src/FluentAssertions/Equivalency/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/ObjectReference.cs
@@ -16,7 +16,12 @@ namespace FluentAssertions.Equivalency
         public ObjectReference(object @object, string path, bool? isComplexType = null)
         {
             this.@object = @object;
-            this.path = path.ToLower().Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+
+            this.path = path
+                .ToLower()
+                .Replace("][", "].[")
+                .Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+
             this.isComplexType = isComplexType;
         }
 

--- a/Tests/Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/BasicEquivalencySpecs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Collections;
 using System.Net;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
@@ -3332,6 +3333,40 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_an_enumerable_collection_returns_itself_it_should_detect_the_cyclic_reference()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            var instance1 = new SelfReturningEnumerable();
+            var instance2 = new SelfReturningEnumerable();
+            var actual = new List<SelfReturningEnumerable> {instance1, instance2};
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => actual.Should().BeEquivalentTo(new SelfReturningEnumerable(), new SelfReturningEnumerable());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>().WithMessage("*cyclic*");
+        }
+
+        public class SelfReturningEnumerable : IEnumerable<SelfReturningEnumerable>
+        {
+            public IEnumerator<SelfReturningEnumerable> GetEnumerator()
+            {
+                yield return this;
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
         }
 
         internal class LogbookEntryProjection


### PR DESCRIPTION
If you compare an object that implements `IEnumerable<T>` and returns itself, you'll end up with a deeply nested path description like `[0][0][0]`. The cyclic reference detection logic would treat that as a single element instead of a deeply nested path. 

Fixes #880

