### PR TITLE
Disabled parallel execution of unit tests

### DIFF
--- a/Tests/Shared.Specs/AssertionOptionSpecs.cs
+++ b/Tests/Shared.Specs/AssertionOptionSpecs.cs
@@ -17,7 +17,6 @@ namespace FluentAssertions.Specs
     namespace AssertionOptionsSpecs
     {
 #if NET45 || NET47 || NETCOREAPP2_0
-        [Collection("Equivalency")]
         public class When_concurrently_getting_equality_strategy : GivenSubject<EquivalencyAssertionOptions, Action>
         {
             public When_concurrently_getting_equality_strategy()
@@ -48,7 +47,6 @@ namespace FluentAssertions.Specs
             }
         }
 
-        [Collection("Equivalency")]
         public class When_assertion_doubles_should_always_allow_small_deviations :
             Given_temporary_global_assertion_options
         {
@@ -81,7 +79,6 @@ namespace FluentAssertions.Specs
             }
         }
 
-        [Collection("Equivalency")]
         public class When_local_similar_options_are_used : Given_temporary_global_assertion_options
         {
             public When_local_similar_options_are_used()
@@ -133,7 +130,6 @@ namespace FluentAssertions.Specs
             }
         }
 
-        [Collection("Equivalency")]
         public class Given_temporary_equivalency_steps : GivenWhenThen
         {
             protected override void Dispose(bool disposing)
@@ -148,7 +144,6 @@ namespace FluentAssertions.Specs
             }
         }
 
-        [Collection("Equivalency")]
         public class When_inserting_a_step : Given_temporary_equivalency_steps
         {
             public When_inserting_a_step()
@@ -165,7 +160,6 @@ namespace FluentAssertions.Specs
             }
         }
 
-        [Collection("Equivalency")]
         public class When_inserting_a_step_before_another : Given_temporary_equivalency_steps
         {
             public When_inserting_a_step_before_another()
@@ -183,7 +177,6 @@ namespace FluentAssertions.Specs
             }
         }
 
-        [Collection("Equivalency")]
         public class When_appending_a_step : Given_temporary_equivalency_steps
         {
             public When_appending_a_step()
@@ -201,7 +194,6 @@ namespace FluentAssertions.Specs
             }
         }
 
-        [Collection("Equivalency")]
         public class When_appending_a_step_after_another : Given_temporary_equivalency_steps
         {
             public When_appending_a_step_after_another()
@@ -219,7 +211,6 @@ namespace FluentAssertions.Specs
             }
         }
 
-        [Collection("Equivalency")]
         public class When_appending_a_step_and_no_builtin_steps_are_there : Given_temporary_equivalency_steps
         {
             public When_appending_a_step_and_no_builtin_steps_are_there()
@@ -240,7 +231,6 @@ namespace FluentAssertions.Specs
             }
         }
 
-        [Collection("Equivalency")]
         public class When_removing_a_specific_step : Given_temporary_equivalency_steps
         {
             public When_removing_a_specific_step()
@@ -255,7 +245,6 @@ namespace FluentAssertions.Specs
             }
         }
 
-        [Collection("Equivalency")]
         public class When_removing_a_specific_step_that_doesnt_exist : Given_temporary_equivalency_steps
         {
             public When_removing_a_specific_step_that_doesnt_exist()

--- a/Tests/Shared.Specs/CustomAssemblyInfo.cs
+++ b/Tests/Shared.Specs/CustomAssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]

--- a/Tests/Shared.Specs/Shared.Specs.projitems
+++ b/Tests/Shared.Specs/Shared.Specs.projitems
@@ -21,6 +21,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionEquivalencySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ComparableSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ConfigurationSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CustomAssemblyInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DateTimeAssertionSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DateTimeOffsetAssertionSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DateTimeOffsetValueFormatterSpecs.cs" />

--- a/Tests/Shared.Specs/Shared.Specs.shproj
+++ b/Tests/Shared.Specs/Shared.Specs.shproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>0c23c12c-899f-4ad1-b737-b967a9910c08</ProjectGuid>


### PR DESCRIPTION
When the `AssertionOptionSpecs` run in parallel with other tests, they can affect the outcome.

