### PR TITLE
Nullable assertion extenions cleanup

### DIFF
--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -45,11 +45,7 @@ namespace FluentAssertions
                 maxValue = sbyte.MaxValue;
             }
 
-            Execute.Assertion
-                .ForCondition(minValue <= actualValue && actualValue <= maxValue)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be within {0} from {1}{reason}, but found {2}.",
-                    delta, nearbyValue, actualValue);
+            FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<sbyte>>(parent);
         }
@@ -88,11 +84,7 @@ namespace FluentAssertions
                 maxValue = byte.MaxValue;
             }
 
-            Execute.Assertion
-                .ForCondition(minValue <= actualValue && actualValue <= maxValue)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be within {0} from {1}{reason}, but found {2}.",
-                    delta, nearbyValue, actualValue);
+            FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<byte>>(parent);
         }
@@ -131,11 +123,7 @@ namespace FluentAssertions
                 maxValue = short.MaxValue;
             }
 
-            Execute.Assertion
-                .ForCondition(minValue <= actualValue && actualValue <= maxValue)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be within {0} from {1}{reason}, but found {2}.",
-                    delta, nearbyValue, actualValue);
+            FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<short>>(parent);
         }
@@ -174,11 +162,7 @@ namespace FluentAssertions
                 maxValue = ushort.MaxValue;
             }
 
-            Execute.Assertion
-                .ForCondition(minValue <= actualValue && actualValue <= maxValue)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be within {0} from {1}{reason}, but found {2}.",
-                    delta, nearbyValue, actualValue);
+            FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<ushort>>(parent);
         }
@@ -217,11 +201,7 @@ namespace FluentAssertions
                 maxValue = int.MaxValue;
             }
 
-            Execute.Assertion
-                .ForCondition(minValue <= actualValue && actualValue <= maxValue)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be within {0} from {1}{reason}, but found {2}.",
-                    delta, nearbyValue, actualValue);
+            FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<int>>(parent);
         }
@@ -260,11 +240,7 @@ namespace FluentAssertions
                 maxValue = uint.MaxValue;
             }
 
-            Execute.Assertion
-                .ForCondition(minValue <= actualValue && actualValue <= maxValue)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be within {0} from {1}{reason}, but found {2}.",
-                    delta, nearbyValue, actualValue);
+            FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<uint>>(parent);
         }
@@ -294,11 +270,7 @@ namespace FluentAssertions
             long minValue = GetMinValue(nearbyValue, delta);
             long maxValue = GetMaxValue(nearbyValue, delta);
 
-            Execute.Assertion
-                .ForCondition(minValue <= actualValue && actualValue <= maxValue)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be within {0} from {1}{reason}, but found {2}.",
-                    delta, nearbyValue, actualValue);
+            FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<long>>(parent);
         }
@@ -337,13 +309,20 @@ namespace FluentAssertions
                 maxValue = ulong.MaxValue;
             }
 
+            FailIfValueOutsideBounds(minValue <= actualValue && actualValue <= maxValue, nearbyValue, delta, actualValue, because, becauseArgs);
+
+            return new AndConstraint<NumericAssertions<ulong>>(parent);
+        }
+
+        private static void FailIfValueOutsideBounds<TValue, TDelta>(bool valueWithinBounds,
+            TValue nearbyValue, TDelta delta, TValue actualValue,
+            string because, object[] becauseArgs)
+        {
             Execute.Assertion
-                .ForCondition(minValue <= actualValue && actualValue <= maxValue)
+                .ForCondition(valueWithinBounds)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be within {0} from {1}{reason}, but found {2}.",
                     delta, nearbyValue, actualValue);
-
-            return new AndConstraint<NumericAssertions<ulong>>(parent);
         }
 
         #endregion
@@ -384,11 +363,7 @@ namespace FluentAssertions
                 maxValue = sbyte.MaxValue;
             }
 
-            Execute.Assertion
-                .ForCondition(!(minValue <= actualValue && actualValue <= maxValue))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {context:value} to be within {0} from {1}{reason}, but found {2}.",
-                    delta, distantValue, actualValue);
+            FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<sbyte>>(parent);
         }
@@ -427,11 +402,7 @@ namespace FluentAssertions
                 maxValue = byte.MaxValue;
             }
 
-            Execute.Assertion
-                .ForCondition(!(minValue <= actualValue && actualValue <= maxValue))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {context:value} to be within {0} from {1}{reason}, but found {2}.",
-                    delta, distantValue, actualValue);
+            FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<byte>>(parent);
         }
