### PR TITLE
Allows BeEquivalentTo to handle a non-generic collection as the SUT

### DIFF
--- a/Src/FluentAssertions/Equivalency/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericEnumerableEquivalencyStep.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -61,7 +62,7 @@ namespace FluentAssertions.Equivalency
                 MethodCallExpression executeExpression = Expression.Call(
                     Expression.Constant(validator),
                     ExpressionExtensions.GetMethodName(() => validator.Execute<object>(null, null)),
-                    new[] { typeOfEnumeration },
+                    new[] {typeOfEnumeration},
                     subjectAsArray,
                     expectationAsArray);
 
@@ -82,16 +83,21 @@ namespace FluentAssertions.Equivalency
         {
             bool conditionMet = AssertionScope.Current
                 .ForCondition(!(subject is null))
-                .FailWith("Expected {context:Subject} not to be {0}.", new object[] { null });
+                .FailWith("Expected {context:subject} not to be {0}.", new object[] {null});
 
             if (conditionMet)
             {
                 conditionMet = AssertionScope.Current
-                    .ForCondition(IsGenericCollection(subject.GetType()))
-                    .FailWith("Expected {context:Subject} to be {0}, but found {1}.", expectation, subject);
+                    .ForCondition(IsCollection(subject.GetType()))
+                    .FailWith("Expected {context:subject} to be a collection, but it was a {0}", subject.GetType());
             }
 
             return conditionMet;
+        }
+
+        private static bool IsCollection(Type type)
+        {
+            return !typeof(string).IsAssignableFrom(type) && typeof(IEnumerable).IsAssignableFrom(type);
         }
 
         private static bool IsGenericCollection(Type type)
@@ -120,7 +126,7 @@ namespace FluentAssertions.Equivalency
             return Expression.Call(
                 typeof(Enumerable),
                 "ToArray",
-                new[] { typeOfEnumeration },
+                new[] {typeOfEnumeration},
                 Expression.Constant(value, typeof(IEnumerable<>).MakeGenericType(typeOfEnumeration)));
         }
     }

--- a/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
@@ -649,6 +649,24 @@ namespace FluentAssertions.Specs
                 .WithMessage("*Customers[0].Name*John*Jane*");
         }
 
+
+        [Fact]
+        public void When_the_subject_is_a_non_generic_collection_it_should_still_work()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            object item = new object();
+            object[] array = new[] { item };
+            IList readOnlyList = ArrayList.ReadOnly(array);
+
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            readOnlyList.Should().BeEquivalentTo(array);
+        }
+
         [Fact]
         public void
             When_a_collection_property_was_expected_but_the_property_is_not_a_collection_it_should_throw
@@ -685,7 +703,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "*member Customers to be {*Customer*{*Age*38*, but*Jane, John*");
+                    "Expected*Customers*collection*String*");
         }
 
         [Fact]
@@ -1596,30 +1614,6 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected subject not to be <null>*");
-        }
-
-        [Fact]
-        public void When_the_expectation_is_not_a_multi_dimensional_array_it_should_throw()
-        {
-            //-----------------------------------------------------------------------------------------------------------
-            // Arrange
-            //-----------------------------------------------------------------------------------------------------------
-            var actual = new[,]
-            {
-                { 1, 2, 3 },
-                { 4, 5, 6 }
-            };
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Act
-            //-----------------------------------------------------------------------------------------------------------
-            Action act = () => actual.Should().BeEquivalentTo("not-a-multi-dimensional-array");
-
-            //-----------------------------------------------------------------------------------------------------------
-            // Assert
-            //-----------------------------------------------------------------------------------------------------------
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected*not-a-multi-dimensional-array*but found {1, 2, 3, 4, 5, 6}*");
         }
 
         [Fact]


### PR DESCRIPTION
The `GenericEnumerableEquivalencyStep` did not properly support the subject to be a non-generic collection. 

Fixes #973