### PR TITLE
Allow nesting equivalency checks in custom assertion rules

### DIFF
--- a/Src/FluentAssertions/Equivalency/AssertionRuleEquivalencyStepAdapter.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionRuleEquivalencyStepAdapter.cs
@@ -14,7 +14,7 @@ namespace FluentAssertions.Equivalency
 
         public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
         {
-            return !context.IsRoot;
+            return true;
         }
 
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)

--- a/Src/FluentAssertions/Equivalency/IAssertionRule.cs
+++ b/Src/FluentAssertions/Equivalency/IAssertionRule.cs
@@ -1,5 +1,6 @@
 namespace FluentAssertions.Equivalency
 {
+    // REFACTOR: Should be removed in a future breaking change since it is replaced by IEquivalencyStep
     public interface IAssertionRule
     {
         /// <summary>

--- a/Src/FluentAssertions/Equivalency/RunAllUserStepsEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/RunAllUserStepsEquivalencyStep.cs
@@ -16,8 +16,15 @@ namespace FluentAssertions.Equivalency
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent,
             IEquivalencyAssertionOptions config)
         {
-            return config.GetUserEquivalencySteps(config.ConversionSelector)
-                .Any(step => step.CanHandle(context, config) && step.Handle(context, parent, config));
+            foreach (IEquivalencyStep step in config.GetUserEquivalencySteps(config.ConversionSelector))
+            {
+                if (step.CanHandle(context, config) && step.Handle(context, parent, config))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
Implementations of `IAssertionRule` (including the usage of `Using().WhenTypeIs()` were never run for root objects. 

Fixes #1032