### PR TITLE
Define lazy version of `AssertionScope.FailWith`

### DIFF
--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -198,6 +198,12 @@ namespace FluentAssertions.Execution
             return this;
         }
 
+        /// <summary>
+        /// Sets the failure message when the assertion is not met, or completes the failure message set to a
+        /// prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>.
+        /// <paramref name="failReasonFunc"/> will not be called unless the assertion is not met.
+        /// </summary>
+        /// <param name="failReasonFunc">Function returning <see cref="FailReason"/> object on demand. Called only when the assertion is not met.</param>
         public Continuation FailWith(Func<FailReason> failReasonFunc)
         {
             try

--- a/Src/FluentAssertions/Execution/FailReason.cs
+++ b/Src/FluentAssertions/Execution/FailReason.cs
@@ -1,5 +1,20 @@
 ﻿namespace FluentAssertions.Execution
 {
+    /// <summary>
+    /// Represents assertion fail reason. Contains the message and arguments for
+    /// message's numbered placeholders.
+    /// </summary>
+    /// <remarks>
+    /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a few
+    /// specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as passed
+    /// to <see cref="FluentAssertions.Execution.AssertionScope.BecauseOf"/>. Other named placeholders will be replaced with
+    /// the <see cref="FluentAssertions.Execution.AssertionScope.Current"/> scope data passed through
+    /// <see cref="FluentAssertions.Execution.AssertionScope.AddNonReportable"/> and
+    /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable"/>. Finally, a description of the
+    /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
+    /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
+    /// Note that only 10 arguments are supported in combination with a {reason}.
+    /// </remarks>
     public class FailReason
     {
         public FailReason(string message, params object[] args)
@@ -7,7 +22,18 @@
             Message = message;
             Args = args;
         }
+
+        /// <summary>
+        /// Message to be displayed in case of failed assertion. May contain
+        /// numbered <see cref="string.Format(string,object[])"/>-style placeholders as well
+        /// as specialized placeholders.
+        /// </summary>
         public string Message { get; }
+
+        /// <summary>
+        /// Arguments for the numbered <see cref="string.Format(string,object[])"/>-style placeholders
+        /// of <see cref="Message"/>.
+        /// </summary>
         public object[] Args { get; }
     }
 }

--- a/Src/FluentAssertions/Execution/FailReason.cs
+++ b/Src/FluentAssertions/Execution/FailReason.cs
@@ -1,0 +1,13 @@
+﻿namespace FluentAssertions.Execution
+{
+    public class FailReason
+    {
+        public FailReason(string message, params object[] args)
+        {
+            Message = message;
+            Args = args;
+        }
+        public string Message { get; }
+        public object[] Args { get; }
+    }
+}

--- a/Src/FluentAssertions/Primitives/StringEqualityValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityValidator.cs
@@ -1,5 +1,6 @@
 using System;
 using FluentAssertions.Common;
+using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives
 {
@@ -27,29 +28,23 @@ namespace FluentAssertions.Primitives
 
         protected override bool ValidateAgainstLengthDifferences()
         {
-            // Logic is a little bit convoluted because I want to avoid calculation
-            // of mismatch segment in case of equalLength == true for performance reason.
-            // If lazy version of FailWith would be introduced, calculation of mismatch
-            // segment can be moved directly to FailWith's argument
-            bool equalLength = subject.Length == expected.Length;
-
-            string mismatchSegment = GetMismatchSegmentForStringsOfDifferentLengths(equalLength);
-
             return assertion
-                .ForCondition(equalLength)
-                .FailWith(
-                    ExpectationDescription + "{0} with a length of {1}{reason}, but {2} has a length of {3}, differs near " + mismatchSegment +  ".",
-                    expected, expected.Length, subject, subject.Length)
-                .SourceSucceeded;
+                .ForCondition(subject.Length == expected.Length)
+                .FailWith(() =>
+                    {
+                        string mismatchSegment = GetMismatchSegmentForStringsOfDifferentLengths();
+
+                        string message = ExpectationDescription +
+                                         "{0} with a length of {1}{reason}, but {2} has a length of {3}, differs near " + mismatchSegment + ".";
+
+                        return new FailReason(message, expected, expected.Length, subject, subject.Length);
+                        
+                    }
+               ).SourceSucceeded; ;
         }
 
-        private string GetMismatchSegmentForStringsOfDifferentLengths(bool equalLength)
+        private string GetMismatchSegmentForStringsOfDifferentLengths()
         {
-            if (equalLength)
-            {
-                return "";
-            }
-
             int indexOfMismatch = subject.IndexOfFirstMismatch(expected, comparisonMode);
 
             // If there is no difference it means that either

--- a/Tests/Shared.Specs/AssertionScopeSpecs.cs
+++ b/Tests/Shared.Specs/AssertionScopeSpecs.cs
@@ -127,6 +127,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
+            act();
             failReasonCalled.Should().BeFalse(" fail reason function cannot be called for scope that successful");
         }
 

--- a/Tests/Shared.Specs/AssertionScopeSpecs.cs
+++ b/Tests/Shared.Specs/AssertionScopeSpecs.cs
@@ -104,6 +104,61 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_lazy_version_is_not_disposed_it_should_not_execute_fail_reason_function()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var scope = new AssertionScope();
+            bool failReasonCalled = false;
+            AssertionScope.Current
+                .ForCondition(true)
+                .FailWith(() =>
+                {
+                    failReasonCalled = true;
+                    return new FailReason("Failure");
+                });
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = scope.Dispose;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            failReasonCalled.Should().BeFalse(" fail reason function cannot be called for scope that successful");
+        }
+
+        [Fact]
+        public void When_lazy_version_is_disposed_it_should_throw_any_failures_and_properly_format_using_args()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var scope = new AssertionScope();
+
+            AssertionScope.Current.FailWith(() => new FailReason("Failure{0}", 1));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = scope.Dispose;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            try
+            {
+                act();
+            }
+            catch (Exception exception)
+            {
+                exception.Message.Should().StartWith("Failure1");
+            }
+        }
+
+        [Fact]
         public void When_multiple_scopes_are_nested_it_should_throw_all_failures_from_the_outer_scope()
         {
             //-----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Follow up for #915.

A lazy version of `FailWith` is useful when calculations of messages are "expensive' and could be delayed until we are that we will throw. FA main scenario is that most tests do not fail, so I think it makes sense to take care of performance in that case.

Of course, as usual, tests for new functions are added.

I am curious about your comments @jnyrup @dennisdoomen. 