### PR TITLE
Update test packages

### DIFF
--- a/Build/packages.config
+++ b/Build/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.27.1" />
+    <package id="Cake" version="0.30.0" />
 </packages>

--- a/Tests/Benchmarks/BeEquivalentTo.cs
+++ b/Tests/Benchmarks/BeEquivalentTo.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Attributes.Jobs;
 using FluentAssertions;
 using FluentAssertions.Collections;
 

--- a/Tests/Benchmarks/Benchmarks.csproj
+++ b/Tests/Benchmarks/Benchmarks.csproj
@@ -7,6 +7,6 @@
     <ProjectReference Include="..\..\Src\FluentAssertions\FluentAssertions.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.1" />
   </ItemGroup>
 </Project>

--- a/Tests/Benchmarks/CollectionEqual.cs
+++ b/Tests/Benchmarks/CollectionEqual.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Attributes.Jobs;
 using FluentAssertions;
 using FluentAssertions.Common;
 

--- a/Tests/Net45.Specs/Net45.Specs.csproj
+++ b/Tests/Net45.Specs/Net45.Specs.csproj
@@ -15,9 +15,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Src\FluentAssertions\FluentAssertions.csproj" />

--- a/Tests/Net45.Specs/Net45.Specs.csproj
+++ b/Tests/Net45.Specs/Net45.Specs.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.8.1" />
     <PackageReference Include="Chill" Version="3.2.0" />
-    <PackageReference Include="FakeItEasy" Version="4.5.1" />
+    <PackageReference Include="FakeItEasy" Version="4.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />

--- a/Tests/Net45.Specs/Net45.Specs.csproj
+++ b/Tests/Net45.Specs/Net45.Specs.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.8.0" />
+    <PackageReference Include="Autofac" Version="4.8.1" />
     <PackageReference Include="Chill" Version="3.2.0" />
     <PackageReference Include="FakeItEasy" Version="4.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />

--- a/Tests/Net47.Specs/Net47.Specs.csproj
+++ b/Tests/Net47.Specs/Net47.Specs.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.8.1" />
     <PackageReference Include="Chill" Version="3.2.0" />
-    <PackageReference Include="FakeItEasy" Version="4.5.1" />
+    <PackageReference Include="FakeItEasy" Version="4.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />

--- a/Tests/Net47.Specs/Net47.Specs.csproj
+++ b/Tests/Net47.Specs/Net47.Specs.csproj
@@ -14,9 +14,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Src\FluentAssertions\FluentAssertions.csproj" />

--- a/Tests/Net47.Specs/Net47.Specs.csproj
+++ b/Tests/Net47.Specs/Net47.Specs.csproj
@@ -8,7 +8,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.8.0" />
+    <PackageReference Include="Autofac" Version="4.8.1" />
     <PackageReference Include="Chill" Version="3.2.0" />
     <PackageReference Include="FakeItEasy" Version="4.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />

--- a/Tests/NetCore.Specs/NetCore.Specs.csproj
+++ b/Tests/NetCore.Specs/NetCore.Specs.csproj
@@ -10,9 +10,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Src\FluentAssertions\FluentAssertions.csproj" />

--- a/Tests/NetCore.Specs/NetCore.Specs.csproj
+++ b/Tests/NetCore.Specs/NetCore.Specs.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>..\..\TestRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="4.5.1" />
+    <PackageReference Include="FakeItEasy" Version="4.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/Tests/NetCore20.Specs/NetCore20.Specs.csproj
+++ b/Tests/NetCore20.Specs/NetCore20.Specs.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Chill" Version="3.2.0" />
-    <PackageReference Include="FakeItEasy" Version="4.5.1" />
+    <PackageReference Include="FakeItEasy" Version="4.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />

--- a/Tests/NetCore20.Specs/NetCore20.Specs.csproj
+++ b/Tests/NetCore20.Specs/NetCore20.Specs.csproj
@@ -10,9 +10,8 @@
     <PackageReference Include="FakeItEasy" Version="4.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Src\FluentAssertions\FluentAssertions.csproj" />

--- a/Tests/NetStandard13.Specs/NetStandard13.Specs.csproj
+++ b/Tests/NetStandard13.Specs/NetStandard13.Specs.csproj
@@ -7,7 +7,7 @@
     <CodeAnalysisRuleSet>..\..\TestRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="4.5.1" />
+    <PackageReference Include="FakeItEasy" Version="4.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/Tests/NetStandard13.Specs/NetStandard13.Specs.csproj
+++ b/Tests/NetStandard13.Specs/NetStandard13.Specs.csproj
@@ -11,9 +11,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FluentAssertions">

--- a/Tests/TestFrameworks/MSTestV2.Specs/MSTestV2.Specs.csproj
+++ b/Tests/TestFrameworks/MSTestV2.Specs/MSTestV2.Specs.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
   </ItemGroup>
 </Project>

