### PR TITLE
Updating AssertionScope.current from ThreadStatic to AsyncLocal to su…

### DIFF
--- a/AssertionScope.cs
+++ b/AssertionScope.cs
@@ -1,0 +1,332 @@
+﻿using System;
+using System.Linq;
+#if NOTNET45
+using Microsoft.VisualStudio.Threading;
+#else
+using System.Runtime.Remoting.Messaging;
+#endif
+using FluentAssertions.Common;
+
+
+
+namespace FluentAssertions.Execution
+{
+    /// <summary>
+    /// Represents an implicit or explicit scope within which multiple assertions can be collected.
+    /// </summary>
+    /// <remarks>
+    /// This class is supposed to have a very short life time and is not safe to be used in assertion that cross thread-boundaries such as when
+    /// using <c>async</c> or <c>await</c>.
+    /// </remarks>
+    public class AssertionScope : IAssertionScope
+    {
+        #region Private Definitions
+
+        private readonly IAssertionStrategy assertionStrategy;
+        private readonly ContextDataItems contextData = new ContextDataItems();
+
+        private Func<string> reason;
+        private bool useLineBreaks;
+
+#if NOTNET45
+        private static AsyncLocal<AssertionScope> current = new AsyncLocal<AssertionScope>();
+#endif
+        private AssertionScope parent;
+        private Func<string> expectation;
+        private string fallbackIdentifier = "object";
+        private bool? succeeded;
+
+#endregion
+
+        private AssertionScope(IAssertionStrategy _assertionStrategy)
+        {
+            assertionStrategy = _assertionStrategy;
+            parent = null;
+        }
+
+        /// <summary>
+        /// Starts an unnamed scope within which multiple assertions can be executed
+        /// and which will not throw until the scope is disposed.
+        /// </summary>
+        public AssertionScope()
+            : this(new CollectingAssertionStrategy())
+        {
+
+#if NOTNET45
+            parent = current.Value;
+            current.Value = this;
+#else
+            
+            parent = (AssertionScope) CallContext.LogicalGetData("this");
+            CallContext.LogicalSetData("this", this);
+#endif
+            if (parent != null)
+            {
+                contextData.Add(parent.contextData);
+                Context = parent.Context;
+            }
+        }
+
+        /// <summary>
+        /// Starts a named scope within which multiple assertions can be executed and which will not throw until the scope is disposed.
+        /// </summary>
+        public AssertionScope(string context)
+            : this()
+        {
+            Context = context;
+        }
+
+        /// <summary>
+        /// Gets or sets the context of the current assertion scope, e.g. the path of the object graph
+        /// that is being asserted on.
+        /// </summary>
+        public string Context { get; set; }
+
+#if NOTNET45
+        /// <summary>
+        /// Gets the current thread-specific assertion scope.
+        /// </summary>
+        public static AssertionScope Current
+        {
+
+            get => current.Value ?? new AssertionScope(new DefaultAssertionStrategy());
+            private set => current.Value = value;
+
+        }
+#else
+        /// <summary>
+        /// Gets the current thread-specific assertion scope.
+        /// </summary>
+        public static AssertionScope Current => LogicalCurrent(); 
+
+        public static AssertionScope LogicalCurrent()
+        {
+            if (CallContext.LogicalGetData("this") == null)
+            {
+                CallContext.LogicalSetData("this", new AssertionScope(new DefaultAssertionStrategy()));
+            }
+
+            return CallContext.LogicalGetData("this").As<AssertionScope>();
+        }
+#endif
+        public AssertionScope UsingLineBreaks
+        {
+            get
+            {
+                useLineBreaks = true;
+                return this;
+            }
+        }
+
+        public bool Succeeded
+        {
+            get => succeeded.HasValue && succeeded.Value;
+        }
+
+        public AssertionScope BecauseOf(string because, params object[] becauseArgs)
+        {
+            reason = () =>
+            {
+                try
+                {
+                    string becauseOrEmpty = because ?? "";
+                    return (becauseArgs?.Any() == true) ? string.Format(becauseOrEmpty, becauseArgs) : becauseOrEmpty;
+                }
+                catch (FormatException formatException)
+                {
+                    return $"**WARNING** because message '{because}' could not be formatted with string.Format{Environment.NewLine}{formatException.StackTrace}";
+                }
+            };
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the expectation part of the failure message when the assertion is not met.
+        /// </summary>
+        /// <remarks>
+        /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a few
+        /// specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as passed
+        /// to <see cref="BecauseOf"/>. Other named placeholders will be replaced with the <see cref="Current"/> scope data
+        /// passed through <see cref="AddNonReportable"/> and <see cref="AddReportable"/>. Finally, a description of the
+        /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
+        /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
+        /// Note that only 10 <paramref name="args"/> are supported in combination with a {reason}.
+        /// If an expectation was set through a prior call to <see cref="WithExpectation"/>, then the failure message is appended to that
+        /// expectation.
+        /// </remarks>
+        /// <param name="message">The format string that represents the failure message.</param>
+        /// <param name="args">Optional arguments to any numbered placeholders.</param>
+        public AssertionScope WithExpectation(string message, params object[] args)
+        {
+            var localReason = reason;
+            expectation = () =>
+            {
+                var messageBuilder = new MessageBuilder(useLineBreaks);
+                string reason = localReason?.Invoke() ?? "";
+                string identifier = GetIdentifier();
+
+                return messageBuilder.Build(message, args, reason, contextData, identifier, fallbackIdentifier);
+            };
+
+            return this;
+        }
+
+        internal void TrackComparands(object subject, object expectation)
+        {
+            contextData.Add(new ContextDataItems.DataItem("subject", subject, reportable: false, requiresFormatting: true));
+            contextData.Add(new ContextDataItems.DataItem("expectation", expectation, reportable: false, requiresFormatting: true));
+        }
+
+        public Continuation ClearExpectation()
+        {
+            expectation = null;
+
+            return new Continuation(this, !succeeded.HasValue || succeeded.Value);
+        }
+
+        public GivenSelector<T> Given<T>(Func<T> selector)
+        {
+            return new GivenSelector<T>(selector, !succeeded.HasValue || succeeded.Value, this);
+        }
+
+        public AssertionScope ForCondition(bool condition)
+        {
+            succeeded = condition;
+
+            return this;
+        }
+
+        public Continuation FailWith(Func<FailReason> failReasonFunc)
+        {
+            try
+            {
+                if (!succeeded.HasValue || !succeeded.Value)
+                {
+                    string localReason = reason?.Invoke() ?? "";
+                    var messageBuilder = new MessageBuilder(useLineBreaks);
+                    string identifier = GetIdentifier();
+                    var failReason = failReasonFunc();
+                    string result = messageBuilder.Build(failReason.Message, failReason.Args, localReason, contextData, identifier, fallbackIdentifier);
+
+                    if (expectation != null)
+                    {
+                        result = expectation() + result;
+                    }
+
+                    assertionStrategy.HandleFailure(result.Capitalize());
+
+                    succeeded = false;
+                }
+
+                return new Continuation(this, succeeded.Value);
+            }
+            finally
+            {
+                succeeded = null;
+            }
+        }
+
+        public Continuation FailWith(string message, params object[] args)
+        {
+            return FailWith(() => new FailReason(message, args));
+        }
+
+        private string GetIdentifier()
+        {
+            if (!string.IsNullOrEmpty(Context))
+            {
+                return Context;
+            }
+
+            return CallerIdentifier.DetermineCallerIdentity();
+        }
+
+        /// <summary>
+        /// Adds a pre-formatted failure message to the current scope.
+        /// </summary>
+        public void AddPreFormattedFailure(string formattedFailureMessage)
+        {
+            assertionStrategy.HandleFailure(formattedFailureMessage);
+        }
+
+        /// <summary>
+        /// Tracks a keyed object in the current scope that is excluded from the failure message in case an assertion fails.
+        /// </summary>
+        public void AddNonReportable(string key, object value)
+        {
+            contextData.Add(new ContextDataItems.DataItem(key, value, reportable: false, requiresFormatting: false));
+        }
+
+        /// <summary>
+        /// Adds some information to the assertion scope that will be included in the message
+        /// that is emitted if an assertion fails.
+        /// </summary>
+        public void AddReportable(string key, string value)
+        {
+            contextData.Add(new ContextDataItems.DataItem(key, value, reportable: true, requiresFormatting: false));
+        }
+
+        public string[] Discard()
+        {
+            return assertionStrategy.DiscardFailures().ToArray();
+        }
+
+        public bool HasFailures()
+        {
+            return assertionStrategy.FailureMessages.Any();
+        }
+
+        /// <summary>
+        /// Gets data associated with the current scope and identified by <paramref name="key"/>.
+        /// </summary>
+        public T Get<T>(string key)
+        {
+            return contextData.Get<T>(key);
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+#if NOTNET45
+            Current = parent;
+#else
+            CallContext.LogicalSetData("this", parent);
+#endif
+            if (parent != null)
+            {
+                foreach (string failureMessage in assertionStrategy.FailureMessages)
+                {
+                    parent.assertionStrategy.HandleFailure(failureMessage);
+                }
+
+                parent = null;
+            }
+            else
+            {
+                assertionStrategy.ThrowIfAny(contextData.GetReportable());
+            }
+        }
+
+        public AssertionScope WithDefaultIdentifier(string identifier)
+        {
+            fallbackIdentifier = identifier;
+            return this;
+        }
+
+#region Explicit Implementation to support the interface
+
+        IAssertionScope IAssertionScope.ForCondition(bool condition) => ForCondition(condition);
+
+        IAssertionScope IAssertionScope.BecauseOf(string because, params object[] becauseArgs) => BecauseOf(because, becauseArgs);
+
+        IAssertionScope IAssertionScope.WithExpectation(string message, params object[] args) => WithExpectation(message, args);
+
+        IAssertionScope IAssertionScope.WithDefaultIdentifier(string identifier) => WithDefaultIdentifier(identifier);
+
+        IAssertionScope IAssertionScope.UsingLineBreaks => UsingLineBreaks;
+
+#endregion
+    }
+}

--- a/FluentAssertions.csproj
+++ b/FluentAssertions.csproj
@@ -1,0 +1,72 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net45;net47;netstandard1.3;netstandard1.6;netstandard2.0;netcoreapp2.0</TargetFrameworks>
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>FluentAssertions.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1705;1591;1574;1572;1573;419</NoWarn>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <CodeAnalysisRuleSet>..\..\Rules.ruleset</CodeAnalysisRuleSet>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Authors>Dennis Doomen;Jonas Nyrup</Authors>
+    <PackageDescription>
+      A very extensive set of extension methods that allow you to more naturally specify the expected outcome of a TDD or
+      BDD-style unit tests. Targets .NET Framework 4.5 and 4.7, as well as .NET Core 2.0, .NET Core 3.0, .NET Standard 1.3, 1.6 and 2.0.
+      Supports the unit test frameworks MSTest, MSTest2, Gallio, NUnit, XUnit, MBUnit, MSpec, and NSpec.
+    </PackageDescription>
+    <PackageProjectUrl>https://www.fluentassertions.com</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/fluentassertions/fluentassertions.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>MSTest;MSTest2;xUnit;xUnit2;NUnit;MSpec;NSpec;Gallio;MbUnit;TDD;BDD;Fluent;netcore;netstandard;uwp</PackageTags>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageIconUrl>https://raw.githubusercontent.com/fluentassertions/fluentassertions/master/Src/FluentAssertions.png</PackageIconUrl>
+    <PackageReleaseNotes>See https://github.com/fluentassertions/fluentassertions/releases/</PackageReleaseNotes>
+    <Copyright>Copyright Dennis Doomen 2010-2019</Copyright>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net45'">
+    <DefineConstants>NOTNET45</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
+    <DefineConstants>NET45</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net47'">
+    <DefineConstants>NET47</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <OutputPath>..\..\Artifacts\Debug\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <OutputPath>..\..\Artifacts\Release</OutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\JetBrainsAnnotations.cs" Link="JetBrainsAnnotations.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.2" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <Reference Include="System.Configuration" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
+    <Reference Include="System.Configuration" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.0.102" />
+  </ItemGroup>
+</Project>

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using FluentAssertions.Common;
+using Microsoft.VisualStudio.Threading;
 
 namespace FluentAssertions.Execution
 {
@@ -21,8 +22,8 @@ namespace FluentAssertions.Execution
         private Func<string> reason;
         private bool useLineBreaks;
 
-        [ThreadStatic]
-        private static AssertionScope current;
+        
+        private static AsyncLocal<AssertionScope> current = new AsyncLocal<AssertionScope>();
 
         private AssertionScope parent;
         private Func<string> expectation;
@@ -44,8 +45,8 @@ namespace FluentAssertions.Execution
         public AssertionScope()
             : this(new CollectingAssertionStrategy())
         {
-            parent = current;
-            current = this;
+            parent = current.Value;
+            current.Value = this;
 
             if (parent != null)
             {
@@ -74,8 +75,8 @@ namespace FluentAssertions.Execution
         /// </summary>
         public static AssertionScope Current
         {
-            get => current ?? new AssertionScope(new DefaultAssertionStrategy());
-            private set => current = value;
+            get => current.Value ?? new AssertionScope(new DefaultAssertionStrategy());
+            private set => current.Value = value;
         }
 
         public AssertionScope UsingLineBreaks


### PR DESCRIPTION
Adding support for async code used within using (new AssertionScope())

This will have no impact on current functionality - however, this should prevent unintended consequences when running the code on multiple threads

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/_pages/documentation.md) in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com).
