### PR TITLE
Rename expected to unexpected for negative tests

### DIFF
--- a/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
@@ -110,7 +110,7 @@ namespace FluentAssertions.Numeric
         /// <summary>
         /// Asserts that the subject is not equal to another object according to its implementation of <see cref="IComparable{T}"/>.
         /// </summary>
-        /// <param name="expected">
+        /// <param name="unexpected">
         /// The object to pass to the subject's <see cref="IComparable{T}.CompareTo"/> method.
         /// </param>
         /// <param name="because">
@@ -120,12 +120,12 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> NotBe(T expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.CompareTo(expected) != Equal)
+                .ForCondition(Subject.CompareTo(unexpected) != Equal)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {context:object} to be equal to {0}{reason}.", expected);
+                .FailWith("Did not expect {context:object} to be equal to {0}{reason}.", unexpected);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
         }

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -366,9 +366,9 @@ namespace FluentAssertions.Numeric
         }
 
         /// <summary>
-        /// Asserts that the object is not of the specified type <paramref name="expectedType"/>.
+        /// Asserts that the object is not of the specified type <paramref name="unexpectedType"/>.
         /// </summary>
-        /// <param name="expectedType">
+        /// <param name="unexpectedType">
         /// The type that the subject is not supposed to be of.
         /// </param>
         /// <param name="because">
@@ -378,9 +378,9 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> NotBeOfType(Type expectedType, string because = "", params object[] becauseArgs)
+        public AndConstraint<NumericAssertions<T>> NotBeOfType(Type unexpectedType, string because = "", params object[] becauseArgs)
         {
-            Subject.GetType().Should().NotBe(expectedType, because, becauseArgs);
+            Subject.GetType().Should().NotBe(unexpectedType, because, becauseArgs);
 
             return new AndConstraint<NumericAssertions<T>>(this);
         }

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -179,9 +179,9 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Asserts that the object is not of the specified type <paramref name="expectedType"/>.
+        /// Asserts that the object is not of the specified type <paramref name="unexpectedType"/>.
         /// </summary>
-        /// <param name="expectedType">
+        /// <param name="unexpectedType">
         /// The type that the subject is not supposed to be of.
         /// </param>
         /// <param name="because">
@@ -191,22 +191,22 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotBeOfType(Type expectedType, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBeOfType(Type unexpectedType, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!ReferenceEquals(Subject, null))
                 .BecauseOf(because, becauseArgs)
                 .WithDefaultIdentifier("type")
-                .FailWith("Expected {context} not to be {0}{reason}, but found <null>.", expectedType);
+                .FailWith("Expected {context} not to be {0}{reason}, but found <null>.", unexpectedType);
 
             Type subjectType = Subject.GetType();
-            if (expectedType.GetTypeInfo().IsGenericTypeDefinition && subjectType.GetTypeInfo().IsGenericType)
+            if (unexpectedType.GetTypeInfo().IsGenericTypeDefinition && subjectType.GetTypeInfo().IsGenericType)
             {
-                subjectType.GetGenericTypeDefinition().Should().NotBe(expectedType, because, becauseArgs);
+                subjectType.GetGenericTypeDefinition().Should().NotBe(unexpectedType, because, becauseArgs);
             }
             else
             {
-                subjectType.Should().NotBe(expectedType, because, becauseArgs);
+                subjectType.Should().NotBe(unexpectedType, because, becauseArgs);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -746,7 +746,7 @@ namespace FluentAssertions.Primitives
         /// <summary>
         /// Asserts that a string does not contain another (fragment of a) string.
         /// </summary>
-        /// <param name="expected">
+        /// <param name="unexpected">
         /// The (fragment of a) string that the current string should not contain.
         /// </param>
         /// <param name="because">
@@ -756,23 +756,23 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotContain(string expected, string because = "",
+        public AndConstraint<StringAssertions> NotContain(string unexpected, string because = "",
             params object[] becauseArgs)
         {
-            if (expected == null)
+            if (unexpected == null)
             {
-                throw new ArgumentNullException(nameof(expected), "Cannot assert string containment against <null>.");
+                throw new ArgumentNullException(nameof(unexpected), "Cannot assert string containment against <null>.");
             }
 
-            if (expected.Length == 0)
+            if (unexpected.Length == 0)
             {
-                throw new ArgumentException("Cannot assert string containment against an empty string.", nameof(expected));
+                throw new ArgumentException("Cannot assert string containment against an empty string.", nameof(unexpected));
             }
 
             Execute.Assertion
-                .ForCondition(!Contains(Subject, expected, StringComparison.Ordinal))
+                .ForCondition(!Contains(Subject, unexpected, StringComparison.Ordinal))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {context:string} {0} to contain {1}{reason}.", Subject, expected);
+                .FailWith("Did not expect {context:string} {0} to contain {1}{reason}.", Subject, unexpected);
 
             return new AndConstraint<StringAssertions>(this);
         }


### PR DESCRIPTION
Rename parameter of `Not*` assertions to be in negative form, i.e. `expected` into `unexpected`.