### PR TITLE
Removed redundant multithreading

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions.Collections;
+using FluentAssertions.Common;
 using FluentAssertions.Events;
 using FluentAssertions.Numeric;
 using FluentAssertions.Primitives;
@@ -77,7 +78,7 @@ namespace FluentAssertions
         [MustUseReturnValue /* do not use Pure because this method executes the action before returning to the caller */]
         public static ExecutionTime ExecutionTime(this Func<Task> action)
         {
-            return new ExecutionTime(action);
+            return new ExecutionTime(action.ExecuteInDefaultSynchronizationContext);
         }
 
         /// <summary>
@@ -639,7 +640,7 @@ namespace FluentAssertions
         [Pure]
         public static AsyncFunctionAssertions Should(this Func<Task> action)
         {
-            return new AsyncFunctionAssertions(action, extractor);
+            return new AsyncFunctionAssertions(action.ExecuteInDefaultSynchronizationContext, extractor);
         }
 
         /// <summary>
@@ -649,7 +650,7 @@ namespace FluentAssertions
         [Pure]
         public static AsyncFunctionAssertions Should<T>(this Func<Task<T>> action)
         {
-            return new AsyncFunctionAssertions(action, extractor);
+            return new AsyncFunctionAssertions(action.ExecuteInDefaultSynchronizationContext, extractor);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Common/NoSynchronizationContextScope.cs
+++ b/Src/FluentAssertions/Common/NoSynchronizationContextScope.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading;
+
+namespace FluentAssertions.Common
+{
+    internal static class NoSynchronizationContextScope
+    {
+        public static DisposingAction Enter()
+        {
+            var context = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(null);
+            return new DisposingAction(() => SynchronizationContext.SetSynchronizationContext(context));
+        }
+
+        internal class DisposingAction : IDisposable
+        {
+            private readonly Action action;
+
+            public DisposingAction(Action action)
+            {
+                this.action = action;
+            }
+
+            public void Dispose()
+            {
+                action();
+            }
+        }
+    }
+}

--- a/Src/FluentAssertions/Common/TaskExtensions.cs
+++ b/Src/FluentAssertions/Common/TaskExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace FluentAssertions.Common
+{
+    /// <summary>
+    /// Some unit test frameworks (like xUnit) have their own synchronization context
+    /// that does not work well with blocking waits and can lead to deadlocks.
+    /// These methods create the task in the default synchronization context
+    /// and blocks until the task is completed.
+    /// </summary>
+    internal static class TaskExtensions
+    {
+        public static void ExecuteInDefaultSynchronizationContext(this Action action)
+        {
+            using (NoSynchronizationContextScope.Enter())
+            {
+                action();
+            }
+        }
+
+        public static TResult ExecuteInDefaultSynchronizationContext<TResult>(this Func<TResult> action)
+        {
+            using (NoSynchronizationContextScope.Enter())
+            {
+                return action();
+            }
+        }
+
+    }
+}

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Specialized
@@ -74,7 +73,7 @@ namespace FluentAssertions.Specialized
         {
             try
             {
-                Task.Run(Subject).Wait();
+                Subject().Wait();
             }
             catch (Exception exception)
             {
@@ -96,7 +95,7 @@ namespace FluentAssertions.Specialized
         {
             try
             {
-                await Task.Run(Subject);
+                await Subject();
             }
             catch (Exception exception)
             {
@@ -119,7 +118,7 @@ namespace FluentAssertions.Specialized
         {
             try
             {
-                Task.Run(Subject).Wait();
+                Subject().Wait();
             }
             catch (Exception exception)
             {
@@ -142,7 +141,7 @@ namespace FluentAssertions.Specialized
         {
             try
             {
-                await Task.Run(Subject);
+                await Subject();
             }
             catch (Exception exception)
             {
@@ -323,7 +322,7 @@ namespace FluentAssertions.Specialized
         {
             try
             {
-                Task.Run(Subject).Wait();
+                Subject().Wait();
                 return null;
             }
             catch (Exception exception)
@@ -336,7 +335,7 @@ namespace FluentAssertions.Specialized
         {
             try
             {
-                await Task.Run(Subject);
+                await Subject();
                 return null;
             }
             catch (Exception exception)

--- a/Tests/Shared.Specs/ExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/ExceptionAssertionSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Sdk;
 
@@ -829,6 +830,20 @@ namespace FluentAssertions.Specs
             // Act / Assert
             //-----------------------------------------------------------------------------------------------------------
             foo.Invoking(f => f.Do()).Should().NotThrow<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void When_no_exception_should_be_thrown_by_sync_over_async_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => Task.Delay(0).Wait(0);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow();
         }
 
         [Fact]

--- a/Tests/Shared.Specs/FunctionExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/FunctionExceptionAssertionSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
 using FluentAssertions.Specialized;
@@ -592,6 +593,20 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_no_exception_should_be_thrown_by_sync_over_async_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Func<bool> func = () => Task.Delay(0).Wait(0);
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            func.Should().NotThrow();
         }
 
         #endregion


### PR DESCRIPTION
Fix for issue #1020

Removed redundant multithreading which was implemented using Task.Run.