@@ -470,11 +441,7 @@ namespace FluentAssertions
                 maxValue = short.MaxValue;
             }
 
-            Execute.Assertion
-                .ForCondition(!(minValue <= actualValue && actualValue <= maxValue))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {context:value} to be within {0} from {1}{reason}, but found {2}.",
-                    delta, distantValue, actualValue);
+            FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<short>>(parent);
         }
@@ -513,11 +480,7 @@ namespace FluentAssertions
                 maxValue = ushort.MaxValue;
             }
 
-            Execute.Assertion
-                .ForCondition(!(minValue <= actualValue && actualValue <= maxValue))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {context:value} to be within {0} from {1}{reason}, but found {2}.",
-                    delta, distantValue, actualValue);
+            FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<ushort>>(parent);
         }
@@ -556,11 +519,7 @@ namespace FluentAssertions
                 maxValue = int.MaxValue;
             }
 
-            Execute.Assertion
-                .ForCondition(!(minValue <= actualValue && actualValue <= maxValue))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {context:value} to be within {0} from {1}{reason}, but found {2}.",
-                    delta, distantValue, actualValue);
+            FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<int>>(parent);
         }
@@ -599,11 +558,7 @@ namespace FluentAssertions
                 maxValue = uint.MaxValue;
             }
 
-            Execute.Assertion
-                .ForCondition(!(minValue <= actualValue && actualValue <= maxValue))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {context:value} to be within {0} from {1}{reason}, but found {2}.",
-                    delta, distantValue, actualValue);
+            FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<uint>>(parent);
         }
@@ -633,11 +588,7 @@ namespace FluentAssertions
             long minValue = GetMinValue(distantValue, delta);
             long maxValue = GetMaxValue(distantValue, delta);
 
-            Execute.Assertion
-                .ForCondition(!(minValue <= actualValue && actualValue <= maxValue))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {context:value} to be within {0} from {1}{reason}, but found {2}.",
-                    delta, distantValue, actualValue);
+            FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<long>>(parent);
         }
@@ -676,13 +627,21 @@ namespace FluentAssertions
                 maxValue = ulong.MaxValue;
             }
 
+            FailIfValueInsideBounds(!(minValue <= actualValue && actualValue <= maxValue), distantValue, delta, actualValue, because, becauseArgs);
+
+            return new AndConstraint<NumericAssertions<ulong>>(parent);
+        }
+
+        private static void FailIfValueInsideBounds<TValue, TDelta>(
+            bool valueOutsideBounds,
+            TValue distantValue, TDelta delta, TValue actualValue,
+            string because, object[] becauseArgs)
+        {
             Execute.Assertion
-                .ForCondition(!(minValue <= actualValue && actualValue <= maxValue))
+                .ForCondition(valueOutsideBounds)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:value} to be within {0} from {1}{reason}, but found {2}.",
                     delta, distantValue, actualValue);
-
-            return new AndConstraint<NumericAssertions<ulong>>(parent);
         }
 
         #endregion

--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -785,11 +785,7 @@ namespace FluentAssertions
         {
             float actualDifference = Math.Abs(expectedValue - (float)parent.Subject);
 
-            Execute.Assertion
-                .ForCondition(actualDifference <= precision)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to approximate {1} +/- {2}{reason}, but {0} differed by {3}.",
-                    parent.Subject, expectedValue, precision, actualDifference);
+            FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<float>>(parent);
         }
@@ -890,11 +886,7 @@ namespace FluentAssertions
         {
             double actualDifference = Math.Abs(expectedValue - (double)parent.Subject);
 
-            Execute.Assertion
-                .ForCondition(actualDifference <= precision)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to approximate {1} +/- {2}{reason}, but {0} differed by {3}.",
-                    parent.Subject, expectedValue, precision, actualDifference);
+            FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<double>>(parent);
         }
@@ -995,13 +987,21 @@ namespace FluentAssertions
         {
             decimal actualDifference = Math.Abs(expectedValue - (decimal)parent.Subject);
 
+            FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference, because, becauseArgs);
+
+            return new AndConstraint<NumericAssertions<decimal>>(parent);
+        }
+
+        private static void FailIfDifferenceOutsidePrecision<T>(
+            bool differenceWithinPrecision,
+            NumericAssertions<T> parent, T expectedValue, T precision, T actualDifference,
+            string because, object[] becauseArgs) where T:struct
+        {
             Execute.Assertion
-                .ForCondition(actualDifference <= precision)
+                .ForCondition(differenceWithinPrecision)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to approximate {1} +/- {2}{reason}, but {0} differed by {3}.",
                     parent.Subject, expectedValue, precision, actualDifference);
