### PR TITLE
Replace properties with methods

### DIFF
--- a/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
@@ -28,9 +28,10 @@ namespace FluentAssertions.Equivalency
 
                 do
                 {
-                    object subject = ((Array)context.Subject).GetValue(digit.Indices);
-                    string listOfIndices = string.Join(",", digit.Indices);
-                    object expectation = expectationAsArray.GetValue(digit.Indices);
+                    int[] indices = digit.GetIndices();
+                    object subject = ((Array)context.Subject).GetValue(indices);
+                    string listOfIndices = string.Join(",", indices);
+                    object expectation = expectationAsArray.GetValue(indices);
                     IEquivalencyValidationContext itemContext = context.CreateForCollectionItem(
                         listOfIndices,
                         subject,
@@ -111,21 +112,18 @@ namespace FluentAssertions.Equivalency
             this.nextDigit = nextDigit;
         }
 
-        public int[] Indices
+        public int[] GetIndices()
         {
-            get
+            var indices = new List<int>();
+
+            Digit digit = this;
+            while (digit != null)
             {
-                var indices = new List<int>();
-
-                Digit digit = this;
-                while (digit != null)
-                {
-                    indices.Add(digit.index);
-                    digit = digit.nextDigit;
-                }
-
-                return indices.ToArray();
+                indices.Add(digit.index);
+                digit = digit.nextDigit;
             }
+
+            return indices.ToArray();
         }
 
         public bool Increment()

--- a/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
@@ -14,28 +14,27 @@ namespace FluentAssertions.Primitives
 
         protected override void ValidateAgainstMismatch()
         {
-            if (!IsMatch && !Negate)
+            bool isMatch = IsMatch();
+
+            if (!isMatch && !Negate)
             {
                 assertion.FailWith(ExpectationDescription + "but {1} does not.", expected, subject);
             }
 
-            if (IsMatch && Negate)
+            if (isMatch && Negate)
             {
                 assertion.FailWith(ExpectationDescription + "but {1} matches.", expected, subject);
             }
         }
 
-        private bool IsMatch
+        private bool IsMatch()
         {
-            get
-            {
-                var options = IgnoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
+            var options = IgnoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
 
-                string input = CleanNewLines(subject);
-                string pattern = ConvertWildcardToRegEx(CleanNewLines(expected));
+            string input = CleanNewLines(subject);
+            string pattern = ConvertWildcardToRegEx(CleanNewLines(expected));
 
-                return Regex.IsMatch(input, pattern, options | RegexOptions.Singleline);
-            }
+            return Regex.IsMatch(input, pattern, options | RegexOptions.Singleline);
         }
 
         private string ConvertWildcardToRegEx(string wildcardExpression)


### PR DESCRIPTION
Replace properties with methods, as they do more work than simply returning a backing field.
This affects neither ABI nor API compatibility, as the property `IsMatch` is `private` and the class `Digit` is `internal`.