### PR TITLE
Add support for private protected access modifier

### DIFF
--- a/Src/FluentAssertions/Common/CSharpAccessModifier.cs
+++ b/Src/FluentAssertions/Common/CSharpAccessModifier.cs
@@ -7,6 +7,7 @@
         Protected,
         Internal,
         ProtectedInternal,
-        InvalidForCSharp
+        InvalidForCSharp,
+        PrivateProtected,
     }
 }

--- a/Src/FluentAssertions/Common/CSharpAccessModifierExtensions.cs
+++ b/Src/FluentAssertions/Common/CSharpAccessModifierExtensions.cs
@@ -32,6 +32,11 @@ namespace FluentAssertions.Common
                 return CSharpAccessModifier.ProtectedInternal;
             }
 
+            if (methodBase.IsFamilyAndAssembly)
+            {
+                return CSharpAccessModifier.PrivateProtected;
+            }
+
             return CSharpAccessModifier.InvalidForCSharp;
         }
 
@@ -60,6 +65,11 @@ namespace FluentAssertions.Common
             if (fieldInfo.IsFamilyOrAssembly)
             {
                 return CSharpAccessModifier.ProtectedInternal;
+            }
+
+            if(fieldInfo.IsFamilyAndAssembly)
+            {
+                return CSharpAccessModifier.PrivateProtected;
             }
 
             return CSharpAccessModifier.InvalidForCSharp;

--- a/Tests/Net45.Specs/Net45.Specs.csproj
+++ b/Tests/Net45.Specs/Net45.Specs.csproj
@@ -6,6 +6,7 @@
     <DefineConstants>$(DefineConstants);NET45</DefineConstants>
     <CodeAnalysisRuleSet>..\..\TestRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.8.1" />

--- a/Tests/Net47.Specs/Net47.Specs.csproj
+++ b/Tests/Net47.Specs/Net47.Specs.csproj
@@ -6,6 +6,7 @@
     <DefineConstants>$(DefineConstants);NET47</DefineConstants>
     <CodeAnalysisRuleSet>..\..\TestRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.8.1" />

--- a/Tests/NetCore.Specs/NetCore.Specs.csproj
+++ b/Tests/NetCore.Specs/NetCore.Specs.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>FluentAssertions.NetCore.Specs</AssemblyName>
     <RootNamespace>FluentAssertions.NetCore.Specs</RootNamespace>
     <CodeAnalysisRuleSet>..\..\TestRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="4.8.0" />

--- a/Tests/NetCore20.Specs/NetCore20.Specs.csproj
+++ b/Tests/NetCore20.Specs/NetCore20.Specs.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>FluentAssertions.NetCore20.Specs</AssemblyName>
     <RootNamespace>FluentAssertions.NetCore20.Specs</RootNamespace>
     <CodeAnalysisRuleSet>..\..\TestRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Chill" Version="3.2.0" />

--- a/Tests/NetStandard13.Specs/NetStandard13.Specs.csproj
+++ b/Tests/NetStandard13.Specs/NetStandard13.Specs.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>FluentAssertions.NetStandard13.Specs</RootNamespace>
     <DefineConstants>NETSTANDARD1_3</DefineConstants>
     <CodeAnalysisRuleSet>..\..\TestRules.ruleset</CodeAnalysisRuleSet>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="4.8.0" />

--- a/Tests/Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/BasicEquivalencySpecs.cs
@@ -1442,21 +1442,24 @@ namespace FluentAssertions.Specs
                 "protected",
                 "internal",
                 "protected-internal",
-                "private");
+                "private",
+                "private-protected");
 
             var expected = new ClassWithAllAccessModifiersForMembers(
                 "public",
                 "protected",
                 "ignored-internal",
                 "ignored-protected-internal",
-                "private");
+                "private",
+                "ignore-private-protected");
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
             Action act = () => subject.Should().BeEquivalentTo(expected, config =>
                 config.Excluding(ctx => ctx.WhichGetterHas(CSharpAccessModifier.Internal) ||
-                                        ctx.WhichGetterHas(CSharpAccessModifier.ProtectedInternal)));
+                                        ctx.WhichGetterHas(CSharpAccessModifier.ProtectedInternal) ||
+                                        ctx.WhichGetterHas(CSharpAccessModifier.PrivateProtected)));
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -1475,14 +1478,16 @@ namespace FluentAssertions.Specs
                 "protected",
                 "internal",
                 "protected-internal",
