### PR TITLE
Replace == null with is null

### DIFF
--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -42,7 +42,7 @@ namespace FluentAssertions
 
         private static bool IsDynamic(StackFrame frame)
         {
-            return frame.GetMethod().DeclaringType == null;
+            return frame.GetMethod().DeclaringType is null;
         }
 
         private static bool IsCurrentAssembly(StackFrame frame)

--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -247,7 +247,7 @@ namespace FluentAssertions.Collections
                 return;
             }
 
-            if (expectation == null)
+            if (expectation is null)
             {
                 throw new ArgumentNullException(nameof(expectation), "Cannot compare collection with <null>.");
             }
@@ -289,7 +289,7 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected collections not to be equal{reason}, but found <null>.");
             }
 
-            if (unexpected == null)
+            if (unexpected is null)
             {
                 throw new ArgumentNullException(nameof(unexpected), "Cannot compare collection with <null>.");
             }
@@ -490,7 +490,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<TAssertions> NotBeEquivalentTo(IEnumerable unexpected, string because = "",
             params object[] becauseArgs)
         {
-            if (unexpected == null)
+            if (unexpected is null)
             {
                 throw new ArgumentNullException(nameof(unexpected), "Cannot verify inequivalence against a <null> collection.");
             }
@@ -706,7 +706,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> Contain(IEnumerable expected, string because = "", params object[] becauseArgs)
         {
-            if (expected == null)
+            if (expected is null)
             {
                 throw new ArgumentNullException(nameof(expected), "Cannot verify containment against a <null> collection");
             }
@@ -786,7 +786,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<TAssertions> ContainInOrder(IEnumerable expected, string because = "",
             params object[] becauseArgs)
         {
-            if (expected == null)
+            if (expected is null)
             {
                 throw new ArgumentNullException(nameof(expected), "Cannot verify ordered containment against a <null> collection.");
             }
@@ -1050,7 +1050,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<TAssertions> BeSubsetOf(IEnumerable expectedSuperset, string because = "",
             params object[] becauseArgs)
         {
-            if (expectedSuperset == null)
+            if (expectedSuperset is null)
             {
                 throw new ArgumentNullException(nameof(expectedSuperset), "Cannot verify a subset against a <null> collection.");
             }
@@ -1135,7 +1135,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<TAssertions> HaveSameCount(IEnumerable otherCollection, string because = "",
             params object[] becauseArgs)
         {
-            if (otherCollection == null)
+            if (otherCollection is null)
             {
                 throw new ArgumentNullException(nameof(otherCollection), "Cannot verify count against a <null> collection.");
             }
@@ -1176,7 +1176,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<TAssertions> NotHaveSameCount(IEnumerable otherCollection, string because = "",
             params object[] becauseArgs)
         {
-            if (otherCollection == null)
+            if (otherCollection is null)
             {
                 throw new ArgumentNullException(nameof(otherCollection), "Cannot verify count against a <null> collection.");
             }
@@ -1271,7 +1271,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> NotContain(IEnumerable unexpected, string because = "", params object[] becauseArgs)
         {
-            if (unexpected == null)
+            if (unexpected is null)
             {
                 throw new ArgumentNullException(nameof(unexpected), "Cannot verify non-containment against a <null> collection");
             }
@@ -1338,7 +1338,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<TAssertions> IntersectWith(IEnumerable otherCollection, string because = "",
             params object[] becauseArgs)
         {
-            if (otherCollection == null)
+            if (otherCollection is null)
             {
                 throw new ArgumentNullException(nameof(otherCollection), "Cannot verify intersection against a <null> collection.");
             }
@@ -1380,7 +1380,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<TAssertions> NotIntersectWith(IEnumerable otherCollection, string because = "",
             params object[] becauseArgs)
         {
-            if (otherCollection == null)
+            if (otherCollection is null)
             {
                 throw new ArgumentNullException(nameof(otherCollection), "Cannot verify intersection against a <null> collection.");
             }

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -238,7 +238,7 @@ namespace FluentAssertions.Collections
         private AndConstraint<GenericCollectionAssertions<T>> BeOrderedBy<TSelector>(
             Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, SortOrder direction, string because, object[] args)
         {
-            if (comparer == null)
+            if (comparer is null)
             {
                 throw new ArgumentNullException(nameof(comparer),
                     "Cannot assert collection ordering without specifying a comparer.");
@@ -269,7 +269,7 @@ namespace FluentAssertions.Collections
 
         private bool IsValidProperty<TSelector>(Expression<Func<T, TSelector>> propertyExpression, string because, object[] args)
         {
-            if (propertyExpression == null)
+            if (propertyExpression is null)
             {
                 throw new ArgumentNullException(nameof(propertyExpression),
                     "Cannot assert collection ordering without specifying a property.");
@@ -459,7 +459,7 @@ namespace FluentAssertions.Collections
 
         private static IEnumerable<TExpectation> RepeatAsManyAs<TExpectation>(TExpectation value, IEnumerable<T> enumerable)
         {
-            if (enumerable == null)
+            if (enumerable is null)
             {
                 return Enumerable.Empty<TExpectation>();
             }

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -218,7 +218,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> HaveCount(Expression<Func<int, bool>> countPredicate,
             string because = "", params object[] becauseArgs)
         {
-            if (countPredicate == null)
+            if (countPredicate is null)
             {
                 throw new ArgumentNullException(nameof(countPredicate), "Cannot compare dictionary count against a <null> predicate.");
             }
@@ -331,7 +331,7 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but found {1}.", expected, Subject);
             }
 
-            if (expected == null)
+            if (expected is null)
             {
                 throw new ArgumentNullException(nameof(expected), "Cannot compare dictionary with <null>.");
             }
@@ -390,7 +390,7 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected dictionaries not to be equal{reason}, but found {0}.", Subject);
             }
 
-            if (unexpected == null)
+            if (unexpected is null)
             {
                 throw new ArgumentNullException(nameof(unexpected), "Cannot compare dictionary with <null>.");
             }
@@ -539,7 +539,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> ContainKeys(IEnumerable<TKey> expected,
             string because = "", params object[] becauseArgs)
         {
-            if (expected == null)
+            if (expected is null)
             {
                 throw new ArgumentNullException(nameof(expected), "Cannot verify key containment against a <null> collection of keys");
             }
@@ -642,7 +642,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(IEnumerable<TKey> unexpected,
             string because = "", params object[] becauseArgs)
         {
-            if (unexpected == null)
+            if (unexpected is null)
             {
                 throw new ArgumentNullException(nameof(unexpected), "Cannot verify key containment against a <null> collection of keys");
             }
@@ -743,7 +743,7 @@ namespace FluentAssertions.Collections
         private AndWhichConstraint<GenericDictionaryAssertions<TKey, TValue>, IEnumerable<TValue>> ContainValuesAndWhich(IEnumerable<TValue> expected, string because = "",
             params object[] becauseArgs)
         {
-            if (expected == null)
+            if (expected is null)
             {
                 throw new ArgumentNullException(nameof(expected), "Cannot verify value containment against a <null> collection of values");
             }
@@ -860,7 +860,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainValues(IEnumerable<TValue> unexpected,
             string because = "", params object[] becauseArgs)
         {
-            if (unexpected == null)
+            if (unexpected is null)
             {
                 throw new ArgumentNullException(nameof(unexpected), "Cannot verify value containment against a <null> collection of values");
             }
@@ -930,7 +930,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> Contain(IEnumerable<KeyValuePair<TKey, TValue>> expected,
             string because = "", params object[] becauseArgs)
         {
-            if (expected == null)
+            if (expected is null)
             {
                 throw new ArgumentNullException(nameof(expected), "Cannot compare dictionary with <null>.");
             }
@@ -1085,7 +1085,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContain(IEnumerable<KeyValuePair<TKey, TValue>> items,
             string because = "", params object[] becauseArgs)
         {
-            if (items == null)
+            if (items is null)
             {
                 throw new ArgumentNullException(nameof(items), "Cannot compare dictionary with <null>.");
             }

--- a/Src/FluentAssertions/Collections/NonGenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/NonGenericCollectionAssertions.cs
@@ -212,7 +212,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<NonGenericCollectionAssertions> HaveCount(Expression<Func<int, bool>> countPredicate, string because = "",
             params object[] becauseArgs)
         {
-            if (countPredicate == null)
+            if (countPredicate is null)
             {
                 throw new ArgumentNullException(nameof(countPredicate), "Cannot compare collection count against a <null> predicate.");
             }

--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -63,7 +63,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<TAssertions> HaveCount(Expression<Func<int, bool>> countPredicate, string because = "",
             params object[] becauseArgs)
         {
-            if (countPredicate == null)
+            if (countPredicate is null)
             {
                 throw new ArgumentNullException(nameof(countPredicate), "Cannot compare collection count against a <null> predicate.");
             }
@@ -305,7 +305,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> StartWith(IEnumerable<T> expectation, string because = "", params object[] becauseArgs)
         {
-            if (expectation == null)
+            if (expectation is null)
             {
                 return base.StartWith(null, because, becauseArgs);
             }
@@ -334,7 +334,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<TAssertions> StartWith<TExpected>(
             IEnumerable<TExpected> expectation, Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs)
         {
-            if (expectation == null)
+            if (expectation is null)
             {
                 throw new ArgumentNullException(nameof(expectation), "Cannot compare collection with <null>.");
             }
@@ -359,7 +359,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> EndWith(IEnumerable<T> expectation, string because = "", params object[] becauseArgs)
         {
-            if (expectation == null)
+            if (expectation is null)
             {
                 return base.EndWith(null, because, becauseArgs);
             }
@@ -388,7 +388,7 @@ namespace FluentAssertions.Collections
         public AndConstraint<TAssertions> EndWith<TExpected>(
             IEnumerable<TExpected> expectation, Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs)
         {
-            if (expectation == null)
+            if (expectation is null)
             {
                 throw new ArgumentNullException(nameof(expectation), "Cannot compare collection with <null>.");
             }

--- a/Src/FluentAssertions/Common/Configuration.cs
+++ b/Src/FluentAssertions/Common/Configuration.cs
@@ -83,7 +83,7 @@ namespace FluentAssertions.Common
         {
             get
             {
-                if (valueFormatterAssembly == null)
+                if (valueFormatterAssembly is null)
                 {
                     string assemblyName = store.GetSetting("valueFormattersAssembly");
                     if (!string.IsNullOrEmpty(assemblyName))

--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -88,7 +88,7 @@ namespace FluentAssertions.Common
         public static MemberPath GetMemberPath<TDeclaringType, TPropertyType>(
             this Expression<Func<TDeclaringType, TPropertyType>> expression)
         {
-            if (expression == null)
+            if (expression is null)
             {
                 throw new ArgumentNullException(nameof(expression), "Expected an expression, but found <null>.");
             }

--- a/Src/FluentAssertions/Common/Services.cs
+++ b/Src/FluentAssertions/Common/Services.cs
@@ -32,7 +32,7 @@ namespace FluentAssertions.Common
             {
                 lock (lockable)
                 {
-                    if (configuration == null)
+                    if (configuration is null)
                     {
                         configuration = new Configuration(ConfigurationStore);
                     }

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -199,7 +199,7 @@ namespace FluentAssertions.Common
                 from propertyInfo in GetPropertiesFromHierarchy(typeToReflect)
                 where HasNonPrivateGetter(propertyInfo)
                 where !propertyInfo.IsIndexer()
-                where filter == null || filter.Contains(propertyInfo.Name)
+                where filter is null || filter.Contains(propertyInfo.Name)
                 select propertyInfo;
 
             return query.ToArray();

--- a/Src/FluentAssertions/Equivalency/DictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DictionaryEquivalencyStep.cs
@@ -64,7 +64,7 @@ namespace FluentAssertions.Equivalency
         private static bool AssertEitherIsNotNull(IDictionary expectation, IDictionary subject)
         {
             return AssertionScope.Current
-                .ForCondition(((expectation == null) && (subject == null)) || (expectation != null))
+                .ForCondition(((expectation is null) && (subject is null)) || (expectation != null))
                 .FailWith("Expected {context:subject} to be {0}, but found {1}.", null, subject);
         }
 
@@ -78,7 +78,7 @@ namespace FluentAssertions.Equivalency
         private static bool AssertSameLength(IDictionary expectation, IDictionary subject)
         {
             return AssertionScope.Current
-                .ForCondition((expectation == null) || (subject.Keys.Count == expectation.Keys.Count))
+                .ForCondition((expectation is null) || (subject.Keys.Count == expectation.Keys.Count))
                 .FailWith("Expected {context:subject} to be a dictionary with {0} item(s), but it only contains {1} item(s).",
                     expectation?.Keys.Count, subject?.Keys.Count);
         }

--- a/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
+++ b/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
@@ -90,7 +90,7 @@ namespace FluentAssertions.Equivalency
 
         private static string GetDisplayNameForEnumComparison(object o, decimal? v)
         {
-            if (o == null || v == null)
+            if (o is null || v is null)
             {
                 return "null";
             }

--- a/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
@@ -19,18 +19,18 @@ namespace FluentAssertions.Equivalency.Matching
                     .FindProperty(expectedMember.Name, expectedMember.MemberType));
             }
 
-            if ((compareeSelectedMemberInfoInfo == null) && config.IncludeFields)
+            if ((compareeSelectedMemberInfoInfo is null) && config.IncludeFields)
             {
                 compareeSelectedMemberInfoInfo = SelectedMemberInfo.Create(subject.GetType()
                     .FindField(expectedMember.Name, expectedMember.MemberType));
             }
 
-            if ((compareeSelectedMemberInfoInfo == null) && ExpectationImplementsMemberExplicitly(subject, expectedMember))
+            if ((compareeSelectedMemberInfoInfo is null) && ExpectationImplementsMemberExplicitly(subject, expectedMember))
             {
                 compareeSelectedMemberInfoInfo = expectedMember;
             }
 
-            if (compareeSelectedMemberInfoInfo == null)
+            if (compareeSelectedMemberInfoInfo is null)
             {
                 string path = (memberPath.Length > 0) ? memberPath + "." : "member ";
 

--- a/Src/FluentAssertions/Equivalency/SelectedMemberInfo.cs
+++ b/Src/FluentAssertions/Equivalency/SelectedMemberInfo.cs
@@ -11,7 +11,7 @@ namespace FluentAssertions.Equivalency
     {
         public static SelectedMemberInfo Create(PropertyInfo propertyInfo)
         {
-            if (propertyInfo == null || propertyInfo.IsIndexer())
+            if (propertyInfo is null || propertyInfo.IsIndexer())
             {
                 return null;
             }
@@ -21,7 +21,7 @@ namespace FluentAssertions.Equivalency
 
         public static SelectedMemberInfo Create(FieldInfo fieldInfo)
         {
-            if (fieldInfo == null)
+            if (fieldInfo is null)
             {
                 return null;
             }

--- a/Src/FluentAssertions/Events/EventMonitor.cs
+++ b/Src/FluentAssertions/Events/EventMonitor.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Events
 
         public EventMonitor(object eventSource, Func<DateTime> utcNow)
         {
-            if (eventSource == null)
+            if (eventSource is null)
             {
                 throw new ArgumentNullException(nameof(eventSource), "Cannot monitor the events of a <null> object.");
             }
@@ -77,7 +77,7 @@ namespace FluentAssertions.Events
 
         private void Attach(Type typeDefiningEventsToMonitor, Func<DateTime> utcNow)
         {
-            if (subject.Target == null)
+            if (subject.Target is null)
             {
                 throw new InvalidOperationException("Cannot monitor events on garbage-collected object");
             }

--- a/Src/FluentAssertions/Execution/GallioTestFramework.cs
+++ b/Src/FluentAssertions/Execution/GallioTestFramework.cs
@@ -17,7 +17,7 @@ namespace FluentAssertions.Execution
             Type assertionHelperType = assembly.GetType("Gallio.Framework.Assertions.AssertionHelper");
             Type testContextType = assembly.GetType("Gallio.Framework.TestContext");
 
-            if ((assertionFailureBuilderType == null) || (assertionHelperType == null) || (testContextType == null))
+            if ((assertionFailureBuilderType is null) || (assertionHelperType is null) || (testContextType is null))
             {
                 throw new Exception(string.Format(
                     "Failed to create the assertion exception for the current test framework: \"{0}\"",

--- a/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
+++ b/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
@@ -11,7 +11,7 @@ namespace FluentAssertions.Execution
         public void Throw(string message)
         {
             Type exceptionType = assembly.GetType(ExceptionFullName);
-            if (exceptionType == null)
+            if (exceptionType is null)
             {
                 throw new Exception(string.Format(
                     "Failed to create the assertion exception for the current test framework: \"{0}, {1}\"",

--- a/Src/FluentAssertions/Execution/NSpec1Framework.cs
+++ b/Src/FluentAssertions/Execution/NSpec1Framework.cs
@@ -15,7 +15,7 @@ namespace FluentAssertions.Execution
                 {
                     assembly = Assembly.Load(new AssemblyName("nspec"));
 
-                    if (assembly == null)
+                    if (assembly is null)
                     {
                         return false;
                     }
@@ -34,7 +34,7 @@ namespace FluentAssertions.Execution
         public void Throw(string message)
         {
             Type exceptionType = assembly.GetType("NSpec.Domain.ExampleFailureException");
-            if (exceptionType == null)
+            if (exceptionType is null)
             {
                 throw new Exception("Failed to create the NSpec assertion type");
             }

--- a/Src/FluentAssertions/Execution/NSpecFramework.cs
+++ b/Src/FluentAssertions/Execution/NSpecFramework.cs
@@ -15,7 +15,7 @@ namespace FluentAssertions.Execution
                 {
                     assembly = Assembly.Load(new AssemblyName("nspec"));
 
-                    if (assembly == null)
+                    if (assembly is null)
                     {
                         return false;
                     }
@@ -34,7 +34,7 @@ namespace FluentAssertions.Execution
         public void Throw(string message)
         {
             Type exceptionType = assembly.GetType("NSpec.Domain.AssertionException");
-            if (exceptionType == null)
+            if (exceptionType is null)
             {
                 throw new Exception("Failed to create the NSpec assertion type");
             }

--- a/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
+++ b/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
@@ -32,7 +32,7 @@ namespace FluentAssertions.Execution
 
         public static void Throw(string message)
         {
-            if (testFramework == null)
+            if (testFramework is null)
             {
                 testFramework = DetectFramework();
             }

--- a/Src/FluentAssertions/Execution/XUnit2TestFramework.cs
+++ b/Src/FluentAssertions/Execution/XUnit2TestFramework.cs
@@ -27,7 +27,7 @@ namespace FluentAssertions.Execution
         public void Throw(string message)
         {
             Type exceptionType = assembly.GetType("Xunit.Sdk.XunitException");
-            if (exceptionType == null)
+            if (exceptionType is null)
             {
                 throw new Exception("Failed to create the XUnit assertion type");
             }

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -20,7 +20,7 @@ namespace FluentAssertions.Numeric
             if (!(value is null))
             {
                 Subject = value as IComparable;
-                if (Subject == null)
+                if (Subject is null)
                 {
                     throw new InvalidOperationException("This class only supports types implementing IComparable.");
                 }

--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -702,7 +702,7 @@ namespace FluentAssertions
             float? expectedValue, float precision, string because = "",
             params object[] becauseArgs)
         {
-            if (parent.Subject == null && expectedValue == null)
+            if (parent.Subject is null && expectedValue is null)
             {
                 return new AndConstraint<NullableNumericAssertions<float>>(parent);
             }
@@ -803,7 +803,7 @@ namespace FluentAssertions
             double? expectedValue, double precision, string because = "",
             params object[] becauseArgs)
         {
-            if (parent.Subject == null && expectedValue == null)
+            if (parent.Subject is null && expectedValue is null)
             {
                 return new AndConstraint<NullableNumericAssertions<double>>(parent);
             }
@@ -904,7 +904,7 @@ namespace FluentAssertions
             decimal? expectedValue, decimal precision, string because = "",
             params object[] becauseArgs)
         {
-            if (parent.Subject == null && expectedValue == null)
+            if (parent.Subject is null && expectedValue is null)
             {
                 return new AndConstraint<NullableNumericAssertions<decimal>>(parent);
             }
@@ -1019,8 +1019,7 @@ namespace FluentAssertions
             float? unexpectedValue, float precision, string because = "",
             params object[] becauseArgs)
         {
-            if (parent.Subject == null && unexpectedValue != null ||
-                parent.Subject != null && unexpectedValue == null)
+            if (parent.Subject is null ^ unexpectedValue is null)
             {
                 return new AndConstraint<NullableNumericAssertions<float>>(parent);
             }
@@ -1119,8 +1118,7 @@ namespace FluentAssertions
             double? unexpectedValue, double precision, string because = "",
             params object[] becauseArgs)
         {
-            if (parent.Subject == null && unexpectedValue != null ||
-                parent.Subject != null && unexpectedValue == null)
+            if (parent.Subject is null ^ unexpectedValue is null)
             {
                 return new AndConstraint<NullableNumericAssertions<double>>(parent);
             }
@@ -1219,8 +1217,7 @@ namespace FluentAssertions
             decimal? unexpectedValue, decimal precision, string because = "",
             params object[] becauseArgs)
         {
-            if (parent.Subject == null && unexpectedValue != null ||
-                parent.Subject != null && unexpectedValue == null)
+            if (parent.Subject is null ^ unexpectedValue is null)
             {
                 return new AndConstraint<NullableNumericAssertions<decimal>>(parent);
             }

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -359,7 +359,7 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
             where T : TSubject
         {
-            if (predicate == null)
+            if (predicate is null)
             {
                 throw new ArgumentNullException(nameof(predicate), "Cannot match an object against a <null> predicate.");
             }

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -236,7 +236,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<StringAssertions> MatchRegex([RegexPattern] string regularExpression, string because = "", params object[] becauseArgs)
         {
-            if (regularExpression == null)
+            if (regularExpression is null)
             {
                 throw new ArgumentNullException(nameof(regularExpression), "Cannot match string against <null>.");
             }
@@ -282,7 +282,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<StringAssertions> NotMatchRegex([RegexPattern] string regularExpression, string because = "", params object[] becauseArgs)
         {
-            if (regularExpression == null)
+            if (regularExpression is null)
             {
                 throw new ArgumentNullException(nameof(regularExpression), "Cannot match string against <null>.");
             }
@@ -327,7 +327,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs)
         {
-            if (expected == null)
+            if (expected is null)
             {
                 throw new ArgumentNullException(nameof(expected), "Cannot compare start of string with <null>.");
             }
@@ -357,7 +357,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs)
         {
-            if (unexpected == null)
+            if (unexpected is null)
             {
                 throw new ArgumentNullException(nameof(unexpected), "Cannot compare start of string with <null>.");
             }
@@ -388,7 +388,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<StringAssertions> StartWithEquivalent(string expected, string because = "",
             params object[] becauseArgs)
         {
-            if (expected == null)
+            if (expected is null)
             {
                 throw new ArgumentNullException(nameof(expected), "Cannot compare string start equivalence with <null>.");
             }
@@ -418,7 +418,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs)
         {
-            if (unexpected == null)
+            if (unexpected is null)
             {
                 throw new ArgumentNullException(nameof(unexpected), "Cannot compare start of string with <null>.");
             }
@@ -448,7 +448,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs)
         {
-            if (expected == null)
+            if (expected is null)
             {
                 throw new ArgumentNullException(nameof(expected), "Cannot compare string end with <null>.");
             }
@@ -458,7 +458,7 @@ namespace FluentAssertions.Primitives
                 throw new ArgumentException("Cannot compare string end with empty string.", nameof(expected));
             }
 
-            if (Subject == null)
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -494,7 +494,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<StringAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs)
         {
-            if (unexpected == null)
+            if (unexpected is null)
             {
                 throw new ArgumentNullException(nameof(unexpected), "Cannot compare end of string with <null>.");
             }
@@ -504,7 +504,7 @@ namespace FluentAssertions.Primitives
                 throw new ArgumentException("Cannot compare end of string with empty string.", nameof(unexpected));
             }
 
-            if (Subject == null)
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -533,7 +533,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<StringAssertions> EndWithEquivalent(string expected, string because = "", params object[] becauseArgs)
         {
-            if (expected == null)
+            if (expected is null)
             {
                 throw new ArgumentNullException(nameof(expected), "Cannot compare string end equivalence with <null>.");
             }
@@ -543,7 +543,7 @@ namespace FluentAssertions.Primitives
                 throw new ArgumentException("Cannot compare string end equivalence with empty string.", nameof(expected));
             }
 
-            if (Subject == null)
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -579,7 +579,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<StringAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs)
         {
-            if (unexpected == null)
+            if (unexpected is null)
             {
                 throw new ArgumentNullException(nameof(unexpected), "Cannot compare end of string with <null>.");
             }
@@ -589,7 +589,7 @@ namespace FluentAssertions.Primitives
                 throw new ArgumentException("Cannot compare end of string with empty string.", nameof(unexpected));
             }
 
-            if (Subject == null)
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -619,7 +619,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<StringAssertions> Contain(string expected, string because = "", params object[] becauseArgs)
         {
-            if (expected == null)
+            if (expected is null)
             {
                 throw new ArgumentNullException(nameof(expected), "Cannot assert string containment against <null>.");
             }
@@ -651,7 +651,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs)
         {
-            if (expected == null)
+            if (expected is null)
             {
                 throw new ArgumentNullException(nameof(expected), "Cannot assert string containment against <null>.");
             }
@@ -758,7 +758,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<StringAssertions> NotContain(string unexpected, string because = "",
             params object[] becauseArgs)
         {
-            if (unexpected == null)
+            if (unexpected is null)
             {
                 throw new ArgumentNullException(nameof(unexpected), "Cannot assert string containment against <null>.");
             }
@@ -1028,7 +1028,7 @@ namespace FluentAssertions.Primitives
 
         private static void ThrowIfValuesNullOrEmpty(IEnumerable<string> values)
         {
-            if (values == null)
+            if (values is null)
             {
                 throw new ArgumentNullException(nameof(values), "Cannot assert string containment of values in null collection");
             }

--- a/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
@@ -44,7 +44,7 @@ namespace FluentAssertions.Primitives
 
         private string CleanNewLines(string input)
         {
-            if (input == null)
+            if (input is null)
             {
                 return null;
             }

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -200,7 +200,7 @@ namespace FluentAssertions.Specialized
         protected void NotThrow(Exception exception, string because, object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(exception == null)
+                .ForCondition(exception is null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect any exception{reason}, but found {0}.", exception);
         }

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -741,7 +741,7 @@ namespace FluentAssertions.Types
                 propertyInfoDescription = PropertyInfoAssertions.GetDescriptionFor(propertyInfo);
             }
 
-            Execute.Assertion.ForCondition(propertyInfo == null)
+            Execute.Assertion.ForCondition(propertyInfo is null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(string.Format("Expected {0} to not exist{{reason}}, but it does.", propertyInfoDescription));
 
@@ -949,7 +949,7 @@ namespace FluentAssertions.Types
         {
             PropertyInfo propertyInfo = Subject.GetIndexerByParameterTypes(parameterTypes);
 
-            Execute.Assertion.ForCondition(propertyInfo == null)
+            Execute.Assertion.ForCondition(propertyInfo is null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(string.Format("Expected indexer {0}[{1}] to not exist{{reason}}, but it does.",
                     Subject.FullName,
@@ -999,7 +999,7 @@ namespace FluentAssertions.Types
                 methodInfoDescription = MethodInfoAssertions.GetDescriptionFor(methodInfo);
             }
 
-            Execute.Assertion.ForCondition(methodInfo == null)
+            Execute.Assertion.ForCondition(methodInfo is null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(string.Format("Expected method {0}({1}) to not exist{{reason}}, but it does.", methodInfoDescription,
                     GetParameterString(parameterTypes)));
@@ -1050,7 +1050,7 @@ namespace FluentAssertions.Types
             ConstructorInfo constructorInfo = Subject.GetConstructor(parameterTypes);
 
             Execute.Assertion
-                .ForCondition(constructorInfo == null)
+                .ForCondition(constructorInfo is null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(string.Format("Expected constructor {0}({1}) not to exist{{reason}}, but it does.",
                     Subject.FullName,
@@ -1179,7 +1179,7 @@ namespace FluentAssertions.Types
         {
             MethodInfo methodInfo = Subject.GetImplicitConversionOperator(sourceType, targetType);
 
-            Execute.Assertion.ForCondition(methodInfo == null)
+            Execute.Assertion.ForCondition(methodInfo is null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(string.Format("Expected public static implicit {0}({1}) to not exist{{reason}}, but it does.",
                     targetType.FullName, sourceType.FullName));
@@ -1245,7 +1245,7 @@ namespace FluentAssertions.Types
         {
             MethodInfo methodInfo = Subject.GetExplicitConversionOperator(sourceType, targetType);
 
-            Execute.Assertion.ForCondition(methodInfo == null)
+            Execute.Assertion.ForCondition(methodInfo is null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(string.Format("Expected public static explicit {0}({1}) to not exist{{reason}}, but it does.",
                     targetType.FullName, sourceType.FullName));

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -185,7 +185,7 @@ namespace FluentAssertions.Xml
         public AndWhichConstraint<XDocumentAssertions, XElement> HaveRoot(string expected, string because,
             params object[] becauseArgs)
         {
-            if (expected == null)
+            if (expected is null)
             {
                 throw new ArgumentNullException(nameof(expected),
                     "Cannot assert the document has a root element if the element name is <null>*");
@@ -208,12 +208,12 @@ namespace FluentAssertions.Xml
         /// </param>
         public AndWhichConstraint<XDocumentAssertions, XElement> HaveRoot(XName expected, string because, params object[] becauseArgs)
         {
-            if (Subject == null)
+            if (Subject is null)
             {
                 throw new InvalidOperationException("Cannot assert the document has a root element if the document itself is <null>.");
             }
 
-            if (expected == null)
+            if (expected is null)
             {
                 throw new ArgumentNullException(nameof(expected),
                     "Cannot assert the document has a root element if the element name is <null>*");
@@ -271,7 +271,7 @@ namespace FluentAssertions.Xml
         public AndWhichConstraint<XDocumentAssertions, XElement> HaveElement(string expected, string because,
             params object[] becauseArgs)
         {
-            if (expected == null)
+            if (expected is null)
             {
                 throw new ArgumentNullException(nameof(expected),
                     "Cannot assert the document has an element if the element name is <null>*");
@@ -297,12 +297,12 @@ namespace FluentAssertions.Xml
         public AndWhichConstraint<XDocumentAssertions, XElement> HaveElement(XName expected, string because,
             params object[] becauseArgs)
         {
-            if (Subject == null)
+            if (Subject is null)
             {
                 throw new InvalidOperationException("Cannot assert the document has an element if the document itself is <null>.");
             }
 
-            if (expected == null)
+            if (expected is null)
             {
                 throw new ArgumentNullException(nameof(expected),
                     "Cannot assert the document has an element if the element name is <null>*");

--- a/Src/FluentAssertions/Xml/XmlReaderValidator.cs
+++ b/Src/FluentAssertions/Xml/XmlReaderValidator.cs
@@ -46,7 +46,7 @@ namespace FluentAssertions.Xml
                 assertion.FailWith(validationResult.FormatString, validationResult.FormatParams);
             }
 
-            if (!expectedEquivalence && validationResult == null)
+            if (!expectedEquivalence && validationResult is null)
             {
                 assertion.FailWith("Did not expect Xml to be equivalent{reason}, but it is.");
             }
@@ -166,7 +166,7 @@ namespace FluentAssertions.Xml
                     ea => ea.NamespaceUri == subjectAttribute.NamespaceUri
                     && ea.LocalName == subjectAttribute.LocalName);
 
-                if (expectedAttribute == null)
+                if (expectedAttribute is null)
                 {
                     return new ValidationResult("Did not expect to find attribute {0} at {1}{reason}.",
                         subjectAttribute.QualifiedName, GetCurrentLocation());

--- a/Src/JetBrainsAnnotations.cs
+++ b/Src/JetBrainsAnnotations.cs
@@ -145,7 +145,7 @@ namespace JetBrains.Annotations
     /// </summary>
     /// <example><code>
     /// void Foo(string param) {
-    ///   if (param == null)
+    ///   if (param is null)
     ///     throw new ArgumentNullException("par"); // Warning: Cannot resolve symbol
     /// }
     /// </code></example>


### PR DESCRIPTION
We're already using the "null pattern matching check" 115 places, this PR replaces the remaining occurrences.