### PR TITLE
Split nested function calls into variables

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -389,7 +389,8 @@ namespace FluentAssertions.Collections
                 Tracer = options.TraceWriter
             };
 
-            new EquivalencyValidator(options).AssertEquality(context);
+            var equivalencyValidator = new EquivalencyValidator(options);
+            equivalencyValidator.AssertEquality(context);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -491,7 +491,8 @@ namespace FluentAssertions.Collections
                 Tracer = options.TraceWriter
             };
 
-            new EquivalencyValidator(options).AssertEquality(context);
+            var equivalencyValidator = new EquivalencyValidator(options);
+            equivalencyValidator.AssertEquality(context);
         }
 
         #region ContainKey

--- a/Src/FluentAssertions/Collections/NonGenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/NonGenericCollectionAssertions.cs
@@ -365,7 +365,8 @@ namespace FluentAssertions.Collections
                 Tracer = options.TraceWriter
             };
 
-            new EquivalencyValidator(options).AssertEquality(context);
+            var equivalencyValidator = new EquivalencyValidator(options);
+            equivalencyValidator.AssertEquality(context);
         }
     }
 }

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -102,7 +102,8 @@ namespace FluentAssertions.Collections
                 Tracer = options.TraceWriter
             };
 
-            new EquivalencyValidator(options).AssertEquality(context);
+            var equivalencyValidator = new EquivalencyValidator(options);
+            equivalencyValidator.AssertEquality(context);
 
             return new AndConstraint<StringCollectionAssertions>(this);
         }

--- a/Src/FluentAssertions/Common/CSharpAccessModifierExtensions.cs
+++ b/Src/FluentAssertions/Common/CSharpAccessModifierExtensions.cs
@@ -67,27 +67,29 @@ namespace FluentAssertions.Common
 
         internal static CSharpAccessModifier GetCSharpAccessModifier(this Type type)
         {
-            if (type.GetTypeInfo().IsNestedPrivate)
+            TypeInfo typeInfo = type.GetTypeInfo();
+
+            if (typeInfo.IsNestedPrivate)
             {
                 return CSharpAccessModifier.Private;
             }
 
-            if (type.GetTypeInfo().IsNestedFamily)
+            if (typeInfo.IsNestedFamily)
             {
                 return CSharpAccessModifier.Protected;
             }
 
-            if (type.GetTypeInfo().IsNestedAssembly || (type.GetTypeInfo().IsClass && type.GetTypeInfo().IsNotPublic))
+            if (typeInfo.IsNestedAssembly || typeInfo.IsClass && typeInfo.IsNotPublic)
             {
                 return CSharpAccessModifier.Internal;
             }
 
-            if (type.GetTypeInfo().IsPublic || type.GetTypeInfo().IsNestedPublic)
+            if (typeInfo.IsPublic || typeInfo.IsNestedPublic)
             {
                 return CSharpAccessModifier.Public;
             }
 
-            if (type.GetTypeInfo().IsNestedFamORAssem)
+            if (typeInfo.IsNestedFamORAssem)
             {
                 return CSharpAccessModifier.ProtectedInternal;
             }

--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -144,7 +144,9 @@ namespace FluentAssertions.Common
                 }
             }
 
-            return string.Join(".", segments.AsEnumerable().Reverse().ToArray()).Replace(".[", "[");
+            string[] reversedSegments = segments.AsEnumerable().Reverse().ToArray();
+            string segmentPath = string.Join(".", reversedSegments);
+            return segmentPath.Replace(".[", "[");
         }
 
         internal static string GetMethodName(Expression<Action> action)

