### PR TITLE
Test for trace for successful assertion

### DIFF
--- a/Tests/Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/BasicEquivalencySpecs.cs
@@ -506,7 +506,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_nummer_values_are_convertible_it_should_treat_them_as_equivalent()
+        public void When_number_values_are_convertible_it_should_treat_them_as_equivalent()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -526,7 +526,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => actual.Should().BeEquivalentTo(expected, x => x.WithTracing());
+            Action act = () => actual.Should().BeEquivalentTo(expected);
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert

--- a/Tests/Shared.Specs/DictionaryEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/DictionaryEquivalencySpecs.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
+using FluentAssertions.Equivalency;
 using Newtonsoft.Json;
 using Xunit;
 using Xunit.Sdk;
@@ -473,6 +474,29 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().NotThrow("the runtime type is a dictionary and the dictionaries are equivalent");
+        }
+
+        [Fact]
+        public void
+            When_a_non_generic_dictionary_is_decided_to_be_equivalent_to_expected_trace_is_still_written()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            object object1 = new NonGenericDictionary { ["greeting"] = "hello" };
+            object object2 = new NonGenericDictionary { ["greeting"] = "hello" };
+            var traceWriter = new StringBuilderTraceWriter();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            object1.Should().BeEquivalentTo(object2, opts => opts.RespectingRuntimeTypes().WithTracing(traceWriter));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            string trace = traceWriter.ToString();
+            trace.Should().Contain("Recursing into dictionary item greeting at root");
         }
 
         [Fact]


### PR DESCRIPTION
While analyzing #846 I wrote a test, then figured it could to the main repository.
Also, removed one probably leftover `WithTracing` call in `BasicEquivalencySpecs`.