### PR TITLE
Ensure specific nuget.config is used

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -47,12 +47,18 @@ Task("Restore-NuGet-Packages")
     .IsDependentOn("Clean")
     .Does(() =>
 {
-	DotNetCoreRestore();
+	DotNetCoreRestore(new DotNetCoreRestoreSettings
+	{
+		NoCache = true,
+		ConfigFile = "./nuget.config",
+		Verbosity = DotNetCoreVerbosity.Normal
+	});
 
     NuGetRestore("./FluentAssertions.sln", new NuGetRestoreSettings 
 	{ 
 		NoCache = true,
-		Verbosity = NuGetVerbosity.Detailed,
+		ConfigFile = "./nuget.config",
+		Verbosity = NuGetVerbosity.Normal,
 		ToolPath = "./build/nuget.exe"
 	});
 });


### PR DESCRIPTION
Specifies that both `DotNetCoreRestore` and `NuGetRestore` should use `nuget.config` to ensure that `nuget.org` is used.