--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -38,8 +38,9 @@ namespace FluentAssertions.Common
         public static string IndexedSegmentAt(this string value, int index)
         {
             int length = Math.Min(value.Length - index, 3);
+            string formattedString = Formatter.ToString(value.Substring(index, length));
 
-            return $"{Formatter.ToString(value.Substring(index, length))} (index {index})".Replace("{", "{{").Replace("}", "}}");
+            return $"{formattedString} (index {index})".Replace("{", "{{").Replace("}", "}}");
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
+++ b/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
@@ -43,7 +43,10 @@ namespace FluentAssertions.Equivalency
                     break;
 
                 case EnumEquivalencyHandling.ByName:
-                    context.Subject.ToString().Should().Be(context.Expectation.ToString(), context.Because, context.BecauseArgs);
+                    string subject = context.Subject.ToString();
+                    string expected = context.Expectation.ToString();
+
+                    subject.Should().Be(expected, context.Because, context.BecauseArgs);
                     break;
 
                 default:

--- a/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptions.cs
@@ -68,7 +68,8 @@ namespace FluentAssertions.Equivalency
         public EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(
             Expression<Func<TExpectation, object>> expression)
         {
-            orderingRules.Add(new PathBasedOrderingRule(expression.GetMemberPath()));
+            string expressionMemberPath = expression.GetMemberPath();
+            orderingRules.Add(new PathBasedOrderingRule(expressionMemberPath));
             return this;
         }
 

--- a/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
@@ -28,11 +28,13 @@ namespace FluentAssertions.Equivalency
 
                 do
                 {
-                    var subject = ((Array)context.Subject).GetValue(digit.Indices);
+                    object subject = ((Array)context.Subject).GetValue(digit.Indices);
+                    string listOfIndices = string.Join(",", digit.Indices);
+                    object expectation = expectationAsArray.GetValue(digit.Indices);
                     IEquivalencyValidationContext itemContext = context.CreateForCollectionItem(
-                        string.Join(",", digit.Indices),
+                        listOfIndices,
                         subject,
-                        expectationAsArray.GetValue(digit.Indices));
+                        expectation);
 
                     parent.AssertEqualityUsing(itemContext);
                 }

