### PR TITLE
Unify API methods to check for attribute (GH-731)

### DIFF
--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -39,7 +39,7 @@ namespace FluentAssertions
 
         private static bool IsCustomAssertion(StackFrame frame)
         {
-            return frame.GetMethod().HasAttribute<CustomAssertionAttribute>();
+            return frame.GetMethod().IsDecoratedWithOrInherit<CustomAssertionAttribute>();
         }
 
         private static bool IsDynamic(StackFrame frame)

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -137,7 +137,9 @@ namespace FluentAssertions.Common
         private static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(MemberInfo type, bool inherit = false)
             where TAttribute : Attribute
         {
-            return type.GetCustomAttributes(inherit).OfType<TAttribute>();
+            // Do not use as extension method here, there is an issue with PropertyInfo and EventInfo
+            // preventing the inherit option to work.
+            return CustomAttributeExtensions.GetCustomAttributes(type, inherit).OfType<TAttribute>();
         }
 
         private static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(Type type, bool inherit = false)

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -22,12 +22,14 @@ namespace FluentAssertions.Common
         /// <returns>
         /// <c>true</c> if the specified method has attribute; otherwise, <c>false</c>.
         /// </returns>
+        [Obsolete("This method is deprecated and will be removed on the next major version. Please use <IsDecoratedWithOrInherits> instead.")]
         public static bool HasAttribute<TAttribute>(this MemberInfo method)
             where TAttribute : Attribute
         {
             return method.GetCustomAttributes(typeof(TAttribute), true).Any();
         }
 
+        [Obsolete("This method is deprecated and will be removed on the next major version. Please use <IsDecoratedWith> instead.")]
         public static bool HasMatchingAttribute<TAttribute>(this MemberInfo type,
             Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
             where TAttribute : Attribute
@@ -37,6 +39,7 @@ namespace FluentAssertions.Common
             return GetCustomAttributes<TAttribute>(type).Any(isMatchingAttribute);
         }
 
