### PR TITLE
Limits the depth of rendering an object to a max of 5

### DIFF
--- a/Src/FluentAssertions/Equivalency/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/ObjectReference.cs
@@ -64,7 +64,7 @@ namespace FluentAssertions.Equivalency
 
         public override string ToString()
         {
-            return $"{{\"{path}\", {@object}}}";
+            return $"{{\"{string.Join(".", path)}\", {@object}}}";
         }
 
         public bool IsComplexType => isComplexType ?? (!(@object is null) && !@object.GetType().OverridesEquals());

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -13,8 +13,6 @@ namespace FluentAssertions.Formatting
     {
         #region Private Definitions
 
-        private const int MaxDepth = 15;
-
         private static readonly List<IValueFormatter> customFormatters = new List<IValueFormatter>();
 
         private static readonly List<IValueFormatter> defaultFormatters = new List<IValueFormatter>
@@ -115,7 +113,7 @@ namespace FluentAssertions.Formatting
                 {
                     return $"{{Cyclic reference to type {childValue.GetType()} detected}}";
                 }
-                else if (graph.Depth > MaxDepth)
+                else if (graph.Depth > 5)
                 {
                     return "{Maximum recursion depth was reached…}";
                 }
@@ -198,6 +196,11 @@ namespace FluentAssertions.Formatting
             }
 
             public int Depth => (pathStack.Count - 1);
+
+            public override string ToString()
+            {
+                return String.Join(".", pathStack.Reverse().ToArray());
+            }
         }
     }
 }


### PR DESCRIPTION
I see no value in rendering a graph 15 levels deep. This should help prevent OOM exceptions while rendering an object graph. 

Fixes #889 