### PR TITLE
Ensures expectations involving multiple assertions can be cleared

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -246,7 +246,7 @@ namespace FluentAssertions.Collections
 
             ICollection<TExpected> expectedItems = expectation.ConvertOrCastToCollection<TExpected>();
 
-            AssertionScope assertion = Execute.Assertion.BecauseOf(because, becauseArgs);
+            IAssertionScope assertion = Execute.Assertion.BecauseOf(because, becauseArgs);
             if (subjectIsNull)
             {
                 assertion.FailWith("Expected {context:collection} to be equal to {0}{reason}, but found <null>.", expectedItems);
@@ -1371,7 +1371,9 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(subject => PredecessorOf(successor, subject))
                 .ForCondition(predecessor => predecessor.IsSameOrEqualTo(expectation))
-                .FailWith("but found {0}.", predecessor => predecessor);
+                .FailWith("but found {0}.", predecessor => predecessor)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidatorExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidatorExtensions.cs
@@ -17,7 +17,7 @@ namespace FluentAssertions.Equivalency
                 .AssertCollectionHasNotTooManyItems(subject, expectation);
         }
 
-        public static Continuation AssertEitherCollectionIsNotEmpty<T>(this AssertionScope scope, ICollection<object> subject, ICollection<T> expectation)
+        public static Continuation AssertEitherCollectionIsNotEmpty<T>(this IAssertionScope scope, ICollection<object> subject, ICollection<T> expectation)
         {
             return scope
                 .ForCondition((subject.Count > 0) || (expectation.Count == 0))
@@ -30,7 +30,7 @@ namespace FluentAssertions.Equivalency
                     Environment.NewLine);
         }
 
-        public static Continuation AssertCollectionHasEnoughItems<T>(this AssertionScope scope, ICollection<object> subject, ICollection<T> expectation)
+        public static Continuation AssertCollectionHasEnoughItems<T>(this IAssertionScope scope, ICollection<object> subject, ICollection<T> expectation)
         {
             return scope
                 .ForCondition(subject.Count >= expectation.Count)
@@ -41,7 +41,7 @@ namespace FluentAssertions.Equivalency
                     Environment.NewLine);
         }
 
-        public static Continuation AssertCollectionHasNotTooManyItems<T>(this AssertionScope scope, ICollection<object> subject, ICollection<T> expectation)
+        public static Continuation AssertCollectionHasNotTooManyItems<T>(this IAssertionScope scope, ICollection<object> subject, ICollection<T> expectation)
         {
             return scope
                 .ForCondition(subject.Count <= expectation.Count)

--- a/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
@@ -184,7 +184,9 @@ namespace FluentAssertions.Equivalency
                 .FailWith("but has additional key(s) {0}", keyDifference.AdditionalKeys)
                 .Then
                 .ForCondition(!hasMissingKeys || !hasAdditionalKeys)
-                .FailWith("but it misses key(s) {0} and has additional key(s) {1}", keyDifference.MissingKeys, keyDifference.AdditionalKeys);
+                .FailWith("but it misses key(s) {0} and has additional key(s) {1}", keyDifference.MissingKeys, keyDifference.AdditionalKeys)
+                .Then
+                .ClearExpectation();
         }
 
         private static KeyDifference<TSubjectKey, TExpectedKey> CalculateKeyDifference<TSubjectKey, TSubjectValue, TExpectedKey,

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using FluentAssertions.Common;
 
 #endregion
@@ -11,7 +12,7 @@ namespace FluentAssertions.Execution
     /// <summary>
     /// Represents an implicit or explicit scope within which multiple assertions can be collected.
     /// </summary>