--- a/Src/FluentAssertions/Equivalency/Selection/AllPublicFieldsSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/AllPublicFieldsSelectionRule.cs
@@ -13,9 +13,11 @@ namespace FluentAssertions.Equivalency.Selection
 
         public IEnumerable<SelectedMemberInfo> SelectMembers(IEnumerable<SelectedMemberInfo> selectedMembers, IMemberInfo context, IEquivalencyAssertionOptions config)
         {
-            return
-                selectedMembers.Union(
-                    config.GetExpectationType(context).GetNonPrivateFields().Select(SelectedMemberInfo.Create));
+            IEnumerable<SelectedMemberInfo> selectedNonPrivateFields = config.GetExpectationType(context)
+                .GetNonPrivateFields()
+                .Select(SelectedMemberInfo.Create);
+
+            return selectedMembers.Union(selectedNonPrivateFields);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Equivalency/Selection/AllPublicPropertiesSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/AllPublicPropertiesSelectionRule.cs
@@ -13,9 +13,11 @@ namespace FluentAssertions.Equivalency.Selection
 
         public IEnumerable<SelectedMemberInfo> SelectMembers(IEnumerable<SelectedMemberInfo> selectedMembers, IMemberInfo context, IEquivalencyAssertionOptions config)
         {
-            return
-                selectedMembers.Union(
-                    config.GetExpectationType(context).GetNonPrivateProperties().Select(SelectedMemberInfo.Create));
+            IEnumerable<SelectedMemberInfo> selectedNonPrivateProperties = config.GetExpectationType(context)
+                .GetNonPrivateProperties()
+                .Select(SelectedMemberInfo.Create);
+
+            return selectedMembers.Union(selectedNonPrivateProperties);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Equivalency/Selection/MemberPath.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/MemberPath.cs
@@ -23,7 +23,9 @@ namespace FluentAssertions.Equivalency.Selection
 
         private bool IsChild(string candidate)
         {
-            return Segmentize(candidate).Take(segments.Count).SequenceEqual(segments);
+            string[] candidateSegments = Segmentize(candidate);
+
+            return candidateSegments.Take(segments.Count).SequenceEqual(segments);
         }
 
         private bool IsParent(string candidate)

--- a/Src/FluentAssertions/Events/EventMonitor.cs
+++ b/Src/FluentAssertions/Events/EventMonitor.cs
@@ -118,8 +118,7 @@ namespace FluentAssertions.Events
 
         public IEventRecorder GetEventRecorder(string eventName)
         {
-            IEventRecorder recorder;
-            if (!recorderMap.TryGetValue(eventName, out recorder))
+            if (!recorderMap.TryGetValue(eventName, out IEventRecorder recorder))
             {
                 throw new InvalidOperationException($"Not monitoring any events named \"{eventName}\".");
             }

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -159,7 +159,15 @@ namespace FluentAssertions.Execution
         public AssertionScope WithExpectation(string message, params object[] args)
         {
             var localReason = reason;
-            expectation = () => new MessageBuilder(useLineBreaks).Build(message, args, localReason != null ? localReason() : "", contextData, GetIdentifier(), fallbackIdentifier);
+            expectation = () =>
+            {
+                var messageBuilder = new MessageBuilder(useLineBreaks);
+                string reason = localReason != null ? localReason() : "";
+                string identifier = GetIdentifier();
+
+                return messageBuilder.Build(message, args, reason, contextData, identifier, fallbackIdentifier);
+            };
+
             return this;
         }
 
@@ -215,7 +223,10 @@ namespace FluentAssertions.Execution
             {
                 if (evaluateCondition && !Succeeded)
                 {
-                    string result = new MessageBuilder(useLineBreaks).Build(message, args, reason != null ? reason() : "", contextData, GetIdentifier(), fallbackIdentifier);
+                    string localReason = reason != null ? reason() : "";
+                    var messageBuilder = new MessageBuilder(useLineBreaks);
+                    string identifier = GetIdentifier();
+                    string result = messageBuilder.Build(message, args, localReason, contextData, identifier, fallbackIdentifier);
 
                     if (expectation != null)
                     {

--- a/Src/FluentAssertions/Execution/GivenSelector.cs
+++ b/Src/FluentAssertions/Execution/GivenSelector.cs
@@ -95,7 +95,8 @@ namespace FluentAssertions.Execution
         /// <param name="args">Optional arguments to any numbered placeholders.</param>
         public ContinuationOfGiven<T> FailWith(string message, params Func<T, object>[] args)
         {
-            return FailWith(message, args.Select(a => a(subject)).ToArray());
+            object[] mappedArguments = args.Select(a => a(subject)).ToArray();
+            return FailWith(message, mappedArguments);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
+++ b/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
@@ -29,7 +29,7 @@ namespace FluentAssertions.Execution
                 // For .NET Standard < 2.0, we need to attempt to load the assembly
                 try
                 {
-                    assembly = Assembly.Load(new AssemblyName(AssemblyName) { Version = new Version(0,0,0,0)});
+                    assembly = Assembly.Load(new AssemblyName(AssemblyName) { Version = new Version(0, 0, 0, 0) });
                     return assembly != null;
                 }
                 catch

--- a/Src/FluentAssertions/Execution/MessageBuilder.cs
+++ b/Src/FluentAssertions/Execution/MessageBuilder.cs
@@ -77,7 +77,10 @@ namespace FluentAssertions.Execution
             return Regex.Replace(message, pattern, match =>
             {
                 string key = match.Groups["key"].Value;
-                return contextData.AsStringOrDefault(key)?.Replace("{", "{{").Replace("}", "}}") ?? match.Groups["default"].Value;
+                string contextualTags = contextData.AsStringOrDefault(key);
+                string contextualTagsSubstituted = contextualTags?.Replace("{", "{{").Replace("}", "}}");
+
+                return contextualTagsSubstituted ?? match.Groups["default"].Value;
             });
         }
 

--- a/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
@@ -46,7 +46,10 @@ namespace FluentAssertions.Formatting
 
         private MethodInfo GetFormatter(object value)
         {
-            return Formatters.FirstOrDefault(m => m.GetParameters().Single().ParameterType == value.GetType());
+            Type valueType = value.GetType();
+            MethodInfo formatter = Formatters.FirstOrDefault(m => m.GetParameters().Single().ParameterType == valueType);
+
+            return formatter;
         }
 
         public MethodInfo[] Formatters

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -52,7 +52,9 @@ namespace FluentAssertions.Formatting
 
         private static bool HasDefaultToStringImplementation(object value)
         {
-            return value.ToString() is null || value.ToString().Equals(value.GetType().ToString());
+            string str = value.ToString();
+
+            return str is null || str.Equals(value.GetType().ToString());
         }
 
         private static string GetTypeAndPublicPropertyValues(object obj, FormattingContext context, FormatChild formatChild)
@@ -72,7 +74,8 @@ namespace FluentAssertions.Formatting
             IEnumerable<SelectedMemberInfo> properties = type.GetNonPrivateMembers();
             foreach (var propertyInfo in properties.OrderBy(pi => pi.Name))
             {
-                builder.AppendLine(GetPropertyValueTextFor(obj, propertyInfo, context, formatChild));
+                string propertyValueText = GetPropertyValueTextFor(obj, propertyInfo, context, formatChild);
+                builder.AppendLine(propertyValueText);
             }
 
             builder.Append(CreateWhitespaceForLevel(context.Depth)).Append('}');

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -185,7 +185,9 @@ namespace FluentAssertions.Formatting
             {
                 pathStack.Push(path);
 
-                return !tracker.IsCyclicReference(new ObjectReference(value, GetFullPath()));
+                string fullPath = GetFullPath();
+                var reference = new ObjectReference(value, fullPath);
+                return !tracker.IsCyclicReference(reference);
             }
 
             private string GetFullPath() => string.Join(".", pathStack.Reverse());

--- a/Src/FluentAssertions/Formatting/StringValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/StringValueFormatter.cs
@@ -21,7 +21,10 @@ namespace FluentAssertions.Formatting
         /// <inheritdoc />
         public string Format(object value, FormattingContext context, FormatChild formatChild)
         {
-            return (context.UseLineBreaks ? Environment.NewLine : "") + "\"" + value.ToString().Escape() + "\"";
+            string prefix = context.UseLineBreaks ? Environment.NewLine : "";
+            string escapedString = value.ToString().Escape();
+
+            return prefix + "\"" + escapedString + "\"";
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
@@ -103,7 +103,8 @@ namespace FluentAssertions.Numeric
                 Tracer = options.TraceWriter
             };
 
-            new EquivalencyValidator(options).AssertEquality(context);
+            var equivalencyValidator = new EquivalencyValidator(options);
+            equivalencyValidator.AssertEquality(context);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Primitives/ObjectAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ObjectAssertions.cs
@@ -124,7 +124,8 @@ namespace FluentAssertions.Primitives
                 Tracer = options.TraceWriter
             };
 
-            new EquivalencyValidator(options).AssertEquality(context);
+            var equivalencyValidator = new EquivalencyValidator(options);
+            equivalencyValidator.AssertEquality(context);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -36,7 +36,8 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<StringAssertions> Be(string expected, string because = "", params object[] becauseArgs)
         {
-            new StringEqualityValidator(Subject, expected, StringComparison.CurrentCulture, because, becauseArgs).Validate();
+            var stringEqualityValidator = new StringEqualityValidator(Subject, expected, StringComparison.CurrentCulture, because, becauseArgs);
+            stringEqualityValidator.Validate();
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -137,7 +138,8 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs)
         {
-            new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs).Validate();
+            var stringWildcardMatchingValidator = new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs);
+            stringWildcardMatchingValidator.Validate();
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -336,7 +338,8 @@ namespace FluentAssertions.Primitives
                 throw new ArgumentException("Cannot compare start of string with empty string.", nameof(expected));
             }
 
-            new StringStartValidator(Subject, expected, StringComparison.CurrentCulture, because, becauseArgs).Validate();
+            var stringStartValidator = new StringStartValidator(Subject, expected, StringComparison.CurrentCulture, because, becauseArgs);
+            stringStartValidator.Validate();
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -365,7 +368,8 @@ namespace FluentAssertions.Primitives
                 throw new ArgumentException("Cannot compare start of string with empty string.", nameof(unexpected));
             }
 
-            new NegatedStringStartValidator(Subject, unexpected, StringComparison.CurrentCulture, because, becauseArgs).Validate();
+            var negatedStringStartValidator = new NegatedStringStartValidator(Subject, unexpected, StringComparison.CurrentCulture, because, becauseArgs);
+            negatedStringStartValidator.Validate();
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -395,7 +399,8 @@ namespace FluentAssertions.Primitives
                 throw new ArgumentException("Cannot compare string start equivalence with empty string.", nameof(expected));
             }
 
-            new StringStartValidator(Subject, expected, StringComparison.CurrentCultureIgnoreCase, because, becauseArgs).Validate();
+            var stringStartValidator = new StringStartValidator(Subject, expected, StringComparison.CurrentCultureIgnoreCase, because, becauseArgs);
+            stringStartValidator.Validate();
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -424,7 +429,8 @@ namespace FluentAssertions.Primitives
                 throw new ArgumentException("Cannot compare start of string with empty string.", nameof(unexpected));
             }
 
