### PR TITLE
AllBeAssignableTo and AllBeOfType for List of Types

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -1631,8 +1631,8 @@ namespace FluentAssertions.Collections
                 .ForCondition(subject => subject.All(x => x != null))
                 .FailWith("but found a null element.")
                 .Then
-                .ForCondition(subject => subject.All(x => expectedType.GetTypeInfo().IsAssignableFrom(x.GetType().GetTypeInfo())))
-                .FailWith("but found {0}.", subject => $"[{string.Join(", ", subject.Select(x => x.GetType().FullName))}]");
+                .ForCondition(subject => subject.All(x => expectedType.GetTypeInfo().IsAssignableFrom(GetType(x).GetTypeInfo())))
+                .FailWith("but found {0}.", subject => $"[{string.Join(", ", subject.Select(x => GetType(x).FullName))}]");
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -1673,10 +1673,15 @@ namespace FluentAssertions.Collections
                 .ForCondition(subject => subject.All(x => x != null))
                 .FailWith("but found a null element.")
                 .Then
-                .ForCondition(subject => subject.All(x => expectedType == x.GetType()))
-                .FailWith("but found {0}.", subject => $"[{string.Join(", ", subject.Select(x => x.GetType().FullName))}]");
+                .ForCondition(subject => subject.All(x => expectedType == GetType(x)))
+                .FailWith("but found {0}.", subject => $"[{string.Join(", ", subject.Select(x => GetType(x).FullName))}]");
 
             return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        private static Type GetType(object o)
+        {
+            return o is Type t ? t : o.GetType();
         }
 
         /// <summary>

--- a/Tests/Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/CollectionAssertionSpecs.cs
@@ -5124,6 +5124,68 @@ namespace FluentAssertions.Specs
                 "Expected type to be \"System.Int32\" because they are of different type, but found a null element.");
         }
 
+        [Fact]
+        public void When_collection_is_of_matching_types_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new Type[] { typeof(Exception), typeof(ArgumentException) };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            collection.Should().AllBeAssignableTo<Exception>();
+        }
+
+        [Fact]
+        public void When_collection_of_types_contains_one_type_that_does_not_match_it_should_throw_with_a_clear_explanation()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new Type[] { typeof(int), typeof(string), typeof(int) };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().AllBeAssignableTo<int>("because they are of different type");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to be \"System.Int32\" because they are of different type, but found \"[System.Int32, System.String, System.Int32]\".");
+        }
+
+        [Fact]
+        public void When_collection_of_types_and_objects_are_all_of_matching_types_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new object[] { typeof(int), 2, typeof(int) };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            collection.Should().AllBeAssignableTo<int>();
+        }
+
+        [Fact]
+        public void When_collection_of_different_types_and_objects_are_all_assignable_to_type_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new object[] { typeof(Exception), new ArgumentException() };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            collection.Should().AllBeAssignableTo<Exception>();
+        }
+
         #endregion
 
         #region ShouldAllBeOfType
@@ -5180,6 +5242,54 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected type to be \"System.Int32\" because they are of different type, but found a null element.");
+        }
+
+        [Fact]
+        public void When_collection_of_types_match_expected_type_exactly_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new Type[] { typeof(int), typeof(int), typeof(int) };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            collection.Should().AllBeOfType<int>();
+        }
+        
+        [Fact]
+        public void When_collection_of_types_and_objects_match_type_excactly_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new object[] { typeof(ArgumentException), new ArgumentException() };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            collection.Should().AllBeOfType<ArgumentException>();
+        }
+
+        [Fact]
+        public void When_collection_of_types_and_objects_do_not_match_type_excactly_it_should_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IEnumerable collection = new object[] { typeof(Exception), new ArgumentException() };
+
+            // -----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().AllBeOfType<ArgumentException>();
+
+            // -----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected type to be \"System.ArgumentException\", but found \"[System.Exception, System.ArgumentException]\".");
         }
 
         #endregion


### PR DESCRIPTION
This could be a quick fix to #1006.

When using `AllBeAssignableTo` or `AllBeOfType` on a list of types it did convert the list to a list of `System.RuntimeType` and fail the assertion. That was because the code called `GetType()` on an object that already was a type.

BR,
Matthias