### PR TITLE
Fix continuation on NotThrow(After) in AssertionScope

### DIFF
--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -324,13 +324,12 @@ namespace FluentAssertions.Specialized
             try
             {
                 Task.Run(Subject).Wait();
+                return null;
             }
             catch (Exception exception)
             {
                 return InterceptException(exception);
             }
-
-            return null;
         }
 
         private async Task<Exception> InvokeSubjectWithInterceptionAsync()
@@ -338,13 +337,12 @@ namespace FluentAssertions.Specialized
             try
             {
                 await Task.Run(Subject);
+                return null;
             }
             catch (Exception exception)
             {
                 return InterceptException(exception);
             }
-
-            return null;
         }
 
         private Exception InterceptException(Exception exception)

--- a/Src/FluentAssertions/Specialized/FunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/FunctionAssertions.cs
@@ -80,7 +80,7 @@ namespace FluentAssertions.Specialized
             catch (Exception exception)
             {
                 NotThrow(exception, because, becauseArgs);
-                return null;
+                return new AndWhichConstraint<FunctionAssertions<T>, T>(this, default(T));
             }
         }
 
@@ -175,8 +175,8 @@ namespace FluentAssertions.Specialized
             {
                 try
                 {
-                     T result = Subject();
-                     return new AndWhichConstraint<FunctionAssertions<T>, T>(this, result);
+                    T result = Subject();
+                    return new AndWhichConstraint<FunctionAssertions<T>, T>(this, result);
                 }
                 catch (Exception e)
                 {
@@ -191,7 +191,7 @@ namespace FluentAssertions.Specialized
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect any exceptions after {0}{reason}, but found {1}.", waitTime, exception);
 
-            return null; // never reached
+            return new AndWhichConstraint<FunctionAssertions<T>, T>(this, default(T));
         }
 #endif
 

--- a/Tests/Shared.Specs/FunctionExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/FunctionExceptionAssertionSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
 using FluentAssertions.Specialized;
 using Xunit;
@@ -329,6 +330,36 @@ namespace FluentAssertions.Specs
                 .WithMessage("*no*exception*that's what he told me*but*ArgumentNullException*");
         }
 
+        [Fact]
+        public void When_an_assertion_fails_on_NotThrow_succeeding_message_should_be_included()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Func<int> throwingFunction = () => throw new Exception();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () =>
+            {
+                using (new AssertionScope())
+                {
+                    throwingFunction.Should().NotThrow()
+                        .And.BeNull();
+                }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "*Did not expect any exception*" +
+                    "*to be <null>*"
+                );
+        }
+
         #endregion
 
         #region NotThrowAfter
@@ -473,6 +504,38 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Subject.Should().Be(42);
+        }
+
+        [Fact]
+        public void When_an_assertion_fails_on_NotThrowAfter_succeeding_message_should_be_included()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var waitTime = TimeSpan.Zero;
+            var pollInterval = TimeSpan.Zero;
+            Func<int> throwingFunction = () => throw new Exception();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () =>
+            {
+                using (new AssertionScope())
+                {
+                    throwingFunction.Should().NotThrowAfter(waitTime, pollInterval)
+                        .And.BeNull();
+                }
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "*Did not expect any exceptions after*" +
+                    "*to be <null>*"
+                );
         }
 #endif // NotThrowAfter tests
         #endregion


### PR DESCRIPTION
Got a reminder that `FailWith` does not always throw immediately when wrapping multiple assertions inside an `AssertionScope`.