### PR TITLE
Improve performance of AllBeEquivalentTo

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -331,12 +331,22 @@ namespace FluentAssertions.Collections
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         public void AllBeEquivalentTo<TExpectation>(TExpectation expectation,
-            Func<EquivalencyAssertionOptions<TExpectation>, EquivalencyAssertionOptions<TExpectation>> config, string because = "",
+            Func<EquivalencyAssertionOptions<TExpectation>, EquivalencyAssertionOptions<TExpectation>> config,
+            string because = "",
             params object[] becauseArgs)
         {
             TExpectation[] repeatedExpectation = RepeatAsManyAs(expectation, Subject).ToArray();
 
-            BeEquivalentTo(repeatedExpectation, config, because, becauseArgs);
+            // Because we have just manually created the collection based on single element
+            // we are sure that we can force string ordering, because ordering does not matter in terms
+            // of correctness. On the other hand we do not want to change ordering rules for nested objects
+            // in case user needs to use them. Strict ordering improves algorithmic complexity
+            // from O(n^2) to O(n). For bigger tables it is necessary in order to achieve acceptable
+            // execution times.
+            Func<EquivalencyAssertionOptions<TExpectation>, EquivalencyAssertionOptions<TExpectation>> forceStringOrderingConfig =
+                x => config(x).WithStrictOrderingFor(s => s.SelectedMemberPath == "");
+
+            BeEquivalentTo(repeatedExpectation, forceStringOrderingConfig, because, becauseArgs);
         }
 
         private static IEnumerable<TExpectation> RepeatAsManyAs<TExpectation>(TExpectation value, IEnumerable<T> enumerable)

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -338,7 +338,7 @@ namespace FluentAssertions.Collections
             TExpectation[] repeatedExpectation = RepeatAsManyAs(expectation, Subject).ToArray();
 
             // Because we have just manually created the collection based on single element
-            // we are sure that we can force string ordering, because ordering does not matter in terms
+            // we are sure that we can force strict ordering, because ordering does not matter in terms
             // of correctness. On the other hand we do not want to change ordering rules for nested objects
             // in case user needs to use them. Strict ordering improves algorithmic complexity
             // from O(n^2) to O(n). For bigger tables it is necessary in order to achieve acceptable

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
@@ -62,22 +62,27 @@ namespace FluentAssertions.Equivalency
             unmatchedSubjectIndexes = new List<int>(subjects.Length);
             unmatchedSubjectIndexes.AddRange(Enumerable.Range(0, subjects.Length));
 
