### PR TITLE
Attempt to fix a timing issue for the NotThrowAfter specs

### DIFF
--- a/Src/FluentAssertions/Specialized/ActionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ActionAssertions.cs
@@ -166,8 +166,8 @@ namespace FluentAssertions.Specialized
                     return;
                 }
 
-                Thread.Sleep(pollInterval);
                 invocationEndTime = watch.Elapsed;
+                Thread.Sleep(pollInterval);
             }
 
             Execute.Assertion

--- a/Src/FluentAssertions/Specialized/FunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/FunctionAssertions.cs
@@ -183,13 +183,14 @@ namespace FluentAssertions.Specialized
                     exception = e;
                 }
 
-                Thread.Sleep(pollInterval);
                 invocationEndTime = watch.Elapsed;
+                Thread.Sleep(pollInterval);
             }
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect any exceptions after {0}{reason}, but found {1}.", waitTime, exception);
+
             return null; // never reached
         }
 #endif

--- a/Tests/Shared.Specs/FunctionExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/FunctionExceptionAssertionSpecs.cs
@@ -455,7 +455,7 @@ namespace FluentAssertions.Specs
 
             Func<int> throwShorterThanWaitTime = () =>
             {
-                if (watch.Elapsed <= (waitTime.Milliseconds / 2).Milliseconds())
+                if (watch.Elapsed <= (waitTime.TotalMilliseconds / 2).Milliseconds())
                 {
                     throw new ArgumentException("An exception was forced");
                 }


### PR DESCRIPTION
Attempts to fix a timing issue for the NotThrowAfter specs. Not entirely sure why this misbehaves on AppVeyor, but this seems to fix this.