### PR TITLE
fix BeOfType and BeAssignableTo within AssertionScope (fixes #1002)

### DIFF
--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -123,7 +123,13 @@ namespace FluentAssertions.Primitives
         {
             BeOfType(typeof(T), because, becauseArgs);
 
-            return new AndWhichConstraint<TAssertions, T>((TAssertions)this, (T)(object)Subject);
+            T typedSubject = default(T);
+            if (Subject is T)
+            {
+                typedSubject = (T)(object)Subject;
+            }
+
+            return new AndWhichConstraint<TAssertions, T>((TAssertions)this, typedSubject);
         }
 
         /// <summary>
@@ -229,7 +235,13 @@ namespace FluentAssertions.Primitives
                     typeof(T),
                     Subject.GetType());
 
-            return new AndWhichConstraint<TAssertions, T>((TAssertions)this, (T)((object)Subject));
+            T typedSubject = default(T);
+            if (Subject is T)
+            {
+                typedSubject = (T)(object)Subject;
+            }
+
+            return new AndWhichConstraint<TAssertions, T>((TAssertions)this, typedSubject);
         }
 
         /// <summary>

--- a/Tests/Shared.Specs/AssertionScopeSpecs.cs
+++ b/Tests/Shared.Specs/AssertionScopeSpecs.cs
@@ -346,6 +346,56 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_an_assertion_fails_on_BeOfType_succeeding_message_should_be_included()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () =>
+            {
+                using (new AssertionScope())
+                {
+                    var item = string.Empty;
+                    item.Should().BeOfType<int>();
+                    item.Should().BeOfType<long>();
+                }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                "Expected type to be System.Int32, but found System.String.*" +
+                "Expected type to be System.Int64, but found System.String.");
+        }
+
+        [Fact]
+        public void When_an_assertion_fails_on_BeAssignableTo_succeeding_message_should_be_included()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () =>
+            {
+                using (new AssertionScope())
+                {
+                    var item = string.Empty;
+                    item.Should().BeAssignableTo<int>();
+                    item.Should().BeAssignableTo<long>();
+                }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                "Expected * to be assignable to System.Int32, but System.String is not.*" +
+                "Expected * to be assignable to System.Int64, but System.String is not.");
+        }
+
+        [Fact]
         public void When_parentheses_are_used_in_the_because_arguments_it_should_render_them_correctly()
         {
             //-----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
As discussed in issue #1002 I'm providing fix for BeOfType and BeAssignableTo within an AssertionScope.

While checking the current implementations I was wondering why (Not)BeOfType(<T>) and (Not)BeAssignableTo(<T>) are looking quite different. I expected similar issues in all these methods.
Can somebody explain the differences?