-                "private");
+                "private",
+                "private-protected");
 
             var expected = new ClassWithAllAccessModifiersForMembers(
                 "public",
                 "protected",
                 "ignored-internal",
                 "ignored-protected-internal",
-                "ignored-private");
+                "ignored-private",
+                "ignore-private-protected");
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -1490,7 +1495,8 @@ namespace FluentAssertions.Specs
             Action act = () => subject.Should().BeEquivalentTo(expected, config =>
                 config.Excluding(ctx => ctx.WhichSetterHas(CSharpAccessModifier.Internal) ||
                                         ctx.WhichSetterHas(CSharpAccessModifier.ProtectedInternal) ||
-                                        ctx.WhichSetterHas(CSharpAccessModifier.Private)));
+                                        ctx.WhichSetterHas(CSharpAccessModifier.Private) ||
+                                        ctx.WhichSetterHas(CSharpAccessModifier.PrivateProtected)));
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
@@ -4184,6 +4190,7 @@ namespace FluentAssertions.Specs
         internal string InternalField;
         protected internal string ProtectedInternalField;
         private string PrivateField;
+        private protected string PrivateProtectedField;
 
         public string PublicProperty { get; set; }
         public string ReadOnlyProperty { get; private set; }
@@ -4193,14 +4200,17 @@ namespace FluentAssertions.Specs
         protected internal string ProtectedInternalProperty { get; set; }
         private string PrivateProperty { get; set; }
 
+        private protected string PrivateProtectedProperty { get; set; }
+
         public ClassWithAllAccessModifiersForMembers(string publicValue, string protectedValue, string internalValue,
-            string protectedInternalValue, string privateValue)
+            string protectedInternalValue, string privateValue, string privateProtectedValue)
         {
             PublicField = publicValue;
             ProtectedField = protectedValue;
             InternalField = internalValue;
             ProtectedInternalField = protectedInternalValue;
             PrivateField = privateValue;
+            PrivateProtectedField = privateProtectedValue;
 
             PublicProperty = publicValue;
             ReadOnlyProperty = privateValue;
@@ -4209,6 +4219,7 @@ namespace FluentAssertions.Specs
             InternalProperty = internalValue;
             ProtectedInternalProperty = protectedInternalValue;
             PrivateProperty = privateValue;
+            PrivateProtectedProperty = privateProtectedValue;
         }
     }
 

--- a/Tests/Shared.Specs/MethodBaseAssertionSpecs.cs
+++ b/Tests/Shared.Specs/MethodBaseAssertionSpecs.cs
@@ -329,6 +329,26 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_asserting_a_private_protected_member_is_private_protected_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateProtectedMethod");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.PrivateProtected);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
+        }
+
+        [Fact]
         public void When_asserting_a_private_member_is_protected_it_throws_with_a_useful_message()
         {
             //-------------------------------------------------------------------------------------------------------------------
@@ -556,6 +576,26 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_asserting_a_private_member_is_not_private_protected_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateMethod");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                methodInfo.Should().NotHaveAccessModifier(CSharpAccessModifier.PrivateProtected);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
+        }
+
+        [Fact]
         public void When_asserting_a_private_member_is_not_private_it_throws_with_a_useful_message()
         {
             //-------------------------------------------------------------------------------------------------------------------
@@ -642,6 +682,27 @@ namespace FluentAssertions.Specs
             act.Should().NotThrow();
         }
 
+        [Fact]
+        public void When_asserting_a_private_protected_member_is_not_private_it_succeeds()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-------------------------------------------------------------------------------------------------------------------
+            PropertyInfo propertyInfo = typeof(TestClass).GetPropertyByName("PublicGetPrivateProtectedSet");
+            MethodInfo setMethod = propertyInfo.SetMethod;
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            Action act = () =>
+                setMethod.Should().NotHaveAccessModifier(CSharpAccessModifier.Private);
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
+        }
+        
         [Fact]
         public void When_asserting_a_public_member_is_not_public_it_throws_with_a_useful_message()
         {
@@ -766,9 +827,13 @@ namespace FluentAssertions.Specs
 
         protected string ProtectedSetProperty { private get; set; }
 
+        public string PublicGetPrivateProtectedSet { get; private protected set; }
+
         internal string InternalMethod() { return null; }
 
         protected internal void ProtectedInternalMethod() { }
+
+        private protected void PrivateProtectedMethod() { }
     }
 
     #endregion


### PR DESCRIPTION
I changed Spec assemblies configuration to `<LangVersion>7.2</LangVersion>`. `private protected` access modifier is not available in earlier versions.

Closes #878.