### PR TITLE
Null checks for SimpleTimeSpanAssertions

### DIFF
--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -37,6 +37,11 @@ namespace FluentAssertions.Primitives
         public AndConstraint<SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .ForCondition(Subject.HasValue)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:time} to be positive{reason}, but found <null>.");
+
+            Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(TimeSpan.Zero) > 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:time} to be positive{reason}, but found {0}.", Subject.Value);
@@ -56,6 +61,11 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs)
         {
+            Execute.Assertion
+                .ForCondition(Subject.HasValue)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:time} to be negative{reason}, but found <null>.");
+
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(TimeSpan.Zero) < 0)
                 .BecauseOf(because, becauseArgs)
@@ -79,6 +89,11 @@ namespace FluentAssertions.Primitives
         public AndConstraint<SimpleTimeSpanAssertions> Be(TimeSpan expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .ForCondition(Subject.HasValue)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {0}{reason}, but found <null>.", expected);
+
+            Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(expected) == 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but found {1}.", expected, Subject.Value);
@@ -101,7 +116,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<SimpleTimeSpanAssertions> NotBe(TimeSpan unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.Value.CompareTo(unexpected) != 0)
+                .ForCondition(!Subject.HasValue || Subject.Value.CompareTo(unexpected) != 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {0}{reason}.", unexpected);
 
@@ -122,6 +137,11 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<SimpleTimeSpanAssertions> BeLessThan(TimeSpan expected, string because = "", params object[] becauseArgs)
         {
+            Execute.Assertion
+                .ForCondition(Subject.HasValue)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:time} to be less than {0}{reason}, but found <null>.", expected);
+
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(expected) < 0)
                 .BecauseOf(because, becauseArgs)
@@ -145,6 +165,11 @@ namespace FluentAssertions.Primitives
         public AndConstraint<SimpleTimeSpanAssertions> BeLessOrEqualTo(TimeSpan expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .ForCondition(Subject.HasValue)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:time} to be less or equal to {0}{reason}, but found <null>.", expected);
+
+            Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(expected) <= 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:time} to be less or equal to {0}{reason}, but found {1}.", expected, Subject.Value);
@@ -166,6 +191,11 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<SimpleTimeSpanAssertions> BeGreaterThan(TimeSpan expected, string because = "", params object[] becauseArgs)
         {
+            Execute.Assertion
+                .ForCondition(Subject.HasValue)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:time} to be greater than {0}{reason}, but found <null>.", expected);
+
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(expected) > 0)
                 .BecauseOf(because, becauseArgs)
@@ -189,6 +219,11 @@ namespace FluentAssertions.Primitives
         public AndConstraint<SimpleTimeSpanAssertions> BeGreaterOrEqualTo(TimeSpan expected, string because = "",
             params object[] becauseArgs)
         {
+            Execute.Assertion
+                .ForCondition(Subject.HasValue)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:time} to be greater or equal to {0}{reason}, but found <null>.", expected);
+
             Execute.Assertion
                 .ForCondition(Subject.Value.CompareTo(expected) >= 0)
                 .BecauseOf(because, becauseArgs)

--- a/Tests/Shared.Specs/SimpleTimeSpanAssertionSpecs.cs
+++ b/Tests/Shared.Specs/SimpleTimeSpanAssertionSpecs.cs
@@ -41,6 +41,30 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_asserting_null_value_to_be_positive_it_should_fail()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            TimeSpan? nullTimeSpan = null;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => nullTimeSpan.Should().BePositive("because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>().WithMessage(
+#if NETCOREAPP1_1
+                "Expected time to be positive because we want to test the failure message, but found <null>.");
+#else
+                "Expected nullTimeSpan to be positive because we want to test the failure message, but found <null>.");
+#endif
+        }
+
+        [Fact]
         public void When_asserting_negative_value_to_be_positive_it_should_fail_with_descriptive_message()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -95,6 +119,30 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_asserting_null_value_to_be_negative_it_should_fail()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            TimeSpan? nullTimeSpan = null;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => nullTimeSpan.Should().BeNegative("because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>().WithMessage(
+#if NETCOREAPP1_1
+                "Expected time to be negative because we want to test the failure message, but found <null>.");
+#else
+                "Expected nullTimeSpan to be negative because we want to test the failure message, but found <null>.");
+#endif
         }
 
         [Fact]
