### PR TITLE
Replace FakeItEasy dependency with custom class

### DIFF
--- a/Tests/Net45.Specs/Net45.Specs.csproj
+++ b/Tests/Net45.Specs/Net45.Specs.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.8.1" />
     <PackageReference Include="Chill" Version="3.2.0" />
-    <PackageReference Include="FakeItEasy" Version="4.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />

--- a/Tests/Net47.Specs/Net47.Specs.csproj
+++ b/Tests/Net47.Specs/Net47.Specs.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.8.1" />
     <PackageReference Include="Chill" Version="3.2.0" />
-    <PackageReference Include="FakeItEasy" Version="4.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />

--- a/Tests/NetCore.Specs/NetCore.Specs.csproj
+++ b/Tests/NetCore.Specs/NetCore.Specs.csproj
@@ -7,7 +7,6 @@
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="4.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/Tests/NetCore20.Specs/NetCore20.Specs.csproj
+++ b/Tests/NetCore20.Specs/NetCore20.Specs.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="Chill" Version="3.2.0">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="FakeItEasy" Version="4.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/Tests/NetStandard13.Specs/NetStandard13.Specs.csproj
+++ b/Tests/NetStandard13.Specs/NetStandard13.Specs.csproj
@@ -8,7 +8,6 @@
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="4.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />

--- a/Tests/Shared.Specs/ExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/ExceptionAssertionSpecs.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using FakeItEasy;
 using Xunit;
 using Xunit.Sdk;
 
@@ -21,7 +20,7 @@ namespace FluentAssertions.Specs
                 //-----------------------------------------------------------------------------------------------------------
                 // Act
                 //-----------------------------------------------------------------------------------------------------------
-                act.Should().ThrowExactly<ArgumentException>("because {0} should do that", "IFoo.Do");
+                act.Should().ThrowExactly<ArgumentException>("because {0} should do that", "Does.Do");
 
                 throw new XunitException("This point should not be reached.");
             }
@@ -30,7 +29,7 @@ namespace FluentAssertions.Specs
                 //-----------------------------------------------------------------------------------------------------------
                 // Assert
                 //-----------------------------------------------------------------------------------------------------------
-                ex.Message.Should().Match("Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.ArgumentNullException.");
+                ex.Message.Should().Match("Expected type to be System.ArgumentException because Does.Do should do that, but found System.ArgumentNullException.");
             }
         }
 
@@ -56,8 +55,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new InvalidOperationException("some message"));
+            Does testSubject = Does.Throw(new InvalidOperationException("some message"));
 
             //-----------------------------------------------------------------------------------------------------------
             // Act / Assert
@@ -71,8 +69,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new InvalidOperationException("some"));
+            Does testSubject = Does.Throw(new InvalidOperationException("some"));
 
             try
             {
@@ -102,8 +99,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new InvalidOperationException("expected message"));
+            Does testSubject = Does.Throw(new InvalidOperationException("expected message"));
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -123,8 +119,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new InvalidOperationException("OxpectOd message"));
+            Does testSubject = Does.Throw(new InvalidOperationException("OxpectOd message"));
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -147,8 +142,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new InvalidOperationException("Expected Message"));
+            Does testSubject = Does.Throw(new InvalidOperationException("Expected Message"));
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -168,8 +162,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new InvalidOperationException("OxpectOd message"));
+            Does testSubject = Does.Throw(new InvalidOperationException("OxpectOd message"));
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -192,8 +185,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            IFoo subjectThatThrows = A.Fake<IFoo>();
-            A.CallTo(() => subjectThatThrows.Do()).Throws(new InvalidOperationException("message1"));
+            Does subjectThatThrows = Does.Throw(new InvalidOperationException("message1"));
 
             try
             {
@@ -223,8 +215,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            IFoo subjectThatThrows = A.Fake<IFoo>();
-            A.CallTo(() => subjectThatThrows.Do()).Throws(new InvalidOperationException(""));
+            Does subjectThatThrows = Does.Throw(new InvalidOperationException(""));
 
             try
             {
@@ -254,9 +245,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            IFoo subjectThatThrows = A.Fake<IFoo>();
-            A.CallTo(() => subjectThatThrows.Do(A<string>.Ignored))
-                .Throws(new ArgumentNullException("someParam", "message2"));
+            Does subjectThatThrows = Does.Throw(new ArgumentNullException("someParam", "message2"));
 
             try
             {
@@ -288,12 +277,12 @@ namespace FluentAssertions.Specs
                 //-----------------------------------------------------------------------------------------------------------
                 // Arrange
                 //-----------------------------------------------------------------------------------------------------------
-                IFoo testSubject = A.Fake<IFoo>();
+                Does testSubject = Does.NotThrow();
 
                 //-----------------------------------------------------------------------------------------------------------
                 // Act
                 //-----------------------------------------------------------------------------------------------------------
-                testSubject.Invoking(x => x.Do()).Should().Throw<Exception>("because {0} should do that", "IFoo.Do");
+                testSubject.Invoking(x => x.Do()).Should().Throw<Exception>("because {0} should do that", "Does.Do");
 
                 throw new XunitException("This point should not be reached");
             }
@@ -303,7 +292,7 @@ namespace FluentAssertions.Specs
                 // Assert
                 //-----------------------------------------------------------------------------------------------------------
                 ex.Message.Should().Be(
-                    "Expected a <System.Exception> to be thrown because IFoo.Do should do that, but no exception was thrown.");
+                    "Expected a <System.Exception> to be thrown because Does.Do should do that, but no exception was thrown.");
             }
         }
 
