### PR TITLE
Invoking+Awaiting

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -26,8 +26,8 @@ namespace FluentAssertions
     public static partial class AssertionExtensions
     {
         /// <summary>
-        /// Invokes the specified action on an subject so that you can chain it with any of the ShouldThrow or ShouldNotThrow
-        /// overloads.
+        /// Invokes the specified action on a subject so that you can chain it
+        /// with any of the assertions from <see cref="ActionAssertions"/>
         /// </summary>
         [Pure]
         public static Action Invoking<T>(this T subject, Action<T> action)
@@ -35,8 +35,32 @@ namespace FluentAssertions
             return () => action(subject);
         }
 
+        /// <summary>
+        /// Invokes the specified action on a subject so that you can chain it
+        /// with any of the assertions from <see cref="FunctionAssertions{T}"/>
+        /// </summary>
+        [Pure]
+        public static Func<TResult> Invoking<T, TResult>(this T subject, Func<T, TResult> action)
+        {
+            return () => action(subject);
+        }
+
+        /// <summary>
+        /// Invokes the specified action on a subject so that you can chain it
+        /// with any of the assertions from <see cref="AsyncFunctionAssertions"/>
+        /// </summary>
         [Pure]
         public static Func<Task> Awaiting<T>(this T subject, Func<T, Task> action)
+        {
+            return () => action(subject);
+        }
+
+        /// <summary>
+        /// Invokes the specified action on a subject so that you can chain it
+        /// with any of the assertions from <see cref="AsyncFunctionAssertions"/>
+        /// </summary>
+        [Pure]
+        public static Func<Task<TResult>> Awaiting<T, TResult>(this T subject, Func<T, Task<TResult>> action)
         {
             return () => action(subject);
         }
@@ -662,7 +686,7 @@ namespace FluentAssertions
         {
             return new FunctionAssertions<T>(func, extractor);
         }
-        
+
 
 #if NET45 || NET47 || NETCOREAPP2_0
 

--- a/Tests/Shared.Specs/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/AsyncFunctionExceptionAssertionSpecs.cs
@@ -521,6 +521,49 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_async_method_of_T_succeeds_and_expected_not_to_throw_particular_exception_it_should_succeed()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var asyncObject = new AsyncClass();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => asyncObject
+                .Awaiting(x => asyncObject.ReturnTaskInt())
+                .Should().NotThrow<InvalidOperationException>();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_async_method_of_T_throws_exception_expected_not_to_be_thrown_it_should_fail()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var asyncObject = new AsyncClass();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => asyncObject
+                .Awaiting(x => x.ThrowTaskIntAsync<ArgumentException>(true))
+                .Should().NotThrow<ArgumentException>();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.Should().Throw<XunitException>()
+                .WithMessage("Did not expect System.ArgumentException, but found one*");
+        }
+
+        [Fact]
         public void When_async_method_throws_the_expected_inner_exception_it_should_succeed()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -966,6 +1009,11 @@ namespace FluentAssertions.Specs
         public async Task SucceedAsync()
         {
             await Task.FromResult(0);
+        }
+
+        public Task<int> ReturnTaskInt()
+        {
+            return Task.FromResult(0);
         }
 
         public Task IncompleteTask()

--- a/Tests/Shared.Specs/ExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/ExceptionAssertionSpecs.cs
@@ -1132,6 +1132,8 @@ namespace FluentAssertions.Specs
 
         public abstract void Do(string someParam);
 
+        public abstract int Return();
+
         public static Does Throw<TException>(TException exception)
             where TException : Exception
         {
@@ -1159,6 +1161,8 @@ namespace FluentAssertions.Specs
             public override void Do() => throw exception;
 
             public override void Do(string someParam) => throw exception;
+
+            public override int Return() => throw exception;
         }
 
         private class DoesNotThrow : Does
@@ -1166,6 +1170,8 @@ namespace FluentAssertions.Specs
             public override void Do() { }
 
             public override void Do(string someParam) { }
+
+            public override int Return() => 42;
         }
     }
 

--- a/Tests/Shared.Specs/ThrowAssertionsSpecs.cs
+++ b/Tests/Shared.Specs/ThrowAssertionsSpecs.cs
@@ -21,6 +21,20 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_func_throws_expected_exception_it_should_not_do_anything()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Does testSubject = Does.Throw<InvalidOperationException>();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            testSubject.Invoking(x => x.Return()).Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
         public void When_action_throws_expected_exception_it_should_not_do_anything()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -50,6 +64,39 @@ namespace FluentAssertions.Specs
                 ex.Message.Should().Be(
                     "Expected a <System.Exception> to be thrown, but no exception was thrown.");
             }
+        }
+
+        [Fact]
+        public void When_func_does_not_throw_exception_but_one_was_expected_it_should_throw_with_clear_description()
+        {
+            try
+            {
+                Does testSubject = Does.NotThrow();
+
+                testSubject.Invoking(x => x.Return()).Should().Throw<Exception>();
+
+                throw new XunitException("Should().Throw() did not throw");
+            }
+            catch (XunitException ex)
+            {
+                ex.Message.Should().Be(
+                    "Expected System.Exception, but no exception was thrown.");
+            }
+        }
+
+        [Fact]
+        public void When_func_does_not_throw_it_should_be_chainable()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            Does testSubject = Does.NotThrow();
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act / Assert
+            //-----------------------------------------------------------------------------------------------------------
+            testSubject.Invoking(x => x.Return()).Should().NotThrow()
+                .Which.Should().Be(42);
         }
 
         [Fact]


### PR DESCRIPTION
This fixes #872 and complements #1015 by implementing 
```c#
Func<TResult> Invoking<T, TResult>(this T subject, Func<T, TResult> action)
```

For consistency this also implements 
```c#
Func<Task<TResult>> Awaiting<T, TResult>(this T subject, Func<T, Task<TResult>> action)
```
though this currently doesn't have much benefit as both `Func<Task>` and `Func<Task<T>>` uses `AsyncFunctionAssertions`.