@@ -157,6 +205,27 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_asserting_null_value_to_be_equal_to_different_value_it_should_fail()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            TimeSpan? nullTimeSpan = null;
+            TimeSpan expected = 1.Seconds();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => nullTimeSpan.Should().Be(expected, "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected 1s because we want to test the failure message, but found <null>.");
+        }
+
+        [Fact]
         public void When_asserting_value_to_be_equal_to_different_value_it_should_fail_with_descriptive_message()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -189,6 +258,21 @@ namespace FluentAssertions.Specs
             // Act / Assert
             //-----------------------------------------------------------------------------------------------------------
             actual.Should().NotBe(unexpected);
+        }
+
+        [Fact]
+        public void When_asserting_null_value_to_be_not_equal_to_different_value_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            TimeSpan? nullTimeSpan = null;
+            TimeSpan expected = 1.Seconds();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            nullTimeSpan.Should().NotBe(expected);
         }
 
         [Fact]
@@ -266,6 +350,31 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_asserting_null_value_to_be_greater_than_other_value_it_should_fail()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            TimeSpan? nullTimeSpan = null;
+            TimeSpan expected = 1.Seconds();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => nullTimeSpan.Should().BeGreaterThan(expected, "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>().WithMessage(
+#if NETCOREAPP1_1
+                "Expected time to be greater than 1s because we want to test the failure message, but found <null>.");
+#else
+                "Expected nullTimeSpan to be greater than 1s because we want to test the failure message, but found <null>.");
+#endif
+        }
+
+        [Fact]
         public void When_asserting_value_to_be_greater_than_same_value_it_should_fail()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -321,6 +430,31 @@ namespace FluentAssertions.Specs
             // Act / Assert
             //-----------------------------------------------------------------------------------------------------------
             actual.Should().BeGreaterOrEqualTo(smaller);
+        }
+
+        [Fact]
+        public void When_asserting_null_value_to_be_greater_or_equal_to_other_value_it_should_fail()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            TimeSpan? nullTimeSpan = null;
+            TimeSpan expected = 1.Seconds();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => nullTimeSpan.Should().BeGreaterOrEqualTo(expected, "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>().WithMessage(
+#if NETCOREAPP1_1
+                "Expected time to be greater or equal to 1s because we want to test the failure message, but found <null>.");
+#else
+                "Expected nullTimeSpan to be greater or equal to 1s because we want to test the failure message, but found <null>.");
+#endif
         }
 
         [Fact]
@@ -417,6 +551,31 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_asserting_null_value_to_be_less_than_other_value_it_should_fail()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            TimeSpan? nullTimeSpan = null;
+            TimeSpan expected = 1.Seconds();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => nullTimeSpan.Should().BeLessThan(expected, "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>().WithMessage(
+#if NETCOREAPP1_1
+                "Expected time to be less than 1s because we want to test the failure message, but found <null>.");
+#else
+                "Expected nullTimeSpan to be less than 1s because we want to test the failure message, but found <null>.");
+#endif
+        }
+
+        [Fact]
         public void When_asserting_value_to_be_less_than_same_value_it_should_fail()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -472,6 +631,31 @@ namespace FluentAssertions.Specs
             // Act / Assert
             //-----------------------------------------------------------------------------------------------------------
             actual.Should().BeLessOrEqualTo(greater);
+        }
+
+        [Fact]
+        public void When_asserting_null_value_to_be_less_or_equal_to_other_value_it_should_fail()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            TimeSpan? nullTimeSpan = null;
+            TimeSpan expected = 1.Seconds();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => nullTimeSpan.Should().BeLessOrEqualTo(expected, "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>().WithMessage(
+#if NETCOREAPP1_1
+                "Expected time to be less or equal to 1s because we want to test the failure message, but found <null>.");
+#else
+                "Expected nullTimeSpan to be less or equal to 1s because we want to test the failure message, but found <null>.");
+#endif
         }
 
         [Fact]


### PR DESCRIPTION
This PR adds missing null checks to `SimpleTimeSpanAssertions` that could cause `NullReferenceException`s when using a `null` `TimeSpan`.

Part of #1039