@@ -315,8 +304,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             var actualException = new ArgumentException();
 
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(actualException);
+            Does testSubject = Does.Throw(actualException);
 
             try
             {
@@ -325,7 +313,7 @@ namespace FluentAssertions.Specs
                 //-----------------------------------------------------------------------------------------------------------
                 testSubject
                     .Invoking(x => x.Do())
-                    .Should().Throw<InvalidOperationException>("because {0} should throw that one", "IFoo.Do");
+                    .Should().Throw<InvalidOperationException>("because {0} should throw that one", "Does.Do");
 
                 throw new XunitException("This point should not be reached");
             }
@@ -335,7 +323,7 @@ namespace FluentAssertions.Specs
                 // Assert
                 //-----------------------------------------------------------------------------------------------------------
                 ex.Message.Should().StartWith(
-                    "Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should throw that one, but found a <System.ArgumentException>:");
+                    "Expected a <System.InvalidOperationException> to be thrown because Does.Do should throw that one, but found a <System.ArgumentException>:");
 
                 ex.Message.Should().Contain(actualException.Message);
             }
@@ -347,9 +335,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            IFoo subjectThatThrows = A.Fake<IFoo>();
-            A.CallTo(() => subjectThatThrows.Do(A<string>.Ignored))
-                .Throws(new Exception("message with {}"));
+            Does subjectThatThrows = Does.Throw(new Exception("message with {}"));
 
             try
             {
@@ -379,10 +365,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do())
-                .Throws(new AggregateException("Outer Message",
-                    new Exception("Inner Message")));
+            Does testSubject = Does.Throw(new AggregateException("Outer Message", new Exception("Inner Message")));
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -408,8 +391,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new Exception("", new ArgumentException()));
+            Does testSubject = Does.Throw(new Exception("", new ArgumentException()));
 
             //-----------------------------------------------------------------------------------------------------------
             // Act / Assert
@@ -527,8 +509,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             var innerException = new NullReferenceException();
 
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new Exception("", innerException));
+            Does testSubject = Does.Throw(new Exception("", innerException));
 
             try
             {
@@ -538,7 +519,7 @@ namespace FluentAssertions.Specs
                 testSubject
                     .Invoking(x => x.Do())
                     .Should().Throw<Exception>()
-                    .WithInnerException<ArgumentException>("because {0} should do just that", "IFoo.Do");
+                    .WithInnerException<ArgumentException>("because {0} should do just that", "Does.Do");
 
                 throw new XunitException("This point should not be reached");
             }
@@ -548,7 +529,7 @@ namespace FluentAssertions.Specs
                 // Assert
                 //-----------------------------------------------------------------------------------------------------------
                 exc.Message.Should().StartWith(
-                    "Expected inner System.ArgumentException because IFoo.Do should do just that, but found System.NullReferenceException");
+                    "Expected inner System.ArgumentException because Does.Do should do just that, but found System.NullReferenceException");
 
                 exc.Message.Should().Contain(innerException.Message);
             }