--- a/Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj
+++ b/Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj
@@ -11,6 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Machine.Specifications" Version="0.12.0" />
-    <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.6.1" />
+    <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.7.0" />
   </ItemGroup>
 </Project>

--- a/Tests/TestFrameworks/NUnit2.Net45.Specs/NUnit2.Net45.Specs.csproj
+++ b/Tests/TestFrameworks/NUnit2.Net45.Specs/NUnit2.Net45.Specs.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit" Version="2.6.4" />
+    <PackageReference Include="NUnit" Version="2.7.0" />
     <PackageReference Include="NUnitTestAdapter" Version="2.1.1" />
   </ItemGroup>
 </Project>

--- a/Tests/TestFrameworks/NUnit3.Specs/NUnit3.Specs.csproj
+++ b/Tests/TestFrameworks/NUnit3.Specs/NUnit3.Specs.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
 </Project>

--- a/Tests/TestFrameworks/XUnit2.Specs/XUnit2.Specs.csproj
+++ b/Tests/TestFrameworks/XUnit2.Specs/XUnit2.Specs.csproj
@@ -10,8 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta5-build3769" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta5-build3769" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta5-build3769" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 </Project>

--- a/build.cake
+++ b/build.cake
@@ -2,7 +2,7 @@
 #tool "nuget:?package=nspec&version=1.0.13"
 #tool "nuget:?package=nspec&version=2.0.1"
 #tool "nuget:?package=nspec&version=3.1.0"
-#tool "nuget:?package=nunit.runners&version=2.6.6"
+#tool "nuget:?package=nunit.runners&version=2.7.0"
 #tool "nuget:?package=GitVersion.CommandLine"
 
 //////////////////////////////////////////////////////////////////////

--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-﻿#tool "nuget:?package=xunit.runner.console&version=2.3.0-beta5-build3769"
+﻿#tool "nuget:?package=xunit.runner.console&version=2.4.0"
 #tool "nuget:?package=nspec&version=1.0.13"
 #tool "nuget:?package=nspec&version=2.0.1"
 #tool "nuget:?package=nspec&version=3.1.0"
@@ -85,14 +85,14 @@ Task("Run-Unit-Tests")
 {
     XUnit2("./Tests/Net45.Specs/bin/Debug/**/*.Specs.dll", new XUnit2Settings { });
     XUnit2("./Tests/Net47.Specs/bin/Debug/**/*.Specs.dll", new XUnit2Settings { });
-    DotNetCoreTool("./Tests/NetCore.Specs/NetCore.Specs.csproj", "xunit", "-configuration debug");
-    DotNetCoreTool("./Tests/NetStandard13.Specs/NetStandard13.Specs.csproj", "xunit", "-configuration debug");
-    DotNetCoreTool("./Tests/NetCore20.Specs/NetCore20.Specs.csproj", "xunit", "-configuration debug");
+    DotNetCoreTest("./Tests/NetCore.Specs/NetCore.Specs.csproj", new DotNetCoreTestSettings { Configuration = "Debug" });
+    DotNetCoreTest("./Tests/NetStandard13.Specs/NetStandard13.Specs.csproj", new DotNetCoreTestSettings { Configuration = "Debug" });
+    DotNetCoreTest("./Tests/NetCore20.Specs/NetCore20.Specs.csproj", new DotNetCoreTestSettings { Configuration = "Debug" });
 
     DotNetCoreTest("./Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj", new DotNetCoreTestSettings { Configuration = "Debug" });
     DotNetCoreTest("./Tests/TestFrameworks/MSTestV2.Specs/MSTestV2.Specs.csproj", new DotNetCoreTestSettings { Configuration = "Debug" });
     DotNetCoreTest("./Tests/TestFrameworks/NUnit3.Specs/NUnit3.Specs.csproj", new DotNetCoreTestSettings { Configuration = "Debug" });
-    DotNetCoreTool("./Tests/TestFrameworks/XUnit2.Specs/XUnit2.Specs.csproj", "xunit", "-configuration debug");
+    DotNetCoreTest("./Tests/TestFrameworks/XUnit2.Specs/XUnit2.Specs.csproj", new DotNetCoreTestSettings { Configuration = "Debug" });
     XUnit2("./Tests/TestFrameworks/XUnit.Net45.Specs/**/bin/Debug/**/*.Specs.dll", new XUnit2Settings { });
     NUnit("./Tests/TestFrameworks/NUnit2.Net45.Specs/**/bin/Debug/**/*.Specs.dll", new NUnitSettings { NoResults = true });
 


### PR DESCRIPTION
The problems with upgrading xunit to 2.4.0 was apparently problems with `dotnet xunit`.
It was complete removed in 2.4.0, see [release notes](https://xunit.github.io/releases/2.4)
As recommended in the release notes I've changed from `dotnet xunit` to `dotnet test`.

This fixes #720 