-            new NegatedStringStartValidator(Subject, unexpected, StringComparison.CurrentCultureIgnoreCase, because, becauseArgs).Validate();
+            var negatedStringStartValidator = new NegatedStringStartValidator(Subject, unexpected, StringComparison.CurrentCultureIgnoreCase, because, becauseArgs);
+            negatedStringStartValidator.Validate();
 
             return new AndConstraint<StringAssertions>(this);
         }

--- a/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
@@ -31,7 +31,10 @@ namespace FluentAssertions.Primitives
             {
                 var options = IgnoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
 
-                return Regex.IsMatch(CleanNewLines(subject), ConvertWildcardToRegEx(CleanNewLines(expected)), options | RegexOptions.Singleline);
+                string input = CleanNewLines(subject);
+                string pattern = ConvertWildcardToRegEx(CleanNewLines(expected));
+
+                return Regex.IsMatch(input, pattern, options | RegexOptions.Singleline);
             }
         }
 

--- a/Src/FluentAssertions/Types/MethodBaseAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodBaseAssertions.cs
@@ -29,10 +29,12 @@ namespace FluentAssertions.Types
         public AndConstraint<TAssertions> HaveAccessModifier(
             CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion.ForCondition(accessModifier == Subject.GetCSharpAccessModifier())
+            CSharpAccessModifier subjectAccessModifier = Subject.GetCSharpAccessModifier();
+
+            Execute.Assertion.ForCondition(accessModifier == subjectAccessModifier)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected method " + Subject.Name + " to be {0}{reason}, but it is {1}.",
-                    accessModifier, Subject.GetCSharpAccessModifier());
+                    accessModifier, subjectAccessModifier);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
@@ -204,7 +204,8 @@ namespace FluentAssertions.Types
 
         private static string GetDescriptionsFor(IEnumerable<PropertyInfo> properties)
         {
-            return string.Join(Environment.NewLine, properties.Select(PropertyInfoAssertions.GetDescriptionFor).ToArray());
+            string[] descriptions = properties.Select(PropertyInfoAssertions.GetDescriptionFor).ToArray();
+            return string.Join(Environment.NewLine, descriptions);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -1050,10 +1050,12 @@ namespace FluentAssertions.Types
         public AndConstraint<Type> HaveAccessModifier(
             CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion.ForCondition(accessModifier == Subject.GetCSharpAccessModifier())
+            CSharpAccessModifier subjectAccessModifier = Subject.GetCSharpAccessModifier();
+
+            Execute.Assertion.ForCondition(accessModifier == subjectAccessModifier)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type " + Subject.Name + " to be {0}{reason}, but it is {1}.",
-                    accessModifier, Subject.GetCSharpAccessModifier());
+                    accessModifier, subjectAccessModifier);
 
             return new AndConstraint<Type>(Subject);
         }

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -287,7 +287,8 @@ namespace FluentAssertions.Types
 
         private static string GetDescriptionsFor(IEnumerable<Type> types)
         {
-            return string.Join(Environment.NewLine, types.Select(GetDescriptionFor).ToArray());
+            string[] descriptions = types.Select(GetDescriptionFor).ToArray();
+            return string.Join(Environment.NewLine, descriptions);
         }
 
         private static string GetDescriptionFor(Type type)

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -115,7 +115,8 @@ namespace FluentAssertions.Xml
         /// </param>
         public AndConstraint<XDocumentAssertions> BeEquivalentTo(XDocument expected, string because, params object[] becauseArgs)
         {
-            new XmlReaderValidator(Subject.CreateReader(), expected.CreateReader(), because, becauseArgs).Validate(true);
+            var xmlReaderValidator = new XmlReaderValidator(Subject.CreateReader(), expected.CreateReader(), because, becauseArgs);
+            xmlReaderValidator.Validate(true);
 
             return new AndConstraint<XDocumentAssertions>(this);
         }
