### PR TITLE
Unwrapping of AggregateExceptions

### DIFF
--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -151,25 +151,22 @@ namespace FluentAssertions.Specialized
 
         private static void NotThrow(Exception exception, string because, object[] becauseArgs)
         {
-            Exception nonAggregateException = GetFirstNonAggregateException(exception);
-
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect any exception{reason}, but found a {0} with message {1}.",
-                    nonAggregateException.GetType(), nonAggregateException.ToString());
+                    exception.GetType(), exception.ToString());
         }
 
-        private static void NotThrow<TException>(Exception exception, string because, object[] becauseArgs) where TException : Exception
+        private void NotThrow<TException>(Exception exception, string because, object[] becauseArgs) where TException : Exception
         {
-            Exception nonAggregateException = GetFirstNonAggregateException(exception);
+            var exceptions = extractor.OfType<TException>(exception);
 
-            if (nonAggregateException != null)
+            if (exceptions.Any())
             {
                 Execute.Assertion
-                    .ForCondition(!(nonAggregateException is TException))
                     .BecauseOf(because, becauseArgs)
                     .FailWith("Did not expect {0}{reason}, but found one with message {1}.",
-                        typeof(TException), nonAggregateException.ToString());
+                        typeof(TException), exceptions.First().ToString());
             }
         }
 
@@ -289,17 +286,6 @@ namespace FluentAssertions.Specialized
             }
         }
 
-        private static Exception GetFirstNonAggregateException(Exception exception)
-        {
-            Exception nonAggregateException = exception;
-            while (nonAggregateException is AggregateException)
-            {
-                nonAggregateException = nonAggregateException.InnerException;
-            }
-
-            return nonAggregateException;
-        }
-
         private ExceptionAssertions<TException> Throw<TException>(Exception exception, string because, object[] becauseArgs)
             where TException : Exception
         {
@@ -327,7 +313,7 @@ namespace FluentAssertions.Specialized
             }
             catch (Exception exception)
             {
-                return InterceptException(exception);
+                return exception;
             }
         }
 
@@ -340,19 +326,8 @@ namespace FluentAssertions.Specialized
             }
             catch (Exception exception)
             {
-                return InterceptException(exception);
+                return exception;
             }
-        }
-
-        private Exception InterceptException(Exception exception)
-        {
-            var ar = exception as AggregateException;
-            if (ar?.InnerException is AggregateException)
-            {
-                return ar.InnerException;
-            }
-
-            return exception;
         }
     }
 }

--- a/Src/FluentAssertions/Specialized/FunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/FunctionAssertions.cs
@@ -109,25 +109,22 @@ namespace FluentAssertions.Specialized
 
         private static void NotThrow(Exception exception, string because, object[] becauseArgs)
         {
-            Exception nonAggregateException = GetFirstNonAggregateException(exception);
-
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect any exception{reason}, but found a {0} with message {1}.",
-                    nonAggregateException.GetType(), nonAggregateException.ToString());
+                    exception.GetType(), exception.ToString());
         }
 
-        private static void NotThrow<TException>(Exception exception, string because, object[] becauseArgs) where TException : Exception
+        private void NotThrow<TException>(Exception exception, string because, object[] becauseArgs) where TException : Exception
         {
-            Exception nonAggregateException = GetFirstNonAggregateException(exception);
+            var exceptions = extractor.OfType<TException>(exception);
 
-            if (nonAggregateException != null)
+            if (exceptions.Any())
             {
                 Execute.Assertion
-                    .ForCondition(!(nonAggregateException is TException))
                     .BecauseOf(because, becauseArgs)
                     .FailWith("Did not expect {0}{reason}, but found one with message {1}.",
-                        typeof(TException), nonAggregateException.ToString());
+                        typeof(TException), exceptions.First().ToString());
             }
         }
 
@@ -194,17 +191,6 @@ namespace FluentAssertions.Specialized
             return new AndWhichConstraint<FunctionAssertions<T>, T>(this, default(T));
         }
 #endif