-    public class AssertionScope : IDisposable
+    public class AssertionScope : IAssertionScope
     {
         #region Private Definitions
 
@@ -25,9 +26,9 @@ namespace FluentAssertions.Execution
         private static AssertionScope current;
 
         private AssertionScope parent;
-        private Func<string> expectation = null;
-        private readonly bool evaluateCondition = true;
+        private Func<string> expectation;
         private string fallbackIdentifier = "object";
+        private bool? succeeded;
 
         #endregion
 
@@ -70,21 +71,6 @@ namespace FluentAssertions.Execution
         public string Context { get; set; }
 
         /// <summary>
-        /// Creates a nested scope used during chaining.
-        /// </summary>
-        internal AssertionScope(AssertionScope sourceScope, bool sourceSucceeded)
-        {
-            assertionStrategy = sourceScope.assertionStrategy;
-            contextData = sourceScope.contextData;
-            reason = sourceScope.reason;
-            useLineBreaks = sourceScope.useLineBreaks;
-            parent = sourceScope.parent;
-            expectation = sourceScope.expectation;
-            evaluateCondition = sourceSucceeded;
-            Context = sourceScope.Context;
-        }
-
-        /// <summary>
         /// Gets the current thread-specific assertion scope.
         /// </summary>
         public static AssertionScope Current
@@ -93,10 +79,7 @@ namespace FluentAssertions.Execution
             private set => current = value;
         }
 
-        /// <summary>
-        /// Indicates that every argument passed into <see cref="FailWith"/> is displayed on a separate line.
-        /// </summary>
-        public AssertionScope UsingLineBreaks
+        public IAssertionScope UsingLineBreaks
         {
             get
             {
@@ -105,25 +88,12 @@ namespace FluentAssertions.Execution
             }
         }
 
-        /// <summary>
-        /// Gets a value indicating whether or not the last assertion executed through this scope succeeded.
-        /// </summary>
-        public bool Succeeded { get; private set; }
+        public bool Succeeded
+        {
+            get => succeeded.HasValue && succeeded.Value;
+        }
 
-        /// <summary>
-        /// Specify the reason why you expect the condition to be <c>true</c>.
-        /// </summary>
-        /// <param name="because">
-        /// A formatted phrase compatible with <see cref="string.Format(string,object[])"/> explaining why
-        /// the condition should be satisfied. If the phrase does not start with the word <i>because</i>,
-        /// it is prepended to the message. If the format of <paramref name="because"/> or
-        /// <paramref name="becauseArgs"/> is not compatible with <see cref="string.Format(string,object[])"/>,
-        /// then a warning message is returned instead.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
-        /// </param>
-        public AssertionScope BecauseOf(string because, params object[] becauseArgs)
+        public IAssertionScope BecauseOf(string because, params object[] becauseArgs)
         {
             reason = () =>
             {
@@ -156,7 +126,7 @@ namespace FluentAssertions.Execution
         /// </remarks>
         ///  <param name="message">The format string that represents the failure message.</param>
         /// <param name="args">Optional arguments to any numbered placeholders.</param>
-        public AssertionScope WithExpectation(string message, params object[] args)
+        public IAssertionScope WithExpectation(string message, params object[] args)
         {
             var localReason = reason;
             expectation = () =>
@@ -171,44 +141,30 @@ namespace FluentAssertions.Execution
             return this;
         }
 
-        /// <summary>
-        /// Allows to safely select the subject for successive assertions, even when the prior assertion has failed.
-        /// </summary>
-        /// <paramref name="selector">
-        /// Selector which result is passed to successive calls to <see cref="ForCondition"/>.
-        /// </paramref>
-        public GivenSelector<T> Given<T>(Func<T> selector)
+        public Continuation ClearExpectation()
         {
-            return new GivenSelector<T>(selector, evaluateCondition, this);
+            expectation = null;
+
+            return new Continuation(this, !succeeded.HasValue || succeeded.Value);
         }
 
-        /// <summary>
-        /// Specify the condition that must be satisfied.
-        /// </summary>
-        /// <param name="condition">
-        /// If <c>true</c> the assertion will be treated as successful and no exceptions will be thrown.
-        /// </param>
-        public AssertionScope ForCondition(bool condition)
+        public GivenSelector<T> Given<T>(Func<T> selector)
         {
-            if (evaluateCondition)
-            {
-                Succeeded = condition;
-            }
+            return new GivenSelector<T>(selector, !succeeded.HasValue || succeeded.Value, this);
+        }
+
+        public IAssertionScope ForCondition(bool condition)
+        {
+            succeeded = condition;
 
             return this;
         }
 
-        /// <summary>
-        /// Sets the failure message when the assertion is not met, or completes the failure message set to a
-        /// prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>.
-        /// <paramref name="failReasonFunc"/> will not be called unless the assertion is not met.
-        /// </summary>
-        /// <param name="failReasonFunc">Function returning <see cref="FailReason"/> object on demand. Called only when the assertion is not met.</param>
         public Continuation FailWith(Func<FailReason> failReasonFunc)
         {
             try
             {
-                if (evaluateCondition && !Succeeded)
+                if (!succeeded.HasValue || !succeeded.Value)
                 {
                     string localReason = reason != null ? reason() : "";
                     var messageBuilder = new MessageBuilder(useLineBreaks);
@@ -222,35 +178,18 @@ namespace FluentAssertions.Execution
                     }
 
                     assertionStrategy.HandleFailure(result.Capitalize());
+
+                    succeeded = false;
                 }
 
-                return new Continuation(this, Succeeded);
+                return new Continuation(this, succeeded.Value);
             }
             finally
             {
-                Succeeded = false;
+                succeeded = null;
             }
         }
 
-        /// <summary>
-        /// Sets the failure message when the assertion is not met, or completes the failure message set to a
-        /// prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>.
-        /// </summary>
-        /// <remarks>
-        /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a few
-        /// specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as passed
-        /// to <see cref="FluentAssertions.Execution.AssertionScope.BecauseOf"/>. Other named placeholders will be replaced with
-        /// the <see cref="FluentAssertions.Execution.AssertionScope.Current"/> scope data passed through
-        /// <see cref="FluentAssertions.Execution.AssertionScope.AddNonReportable"/> and
-        /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable"/>. Finally, a description of the
-        /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
-        /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
-        /// Note that only 10 <paramref name="args"/> are supported in combination with a {reason}.
-        /// If an expectation was set through a prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>,
-        /// then the failure message is appended to that expectation.
-        /// </remarks>
-        /// <param name="message">The format string that represents the failure message.</param>
-        /// <param name="args">Optional arguments to any numbered placeholders.</param>
         public Continuation FailWith(string message, params object[] args)
         {
             return FailWith(() => new FailReason(message, args));
@@ -288,9 +227,6 @@ namespace FluentAssertions.Execution
             contextData.Add(key, value, Reportability.Reportable);
         }
 
-        /// <summary>
-        /// Discards and returns the failures that happened up to now.
-        /// </summary>
         public string[] Discard()
         {
             return assertionStrategy.DiscardFailures().ToArray();
@@ -326,9 +262,9 @@ namespace FluentAssertions.Execution
             }
         }
 
