### PR TITLE
When deeply nested collections where compared to an empty collection it threw

### DIFF
--- a/Src/FluentAssertions/Execution/ChainedAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/ChainedAssertionScope.cs
@@ -62,7 +62,9 @@ namespace FluentAssertions.Execution
 
         public Continuation ClearExpectation()
         {
-            return predecessor.ClearExpectation();
+            predecessor.ClearExpectation();
+
+            return new Continuation(predecessor, predecessorSucceeded);
         }
 
         public IAssertionScope WithExpectation(string message, params object[] args)

--- a/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
@@ -583,6 +583,27 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_two_deeply_nested_collections_are_equivalent_while_ignoring_the_order_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var items = new[]
+            {
+                new int[0],
+                new int[] { 42 }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            items.Should().BeEquivalentTo(
+                new int[] { 42 },
+                new int[0]
+            );
+        }
+
+        [Fact]
         public void
             When_a_collection_property_contains_objects_with_mismatching_properties_it_should_throw
             ()


### PR DESCRIPTION
The `ClearExpectation` on a chained `Continuation` would cause the `AssertionScope` to forget the fact that an earlier assertion in that chain failed. This resulted in the equivalency API to choke on not getting any failures back when it tries to compare two collections for unordered equivalency and one of them was empty.

Fixes #965 