@@ -144,7 +145,8 @@ namespace FluentAssertions.Xml
         /// </param>
         public AndConstraint<XDocumentAssertions> NotBeEquivalentTo(XDocument unexpected, string because, params object[] becauseArgs)
         {
-            new XmlReaderValidator(Subject.CreateReader(), unexpected.CreateReader(), because, becauseArgs).Validate(false);
+            var xmlReaderValidator = new XmlReaderValidator(Subject.CreateReader(), unexpected.CreateReader(), because, becauseArgs);
+            xmlReaderValidator.Validate(false);
 
             return new AndConstraint<XDocumentAssertions>(this);
         }

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -118,7 +118,8 @@ namespace FluentAssertions.Xml
             using (XmlReader subjectReader = Subject.CreateReader())
             using (XmlReader expectedReader = expected.CreateReader())
             {
-                new XmlReaderValidator(subjectReader, expectedReader, because, becauseArgs).Validate(true);
+                var xmlReaderValidator = new XmlReaderValidator(subjectReader, expectedReader, because, becauseArgs);
+                xmlReaderValidator.Validate(true);
             }
 
             return new AndConstraint<XElementAssertions>(this);
@@ -150,7 +151,8 @@ namespace FluentAssertions.Xml
         /// </param>
         public AndConstraint<XElementAssertions> NotBeEquivalentTo(XElement unexpected, string because, params object[] becauseArgs)
         {
-            new XmlReaderValidator(Subject.CreateReader(), unexpected.CreateReader(), because, becauseArgs).Validate(false);
+            var xmlReaderValidator = new XmlReaderValidator(Subject.CreateReader(), unexpected.CreateReader(), because, becauseArgs);
+            xmlReaderValidator.Validate(false);
 
             return new AndConstraint<XElementAssertions>(this);
         }

