### PR TITLE
Undone a potential breaking name change

### DIFF
--- a/Src/FluentAssertions/Equivalency/DictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DictionaryEquivalencyStep.cs
@@ -40,7 +40,7 @@ namespace FluentAssertions.Equivalency
                         if (config.IsRecursive)
                         {
                             context.TraceSingle(path => $"Recursing into dictionary item {key} at {path}");
-                            parent.RecursivelyAssertEquality(context.CreateForDictionaryItem(key, subject[key], expectation[key]));
+                            parent.AssertEqualityUsing(context.CreateForDictionaryItem(key, subject[key], expectation[key]));
                         }
                         else
                         {

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
@@ -185,7 +185,7 @@ namespace FluentAssertions.Equivalency
         {
             using (var scope = new AssertionScope())
             {
-                parent.RecursivelyAssertEquality(context.CreateForCollectionItem(expectationIndex.ToString(), subject, expectation));
+                parent.AssertEqualityUsing(context.CreateForCollectionItem(expectationIndex.ToString(), subject, expectation));
 
                 return scope.Discard();
             }
@@ -200,7 +200,7 @@ namespace FluentAssertions.Equivalency
                 IEquivalencyValidationContext equivalencyValidationContext =
                     context.CreateForCollectionItem(indexString, subject, expectation);
 
-                parent.RecursivelyAssertEquality(equivalencyValidationContext);
+                parent.AssertEqualityUsing(equivalencyValidationContext);
 
                 bool failed = scope.HasFailures();
                 return !failed;

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -34,7 +34,7 @@ namespace FluentAssertions.Equivalency
 
                 scope.BecauseOf(context.Because, context.BecauseArgs);
 
-                RecursivelyAssertEquality(context);
+                AssertEqualityUsing(context);
 
                 if (context.Tracer != null)
                 {
@@ -43,7 +43,7 @@ namespace FluentAssertions.Equivalency
             }
         }
 
-        public void RecursivelyAssertEquality(IEquivalencyValidationContext context)
+        public void AssertEqualityUsing(IEquivalencyValidationContext context)
         {
             if (ShouldCompareMembersThisDeep(context.SelectedMemberPath))
             {

--- a/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
@@ -255,7 +255,7 @@ namespace FluentAssertions.Equivalency
                 {
                     if (config.IsRecursive)
                     {
-                        parent.RecursivelyAssertEquality(context.CreateForDictionaryItem(key, subjectValue, expectation[key]));
+                        parent.AssertEqualityUsing(context.CreateForDictionaryItem(key, subjectValue, expectation[key]));
                     }
                     else
                     {

--- a/Src/FluentAssertions/Equivalency/IEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyValidator.cs
@@ -2,6 +2,6 @@ namespace FluentAssertions.Equivalency
 {
     public interface IEquivalencyValidator
     {
-        void RecursivelyAssertEquality(IEquivalencyValidationContext context);
+        void AssertEqualityUsing(IEquivalencyValidationContext context);
     }
 }

--- a/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
@@ -37,7 +37,7 @@ namespace FluentAssertions.Equivalency
                         subject,
                         expectation);
 
-                    parent.RecursivelyAssertEquality(itemContext);
+                    parent.AssertEqualityUsing(itemContext);
                 }
                 while (digit.Increment());
             }

--- a/Src/FluentAssertions/Equivalency/StructuralEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/StructuralEqualityEquivalencyStep.cs
@@ -60,7 +60,7 @@ namespace FluentAssertions.Equivalency
 
                 if (nestedContext != null)
                 {
-                    parent.RecursivelyAssertEquality(nestedContext);
+                    parent.AssertEqualityUsing(nestedContext);
                 }
             }
         }

--- a/Src/FluentAssertions/Equivalency/TryConversionStep.cs
+++ b/Src/FluentAssertions/Equivalency/TryConversionStep.cs
@@ -59,7 +59,7 @@ namespace FluentAssertions.Equivalency
 
                 var newContext = context.CreateWithDifferentSubject(convertedSubject, expectationType);
 
-                structuralEqualityValidator.RecursivelyAssertEquality(newContext);
+                structuralEqualityValidator.AssertEqualityUsing(newContext);
                 return true;
             }
 


### PR DESCRIPTION
Renamed `IEquivalencyValidator.RecursivelyAssertEquality` to `AssertEqualityUsing` to prevent any breaking changes for folks using this as an extension point. This was introduced in #1026.