### PR TITLE
Fix path to NetCore20 project in cake

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -87,7 +87,7 @@ Task("Run-Unit-Tests")
     XUnit2("./Tests/Net47.Specs/bin/Debug/**/*.Specs.dll", new XUnit2Settings { });
     DotNetCoreTool("./Tests/NetCore.Specs/NetCore.Specs.csproj", "xunit", "-configuration debug");
     DotNetCoreTool("./Tests/NetStandard13.Specs/NetStandard13.Specs.csproj", "xunit", "-configuration debug");
-    DotNetCoreTool("./Tests/NetCore20.Specs/NetCore.Specs20.csproj", "xunit", "-configuration debug");
+    DotNetCoreTool("./Tests/NetCore20.Specs/NetCore20.Specs.csproj", "xunit", "-configuration debug");
 
     DotNetCoreTest("./Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj", new DotNetCoreTestSettings { Configuration = "Debug" });
     DotNetCoreTest("./Tests/TestFrameworks/MSTestV2.Specs/MSTestV2.Specs.csproj", new DotNetCoreTestSettings { Configuration = "Debug" });


### PR DESCRIPTION
Even though the path to `NetCore20.Specs.csproj` has always been wrong the tests have always executed.