### PR TITLE
Improving NotThrowAfter

### DIFF
--- a/Src/FluentAssertions/Specialized/ActionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ActionAssertions.cs
@@ -163,8 +163,8 @@ namespace FluentAssertions.Specialized
                     return;
                 }
 
-                invocationEndTime = watch.Elapsed;
                 Task.Delay(pollInterval).GetAwaiter().GetResult();
+                invocationEndTime = watch.Elapsed;
             }
 
             Execute.Assertion

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -219,7 +219,7 @@ namespace FluentAssertions.Specialized
                     return;
                 }
 
-                Task.Delay(pollInterval).Wait();
+                Task.Delay(pollInterval).GetAwaiter().GetResult();
                 invocationEndTime = watch.Elapsed;
             }
 

--- a/Src/FluentAssertions/Specialized/FunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/FunctionAssertions.cs
@@ -177,8 +177,8 @@ namespace FluentAssertions.Specialized
                     exception = e;
                 }
 
-                invocationEndTime = watch.Elapsed;
                 Task.Delay(pollInterval).GetAwaiter().GetResult();
+                invocationEndTime = watch.Elapsed;
             }
 
             Execute.Assertion


### PR DESCRIPTION
From my comments in #1028
`invocationEndTime` should be placed after `pollInterval`.
I tried to exercise the code to see what the difference is.

When the `pollInterval` is close to `waitTime` and the `action` is fast
having `invocationEndTime` before `pollInterval` would cause an extra loop iteration, even if the `waitTime` has already been surpassed.

Just to be clear, this is not an attempt to fix the timing related test issues we've been struggling with.