### PR TITLE
Adds link to repository to nuspec

### DIFF
--- a/Src/FluentAssertions.nuspec
+++ b/Src/FluentAssertions.nuspec
@@ -17,8 +17,9 @@
     </description>
     <language>en-US</language>
     <licenseUrl>https://github.com/fluentassertions/fluentassertions/blob/master/LICENSE</licenseUrl>
-	<iconUrl>https://raw.githubusercontent.com/fluentassertions/fluentassertions/master/Src/FluentAssertions.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/fluentassertions/fluentassertions/master/Src/FluentAssertions.png</iconUrl>
     <projectUrl>http://www.fluentassertions.com</projectUrl>
+    <repository type="git" url="https://github.com/fluentassertions/fluentassertions.git" />
     <tags>MSTest MSTest2 xUnit xUnit2 NUnit MSpec NSpec Gallio MbUnit TDD BDD Fluent netcore netstandard uwp</tags>
     <copyright>Copyright Dennis Doomen 2010-2018</copyright>
     <releaseNotes>
@@ -45,7 +46,7 @@
         <dependency id="System.ValueTuple" version="4.4.0" />
       </group>
       <group targetFramework="netcoreapp2.0">
-          <dependency id="System.Configuration.ConfigurationManager" version="4.4.0" />
+        <dependency id="System.Configuration.ConfigurationManager" version="4.4.0" />
       </group>
       <group targetFramework="netstandard2.0">
         <dependency id="System.Configuration.ConfigurationManager" version="4.4.0" />


### PR DESCRIPTION
This adds a link to the git repository in the nuspec.

Currently this adds a link "Source Code" on nuget.org

See e.g. https://www.nuget.org/packages/Newtonsoft.Json/

https://github.com/NuGet/Home/wiki/Show-source-repository-information-for-packages-on-nuget.org
> Long term ideas on the display and usage
Out-of-scope for this spec. However, some of the ideas include:
> * Show repository info as a separate section with links to file issues, show number of active issues and last activity - all of these are vital information that consumers would like to see for a given package they want to consume.
> * Compute the quality metirc based on issues fixed vs. open issues on the repository
> * Use this to switch from PackageReference to ProjectReference by automatically cloning the repo as a project.