### PR TITLE
EquivalencyValidator performance fixes

### DIFF
--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -158,10 +158,5 @@ namespace FluentAssertions.Common
 
             return new MemberPath(declaringType, segmentPath.Replace(".[", "["));
         }
-
-        internal static string GetMethodName(Expression<Action> action)
-        {
-            return ((MethodCallExpression)action.Body).Method.Name;
-        }
     }
 }

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
@@ -53,7 +53,7 @@ namespace FluentAssertions.Equivalency
 
         private bool AssertIsNotNull(object expectation, object[] subject)
         {
-            return expectation != null || AssertionScope.Current
+            return AssertionScope.Current
                 .ForCondition(!(expectation is null))
                 .FailWith("Expected {context:subject} to be <null>, but found {0}.", new object[] { subject });
         }

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
@@ -53,7 +53,7 @@ namespace FluentAssertions.Equivalency
 
         private bool AssertIsNotNull(object expectation, object[] subject)
         {
-            return AssertionScope.Current
+            return expectation != null || AssertionScope.Current
                 .ForCondition(!(expectation is null))
                 .FailWith("Expected {context:subject} to be <null>, but found {0}.", new object[] { subject });
         }

--- a/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
@@ -13,6 +13,12 @@ namespace FluentAssertions.Equivalency
     /// </remarks>
     public class GenericDictionaryEquivalencyStep : IEquivalencyStep
     {
+        private static readonly MethodInfo AssertSameLengthMethod = new Func<IDictionary<object, object>, IDictionary<object, object>, bool>
+            (AssertSameLength).GetMethodInfo().GetGenericMethodDefinition();
+
+        private static readonly MethodInfo AssertDictionaryEquivalenceMethod = new Action<EquivalencyValidationContext, IEquivalencyValidator, IEquivalencyAssertionOptions, IDictionary<object, object>, IDictionary<object, object>>
+            (AssertDictionaryEquivalence).GetMethodInfo().GetGenericMethodDefinition();
+
         public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
         {
             Type expectationType = config.GetExpectationType(context);
@@ -51,14 +57,14 @@ namespace FluentAssertions.Equivalency
 
         private static bool AssertSubjectIsNotNull(object subject)
         {
-            return subject != null || AssertionScope.Current
+            return AssertionScope.Current
                 .ForCondition(!(subject is null))
                 .FailWith("Expected {context:Subject} not to be {0}.", new object[] { null });
         }
 
         private static bool AssertExpectationIsNotNull(object subject, object expectation)
         {
-            return expectation != null || AssertionScope.Current
+            return AssertionScope.Current
                 .ForCondition(!(expectation is null))
                 .FailWith("Expected {context:Subject} to be {0}, but found {1}.", null, subject);
         }
@@ -159,9 +165,6 @@ namespace FluentAssertions.Equivalency
             return GetIDictionaryInterfaces(expectedType).Single();
         }
 
-        private static readonly MethodInfo AssertSameLengthMethod = new Func<IDictionary<object, object>, IDictionary<object, object>, bool>
-            (AssertSameLength).GetMethodInfo().GetGenericMethodDefinition();
-
         private static bool AssertSameLength<TSubjectKey, TSubjectValue, TExpectedKey, TExpectedValue>(
             IDictionary<TSubjectKey, TSubjectValue> subject, IDictionary<TExpectedKey, TExpectedValue> expectation)
             where TExpectedKey : TSubjectKey
@@ -237,9 +240,6 @@ namespace FluentAssertions.Equivalency
 
             AssertDictionaryEquivalenceMethod.MakeGenericMethod(typeArguments).Invoke(null, new[] { context, parent, config, context.Subject, context.Expectation });
         }