-        public AssertionScope WithDefaultIdentifier(string identifier)
+        public IAssertionScope WithDefaultIdentifier(string identifier)
         {
-            this.fallbackIdentifier = identifier;
+            fallbackIdentifier = identifier;
             return this;
         }
     }

--- a/Src/FluentAssertions/Execution/ChainedAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/ChainedAssertionScope.cs
@@ -1,0 +1,92 @@
+﻿using System;
+
+namespace FluentAssertions.Execution
+{
+    /// <summary>
+    /// Allows chaining multiple assertion scopes together using <see cref="Continuation.Then"/>.
+    /// </summary>
+    /// <remarks>
+    /// If the parent scope has captured a failed assertion, this class ensures that successive assertions
+    /// are no longer evaluated.
+    /// </remarks>
+    public class ContinuedAssertionScope : IAssertionScope
+    {
+        private readonly AssertionScope predecessor;
+        private readonly bool predecessorSucceeded;
+
+        public ContinuedAssertionScope(AssertionScope predecessor, bool predecessorSucceeded)
+        {
+            this.predecessorSucceeded = predecessorSucceeded;
+            this.predecessor = predecessor;
+        }
+
+        public GivenSelector<T> Given<T>(Func<T> selector)
+        {
+            return predecessor.Given<T>(selector);
+        }
+
+        public IAssertionScope ForCondition(bool condition)
+        {
+            if (predecessorSucceeded)
+            {
+                return predecessor.ForCondition(condition);
+            }
+
+            return this;
+        }
+
+        public Continuation FailWith(Func<FailReason> failReasonFunc)
+        {
+            if (predecessorSucceeded)
+            {
+                return predecessor.FailWith(failReasonFunc);
+            }
+
+            return new Continuation(predecessor, false);
+        }
+
+        public Continuation FailWith(string message, params object[] args)
+        {
+            if (predecessorSucceeded)
+            {
+                return predecessor.FailWith(message, args);
+            }
+
+            return new Continuation(predecessor, false);
+        }
+
+        public IAssertionScope BecauseOf(string because, params object[] becauseArgs)
+        {
+            return predecessor.BecauseOf(because, becauseArgs);
+        }
+
+        public Continuation ClearExpectation()
+        {
+            return predecessor.ClearExpectation();
+        }
+
+        public IAssertionScope WithExpectation(string message, params object[] args)
+        {
+            return predecessor.WithExpectation(message, args);
+        }
+
+        public IAssertionScope WithDefaultIdentifier(string identifier)
+        {
+            return predecessor.WithDefaultIdentifier(identifier);
+        }
+
+        public IAssertionScope UsingLineBreaks => predecessor.UsingLineBreaks;
+
+        public bool Succeeded => predecessor.Succeeded;
+
+        public string[] Discard()
+        {
+            return predecessor.Discard();
+        }
+
+        public void Dispose()
+        {
+            predecessor.Dispose();
+        }
+    }
+}