-
-        private static Exception GetFirstNonAggregateException(Exception exception)
-        {
-            Exception nonAggregateException = exception;
-            while (nonAggregateException is AggregateException)
-            {
-                nonAggregateException = nonAggregateException.InnerException;
-            }
-
-            return nonAggregateException;
-        }
 
         private ExceptionAssertions<TException> Throw<TException>(Exception exception, string because, object[] becauseArgs)
             where TException : Exception

--- a/Tests/Shared.Specs/ExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/ExceptionAssertionSpecs.cs
@@ -12,6 +12,103 @@ namespace FluentAssertions.Specs
     public class ExceptionAssertionSpecs
     {
         [Fact]
+        public void When_method_throws_an_empty_AggregateException_it_should_fail()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => throw new AggregateException();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act2 = () => act.Should().NotThrow();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act2.Should().Throw<XunitException>();
+        }
+
+#pragma warning disable xUnit1026 // Theory methods should use all of their parameters
+        [Theory]
+        [MemberData(nameof(AggregateExceptionTestData))]
+        public void When_the_expected_exception_is_wrapped_it_should_succeed<T>(Action action, T _)
+            where T : Exception
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act/Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.Should().Throw<T>();
+        }
+
+        [Theory]
+        [MemberData(nameof(AggregateExceptionTestData))]
+        public void When_the_expected_exception_is_not_wrapped_it_should_fail<T>(Action action, T _)
+            where T : Exception
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act2 = () => action.Should().NotThrow<T>();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act2.Should().Throw<XunitException>();
+        }
+#pragma warning restore xUnit1026 // Theory methods should use all of their parameters
+
+        public static IEnumerable<object[]> AggregateExceptionTestData()
+        {
+            var tasks = new Action[]
+            {
+                AggregateExceptionWithLeftNestedException,
+                AggregateExceptionWithRightNestedException
+            };
+
+            var types = new Exception[]
+            {
+                new AggregateException(),
+                new ArgumentNullException(),
+                new InvalidOperationException()
+            };
+
+            foreach (var task in tasks)
+            {
+                foreach (var type in types)
+                {
+                    yield return new object[] { task, type };
+                }
+            }
+
+            yield return new object[] { (Action)EmptyAggregateException, new AggregateException() };
+        }
+
+        private static void AggregateExceptionWithLeftNestedException()
+        {
+            var ex1 = new AggregateException(new InvalidOperationException());
+            var ex2 = new ArgumentNullException();
+            var wrapped = new AggregateException(ex1, ex2);
+
+            throw wrapped;
+        }
+
+        private static void AggregateExceptionWithRightNestedException()
+        {
+            var ex1 = new ArgumentNullException();
+            var ex2 = new AggregateException(new InvalidOperationException());
+            var wrapped = new AggregateException(ex1, ex2);
+
+            throw wrapped;
+        }
+
+        private static void EmptyAggregateException()
+        {
+            throw new AggregateException();
+        }
+
+        [Fact]
         public void ThrowExactly_when_subject_throws_subclass_of_expected_exception_it_should_throw()
         {
             //-----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
After #1038 got merged, the logic for unwrapping `AggregateException` becomes a lot easier, as we now know that FluentAssertions doesn't wrap exceptions in an `AggregateException`.

Calling `Throw<TException>` is designed to also succeed if an exception of type `TException` is wrapped inside an `AggregateException`.
The same behavior should be present for `NotThrow<TException>`

This PR solves these problems.
1. `NotThrow<TException>` didn't look inside `AggregateException`s to see if an exception of type `TException` was thrown, which made it non-symmetric to `Throw<TException>`.
2. `GetFirstNonAggregateException` only looked at the `InnerException` of an `AggregateException` instead of `InnerExceptions` (*all* wrapped exceptions). E.g. it failed to handle if `TException` was the second `InnerException`.
3. As we no longer unnecessarily wrap exceptions, `InterceptException` unwrapped to much. 