-
-        private static readonly MethodInfo AssertDictionaryEquivalenceMethod = new Action<EquivalencyValidationContext, IEquivalencyValidator, IEquivalencyAssertionOptions, IDictionary<object, object>, IDictionary<object, object>>
-            (AssertDictionaryEquivalence).GetMethodInfo().GetGenericMethodDefinition();
 
         private static void AssertDictionaryEquivalence<TSubjectKey, TSubjectValue, TExpectedKey, TExpectedValue>(
             EquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
@@ -1,9 +1,8 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
-using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency
@@ -52,14 +51,14 @@ namespace FluentAssertions.Equivalency
 
         private static bool AssertSubjectIsNotNull(object subject)
         {
-            return AssertionScope.Current
+            return subject != null || AssertionScope.Current
                 .ForCondition(!(subject is null))
                 .FailWith("Expected {context:Subject} not to be {0}.", new object[] { null });
         }
 
         private static bool AssertExpectationIsNotNull(object subject, object expectation)
         {
-            return AssertionScope.Current
+            return expectation != null || AssertionScope.Current
                 .ForCondition(!(expectation is null))
                 .FailWith("Expected {context:Subject} to be {0}, but found {1}.", null, subject);
         }
@@ -135,22 +134,17 @@ namespace FluentAssertions.Equivalency
 
         private static bool AssertSameLength(object subject, Type expectationType, object expectation)
         {
-            string methodName =
-                ExpressionExtensions.GetMethodName(() => AssertSameLength<object, object, object, object>(null, null));
+            if(subject is ICollection subjectCollection
+                && expectation is ICollection expectationCollection
+                && subjectCollection.Count == expectationCollection.Count)
+                return true;
 
             Type subjectType = subject.GetType();
             Type[] subjectTypeArguments = GetDictionaryTypeArguments(subjectType);
             Type[] expectationTypeArguments = GetDictionaryTypeArguments(expectationType);
             Type[] typeArguments = subjectTypeArguments.Concat(expectationTypeArguments).ToArray();
 
-            MethodCallExpression assertSameLength = Expression.Call(
-                typeof(GenericDictionaryEquivalencyStep),
-                methodName,
-                typeArguments,
-                Expression.Constant(subject, GetIDictionaryInterface(subjectType)),
-                Expression.Constant(expectation, GetIDictionaryInterface(expectationType)));
-
-            return (bool)Expression.Lambda(assertSameLength).Compile().DynamicInvoke();
+            return (bool)AssertSameLengthMethod.MakeGenericMethod(typeArguments).Invoke(null, new[] { subject, expectation });
         }
 
         private static Type[] GetDictionaryTypeArguments(Type type)
@@ -164,6 +158,9 @@ namespace FluentAssertions.Equivalency
         {
             return GetIDictionaryInterfaces(expectedType).Single();
         }
+
+        private static readonly MethodInfo AssertSameLengthMethod = new Func<IDictionary<object, object>, IDictionary<object, object>, bool>
+            (AssertSameLength).GetMethodInfo().GetGenericMethodDefinition();
 
         private static bool AssertSameLength<TSubjectKey, TSubjectValue, TExpectedKey, TExpectedValue>(
             IDictionary<TSubjectKey, TSubjectValue> subject, IDictionary<TExpectedKey, TExpectedValue> expectation)
@@ -233,28 +230,16 @@ namespace FluentAssertions.Equivalency
             IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
         {
             Type expectationType = config.GetExpectationType(context);
-
-            string methodName =
-                ExpressionExtensions.GetMethodName(
-                    () => AssertDictionaryEquivalence<object, object, object, object>(null, null, null, null, null));
-
             Type subjectType = context.Subject.GetType();
             Type[] subjectTypeArguments = GetDictionaryTypeArguments(subjectType);
             Type[] expectationTypeArguments = GetDictionaryTypeArguments(expectationType);
             Type[] typeArguments = subjectTypeArguments.Concat(expectationTypeArguments).ToArray();
 
-            MethodCallExpression assertDictionaryEquivalence = Expression.Call(
-                typeof(GenericDictionaryEquivalencyStep),
-                methodName,
-                typeArguments,
-                Expression.Constant(context),
-                Expression.Constant(parent),
-                Expression.Constant(config),
-                Expression.Constant(context.Subject, GetIDictionaryInterface(subjectType)),
-                Expression.Constant(context.Expectation, GetIDictionaryInterface(expectationType)));
-
-            Expression.Lambda(assertDictionaryEquivalence).Compile().DynamicInvoke();
+            AssertDictionaryEquivalenceMethod.MakeGenericMethod(typeArguments).Invoke(null, new[] { context, parent, config, context.Subject, context.Expectation });
         }
+
+        private static readonly MethodInfo AssertDictionaryEquivalenceMethod = new Action<EquivalencyValidationContext, IEquivalencyValidator, IEquivalencyAssertionOptions, IDictionary<object, object>, IDictionary<object, object>>
+            (AssertDictionaryEquivalence).GetMethodInfo().GetGenericMethodDefinition();
 
         private static void AssertDictionaryEquivalence<TSubjectKey, TSubjectValue, TExpectedKey, TExpectedValue>(
             EquivalencyValidationContext context,

--- a/Src/FluentAssertions/Equivalency/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/ObjectReference.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency
@@ -11,6 +12,7 @@ namespace FluentAssertions.Equivalency
         private readonly object @object;
         private readonly string path;
         private readonly bool? isComplexType;
+        private string[] pathElements;
 
         public ObjectReference(object @object, string path, bool? isComplexType = null)
         {
@@ -36,22 +38,14 @@ namespace FluentAssertions.Equivalency
             return ReferenceEquals(@object, other.@object) && IsParentOf(other);
         }
 
-        string[] pathElements;
-
-        string[] GetPathElements() => pathElements
+        private string[] GetPathElements() => pathElements
             ?? (pathElements = path.ToLowerInvariant().Replace("][", "].[").Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries));
 
         private bool IsParentOf(ObjectReference other)
         {
-            string[] path = GetPathElements(), otherPath = other.GetPathElements();
-
-            if (otherPath.Length <= path.Length)
-                return false;
-
-            for (int i = 0; i < path.Length; i++)
-                if (path[i] != otherPath[i])
-                    return false;
-            return true;
+            string[] path = GetPathElements();
+            string[] otherPath = other.GetPathElements();
+            return (otherPath.Length > path.Length) && otherPath.Take(path.Length).SequenceEqual(path);
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes `GenericDictionaryEquivalencyStep` and `GenericEnumerableEquivalencyStep` performance problems caused by the use of uncached `LambdaCompiler.Compile` which is very expensive.
Related to #475.

This makes `ObjectAssertions.BeEquivalentTo` about 4.3x faster in our test projects.