@@ -559,8 +540,7 @@ namespace FluentAssertions.Specs
         {
             try
             {
-                IFoo testSubject = A.Fake<IFoo>();
-                A.CallTo(() => testSubject.Do()).Throws(new Exception(""));
+                Does testSubject = Does.Throw<Exception>();
 
                 testSubject.Invoking(x => x.Do()).Should().Throw<Exception>()
                     .WithInnerException<InvalidOperationException>();
@@ -581,18 +561,17 @@ namespace FluentAssertions.Specs
         {
             try
             {
-                IFoo testSubject = A.Fake<IFoo>();
-                A.CallTo(() => testSubject.Do()).Throws(new Exception(""));
+                Does testSubject = Does.Throw<Exception>();
 
                 testSubject.Invoking(x => x.Do()).Should().Throw<Exception>()
-                    .WithInnerException<InvalidOperationException>("because {0} should do that", "IFoo.Do");
+                    .WithInnerException<InvalidOperationException>("because {0} should do that", "Does.Do");
 
                 throw new XunitException("This point should not be reached");
             }
             catch (XunitException ex)
             {
                 ex.Message.Should().Be(
-                    "Expected inner System.InvalidOperationException because IFoo.Do should do that, but the thrown exception has no inner exception.");
+                    "Expected inner System.InvalidOperationException because Does.Do should do that, but the thrown exception has no inner exception.");
             }
         }
 
@@ -625,8 +604,7 @@ namespace FluentAssertions.Specs
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
             const string SomeParamNameValue = "param";
-            var target = A.Fake<IFoo>();
-            A.CallTo(() => target.Do()).Throws(new ExceptionWithProperties(SomeParamNameValue));
+            Does target = Does.Throw(new ExceptionWithProperties(SomeParamNameValue));
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -645,9 +623,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(
-                new InvalidOperationException("message", new ArgumentException("inner message")));
+            Does testSubject = Does.Throw(new InvalidOperationException("message", new ArgumentException("inner message")));
 
             //-----------------------------------------------------------------------------------------------------------
             // Act / Assert
@@ -774,9 +750,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do())
-                .Throws(new AggregateException(new Exception(), new Exception()));
+            Does testSubject = Does.Throw(new AggregateException(new Exception(), new Exception()));
             Action throwingMethod = testSubject.Do;
 
             //-----------------------------------------------------------------------------------------------------------
@@ -823,8 +797,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            var foo = A.Fake<IFoo>();
-            A.CallTo(() => foo.Do()).Throws(new ArgumentException("An exception was forced"));
+            Does foo = Does.Throw(new ArgumentException("An exception was forced"));
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -847,8 +820,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            var foo = A.Fake<IFoo>();
-            A.CallTo(() => foo.Do()).Throws(new ArgumentException());
+            Does foo = Does.Throw<ArgumentException>();
 
             //-----------------------------------------------------------------------------------------------------------
             // Act / Assert
@@ -862,8 +834,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            var foo = A.Fake<IFoo>();
-            A.CallTo(() => foo.Do()).Throws(new ArgumentException("An exception was forced"));
+            Does foo = Does.Throw(new ArgumentException("An exception was forced"));
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -885,7 +856,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            var foo = A.Fake<IFoo>();
+            Does foo = Does.NotThrow();
 
             //-----------------------------------------------------------------------------------------------------------
             // Act / Assert
@@ -908,11 +879,47 @@ namespace FluentAssertions.Specs
         }
     }
 
-    public interface IFoo
+    public abstract class Does
     {
-        void Do();
+        public abstract void Do();
 
-        void Do(string someParam);
+        public abstract void Do(string someParam);
+
+        public static Does Throw<TException>(TException exception)
+            where TException : Exception
+        {
+            return new DoesThrow<TException>(exception);
+        }
+
+        public static Does Throw<TException>()
+            where TException : Exception, new()
+        {
+            return Throw(new TException());
+        }
+
+        public static Does NotThrow() => new DoesNotThrow();
+
+        private class DoesThrow<TException> : Does
+            where TException : Exception
+        {
+            private readonly TException exception;
+
+            public DoesThrow(TException exception)
+            {
+                this.exception = exception;
+            }
+
+            public override void Do() => throw exception;
+
+            public override void Do(string someParam) => throw exception;
+        }
+
+        private class DoesNotThrow : Does
+        {
+            public override void Do() { }
+
+            public override void Do(string someParam) { }
+        }
     }
 
     internal class ExceptionWithProperties : Exception

--- a/Tests/Shared.Specs/ThrowAssertionsSpecs.cs
+++ b/Tests/Shared.Specs/ThrowAssertionsSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using FakeItEasy;
 using Xunit;
 using Xunit.Sdk;
 
@@ -13,8 +12,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            IFoo testSubject = A.Fake<IFoo>();
-            A.CallTo(() => testSubject.Do()).Throws(new InvalidOperationException());
+            Does testSubject = Does.Throw<InvalidOperationException>();
 
             //-----------------------------------------------------------------------------------------------------------
             // Act / Assert
@@ -41,7 +39,7 @@ namespace FluentAssertions.Specs
         {
             try
             {
-                IFoo testSubject = A.Fake<IFoo>();
+                Does testSubject = Does.NotThrow();
 
                 testSubject.Invoking(x => x.Do()).Should().Throw<Exception>();
 


### PR DESCRIPTION
This PR removes the dependency on FakeItEasy, because
* we only used FakeItEasy to throw exceptions with `IFoo`, and
* it mislead a contributor to use FakeItEasy instead of just a simple `Action`.