-            foreach (int index in Enumerable.Range(0, expectations.Length))
+            if (OrderingRules.IsOrderingStrictFor(context))
             {
-                T expectation = expectations[index];
+                foreach (int index in Enumerable.Range(0, expectations.Length))
+                {
+                    T expectation = expectations[index];
 
-                if (!OrderingRules.IsOrderingStrictFor(context))
-                {
-                    using (context.TraceBlock(path => $"Finding the best match of {expectation} within all items in {subjects} at {path}[{index}]"))
-                    {
-                        LooselyMatchAgainst(subjects, expectation, index);
-                    }
-                }
-                else
-                {
                     using (context.TraceBlock(path => $"Strictly comparing expectation {expectation} at {path} to item with index {index} in {subjects}"))
                     {
                         StrictlyMatchAgainst(subjects, expectation, index);
+                    }
+                }
+            }
+            else
+            {
+                foreach (int index in Enumerable.Range(0, expectations.Length))
+                {
+                    T expectation = expectations[index];
+                    
+                    using (context.TraceBlock(path => $"Finding the best match of {expectation} within all items in {subjects} at {path}[{index}]"))
+                    {
+                        LooselyMatchAgainst(subjects, expectation, index);
                     }
                 }
             }

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
@@ -74,10 +74,11 @@ namespace FluentAssertions.Equivalency
                         bool succeed = StrictlyMatchAgainst(subjects, expectation, index);
                         if(!succeed)
                         {
+                            const int limit = 10;
                             failedCount++;
                             if(failedCount >= 10)
                             {
-                                //trace;
+                                context.TraceSingle(path => $"Fail failing strict order comparison of collection after {limit} items failed at {path}");
                                 break;
                             }
                         }

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
@@ -139,7 +139,10 @@ namespace FluentAssertions.Equivalency
 
         private void StrictlyMatchAgainst<T>(object[] subjects, T expectation, int expectationIndex)
         {
-            parent.AssertEqualityUsing(context.CreateForCollectionItem(expectationIndex.ToString(), subjects[expectationIndex], expectation));
+            using (var scope = new AssertionScope())
+            {
+                parent.AssertEqualityUsing(context.CreateForCollectionItem(expectationIndex.ToString(), subjects[expectationIndex], expectation));
+            }
         }
     }
 }

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
@@ -91,7 +91,7 @@ namespace FluentAssertions.Equivalency
                         if (failedCount >= FailedItemsFastFailThreshold)
                         {
                             context.TraceSingle(path =>
-                                $"Fail failing strict order comparison of collection after {FailedItemsFastFailThreshold} items failed at {path}");
+                                $"Aborting strict order comparison of collections after {FailedItemsFastFailThreshold} items failed at {path}");
                             break;
                         }
                     }

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
@@ -84,8 +84,8 @@ namespace FluentAssertions.Equivalency
                 using (context.TraceBlock(path =>
                     $"Strictly comparing expectation {expectation} at {path} to item with index {index} in {subjects}"))
                 {
-                    bool succeed = StrictlyMatchAgainst(subjects, expectation, index);
-                    if (!succeed)
+                    bool succeeded = StrictlyMatchAgainst(subjects, expectation, index);
+                    if (!succeeded)
                     {
                         failedCount++;
                         if (failedCount >= FailedItemsFastFailThreshold)
@@ -109,8 +109,8 @@ namespace FluentAssertions.Equivalency
                 using (context.TraceBlock(path =>
                     $"Finding the best match of {expectation} within all items in {subjects} at {path}[{index}]"))
                 {
-                    bool succeed = LooselyMatchAgainst(subjects, expectation, index);
-                    if (!succeed)
+                    bool succeeded = LooselyMatchAgainst(subjects, expectation, index);
+                    if (!succeeded)
                     {
                         failedCount++;
                         if (failedCount >= FailedItemsFastFailThreshold)
@@ -185,12 +185,12 @@ namespace FluentAssertions.Equivalency
             {
                 object subject = subjects[expectationIndex];
                 string indexString = expectationIndex.ToString();
-                var equivalencyValidationContext = context
-                    .CreateForCollectionItem(indexString, subject, expectation);
+                IEquivalencyValidationContext equivalencyValidationContext =
+                    context.CreateForCollectionItem(indexString, subject, expectation);
 
                 parent.AssertEqualityUsing(equivalencyValidationContext);
 
-                bool failed = scope.AnyFailures();
+                bool failed = scope.HasFailures();
                 return !failed;
             }
         }

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -284,7 +284,7 @@ namespace FluentAssertions.Execution
             return assertionStrategy.DiscardFailures().ToArray();
         }
 
-        public bool AnyFailures()
+        public bool HasFailures()
         {
             return assertionStrategy.FailureMessages.Any();
         }

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -284,6 +284,12 @@ namespace FluentAssertions.Execution
             return assertionStrategy.DiscardFailures().ToArray();
         }
 
+        public bool AnyFailures()
+        {
+            return assertionStrategy.FailureMessages.Any();
+        }
+
+
         /// <summary>
         /// Gets data associated with the current scope and identified by <paramref name="key"/>.
         /// </summary>

--- a/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
@@ -325,6 +325,28 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_collection_of_same_count_does_not_match_it_should_include_at_most_10_items_in_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const int commonLength = 11;
+            var subject = new int[commonLength] { 0, 1, 2, 2, 4, 5, 6, 7, 8, 9, 10 };
+            var expectation = Enumerable.Repeat(20, commonLength).ToArray();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => subject.Should().BeEquivalentTo(expectation);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.Should().Throw<XunitException>().Which
+                .Message.Should().Contain("[9]").And.NotContain("[10]");
+        }
+
+        [Fact]
         public void When_a_nullable_collection_does_not_match_it_should_throw()
         {
             //-----------------------------------------------------------------------------------------------------------

--- a/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
@@ -889,7 +889,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_all_subject_items_are_not_equivalent_to_expectation_object_it_should_throw()
+        public void When_some_subject_items_are_not_equivalent_to_expectation_object_it_should_throw()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -900,12 +900,43 @@ namespace FluentAssertions.Specs
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action action = () => subject.Should().AllBeEquivalentTo(1);
-
+            
             ////-----------------------------------------------------------------------------------------------------------
             //// Assert
             ////-----------------------------------------------------------------------------------------------------------
             action.Should().Throw<XunitException>().WithMessage(
                 "Expected item[1] to be 1, but found 2.*Expected item[2] to be 1, but found 3*");
+        }
+
+        [Fact]
+        public void When_some_subject_items_are_not_equivalent_to_expectation_for_huge_table_execution_time_should_still_be_short()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            const int N = 100000;
+            var subject = new List<int>(N) {1};
+            for (int i = 1; i < N; i++)
+            {
+                subject.Add(2);
+            }
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () =>
+            {
+                try { subject.Should().AllBeEquivalentTo(1); }
+                catch (Exception)
+                {
+                    // ignored, we only care about execution time
+                }
+            };
+
+            ////-----------------------------------------------------------------------------------------------------------
+            //// Assert
+            ////-----------------------------------------------------------------------------------------------------------
+            action.ExecutionTime().Should().BeLessThan(100.Seconds());
         }
 
         [Fact]