-
-            return new AndConstraint<NumericAssertions<decimal>>(parent);
         }
 
         #endregion
@@ -1063,11 +1063,7 @@ namespace FluentAssertions
         {
             float actualDifference = Math.Abs(unexpectedValue - (float)parent.Subject);
 
-            Execute.Assertion
-                .ForCondition(actualDifference > precision)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to not approximate {1} +/- {2}{reason}, but {0} only differed by {3}.",
-                    parent.Subject, unexpectedValue, precision, actualDifference);
+            FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<float>>(parent);
         }
@@ -1127,11 +1123,7 @@ namespace FluentAssertions
         {
             double actualDifference = Math.Abs(unexpectedValue - (double)parent.Subject);
 
-            Execute.Assertion
-                .ForCondition(actualDifference > precision)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to not approximate {1} +/- {2}{reason}, but {0} only differed by {3}.",
-                    parent.Subject, unexpectedValue, precision, actualDifference);
+            FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<double>>(parent);
         }
@@ -1191,13 +1183,21 @@ namespace FluentAssertions
         {
             decimal actualDifference = Math.Abs(unexpectedValue - (decimal)parent.Subject);
 
+            FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference, because, becauseArgs);
+
+            return new AndConstraint<NumericAssertions<decimal>>(parent);
+        }
+
+        private static void FailIfDifferenceWithinPrecision<T>(
+            NumericAssertions<T> parent, bool differenceOutsidePrecision,
+            T unexpectedValue, T precision, T actualDifference,
+            string because, object[] becauseArgs) where T : struct
+        {
             Execute.Assertion
-                .ForCondition(actualDifference > precision)
+                .ForCondition(differenceOutsidePrecision)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to not approximate {1} +/- {2}{reason}, but {0} only differed by {3}.",
                     parent.Subject, unexpectedValue, precision, actualDifference);
-
-            return new AndConstraint<NumericAssertions<decimal>>(parent);
         }
 
         #endregion

--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -9,6 +9,8 @@ namespace FluentAssertions
     /// </summary>
     public static class NumericAssertionsExtensions
     {
+
+        #region BeCloseTo
         /// <summary>
         /// Asserts an integral value is close to another value within a specified value.
         /// </summary>
@@ -343,6 +345,10 @@ namespace FluentAssertions
 
             return new AndConstraint<NumericAssertions<ulong>>(parent);
         }
+
+        #endregion
+
+        #region NotBeCloseTo
 
         /// <summary>
         /// Asserts an integral value is not within another value by a specified value.
@@ -679,6 +685,10 @@ namespace FluentAssertions
             return new AndConstraint<NumericAssertions<ulong>>(parent);
         }
 
+        #endregion
+
+        #region BeApproximately
+
         /// <summary>
         /// Asserts a floating point value approximates another value as close as possible.
         /// </summary>
@@ -994,6 +1004,10 @@ namespace FluentAssertions
             return new AndConstraint<NumericAssertions<decimal>>(parent);
         }
 
+        #endregion
+
+        #region NotBeApproximately
+
         /// <summary>
         /// Asserts a floating point value does not approximate another value by a given amount.
         /// </summary>
@@ -1185,6 +1199,8 @@ namespace FluentAssertions
 
             return new AndConstraint<NumericAssertions<decimal>>(parent);
         }
+
+        #endregion
 
         private static long GetMinValue(long value, ulong delta)
         {

--- a/Tests/Shared.Specs/NullableNumericAssertionSpecs.cs
+++ b/Tests/Shared.Specs/NullableNumericAssertionSpecs.cs
@@ -1,5 +1,4 @@
 using System;
-using FluentAssertions.Primitives;
 using Xunit;
 using Xunit.Sdk;
 


### PR DESCRIPTION
Two main topics of the PR:

- Introduce regions for `NumericAssertionsExtensions`, one for each method group
- Extract repeated code from each method group

I would like that to be merged before I will tackle extension of `NotBeEquivalentTo` for nullable subject and expected value (I mean folloup of #934).