--- a/Src/FluentAssertions/Xml/XmlNodeAssertionsofTSubjectTAssertions.cs
+++ b/Src/FluentAssertions/Xml/XmlNodeAssertionsofTSubjectTAssertions.cs
@@ -44,7 +44,8 @@ namespace FluentAssertions.Xml
             using (XmlNodeReader subjectReader = new XmlNodeReader(Subject))
             using (XmlNodeReader expectedReader = new XmlNodeReader(expected))
             {
-                new XmlReaderValidator(subjectReader, expectedReader, because, reasonArgs).Validate(true);
+                var xmlReaderValidator = new XmlReaderValidator(subjectReader, expectedReader, because, reasonArgs);
+                xmlReaderValidator.Validate(true);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)(this));
@@ -78,7 +79,8 @@ namespace FluentAssertions.Xml
             using (XmlNodeReader subjectReader = new XmlNodeReader(Subject))
             using (XmlNodeReader unexpectedReader = new XmlNodeReader(unexpected))
             {
-                new XmlReaderValidator(subjectReader, unexpectedReader, because, reasonArgs).Validate(false);
+                var xmlReaderValidator = new XmlReaderValidator(subjectReader, unexpectedReader, because, reasonArgs);
+                xmlReaderValidator.Validate(false);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);


### PR DESCRIPTION
When debugging a statement such as `new X().Method()`, I can't easily, as far as I know, step over `new X()` and into `.Method()`.

So this PR makes it easier (for me) to debug as it splits nested function calls into separate variables.

It also has some nice side effects:
* Makes intermediate values visible in debugging
* Gives more informative stack traces if FA throws an Exception, as we do fewer operations per line.