+        [Obsolete("This method is deprecated and will be removed on the next major version. Please use <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
         public static bool HasMatchingAttribute<TAttribute>(this Type type,
             Expression<Func<TAttribute, bool>> isMatchingAttributePredicate, bool inherit = false)
             where TAttribute : Attribute
@@ -46,22 +49,95 @@ namespace FluentAssertions.Common
             return GetCustomAttributes<TAttribute>(type, inherit).Any(isMatchingAttribute);
         }
 
+        public static bool IsDecoratedWith<TAttribute>(this Type type)
+            where TAttribute : Attribute
+        {
+            return GetCustomAttributes<TAttribute>(type).Any();
+        }
+
+        public static bool IsDecoratedWith<TAttribute>(this TypeInfo type)
+            where TAttribute : Attribute
+        {
+            return GetCustomAttributes<TAttribute>(type).Any();
+        }
+
         public static bool IsDecoratedWith<TAttribute>(this MemberInfo type)
             where TAttribute : Attribute
         {
             return GetCustomAttributes<TAttribute>(type).Any();
         }
 
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this Type type)
+            where TAttribute : Attribute
+        {
+            return GetCustomAttributes<TAttribute>(type, true).Any();
+        }
+
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this TypeInfo type)
+            where TAttribute : Attribute
+        {
+            return GetCustomAttributes<TAttribute>(type, true).Any();
+        }
+
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this MemberInfo type)
+            where TAttribute : Attribute
+        {
+            return GetCustomAttributes<TAttribute>(type, true).Any();
+        }
+
+        public static bool IsDecoratedWith<TAttribute>(this Type type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : Attribute
+        {
+            Func<TAttribute, bool> isMatchingAttribute = isMatchingAttributePredicate.Compile();
+            return GetCustomAttributes<TAttribute>(type).Any(isMatchingAttribute);
+        }
+
+        public static bool IsDecoratedWith<TAttribute>(this TypeInfo type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : Attribute
+        {
+            Func<TAttribute, bool> isMatchingAttribute = isMatchingAttributePredicate.Compile();
+            return GetCustomAttributes<TAttribute>(type).Any(isMatchingAttribute);
+        }
+
+        public static bool IsDecoratedWith<TAttribute>(this MemberInfo type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : Attribute
+        {
+            Func<TAttribute, bool> isMatchingAttribute = isMatchingAttributePredicate.Compile();
+            return GetCustomAttributes<TAttribute>(type).Any(isMatchingAttribute);
+        }
+
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this Type type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : Attribute
+        {
+            Func<TAttribute, bool> isMatchingAttribute = isMatchingAttributePredicate.Compile();
+            return GetCustomAttributes<TAttribute>(type, true).Any(isMatchingAttribute);
+        }
+
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this TypeInfo type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : Attribute
+        {
+            Func<TAttribute, bool> isMatchingAttribute = isMatchingAttributePredicate.Compile();
+            return GetCustomAttributes<TAttribute>(type, true).Any(isMatchingAttribute);
+        }
+
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this MemberInfo type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : Attribute
+        {
+            Func<TAttribute, bool> isMatchingAttribute = isMatchingAttributePredicate.Compile();
+            return GetCustomAttributes<TAttribute>(type, true).Any(isMatchingAttribute);
+        }
+
+        [Obsolete("This overload is deprecated and will be removed on the next major version. Please use <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
         public static bool IsDecoratedWith<TAttribute>(this Type type, bool inherit = false)
             where TAttribute : Attribute
         {
             return GetCustomAttributes<TAttribute>(type, inherit).Any();
         }
 
-        private static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(MemberInfo type)
+        private static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(MemberInfo type, bool inherit = false)
             where TAttribute : Attribute
         {
-            return type.GetCustomAttributes(false).OfType<TAttribute>();
+            return type.GetCustomAttributes(inherit).OfType<TAttribute>();
         }
 
         private static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(Type type, bool inherit = false)
@@ -433,7 +509,7 @@ namespace FluentAssertions.Common
             }
 
             bool hasCompilerGeneratedAttribute =
-                type.GetTypeInfo().GetCustomAttributes(typeof(CompilerGeneratedAttribute), false).Any();
+                type.GetTypeInfo().IsDecoratedWith<CompilerGeneratedAttribute>();
 
             return hasCompilerGeneratedAttribute;
         }

--- a/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
@@ -77,7 +77,7 @@ namespace FluentAssertions.Formatting
                 where type != null
                 from method in type.GetMethods(BindingFlags.Static | BindingFlags.Public)
                 where method.IsStatic
-                where method.HasAttribute<ValueFormatterAttribute>()
+                where method.IsDecoratedWithOrInherit<ValueFormatterAttribute>()
                 where method.GetParameters().Length == 1
                 select method;
 

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -265,7 +265,7 @@ namespace FluentAssertions.Specialized
 
         private void FailIfSubjectIsAsyncVoid()
         {
-            if (!CanHandleAsync && Subject.GetMethodInfo().HasAttribute<AsyncStateMachineAttribute>())
+            if (!CanHandleAsync && Subject.GetMethodInfo().IsDecoratedWithOrInherit<AsyncStateMachineAttribute>())
             {
                 throw new InvalidOperationException("Cannot use action assertions on an async void method. Assign the async method to a variable of type Func<Task> instead of Action so that it can be awaited.");
             }

--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Types
 {
@@ -93,7 +94,7 @@ namespace FluentAssertions.Types
         public MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : Attribute
         {
-            selectedMethods = selectedMethods.Where(method => method.GetCustomAttributes(false).OfType<TAttribute>().Any());
+            selectedMethods = selectedMethods.Where(method => method.IsDecoratedWith<TAttribute>());
             return this;
         }
 
@@ -103,7 +104,7 @@ namespace FluentAssertions.Types
         public MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : Attribute
         {
-            selectedMethods = selectedMethods.Where(method => method.GetCustomAttributes(true).OfType<TAttribute>().Any());
+            selectedMethods = selectedMethods.Where(method => method.IsDecoratedWithOrInherit<TAttribute>());
             return this;
         }
 
@@ -113,7 +114,7 @@ namespace FluentAssertions.Types
         public MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : Attribute
         {
-            selectedMethods = selectedMethods.Where(method => !method.GetCustomAttributes(false).OfType<TAttribute>().Any());
+            selectedMethods = selectedMethods.Where(method => !method.IsDecoratedWith<TAttribute>());
             return this;
         }
 
@@ -123,7 +124,7 @@ namespace FluentAssertions.Types
         public MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : Attribute
         {
-            selectedMethods = selectedMethods.Where(method => !method.GetCustomAttributes(true).OfType<TAttribute>().Any());
+            selectedMethods = selectedMethods.Where(method => !method.IsDecoratedWithOrInherit<TAttribute>());
             return this;
         }
 

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -208,13 +208,13 @@ namespace FluentAssertions.Types
         private MethodInfo[] GetMethodsWithout<TAttribute>(Expression<Func<TAttribute, bool>> isMatchingPredicate)
             where TAttribute : Attribute
         {
-            return SubjectMethods.Where(method => !method.HasMatchingAttribute(isMatchingPredicate)).ToArray();
+            return SubjectMethods.Where(method => !method.IsDecoratedWith(isMatchingPredicate)).ToArray();
         }
 
         private MethodInfo[] GetMethodsWith<TAttribute>(Expression<Func<TAttribute, bool>> isMatchingPredicate)
             where TAttribute : Attribute
         {
-            return SubjectMethods.Where(method => method.HasMatchingAttribute(isMatchingPredicate)).ToArray();
+            return SubjectMethods.Where(method => method.IsDecoratedWith(isMatchingPredicate)).ToArray();
         }
 
         private static string GetDescriptionsFor(IEnumerable<MethodInfo> methods)

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Types
 {
@@ -55,7 +56,7 @@ namespace FluentAssertions.Types
         public PropertyInfoSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : Attribute
         {
-            selectedProperties = selectedProperties.Where(property => CustomAttributeExtensions.GetCustomAttributes(property, false).OfType<TAttribute>().Any());
+            selectedProperties = selectedProperties.Where(property => property.IsDecoratedWith<TAttribute>());
             return this;
         }
 
@@ -65,7 +66,7 @@ namespace FluentAssertions.Types
         public PropertyInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : Attribute
         {
-            selectedProperties = selectedProperties.Where(property => CustomAttributeExtensions.GetCustomAttributes(property, true).OfType<TAttribute>().Any());
+            selectedProperties = selectedProperties.Where(property => property.IsDecoratedWithOrInherit<TAttribute>());
             return this;
         }
 
@@ -75,7 +76,7 @@ namespace FluentAssertions.Types
         public PropertyInfoSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : Attribute
         {
-            selectedProperties = selectedProperties.Where(property => !property.GetCustomAttributes(false).OfType<TAttribute>().Any());
+            selectedProperties = selectedProperties.Where(property => !property.IsDecoratedWith<TAttribute>());
             return this;
         }
 
@@ -85,7 +86,7 @@ namespace FluentAssertions.Types
         public PropertyInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : Attribute
         {
-            selectedProperties = selectedProperties.Where(property => !CustomAttributeExtensions.GetCustomAttributes(property, true).OfType<TAttribute>().Any());
+            selectedProperties = selectedProperties.Where(property => !property.IsDecoratedWithOrInherit<TAttribute>());
             return this;
         }
 

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -254,7 +254,7 @@ namespace FluentAssertions.Types
             BeDecoratedWith<TAttribute>(because, becauseArgs);
 
             Execute.Assertion
-                .ForCondition(Subject.HasMatchingAttribute(isMatchingAttributePredicate))
+                .ForCondition(Subject.IsDecoratedWith(isMatchingAttributePredicate))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type {0} to be decorated with {1} that matches {2}{reason}, but no matching attribute was found.",
                     Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
@@ -276,7 +276,7 @@ namespace FluentAssertions.Types
             where TAttribute : Attribute
         {
             Execute.Assertion
-                .ForCondition(Subject.IsDecoratedWith<TAttribute>(true))
+                .ForCondition(Subject.IsDecoratedWithOrInherit<TAttribute>())
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type {0} to be decorated with or inherit {1}{reason}, but the attribute was not found.",
                     Subject, typeof(TAttribute));
@@ -307,7 +307,7 @@ namespace FluentAssertions.Types
             BeDecoratedWithOrInherit<TAttribute>(because, becauseArgs);
 
             Execute.Assertion
-                .ForCondition(Subject.HasMatchingAttribute(isMatchingAttributePredicate, true))
+                .ForCondition(Subject.IsDecoratedWithOrInherit(isMatchingAttributePredicate))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type {0} to be decorated with or inherit {1} that matches {2}{reason}, but no matching attribute was found.",
                     Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
@@ -358,7 +358,7 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate, nameof(isMatchingAttributePredicate));
 
             Execute.Assertion
-                .ForCondition(!Subject.HasMatchingAttribute(isMatchingAttributePredicate))
+                .ForCondition(!Subject.IsDecoratedWith(isMatchingAttributePredicate))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type {0} to not be decorated with {1} that matches {2}{reason}, but a matching attribute was found.",
                     Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
@@ -380,7 +380,7 @@ namespace FluentAssertions.Types
             where TAttribute : Attribute
         {
             Execute.Assertion
-                .ForCondition(!Subject.IsDecoratedWith<TAttribute>(true))
+                .ForCondition(!Subject.IsDecoratedWithOrInherit<TAttribute>())
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type {0} to not be decorated with or inherit {1}{reason}, but the attribute was found.",
                     Subject, typeof(TAttribute));
@@ -409,7 +409,7 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate, nameof(isMatchingAttributePredicate));
 
             Execute.Assertion
-                .ForCondition(!Subject.HasMatchingAttribute(isMatchingAttributePredicate, true))
+                .ForCondition(!Subject.IsDecoratedWithOrInherit(isMatchingAttributePredicate))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type {0} to not be decorated with or inherit {1} that matches {2}{reason}, but a matching attribute was found.",
                     Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Types
 {
@@ -81,7 +82,7 @@ namespace FluentAssertions.Types
         {
             types = types
 
-                .Where(t => t.GetTypeInfo().GetCustomAttributes(typeof(TAttribute), false).Any())
+                .Where(t => t.GetTypeInfo().IsDecoratedWith<TAttribute>())
                 .ToList();
 
             return this;
@@ -95,7 +96,7 @@ namespace FluentAssertions.Types
         {
             types = types
 
-                .Where(t => t.GetTypeInfo().GetCustomAttributes(typeof(TAttribute), true).Any())
+                .Where(t => t.GetTypeInfo().IsDecoratedWithOrInherit<TAttribute>())
                 .ToList();
 
             return this;
@@ -109,7 +110,7 @@ namespace FluentAssertions.Types
         {
             types = types
 
-                .Where(t => !t.GetTypeInfo().GetCustomAttributes(typeof(TAttribute), false).Any())
+                .Where(t => !t.GetTypeInfo().IsDecoratedWith<TAttribute>())
                 .ToList();
 
             return this;
@@ -123,7 +124,7 @@ namespace FluentAssertions.Types
         {
             types = types
 
-                .Where(t => !t.GetTypeInfo().GetCustomAttributes(typeof(TAttribute), true).Any())
+                .Where(t => !t.GetTypeInfo().IsDecoratedWithOrInherit<TAttribute>())
                 .ToList();
 
             return this;

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -78,7 +78,7 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate, nameof(isMatchingAttributePredicate));
 
             Type[] typesWithoutMatchingAttribute = Subject
-                .Where(type => !type.HasMatchingAttribute(isMatchingAttributePredicate))
+                .Where(type => !type.IsDecoratedWith(isMatchingAttributePredicate))
                 .ToArray();
 
             Execute.Assertion
@@ -108,7 +108,7 @@ namespace FluentAssertions.Types
             where TAttribute : Attribute
         {
             Type[] typesWithoutAttribute = Subject
-                .Where(type => !type.IsDecoratedWith<TAttribute>(true))
+                .Where(type => !type.IsDecoratedWithOrInherit<TAttribute>())
                 .ToArray();
 
             Execute.Assertion
@@ -144,7 +144,7 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate, nameof(isMatchingAttributePredicate));
 
             Type[] typesWithoutMatchingAttribute = Subject
-                .Where(type => !type.HasMatchingAttribute(isMatchingAttributePredicate, true))
+                .Where(type => !type.IsDecoratedWithOrInherit(isMatchingAttributePredicate))
                 .ToArray();
 
             Execute.Assertion
@@ -210,7 +210,7 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate, nameof(isMatchingAttributePredicate));
 
             Type[] typesWithMatchingAttribute = Subject
-                .Where(type => type.HasMatchingAttribute(isMatchingAttributePredicate))
+                .Where(type => type.IsDecoratedWith(isMatchingAttributePredicate))
                 .ToArray();
 
             Execute.Assertion
@@ -240,7 +240,7 @@ namespace FluentAssertions.Types
             where TAttribute : Attribute
         {
             Type[] typesWithAttribute = Subject
-                .Where(type => type.IsDecoratedWith<TAttribute>(true))
+                .Where(type => type.IsDecoratedWithOrInherit<TAttribute>())
                 .ToArray();
 
             Execute.Assertion
@@ -276,7 +276,7 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate, nameof(isMatchingAttributePredicate));
 
             Type[] typesWithMatchingAttribute = Subject
-                .Where(type => type.HasMatchingAttribute(isMatchingAttributePredicate, true))
+                .Where(type => type.IsDecoratedWithOrInherit(isMatchingAttributePredicate))
                 .ToArray();
 
             Execute.Assertion


### PR DESCRIPTION
Fix #731 

I have marked the old methods as obsolete but depending on your preferences, I could get rid of them (breaking changes).

I decided to name the methods `XXXOrInherit` not `XXXOrInherits` as recommended to follow the convention used by already implemented methods.

Some of the tests are failing because of my changes on `PropertyInfoSelector.cs` but I can't figure out what's wrong with my change. I'd be grateful for some fresh eyes because I am likely missing something obvious.