### PR TITLE
Issue1092

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -413,12 +413,13 @@ namespace FluentAssertions.Collections
 
             if (failuresFromInspectors.Any())
             {
-                string failureMessage = "Expected {context:collection} to satisfy all inspectors{reason}, but some inspectors are not satisfied:"
-                    + Environment.NewLine
+                string failureMessage = Environment.NewLine
                     + string.Join(Environment.NewLine, failuresFromInspectors.Select(x => x.IndentLines()));
+
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith(failureMessage);
+                    .WithExpectation("Expected {context:collection} to satisfy all inspectors{reason}, but some inspectors are not satisfied:")
+                    .FailWithPreFormatted(failureMessage);
             }
 
             return new AndConstraint<GenericCollectionAssertions<T>>(this);
@@ -443,9 +444,7 @@ namespace FluentAssertions.Collections
                     {
                         // Adding one tab and removing trailing dot to allow nested SatisfyRespectively
                         string failures = string.Join(Environment.NewLine, inspectorFailures.Select(x => x.IndentLines().TrimEnd('.')));
-                        // FailWith formatting is not used because of extra quotes being added.
-                        Execute.Assertion
-                            .FailWith($"At index {index}:{Environment.NewLine}{failures}");
+                        collectionScope.AddPreFormattedFailure($"At index {index}:{Environment.NewLine}{failures}");
                     }
 
                     index++;

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -167,15 +167,27 @@ namespace FluentAssertions.Execution
 
         public Continuation FailWith(Func<FailReason> failReasonFunc)
         {
+            return FailWith(() =>
+            {
+                string localReason = reason?.Invoke() ?? "";
+                var messageBuilder = new MessageBuilder(useLineBreaks);
+                string identifier = GetIdentifier();
+                FailReason failReason = failReasonFunc();
+                string result = messageBuilder.Build(failReason.Message, failReason.Args, localReason, contextData, identifier, fallbackIdentifier);
+                return result;
+            });
+        }
+
+        internal Continuation FailWithPreFormatted(string formattedFailReason) =>
+            FailWith(() => formattedFailReason);
+
+        private Continuation FailWith(Func<string> failReasonFunc)
+        {
             try
             {
                 if (!succeeded.HasValue || !succeeded.Value)
                 {
-                    string localReason = reason?.Invoke() ?? "";
-                    var messageBuilder = new MessageBuilder(useLineBreaks);
-                    string identifier = GetIdentifier();
-                    var failReason = failReasonFunc();
-                    string result = messageBuilder.Build(failReason.Message, failReason.Args, localReason, contextData, identifier, fallbackIdentifier);
+                    string result = failReasonFunc();
 
                     if (expectation != null)
                     {

--- a/Tests/Shared.Specs/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/Shared.Specs/GenericCollectionAssertionsSpecs.cs
@@ -1259,7 +1259,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            IEnumerable<int> collection = new []{1, 2};
+            IEnumerable<int> collection = new[] { 1, 2 };
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -1279,7 +1279,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            IEnumerable<int> collection = new []{1, 2};
+            IEnumerable<int> collection = new[] { 1, 2 };
 
             //-----------------------------------------------------------------------------------------------------------
             // Act
@@ -1346,7 +1346,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            var collection = new []
+            var collection = new[]
             {
                 new Customer { Age = 21, Name = "John" },
                 new Customer { Age = 22, Name = "Jane" }
@@ -1379,7 +1379,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            var customers = new []
+            var customers = new[]
             {
                 new CustomerWithItems { Age = 21, Items = new[] {1, 2} },
                 new CustomerWithItems { Age = 22, Items = new[] {3} }
@@ -1411,34 +1411,53 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>().WithMessage(
 #if NETCOREAPP1_1
 @"Expected collection to satisfy all inspectors because we want to test nested assertions, but some inspectors are not satisfied:
-	At index 0:
-		Expected value to be less than 21, but found 21
-		Expected collection to satisfy all inspectors, but some inspectors are not satisfied:
-			At index 0:
-				Expected value to be 2, but found 1
-			At index 1:
-				Expected value to be 1, but found 2
-	At index 1:
-		Expected value to be less than 22, but found 22
-		Expected collection to satisfy all inspectors, but some inspectors are not satisfied:
-			At index 0:
-				Expected value to be 2, but found 3"
+*At index 0:
+*Expected value to be less than 21, but found 21
+*Expected collection to satisfy all inspectors, but some inspectors are not satisfied:
+*At index 0:
+*Expected value to be 2, but found 1
+*At index 1:
+*Expected value to be 1, but found 2
+*At index 1:
+*Expected value to be less than 22, but found 22
+*Expected collection to satisfy all inspectors, but some inspectors are not satisfied:
+*At index 0:
+*Expected value to be 2, but found 3"
 #else
 @"Expected customers to satisfy all inspectors because we want to test nested assertions, but some inspectors are not satisfied:
-	At index 0:
-		Expected customer.Age to be less than 21, but found 21
-		Expected customer.Items to satisfy all inspectors, but some inspectors are not satisfied:
-			At index 0:
-				Expected item to be 2, but found 1
-			At index 1:
-				Expected item to be 1, but found 2
-	At index 1:
-		Expected customer.Age to be less than 22, but found 22
-		Expected customer.Items to satisfy all inspectors, but some inspectors are not satisfied:
-			At index 0:
-				Expected item to be 2, but found 3"
+*At index 0:
+*Expected customer.Age to be less than 21, but found 21
+*Expected customer.Items to satisfy all inspectors, but some inspectors are not satisfied:
+*At index 0:
+*Expected item to be 2, but found 1
+*At index 1:
+*Expected item to be 1, but found 2
+*At index 1:
+*Expected customer.Age to be less than 22, but found 22
+*Expected customer.Items to satisfy all inspectors, but some inspectors are not satisfied:
+*At index 0:
+*Expected item to be 2, but found 3"
 #endif
 );
+        }
+
+        [Fact]
+        public void When_inspector_message_is_not_reformatable_it_should_not_throw()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            byte[][] subject = { new byte[] { 1 } };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => subject.Should().SatisfyRespectively(e => e.Should().BeEquivalentTo(new byte[] { 2, 3, 4 }));
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().NotThrow<FormatException>();
         }
 
         [Fact]
@@ -1447,7 +1466,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
             //-----------------------------------------------------------------------------------------------------------
-            var collection = new[]{1, 2, 3};
+            var collection = new[] { 1, 2, 3 };
 
             //-----------------------------------------------------------------------------------------------------------
             // Act


### PR DESCRIPTION
Reformatting a failure message that has already been formatted can throw a `FormatException`.
This PR avoids reformatting formatted failure messages in `SatisfyRespectively`.

In order to get the inner failure messages after "Expected collection to satisfy all inspectors..." 
I introduced `WithPreFormattedFailure(string)`.

I'm not sure if `formattedFailureMessage` needs to be cleared just as `expectation` is with `ClearExpectation()`.

This fixes #1092 