--- a/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
@@ -331,7 +331,8 @@ namespace FluentAssertions.Specs
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
             const int commonLength = 11;
-            var subject = new int[commonLength] { 0, 1, 2, 2, 4, 5, 6, 7, 8, 9, 10 };
+            // Subjects contains different values, because we want to distinguish them in the assertion message
+            var subject = new int[commonLength] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
             var expectation = Enumerable.Repeat(20, commonLength).ToArray();
 
             //-----------------------------------------------------------------------------------------------------------

--- a/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
@@ -909,6 +909,27 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_more_than_10_subjects_items_are_not_equivalent_to_expectation_only_10_are_reported()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var subject = Enumerable.Repeat(2, 11);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => subject.Should().AllBeEquivalentTo(1);
+
+            ////-----------------------------------------------------------------------------------------------------------
+            //// Assert
+            ////-----------------------------------------------------------------------------------------------------------
+            action.Should().Throw<XunitException>().Which
+                .Message.Should().Contain("item[9] to be 1, but found 2")
+                .And.NotContain("item[10]");
+        }
+
+        [Fact]
         public void When_some_subject_items_are_not_equivalent_to_expectation_for_huge_table_execution_time_should_still_be_short()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -936,7 +957,7 @@ namespace FluentAssertions.Specs
             ////-----------------------------------------------------------------------------------------------------------
             //// Assert
             ////-----------------------------------------------------------------------------------------------------------
-            action.ExecutionTime().Should().BeLessThan(100.Seconds());
+            action.ExecutionTime().Should().BeLessThan(1.Seconds());
         }
 
         [Fact]


### PR DESCRIPTION
Attempt to fix #914.

There are (at least) two bottlenecks:

- [x] `AllBeEquivalentTo` created a collection of items matching the subject's length, and then used loose ordering which results in O(n^2) complexity. Change to strict ordering is necessary to have hope for any kind of reasonable performance.
- [x] Building collection of messages. The more inequivalent items there is the more time it takes to create assert failure messages. I think that some kind of early break is needed in `EnumerableEquivalencyValidator` after say 10 failures.
- [x] Extract `OrderingRules.IsOrderingStrictFor(context)` in `EnumerableEquivalencyValidator.AssertElementGraphEquivalency` before the loop. During profiling, it stands out as an easy-fix with the execution time around 8-10% spent in this method.

I checked that after those three issues there are no more outstanding hot spots. Execution time is split among some `CanHandle` methods, creating objects like `EquivalencyValidationContext` and so on.

Any ideas are warmly welcomed.