--- a/Src/FluentAssertions/Execution/Continuation.cs
+++ b/Src/FluentAssertions/Execution/Continuation.cs
@@ -5,32 +5,27 @@ namespace FluentAssertions.Execution
     /// </summary>
     public class Continuation
     {
-        #region Private Definition
-
         private readonly AssertionScope sourceScope;
-        private readonly bool sourceSucceeded;
-
-        #endregion
 
         public Continuation(AssertionScope sourceScope, bool sourceSucceeded)
         {
             this.sourceScope = sourceScope;
-            this.sourceSucceeded = sourceSucceeded;
+            SourceSucceeded = sourceSucceeded;
         }
 
         /// <summary>
         /// Continuous the assertion chain if the previous assertion was successful.
         /// </summary>
-        public AssertionScope Then => new AssertionScope(sourceScope, sourceSucceeded);
+        public IAssertionScope Then => new ContinuedAssertionScope(sourceScope, SourceSucceeded);
 
-        public bool SourceSucceeded => sourceSucceeded;
+        public bool SourceSucceeded { get; }
 
         /// <summary>
         /// Provides back-wards compatibility for code that expects <see cref="AssertionScope.FailWith"/> to return a boolean.
         /// </summary>
         public static implicit operator bool(Continuation continuation)
         {
-            return continuation.sourceSucceeded;
+            return continuation.SourceSucceeded;
         }
     }
 }

