### PR TITLE
Add tests to prevent breaking changes

### DIFF
--- a/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
@@ -14,6 +14,17 @@ namespace FluentAssertions.Specs
 {
     public class CollectionEquivalencySpecs
     {
+        public interface IInterface
+        {
+            int InterfaceProperty { get; set; }
+        }
+
+        public class MyClass : IInterface
+        {
+            public int InterfaceProperty { get; set; }
+            public int ClassProperty { get; set; }
+        }
+
         public class SubDummy
         {
             public SubDummy(int id)
@@ -179,6 +190,94 @@ namespace FluentAssertions.Specs
             {
                 innerRoles[userId] = roles.ToList();
             }
+        }
+
+        [Fact]
+        public void When_the_expectation_is_an_array_of_interface_type_it_should_respect_runtime_types()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var actual = new IInterface[] { new MyClass() { InterfaceProperty = 1, ClassProperty = 42 } };
+            var expected = new IInterface[] { new MyClass() { InterfaceProperty = 1, ClassProperty = 1337 } };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => actual.Should().BeEquivalentTo(expected);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>(@"Fluent Assertions 5.x.x has the params object[] overload,
+                which discards the compile time type.");
+        }
+
+        [Fact]
+        public void When_the_expectation_has_fewer_dimensions_than_a_multi_dimensional_subject_it_should_fail()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            object objectA = new object();
+            object objectB = new object();
+
+            var actual = new object[][] { new object[] { objectA, objectB } };
+            var expected = actual[0];
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => actual.Should().BeEquivalentTo(expected);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>(@"Fluent Assertions 5.x.x has the params object[] overload,
+                which cannot distinguish an array of objects from an element which is an array of objects.");
+        }
+
+        [Fact]
+        public void When_the_expectation_has_fewer_dimensions_than_a_one_dimensional_subject_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            object objectA = new object();
+
+            var actual = new object[] { objectA };
+            var expected = actual[0];
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => actual.Should().BeEquivalentTo(expected);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow<XunitException>(@"Fluent Assertions 5.x.x has the params object[] overload,
+                which treats a single object as an element of a list.");
+        }
+
+        [Fact]
+        public void When_the_expectation_is_an_array_of_anonymous_types_it_should_respect_runtime_types()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var actual = new[] { new { A = 1, B = 2 }, new { A = 1, B = 2 } };
+            var expected = new object[] { new { A = 1 }, new { B = 2 } };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => actual.Should().BeEquivalentTo(expected);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
         }
 
         [Fact]


### PR DESCRIPTION
The changes proposed in #904 can cause a breaking change at runtime if one uses an array of interface types and implicitly asserts that runtime properties are respected.
Even though the consistent way would be to respect the compile type and require `RespectRuntimeTypes()`, I'd like to keep my breaking change score at 1. #762 

This PR instead adds tests to help anyone who tries to fix the inconsistent behavior of `BeEquivalentTo(params object[])`, at least for 5.x.x, not to cause a breaking change.