### PR TITLE
Updating nugets

### DIFF
--- a/Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj
+++ b/Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Machine.Specifications" Version="0.12.0" />
-    <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.8.1" />
+    <PackageReference Include="Machine.Specifications" Version="1.0.0" />
+    <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.8.2" />
   </ItemGroup>
 </Project>

--- a/Tests/TestFrameworks/NUnit3.Specs/NUnit3.Specs.csproj
+++ b/Tests/TestFrameworks/NUnit3.Specs/NUnit3.Specs.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
 </Project>

--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-﻿#tool "nuget:?package=xunit.runner.console&version=2.4.0"
+﻿#tool "nuget:?package=xunit.runner.console&version=2.4.1"
 #tool "nuget:?package=nspec&version=1.0.13"
 #tool "nuget:?package=nspec&version=2.0.1"
 #tool "nuget:?package=nspec&version=3.1.0"


### PR DESCRIPTION
Updating test frameworks.

Note: the [major bump](https://github.com/machine/machine.specifications/releases/tag/v1.0.0) of MSpec is to start using semver.