### PR TITLE
show error instead of message for async throws

### DIFF
--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -73,12 +73,12 @@ namespace FluentAssertions.Specialized
             }
             catch (Exception exception)
             {
-                var deepestException = GetDeepestException(exception);
+                Exception nonAggregateException = GetFirstNonAggregateException(exception);
 
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
                     .FailWith("Did not expect any exception{reason}, but found a {0} with message {1}.",
-                        deepestException.GetType(), deepestException);
+                        nonAggregateException.GetType(), nonAggregateException.ToString());
             }
         }
 
@@ -101,28 +101,28 @@ namespace FluentAssertions.Specialized
             }
             catch (Exception exception)
             {
-                var deepestException = GetDeepestException(exception);
+                Exception nonAggregateException = GetFirstNonAggregateException(exception);
 
-                if (deepestException != null)
+                if (nonAggregateException != null)
                 {
                     Execute.Assertion
-                        .ForCondition(!(deepestException is TException))
+                        .ForCondition(!(nonAggregateException is TException))
                         .BecauseOf(because, becauseArgs)
                         .FailWith("Did not expect {0}{reason}, but found one with message {1}.",
-                            typeof(TException), deepestException);
+                            typeof(TException), nonAggregateException.ToString());
                 }
             }
         }
 
-        private static Exception GetDeepestException(Exception exception)
+        private static Exception GetFirstNonAggregateException(Exception exception)
         {
-            var deepestException = exception;
-            while (deepestException is AggregateException)
+            Exception nonAggregateException = exception;
+            while (nonAggregateException is AggregateException)
             {
-                deepestException = deepestException.InnerException;
+                nonAggregateException = nonAggregateException.InnerException;
             }
 
-            return deepestException;
+            return nonAggregateException;
         }
 
         private Exception InvokeSubjectWithInterception()

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -73,15 +73,12 @@ namespace FluentAssertions.Specialized
             }
             catch (Exception exception)
             {
-                while (exception is AggregateException)
-                {
-                    exception = exception.InnerException;
-                }
+                var deepestException = GetDeepestException(exception);
 
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
                     .FailWith("Did not expect any exception{reason}, but found a {0} with message {1}.",
-                        exception.GetType(), exception.Message);
+                        deepestException.GetType(), deepestException);
             }
         }
 
@@ -104,20 +101,28 @@ namespace FluentAssertions.Specialized
             }
             catch (Exception exception)
             {
-                while (exception is AggregateException)
-                {
-                    exception = exception.InnerException;
-                }
+                var deepestException = GetDeepestException(exception);
 
-                if (exception != null)
+                if (deepestException != null)
                 {
                     Execute.Assertion
-                        .ForCondition(!(exception is TException))
+                        .ForCondition(!(deepestException is TException))
                         .BecauseOf(because, becauseArgs)
                         .FailWith("Did not expect {0}{reason}, but found one with message {1}.",
-                            typeof(TException), exception.Message);
+                            typeof(TException), deepestException);
                 }
             }
+        }
+
+        private static Exception GetDeepestException(Exception exception)
+        {
+            var deepestException = exception;
+            while (deepestException is AggregateException)
+            {
+                deepestException = deepestException.InnerException;
+            }
+
+            return deepestException;
         }
 
         private Exception InvokeSubjectWithInterception()


### PR DESCRIPTION
## IMPORTANT 

* [x] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [x] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).

Related to #888 
CC: @jnyrup 
Maybe it would be sensible to create some extension method to check if correct exception (or type of exception) is included in `FailWith` continuation? What do you think?
