### PR TITLE
Add generic overloads of BeEquivalentTo

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -323,6 +323,89 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
+        public AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation[] expectations, string because = "",
+            params object[] becauseArgs)
+        {
+            BeEquivalentTo(expectations, config => config, because, becauseArgs);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that a collection of objects is equivalent to another collection of objects.
+        /// </summary>
+        /// <remarks>
+        /// Objects within the collections are equivalent when both object graphs have equally named properties with the same
+        /// value,  irrespective of the type of those objects. Two properties are also equal if one type can be converted to another
+        /// and the result is equal.
+        /// The type of a collection property is ignored as long as the collection implements <see cref="IEnumerable"/> and all
+        /// items in the collection are structurally equal.
+        /// </remarks>
+        /// <param name="config">
+        /// A reference to the <see cref="EquivalencyAssertionOptions{TSubject}"/> configuration object that can be used
+        /// to influence the way the object graphs are compared. You can also provide an alternative instance of the
+        /// <see cref="EquivalencyAssertionOptions{TSubject}"/> class. The global defaults are determined by the
+        /// <see cref="AssertionOptions"/> class.
+        /// </param>
+        /// <param name="because">
+        /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the
+        /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation[] expectations,
+            Func<EquivalencyAssertionOptions<TExpectation>, EquivalencyAssertionOptions<TExpectation>> config, string because = "",
+            params object[] becauseArgs)
+        {
+            BeEquivalentTo((IEnumerable<TExpectation>)expectations, config, because, becauseArgs);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that a collection of objects is equivalent to another collection of objects.
+        /// </summary>
+        /// <remarks>
+        /// Objects within the collections are equivalent when both object graphs have equally named properties with the same
+        /// value, irrespective of the type of those objects. Two properties are also equal if one type can be converted to another
+        /// and the result is equal.
+        /// The type of a collection property is ignored as long as the collection implements <see cref="IEnumerable"/> and all
+        /// items in the collection are structurally equal.
+        /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
+        /// </remarks>
+        /// <param name="because">
+        /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the
+        /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> BeEquivalentTo(IEnumerable expectations, string because = "", params object[] becauseArgs)
+        {
+            BeEquivalentTo(expectations.Cast<object>(), because, becauseArgs);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that a collection of objects is equivalent to another collection of objects.
+        /// </summary>
+        /// <remarks>
+        /// Objects within the collections are equivalent when both object graphs have equally named properties with the same
+        /// value, irrespective of the type of those objects. Two properties are also equal if one type can be converted to another
+        /// and the result is equal.
+        /// The type of a collection property is ignored as long as the collection implements <see cref="IEnumerable"/> and all
+        /// items in the collection are structurally equal.
+        /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
+        /// </remarks>
+        /// <param name="because">
+        /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the
+        /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
         public AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(IEnumerable<TExpectation> expectation,
             string because = "", params object[] becauseArgs)
         {

--- a/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
@@ -14,6 +14,17 @@ namespace FluentAssertions.Specs
 {
     public class CollectionEquivalencySpecs
     {
+        public interface IInterface
+        {
+            int InterfaceProperty { get; set; }
+        }
+
+        public class MyClass : IInterface
+        {
+            public int InterfaceProperty { get; set; }
+            public int ClassProperty { get; set; }
+        }
+
         public class SubDummy
         {
             public SubDummy(int id)
@@ -179,6 +190,66 @@ namespace FluentAssertions.Specs
             {
                 innerRoles[userId] = roles.ToList();
             }
+        }
+
+        [Fact]
+        public void When_the_expectation_is_an_array_of_interface_type_it_should_respect_interface_members()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var actual = new IInterface[] { new MyClass() { InterfaceProperty = 1, ClassProperty = 42 } };
+            var expected = new IInterface[] { new MyClass() { InterfaceProperty = 1, ClassProperty = 1337 } };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => actual.Should().BeEquivalentTo(expected);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_the_expectation_is_an_array_of_anonymous_types_it_should_respect_runtime_types()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var actual = new[] { new { A = 1, B = 2}, new { A = 1, B = 2 } };
+            var expected = new object[] { new { A = 1 }, new { B = 2 } };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => actual.Should().BeEquivalentTo(expected);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_the_expectation_is_an_ienumerable_of_anonymous_types_it_should_respect_runtime_types()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var actual = new[] { new { A = 1, B = 2 }, new { A = 1, B = 2 } };
+            IEnumerable expected = new object[] { new { A = 1 }, new { B = 2 } };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => actual.Should().BeEquivalentTo(expected);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
         }
 
         [Fact]


### PR DESCRIPTION
When using an array as the expectation for `BeEquivalentTo`, the behavior varies whether you provide e.g. the identity config `opt => opt`, as it changes the picked overload from the non-generic 
```c#
BeEquivalentTo(params object[] expectations)
``` 
to the generic 
```c#
BeEquivalentTo<TExpectation>(IEnumerable<TExpectation> expectation, ...)
```

This PR adds two generic overloads to give a more consistent / less surprising experience.

This fixes #903 