--- a/Src/FluentAssertions/Execution/ContinuationOfGiven.cs
+++ b/Src/FluentAssertions/Execution/ContinuationOfGiven.cs
@@ -7,21 +7,20 @@ namespace FluentAssertions.Execution
     {
         #region Private Definitions
 
-        private readonly GivenSelector<TSubject> parent;
         private readonly bool succeeded;
 
         #endregion
 
         public ContinuationOfGiven(GivenSelector<TSubject> parent, bool succeeded)
         {
-            this.parent = parent;
+            Then = parent;
             this.succeeded = succeeded;
         }
 
         /// <summary>
         /// Continuous the assertion chain if the previous assertion was successful.
         /// </summary>
-        public GivenSelector<TSubject> Then => parent;
+        public GivenSelector<TSubject> Then { get; }
 
         /// <summary>
         /// Provides back-wards compatibility for code that expects <see cref="AssertionScope.FailWith"/> to return a boolean.

--- a/Src/FluentAssertions/Execution/IAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/IAssertionScope.cs
@@ -1,0 +1,111 @@
+﻿using System;
+
+namespace FluentAssertions.Execution
+{
+    public interface IAssertionScope : IDisposable
+    {
+        /// <summary>
+        /// Allows to safely select the subject for successive assertions, even when the prior assertion has failed.
+        /// </summary>
+        /// <paramref name="selector">
+        /// Selector which result is passed to successive calls to <see cref="ForCondition"/>.
+        /// </paramref>
+        GivenSelector<T> Given<T>(Func<T> selector);
+
+        /// <summary>
+        /// Specify the condition that must be satisfied.
+        /// </summary>
+        /// <param name="condition">
+        /// If <c>true</c> the assertion will be treated as successful and no exceptions will be thrown.
+        /// </param>
+        IAssertionScope ForCondition(bool condition);
+
+        /// <summary>
+        /// Sets the failure message when the assertion is not met, or completes the failure message set to a
+        /// prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>.
+        /// <paramref name="failReasonFunc"/> will not be called unless the assertion is not met.
+        /// </summary>
+        /// <param name="failReasonFunc">Function returning <see cref="FailReason"/> object on demand. Called only when the assertion is not met.</param>
+        Continuation FailWith(Func<FailReason> failReasonFunc);
+
+        /// <summary>
+        /// Sets the failure message when the assertion is not met, or completes the failure message set to a
+        /// prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>.
+        /// </summary>
+        /// <remarks>
+        /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a few
+        /// specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as passed
+        /// to <see cref="FluentAssertions.Execution.AssertionScope.BecauseOf"/>. Other named placeholders will be replaced with
+        /// the <see cref="FluentAssertions.Execution.AssertionScope.Current"/> scope data passed through
+        /// <see cref="FluentAssertions.Execution.AssertionScope.AddNonReportable"/> and
+        /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable"/>. Finally, a description of the
+        /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
+        /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
+        /// Note that only 10 <paramref name="args"/> are supported in combination with a {reason}.
+        /// If an expectation was set through a prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>,
+        /// then the failure message is appended to that expectation.
+        /// </remarks>
+        /// <param name="message">The format string that represents the failure message.</param>
+        /// <param name="args">Optional arguments to any numbered placeholders.</param>
+        Continuation FailWith(string message, params object[] args);
+
+        /// <summary>
+        /// Specify the reason why you expect the condition to be <c>true</c>.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase compatible with <see cref="string.Format(string,object[])"/> explaining why
+        /// the condition should be satisfied. If the phrase does not start with the word <i>because</i>,
+        /// it is prepended to the message. If the format of <paramref name="because"/> or
+        /// <paramref name="becauseArgs"/> is not compatible with <see cref="string.Format(string,object[])"/>,
+        /// then a warning message is returned instead.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
+        /// </param>
+        IAssertionScope BecauseOf(string because, params object[] becauseArgs);
+
+        /// <summary>
+        /// Clears the expectation set by <see cref="WithExpectation"/>.
+        /// </summary>
+        // SMELL: It would be better to give the expectation an explicit scope, but that would be a breaking change.
+        Continuation ClearExpectation();
+
+        /// <summary>
+        /// Sets the expectation part of the failure message when the assertion is not met.
+        /// </summary>
+        /// <remarks>
+        /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a few
+        /// specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as passed
+        /// to <see cref="AssertionScope.BecauseOf"/>. Other named placeholders will be replaced with the <see cref="AssertionScope.Current"/> scope data
+        /// passed through <see cref="AssertionScope.AddNonReportable"/> and <see cref="AssertionScope.AddReportable"/>. Finally, a description of the
+        /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
+        /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
+        /// Note that only 10 <paramref name="args"/> are supported in combination with a {reason}.
+        /// If an expectation was set through a prior call to <see cref="AssertionScope.WithExpectation"/>, then the failure message is appended to that
+        /// expectation.
+        /// </remarks>
+        ///  <param name="expectation">The format string that represents the failure message.</param>
+        /// <param name="args">Optional arguments to any numbered placeholders.</param>
+        IAssertionScope WithExpectation(string message, params object[] args);
+
+        /// <summary>
+        /// Defines the name of the subject in case this cannot be extracted from the source code.
+        /// </summary>
+        IAssertionScope WithDefaultIdentifier(string identifier);
+
+        /// <summary>
+        /// Indicates that every argument passed into <see cref="FailWith"/> is displayed on a separate line.
+        /// </summary>
+        IAssertionScope UsingLineBreaks { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether or not the last assertion executed through this scope succeeded.
+        /// </summary>
+        bool Succeeded { get; }
+
+        /// <summary>
+        /// Discards and returns the failures that happened up to now.
+        /// </summary>
+        string[] Discard();
+    }
+}

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -386,7 +386,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Year == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(", but found {0}.", Subject.Value.Year);
+                .FailWith(", but found {0}.", Subject.Value.Year)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeAssertions>(this);
         }
@@ -438,7 +440,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Month == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(", but found {0}.", Subject.Value.Month);
+                .FailWith(", but found {0}.", Subject.Value.Month)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeAssertions>(this);
         }
