### PR TITLE
Disposing of disposables

### DIFF
--- a/Src/FluentAssertions/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ObjectAssertionsExtensions.cs
@@ -122,15 +122,17 @@ namespace FluentAssertions
 
         private static object CreateCloneUsingBinarySerializer(object subject)
         {
-            var stream = new MemoryStream();
-            var binaryFormatter = new BinaryFormatter
+            using (var stream = new MemoryStream())
             {
-                Binder = new SimpleBinder(subject.GetType())
-            };
+                var binaryFormatter = new BinaryFormatter
+                {
+                    Binder = new SimpleBinder(subject.GetType())
+                };
 
-            binaryFormatter.Serialize(stream, subject);
-            stream.Position = 0;
-            return binaryFormatter.Deserialize(stream);
+                binaryFormatter.Serialize(stream, subject);
+                stream.Position = 0;
+                return binaryFormatter.Deserialize(stream);
+            }
         }
 
         private class SimpleBinder : SerializationBinder
@@ -202,12 +204,14 @@ namespace FluentAssertions
 
         private static object CreateCloneUsingXmlSerializer(object subject)
         {
-            var stream = new MemoryStream();
-            var binaryFormatter = new XmlSerializer(subject.GetType());
-            binaryFormatter.Serialize(stream, subject);
+            using (var stream = new MemoryStream())
+            {
+                var binaryFormatter = new XmlSerializer(subject.GetType());
+                binaryFormatter.Serialize(stream, subject);
 
-            stream.Position = 0;
-            return binaryFormatter.Deserialize(stream);
+                stream.Position = 0;
+                return binaryFormatter.Deserialize(stream);
+            }
         }
     }
 }

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Xml;
 using System.Xml.Linq;
 
 using FluentAssertions.Common;
@@ -114,8 +115,12 @@ namespace FluentAssertions.Xml
         /// </param>
         public AndConstraint<XDocumentAssertions> BeEquivalentTo(XDocument expected, string because, params object[] becauseArgs)
         {
-            var xmlReaderValidator = new XmlReaderValidator(Subject.CreateReader(), expected.CreateReader(), because, becauseArgs);
-            xmlReaderValidator.Validate(true);
+            using (XmlReader subjectReader = Subject.CreateReader())
+            using (XmlReader otherReader = expected.CreateReader())
+            {
+                var xmlReaderValidator = new XmlReaderValidator(subjectReader, otherReader, because, becauseArgs);
+                xmlReaderValidator.Validate(true);
+            }
 
             return new AndConstraint<XDocumentAssertions>(this);
         }
@@ -144,8 +149,12 @@ namespace FluentAssertions.Xml
         /// </param>
         public AndConstraint<XDocumentAssertions> NotBeEquivalentTo(XDocument unexpected, string because, params object[] becauseArgs)
         {
-            var xmlReaderValidator = new XmlReaderValidator(Subject.CreateReader(), unexpected.CreateReader(), because, becauseArgs);
-            xmlReaderValidator.Validate(false);
+            using (XmlReader subjectReader = Subject.CreateReader())
+            using (XmlReader otherReader = unexpected.CreateReader())
+            {
+                var xmlReaderValidator = new XmlReaderValidator(subjectReader, otherReader, because, becauseArgs);
+                xmlReaderValidator.Validate(false);
+            }
 
             return new AndConstraint<XDocumentAssertions>(this);
         }

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -150,8 +150,12 @@ namespace FluentAssertions.Xml
         /// </param>
         public AndConstraint<XElementAssertions> NotBeEquivalentTo(XElement unexpected, string because, params object[] becauseArgs)
         {
-            var xmlReaderValidator = new XmlReaderValidator(Subject.CreateReader(), unexpected.CreateReader(), because, becauseArgs);
-            xmlReaderValidator.Validate(false);
+            using (XmlReader subjectReader = Subject.CreateReader())
+            using (XmlReader otherReader = unexpected.CreateReader())
+            {
+                var xmlReaderValidator = new XmlReaderValidator(subjectReader, otherReader, because, becauseArgs);
+                xmlReaderValidator.Validate(false);
+            }
 
             return new AndConstraint<XElementAssertions>(this);
         }


### PR DESCRIPTION
Some `IDisposable`s were left open, instead of being wrapped in `using`s.