### PR TITLE
Rename namespace

### DIFF
--- a/Tests/Shared.Specs/AggregateExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/AggregateExceptionAssertionSpecs.cs
@@ -2,7 +2,7 @@
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Net40.Specs
+namespace FluentAssertions.Specs
 {
     public class AggregateExceptionAssertionSpecs
     {


### PR DESCRIPTION
Rename the namespace as there is nothing `net40` specific to it.