### PR TITLE
Enable parallel execution of tests again

### DIFF
--- a/Tests/Shared.Specs/AssertionOptionSpecs.cs
+++ b/Tests/Shared.Specs/AssertionOptionSpecs.cs
@@ -16,7 +16,12 @@ namespace FluentAssertions.Specs
 {
     namespace AssertionOptionsSpecs
     {
+        // Due to tests that call AssertionOptions
+        [CollectionDefinition("AssertionOptionsSpecs", DisableParallelization = true)]
+        public class AssertionOptionsSpecsDefinition { }
+
 #if NET45 || NET47 || NETCOREAPP2_0
+        [Collection("AssertionOptionsSpecs")]
         public class When_concurrently_getting_equality_strategy : GivenSubject<EquivalencyAssertionOptions, Action>
         {
             public When_concurrently_getting_equality_strategy()
@@ -47,6 +52,7 @@ namespace FluentAssertions.Specs
             }
         }
 
+        [Collection("AssertionOptionsSpecs")]
         public class When_assertion_doubles_should_always_allow_small_deviations :
             Given_temporary_global_assertion_options
         {
@@ -79,6 +85,7 @@ namespace FluentAssertions.Specs
             }
         }
 
+        [Collection("AssertionOptionsSpecs")]
         public class When_local_similar_options_are_used : Given_temporary_global_assertion_options
         {
             public When_local_similar_options_are_used()
@@ -144,6 +151,7 @@ namespace FluentAssertions.Specs
             }
         }
 
+        [Collection("AssertionOptionsSpecs")]
         public class When_inserting_a_step : Given_temporary_equivalency_steps
         {
             public When_inserting_a_step()
@@ -160,6 +168,7 @@ namespace FluentAssertions.Specs
             }
         }
 
+        [Collection("AssertionOptionsSpecs")]
         public class When_inserting_a_step_before_another : Given_temporary_equivalency_steps
         {
             public When_inserting_a_step_before_another()
@@ -177,6 +186,7 @@ namespace FluentAssertions.Specs
             }
         }
 
+        [Collection("AssertionOptionsSpecs")]
         public class When_appending_a_step : Given_temporary_equivalency_steps
         {
             public When_appending_a_step()
@@ -194,6 +204,7 @@ namespace FluentAssertions.Specs
             }
         }
 
+        [Collection("AssertionOptionsSpecs")]
         public class When_appending_a_step_after_another : Given_temporary_equivalency_steps
         {
             public When_appending_a_step_after_another()
@@ -211,6 +222,7 @@ namespace FluentAssertions.Specs
             }
         }
 
+        [Collection("AssertionOptionsSpecs")]
         public class When_appending_a_step_and_no_builtin_steps_are_there : Given_temporary_equivalency_steps
         {
             public When_appending_a_step_and_no_builtin_steps_are_there()
@@ -231,6 +243,7 @@ namespace FluentAssertions.Specs
             }
         }
 
+        [Collection("AssertionOptionsSpecs")]
         public class When_removing_a_specific_step : Given_temporary_equivalency_steps
         {
             public When_removing_a_specific_step()
@@ -245,6 +258,7 @@ namespace FluentAssertions.Specs
             }
         }
 
+        [Collection("AssertionOptionsSpecs")]
         public class When_removing_a_specific_step_that_doesnt_exist : Given_temporary_equivalency_steps
         {
             public When_removing_a_specific_step_that_doesnt_exist()

--- a/Tests/Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/BasicEquivalencySpecs.cs
@@ -12,8 +12,6 @@ using Xunit.Sdk;
 
 namespace FluentAssertions.Specs
 {
-    [Collection("Equivalency")]
-
     public class BasicEquivalencySpecs
     {
         public enum LocalOtherType : byte

--- a/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
@@ -12,7 +12,6 @@ using Xunit.Sdk;
 
 namespace FluentAssertions.Specs
 {
-    [Collection("Equivalency")]
     public class CollectionEquivalencySpecs
     {
         public class SubDummy

--- a/Tests/Shared.Specs/ConfigurationSpecs.cs
+++ b/Tests/Shared.Specs/ConfigurationSpecs.cs
@@ -5,6 +5,11 @@ using Xunit;
 
 namespace FluentAssertions.Specs
 {
+    // Due to tests that call Configuration.Current
+    [CollectionDefinition("ConfigurationSpecs", DisableParallelization = true)]
+    public class ConfigurationSpecsDefinition { }
+
+    [Collection("ConfigurationSpecs")]
     public class ConfigurationSpecs
     {
         [Fact]

--- a/Tests/Shared.Specs/CustomAssemblyInfo.cs
+++ b/Tests/Shared.Specs/CustomAssemblyInfo.cs
@@ -1,3 +1,0 @@
-using Xunit;
-
-[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]

--- a/Tests/Shared.Specs/DictionaryEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/DictionaryEquivalencySpecs.cs
@@ -10,7 +10,6 @@ using Xunit.Sdk;
 
 namespace FluentAssertions.Specs
 {
-    [Collection("Equivalency")]
     public class DictionaryEquivalencySpecs
     {
         private class NonGenericDictionary : IDictionary

--- a/Tests/Shared.Specs/ExtensibilityRelatedEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/ExtensibilityRelatedEquivalencySpecs.cs
@@ -12,8 +12,6 @@ namespace FluentAssertions.Specs
     /// <summary>
     /// Test Class containing specs over the extensibility points of Should().BeEquivalentTo
     /// </summary>
-    [Collection("Equivalency")]
-
     public class ExtensibilityRelatedEquivalencySpecs
     {
         #region Selection Rules

--- a/Tests/Shared.Specs/FormatterSpecs.cs
+++ b/Tests/Shared.Specs/FormatterSpecs.cs
@@ -9,6 +9,11 @@ using Xunit.Sdk;
 
 namespace FluentAssertions.Specs
 {
+    // Due to the tests that call Configuration.Current
+    [CollectionDefinition("FormatterSpecs", DisableParallelization = true)]
+    public class FormatterSpecsDefinition { }
+
+    [Collection("FormatterSpecs")]
     public class FormatterSpecs
     {
         [Fact]

--- a/Tests/Shared.Specs/Shared.Specs.projitems
+++ b/Tests/Shared.Specs/Shared.Specs.projitems
@@ -21,7 +21,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionEquivalencySpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ComparableSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ConfigurationSpecs.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)CustomAssemblyInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DateTimeAssertionSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DateTimeOffsetAssertionSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DateTimeOffsetValueFormatterSpecs.cs" />


### PR DESCRIPTION
Instead of disabling intra-assembly parallel test execution, we can explicitly mark which test classes that contain tests which alters static state and hence must be executed sequentially.

To my knowledge those things from the public API are:
* `AssertionOptions`
* `Configuration.Current`