### PR TITLE
Cross-platform compatibility

### DIFF
--- a/Tests/NetCore20.Specs/NetCore20.Specs.csproj
+++ b/Tests/NetCore20.Specs/NetCore20.Specs.csproj
@@ -7,7 +7,9 @@
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Chill" Version="3.2.0" />
+    <PackageReference Include="Chill" Version="3.2.0">
+      <NoWarn>NU1701</NoWarn>
+    </PackageReference>
     <PackageReference Include="FakeItEasy" Version="4.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/Tests/Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/BasicEquivalencySpecs.cs
@@ -2789,13 +2789,12 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            act
-                .Should().Throw<XunitException>().Which.Message
+            act.Should().Throw<XunitException>().Which.Message
                 // Checking exception message exactly is against general guidelines
                 // but in that case it was done on purpose, so that we have at least single
                 // test confirming that whole mechanism of gathering description from
                 // equivalency steps works.
-                .Should().Be("Expected member Level.Text to be \"Level2\", but \"Level1\" differs near \"1\" (index 5).\r\n\nWith configuration:\n- Use declared types and members\r\n- Compare enums by value\r\n- Match member by name (or throw)\r\n- Without automatic conversion.\r\n- Be strict about the order of items in byte arrays\r\n");
+                .Should().MatchRegex(@"^Expected member Level\.Text to be ""Level2"", but ""Level1"" differs near ""1"" \(index 5\)\.[\r\n]+With configuration:[\r\n]+\- Use declared types and members[\r\n]+\- Compare enums by value[\r\n]+\- Match member by name \(or throw\)[\r\n]+\- Without automatic conversion\.[\r\n]+\- Be strict about the order of items in byte arrays[\r\n]+$");
         }
 
         [Fact]


### PR DESCRIPTION
A single test didn't succeed on linux, due to difference in newlines.
Ignore NU1701 about referencing Chill (which targets .net framework) from .net core test projects as the tests ran fine.