### PR TITLE
Add TimeSpan helpers

### DIFF
--- a/Tests/Shared.Specs/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/AsyncFunctionExceptionAssertionSpecs.cs
@@ -606,7 +606,7 @@ namespace FluentAssertions.Specs
 
             Func<Task> throwLongerThanWaitTime = async () =>
             {
-                if (watch.ElapsedMilliseconds <= waitTime.TotalMilliseconds * 1.5)
+                if (watch.Elapsed <= waitTime.Multiply(1.5))
                 {
                     throw new ArgumentException("An exception was forced");
                 }
@@ -639,7 +639,7 @@ namespace FluentAssertions.Specs
 
             Func<Task> throwShorterThanWaitTime = async () =>
             {
-                if (watch.ElapsedMilliseconds <= waitTime.TotalMilliseconds / 12)
+                if (watch.Elapsed <= waitTime.Divide(12))
                 {
                     throw new ArgumentException("An exception was forced");
                 }
@@ -720,7 +720,7 @@ namespace FluentAssertions.Specs
 
             Func<Task> throwLongerThanWaitTime = async () =>
             {
-                if (watch.ElapsedMilliseconds <= waitTime.TotalMilliseconds * 1.5)
+                if (watch.Elapsed <= waitTime.Multiply(1.5))
                 {
                     throw new ArgumentException("An exception was forced");
                 }
@@ -753,7 +753,7 @@ namespace FluentAssertions.Specs
 
             Func<Task> throwShorterThanWaitTime = async () =>
             {
-                if (watch.ElapsedMilliseconds <= waitTime.TotalMilliseconds / 12)
+                if (watch.Elapsed <= waitTime.Divide(12))
                 {
                     throw new ArgumentException("An exception was forced");
                 }

--- a/Tests/Shared.Specs/ExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/ExceptionAssertionSpecs.cs
@@ -949,7 +949,7 @@ namespace FluentAssertions.Specs
 
             Action throwLongerThanWaitTime = () =>
             {
-                if (watch.Elapsed <= waitTime + (waitTime.Milliseconds / 2).Milliseconds())
+                if (watch.Elapsed <= waitTime.Multiply(1.5))
                 {
                     throw new ArgumentException("An exception was forced");
                 }
@@ -980,7 +980,7 @@ namespace FluentAssertions.Specs
 
             Action throwShorterThanWaitTime = () =>
             {
-                if (watch.Elapsed <= (waitTime.Milliseconds / 2).Milliseconds())
+                if (watch.Elapsed <= waitTime.Divide(2))
                 {
                     throw new ArgumentException("An exception was forced");
                 }

--- a/Tests/Shared.Specs/FunctionExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/FunctionExceptionAssertionSpecs.cs
@@ -391,7 +391,7 @@ namespace FluentAssertions.Specs
 
             Func<int> throwLongerThanWaitTime = () =>
             {
-                if (watch.Elapsed <= waitTime + (waitTime.Milliseconds / 2).Milliseconds())
+                if (watch.Elapsed <= waitTime.Multiply(1.5))
                 {
                     throw new ArgumentException("An exception was forced");
                 }
@@ -424,7 +424,7 @@ namespace FluentAssertions.Specs
 
             Func<int> throwShorterThanWaitTime = () =>
             {
-                if (watch.Elapsed <= (waitTime.Milliseconds / 2).Milliseconds())
+                if (watch.Elapsed <= waitTime.Divide(2))
                 {
                     throw new ArgumentException("An exception was forced");
                 }
@@ -455,7 +455,7 @@ namespace FluentAssertions.Specs
 
             Func<int> throwShorterThanWaitTime = () =>
             {
-                if (watch.Elapsed <= (waitTime.TotalMilliseconds / 2).Milliseconds())
+                if (watch.Elapsed <= waitTime.Divide(2))
                 {
                     throw new ArgumentException("An exception was forced");
                 }

--- a/Tests/Shared.Specs/Shared.Specs.projitems
+++ b/Tests/Shared.Specs/Shared.Specs.projitems
@@ -65,6 +65,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TypeAssertionSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TypeExtensionsSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TypeSelectorSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)XAttributeAssertionSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)XAttributeFormatterSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)XDocumentAssertionSpecs.cs" />

--- a/Tests/Shared.Specs/Utilities.cs
+++ b/Tests/Shared.Specs/Utilities.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace FluentAssertions.Specs
+{
+    public static class Utilities
+    {
+#if NET45 || NET47 || NETCOREAPP1_1
+        public static TimeSpan Multiply(this TimeSpan timeSpan, double factor)
+        {
+            if (double.IsNaN(factor))
+            {
+                throw new ArgumentException("Argument cannot be NaN", nameof(factor));
+            }
+
+            // Rounding to the nearest tick is as close to the result we would have with unlimited
+            // precision as possible, and so likely to have the least potential to surprise.
+            double ticks = Math.Round(timeSpan.Ticks * factor);
+            if (ticks > long.MaxValue || ticks < long.MinValue)
+            {
+                throw new OverflowException("TimeSpan overflowed because the duration is too long.");
+            }
+
+            return TimeSpan.FromTicks((long)ticks);
+        }
+
+        public static TimeSpan Divide(this TimeSpan timeSpan, double divisor)
+        {
+            if (double.IsNaN(divisor))
+            {
+                throw new ArgumentException("Argument cannot be NaN", nameof(divisor));
+            }
+
+            double ticks = Math.Round(timeSpan.Ticks / divisor);
+            if (ticks > long.MaxValue || ticks < long.MinValue || double.IsNaN(ticks))
+            {
+                throw new OverflowException("TimeSpan overflowed because the duration is too long.");
+            }
+
+            return TimeSpan.FromTicks((long)ticks);
+        }
+#endif
+    }
+}


### PR DESCRIPTION
Some tests were using `.Milliseconds` instead of `.TotalMilliseconds`, which might(?) explain the flaky tests.
It could be pure coincidence when they failed or passed.

By adding `Multiply` and `Divide` (copied from [corefx](https://github.com/dotnet/corefx/blob/09e2417cd0505df4558535651efb1bbcffdf0c59/src/Common/src/CoreLib/System/TimeSpan.cs#L489)), we retain the lifted types in the test code.