### PR TITLE
Feature/assertionscope

### DIFF
--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -18,7 +18,9 @@ namespace FluentAssertions.Execution
     /// This class is supposed to have a very short life time and is not safe to be used in assertion that cross thread-boundaries such as when
     /// using <c>async</c> or <c>await</c>.
     /// </remarks>
+#if NET45
     [Serializable]
+#endif
     public class AssertionScope : IAssertionScope
     {
         #region Private Definitions

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -18,6 +18,7 @@ namespace FluentAssertions.Execution
     /// This class is supposed to have a very short life time and is not safe to be used in assertion that cross thread-boundaries such as when
     /// using <c>async</c> or <c>await</c>.
     /// </remarks>
+    [Serializable]
     public class AssertionScope : IAssertionScope
     {
         #region Private Definitions

--- a/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -7,6 +7,9 @@ using FluentAssertions.Common;
 
 namespace FluentAssertions.Execution
 {
+#if NET45
+    [Serializable]
+#endif
     internal class CollectingAssertionStrategy : IAssertionStrategy
     {
         private readonly List<string> failureMessages = new List<string>();

--- a/Src/FluentAssertions/Execution/Continuation.cs
+++ b/Src/FluentAssertions/Execution/Continuation.cs
@@ -1,8 +1,13 @@
+using System;
+
 namespace FluentAssertions.Execution
 {
     /// <summary>
     /// Enables chaining multiple assertions on an <see cref="AssertionScope"/>.
     /// </summary>
+#if NET45
+    [Serializable]
+#endif
     public class Continuation
     {
         private readonly AssertionScope sourceScope;

--- a/Src/FluentAssertions/Execution/ContinuedAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/ContinuedAssertionScope.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace FluentAssertions.Execution
 {
@@ -9,6 +9,9 @@ namespace FluentAssertions.Execution
     /// If the parent scope has captured a failed assertion, this class ensures that successive assertions
     /// are no longer evaluated.
     /// </remarks>
+#if NET45
+    [Serializable]
+#endif
     public class ContinuedAssertionScope : IAssertionScope
     {
         private readonly AssertionScope predecessor;

--- a/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 using FluentAssertions.Common;
 
@@ -10,44 +8,16 @@ namespace FluentAssertions.Execution
 #if NET45
     [Serializable]
 #endif
-    internal class CollectingAssertionStrategy : IAssertionStrategy
+    internal class DefaultAssertionStrategy : IAssertionStrategy
     {
-        private readonly List<string> failureMessages = new List<string>();
-
         /// <summary>
         /// Returns the messages for the assertion failures that happened until now.
         /// </summary>
-        public IEnumerable<string> FailureMessages => failureMessages;
-
-        /// <summary>
-        /// Discards and returns the failure messages that happened up to now.
-        /// </summary>
-        public IEnumerable<string> DiscardFailures()
+        public IEnumerable<string> FailureMessages
         {
-            var discardedFailures = failureMessages.ToArray();
-            failureMessages.Clear();
-            return discardedFailures;
-        }
-
-        /// <summary>
-        /// Will throw a combined exception for any failures have been collected since <see cref="StartCollecting"/> was called.
-        /// </summary>
-        public void ThrowIfAny(IDictionary<string, object> context)
-        {
-            if (failureMessages.Any())
+            get
             {
-                var builder = new StringBuilder();
-                builder.AppendLine(string.Join(Environment.NewLine, failureMessages));
-
-                if (context.Any())
-                {
-                    foreach (KeyValuePair<string, object> pair in context)
-                    {
-                        builder.AppendFormat("\nWith {0}:\n{1}", pair.Key, pair.Value);
-                    }
-                }
-
-                Services.ThrowException(builder.ToString());
+                return new string[0];
             }
         }
 
@@ -56,7 +26,22 @@ namespace FluentAssertions.Execution
         /// </summary>
         public void HandleFailure(string message)
         {
-            failureMessages.Add(message);
+            Services.ThrowException(message);
+        }
+
+        /// <summary>
+        /// Discards and returns the failure messages that happened up to now.
+        /// </summary>
+        public IEnumerable<string> DiscardFailures()
+        {
+            return new string[0];
+        }
+
+        /// <summary>
+        /// Will throw a combined exception for any failures have been collected since <see cref="StartCollecting"/> was called.
+        /// </summary>
+        public void ThrowIfAny(IDictionary<string, object> context)
+        {
         }
     }
 }

--- a/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
@@ -1,19 +1,53 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Execution
 {
-    internal class DefaultAssertionStrategy : IAssertionStrategy
+#if NET45
+    [Serializable]
+#endif
+    internal class CollectingAssertionStrategy : IAssertionStrategy
     {
+        private readonly List<string> failureMessages = new List<string>();
+
         /// <summary>
         /// Returns the messages for the assertion failures that happened until now.
         /// </summary>
-        public IEnumerable<string> FailureMessages
+        public IEnumerable<string> FailureMessages => failureMessages;
+
+        /// <summary>
+        /// Discards and returns the failure messages that happened up to now.
+        /// </summary>
+        public IEnumerable<string> DiscardFailures()
         {
-            get
+            var discardedFailures = failureMessages.ToArray();
+            failureMessages.Clear();
+            return discardedFailures;
+        }
+
+        /// <summary>
+        /// Will throw a combined exception for any failures have been collected since <see cref="StartCollecting"/> was called.
+        /// </summary>
+        public void ThrowIfAny(IDictionary<string, object> context)
+        {
+            if (failureMessages.Any())
             {
-                return new string[0];
+                var builder = new StringBuilder();
+                builder.AppendLine(string.Join(Environment.NewLine, failureMessages));
+
+                if (context.Any())
+                {
+                    foreach (KeyValuePair<string, object> pair in context)
+                    {
+                        builder.AppendFormat("\nWith {0}:\n{1}", pair.Key, pair.Value);
+                    }
+                }
+
+                Services.ThrowException(builder.ToString());
             }
         }
 
@@ -22,22 +56,7 @@ namespace FluentAssertions.Execution
         /// </summary>
         public void HandleFailure(string message)
         {
-            Services.ThrowException(message);
-        }
-
-        /// <summary>
-        /// Discards and returns the failure messages that happened up to now.
-        /// </summary>
-        public IEnumerable<string> DiscardFailures()
-        {
-            return new string[0];
-        }
-
-        /// <summary>
-        /// Will throw a combined exception for any failures have been collected since <see cref="StartCollecting"/> was called.
-        /// </summary>
-        public void ThrowIfAny(IDictionary<string, object> context)
-        {
+            failureMessages.Add(message);
         }
     }
 }

--- a/Src/FluentAssertions/Execution/GivenSelector.cs
+++ b/Src/FluentAssertions/Execution/GivenSelector.cs
@@ -7,6 +7,9 @@ namespace FluentAssertions.Execution
     /// Represents a chaining object returned from <see cref="AssertionScope.Given{T}"/> to continue the assertion using
     /// an object returned by a selector.
     /// </summary>
+#if NET45
+    [Serializable]
+#endif
     public class GivenSelector<T>
     {
         #region Private Definitions

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -27,9 +27,6 @@
     <Copyright>Copyright Dennis Doomen 2010-2019</Copyright>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net45'">
-    <DefineConstants>NOTNET45</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
     <DefineConstants>NET45</DefineConstants>
   </PropertyGroup>
@@ -62,9 +59,6 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <Reference Include="System.Configuration" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net45'">
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.0.102" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
     <Reference Include="System.Configuration" />

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -63,10 +63,10 @@
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <Reference Include="System.Configuration" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net45'">
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.0.102" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
     <Reference Include="System.Configuration" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.0.102" />
   </ItemGroup>
 </Project>

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net45;net47;netstandard1.3;netstandard1.6;netstandard2.0;netcoreapp2.0</TargetFrameworks>
     <SignAssembly>True</SignAssembly>
@@ -26,6 +26,9 @@
     <PackageReleaseNotes>See https://github.com/fluentassertions/fluentassertions/releases/</PackageReleaseNotes>
     <Copyright>Copyright Dennis Doomen 2010-2019</Copyright>
     <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net45'">
+    <DefineConstants>NOTNET45</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
     <DefineConstants>NET45</DefineConstants>
@@ -62,5 +65,8 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
     <Reference Include="System.Configuration" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.0.102" />
   </ItemGroup>
 </Project>

--- a/Tests/NetStandard13.Specs/NetStandard13.Specs.csproj
+++ b/Tests/NetStandard13.Specs/NetStandard13.Specs.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Chill" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="System.Threading" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/Tests/NetStandard13.Specs/NetStandard13.Specs.csproj
+++ b/Tests/NetStandard13.Specs/NetStandard13.Specs.csproj
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Chill" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.0.102" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/Tests/NetStandard13.Specs/NetStandard13.Specs.csproj
+++ b/Tests/NetStandard13.Specs/NetStandard13.Specs.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <AssemblyName>FluentAssertions.NetStandard13.Specs</AssemblyName>
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Chill" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.0.102" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Adds safety to tests using AssertionScope while running many tests in parallel

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/_pages/documentation.md) in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com).