@@ -464,7 +468,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Month != unexpected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(", but it was.");
+                .FailWith(", but it was.")
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeAssertions>(this);
         }
@@ -490,7 +496,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Day == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(", but found {0}.", Subject.Value.Day);
+                .FailWith(", but found {0}.", Subject.Value.Day)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeAssertions>(this);
         }
@@ -516,7 +524,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Day != unexpected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(", but it was.");
+                .FailWith(", but it was.")
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeAssertions>(this);
         }
@@ -542,7 +552,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Hour == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(", but found {0}.", Subject.Value.Hour);
+                .FailWith(", but found {0}.", Subject.Value.Hour)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeAssertions>(this);
         }
@@ -568,8 +580,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Hour != unexpected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(", but it was.", unexpected,
-                    Subject.Value.Hour);
+                .FailWith(", but it was.", unexpected, Subject.Value.Hour)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeAssertions>(this);
         }
@@ -596,7 +609,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Minute == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(", but found {0}.", Subject.Value.Minute);
+                .FailWith(", but found {0}.", Subject.Value.Minute)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeAssertions>(this);
         }
@@ -623,8 +638,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Minute != unexpected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(", but it was.", unexpected,
-                    Subject.Value.Minute);
+                .FailWith(", but it was.", unexpected, Subject.Value.Minute)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeAssertions>(this);
         }
@@ -651,7 +667,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Second == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(", but found {0}.", Subject.Value.Second);
+                .FailWith(", but found {0}.", Subject.Value.Second)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeAssertions>(this);
         }
@@ -678,7 +696,8 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Second != unexpected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(", but it was.");
+                .FailWith(", but it was.")
+                .Then.ClearExpectation();
 
             return new AndConstraint<DateTimeAssertions>(this);
         }
@@ -768,7 +787,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Date == expectedDate)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(", but found {1}.", expectedDate, Subject.Value);
+                .FailWith(", but found {1}.", expectedDate, Subject.Value)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeAssertions>(this);
         }
@@ -797,7 +818,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Date != unexpectedDate)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(", but it was.");
+                .FailWith(", but it was.")
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeAssertions>(this);
         }
@@ -888,7 +911,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Kind == expectedKind)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(", but found {0}.", Subject.Value.Kind);
+                .FailWith(", but found {0}.", Subject.Value.Kind)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeAssertions>(this);
         }

--- a/Src/FluentAssertions/Primitives/StringValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringValidator.cs
@@ -12,7 +12,7 @@ namespace FluentAssertions.Primitives
 
         protected readonly string subject;
         protected readonly string expected;
-        protected AssertionScope assertion;
+        protected IAssertionScope assertion;
         private const int HumanReadableLength = 8;
 
         #endregion

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -63,7 +63,7 @@ namespace FluentAssertions.Specialized
         public virtual ExceptionAssertions<TException> WithMessage(string expectedMessage, string because = "",
             params object[] becauseArgs)
         {
-            AssertionScope assertion = Execute.Assertion.BecauseOf(because, becauseArgs).UsingLineBreaks;
+            IAssertionScope assertion = Execute.Assertion.BecauseOf(because, becauseArgs).UsingLineBreaks;
 
             assertion
                 .ForCondition(Subject.Any())

--- a/Src/FluentAssertions/Xml/XmlReaderValidator.cs
+++ b/Src/FluentAssertions/Xml/XmlReaderValidator.cs
@@ -8,7 +8,7 @@ namespace FluentAssertions.Xml
 {
     internal class XmlReaderValidator
     {
-        private readonly AssertionScope assertion;
+        private readonly IAssertionScope assertion;
         private readonly XmlReader subjectReader;
         private readonly XmlReader otherReader;
 


### PR DESCRIPTION
Introduces a `ClearExpectation` to undo the expectation that is associated with multiple assertions using `WithExpectation`. Without it, it is possible that this expectation gets appended to any successive assertions.

Fixes #918

