### PR TITLE
Fix MemberPath so that it can exclude overriden members

### DIFF
--- a/Src/FluentAssertions/Common/MemberPath.cs
+++ b/Src/FluentAssertions/Common/MemberPath.cs
@@ -27,7 +27,7 @@ namespace FluentAssertions.Common
 
         public bool IsSameAs(MemberPath candidate)
         {
-            if (candidate.declaringType != declaringType)
+            if (!candidate.declaringType.IsSameOrInherits(declaringType))
             {
                 return false;
             }

--- a/Tests/Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/BasicEquivalencySpecs.cs
@@ -1918,6 +1918,18 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>().Which.Message.Should().Contain("Field1").And.Contain("Property1");
         }
 
+        [Fact]
+        public void When_excluding_virtual_or_abstract_property_exclusion_works_properly()
+        {
+            var obj1 = new Derived { DerivedProperty1 = "Something", DerivedProperty2 = "A" };
+            var obj2 = new Derived { DerivedProperty1 = "Something", DerivedProperty2 = "B" };
+
+            obj1.Should().BeEquivalentTo(obj2, opt => opt
+                .Excluding(o => o.AbstractProperty)
+                .Excluding(o => o.VirtualProperty)
+                .Excluding(o => o.DerivedProperty2));
+        }
+
         #endregion
 
         #region Matching Rules
@@ -4253,6 +4265,24 @@ namespace FluentAssertions.Specs
         {
             throw new InvalidCastException();
         }
+    }
+
+    public abstract class Base
+    {
+        public abstract string AbstractProperty { get; }
+
+        public virtual string VirtualProperty => "Foo";
+    }
+
+    public class Derived : Base
+    {
+        public string DerivedProperty1 { get; set; }
+
+        public string DerivedProperty2 { get; set; }
+
+        public override string AbstractProperty => $"{DerivedProperty1} {DerivedProperty2}";
+
+        public override string VirtualProperty => "Bar";
     }
 
     #endregion

--- a/Tests/Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/BasicEquivalencySpecs.cs
@@ -4272,6 +4272,8 @@ namespace FluentAssertions.Specs
         public abstract string AbstractProperty { get; }
 
         public virtual string VirtualProperty => "Foo";
+
+        public virtual string NonExcludedBaseProperty => "Foo";
     }
 
     public class Derived : Base
@@ -4283,6 +4285,10 @@ namespace FluentAssertions.Specs
         public override string AbstractProperty => $"{DerivedProperty1} {DerivedProperty2}";
 
         public override string VirtualProperty => "Bar";
+
+        public override string NonExcludedBaseProperty => "Bar";
+
+        public virtual string NonExcludedDerivedProperty => "Foo";
     }
 
     #endregion


### PR DESCRIPTION
Fix #1077 

I think that the method `IsSameOrInherits` should be updated to use `IsSubclassOf` instead of `AssignableFrom` to avoid some potential FPs (assignable checks also for cast not only direct inheritance).
