### PR TITLE
Missing ClearExpectation

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -45,7 +45,9 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(() => Subject.Cast<object>())
                 .ForCondition(collection => !collection.Any())
-                .FailWith("but found {0}.", collection => collection);
+                .FailWith("but found {0}.", collection => collection)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -265,7 +267,9 @@ namespace FluentAssertions.Collections
                 .Given(() => Subject.ConvertOrCastToCollection<TActual>())
                 .AssertCollectionsHaveSameCount(expectedItems.Count)
                 .Then
-                .AssertCollectionsHaveSameItems(expectedItems, (a, e) => a.IndexOfFirstDifferenceWith(e, equalityComparison));
+                .AssertCollectionsHaveSameItems(expectedItems, (a, e) => a.IndexOfFirstDifferenceWith(e, equalityComparison))
+                .Then
+                .ClearExpectation();
         }
 
         /// <summary>
@@ -1447,7 +1451,9 @@ namespace FluentAssertions.Collections
                 .Then
                 .AssertCollectionHasEnoughItems(expected.Length)
                 .Then
-                .AssertCollectionsHaveSameItems(expected, (a, e) => a.Take(e.Count).IndexOfFirstDifferenceWith(e, equalityComparison));
+                .AssertCollectionsHaveSameItems(expected, (a, e) => a.Take(e.Count).IndexOfFirstDifferenceWith(e, equalityComparison))
+                .Then
+                .ClearExpectation();
         }
 
         protected void AssertCollectionStartsWith<TActual, TExpected>(IEnumerable<TActual> actualItems, ICollection<TExpected> expected, Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs)
@@ -1460,7 +1466,9 @@ namespace FluentAssertions.Collections
                 .Then
                 .AssertCollectionHasEnoughItems(expected.Count)
                 .Then
-                .AssertCollectionsHaveSameItems(expected, (a, e) => a.Take(e.Count).IndexOfFirstDifferenceWith(e, equalityComparison));
+                .AssertCollectionsHaveSameItems(expected, (a, e) => a.Take(e.Count).IndexOfFirstDifferenceWith(e, equalityComparison))
+                .Then
+                .ClearExpectation();
         }
 
         /// <summary>
@@ -1498,7 +1506,9 @@ namespace FluentAssertions.Collections
                     int firstIndexToCompare = a.Count - e.Count;
                     int index = a.Skip(firstIndexToCompare).IndexOfFirstDifferenceWith(e, equalityComparison);
                     return index >= 0 ? index + firstIndexToCompare : index;
-                });
+                })
+                .Then
+                .ClearExpectation();
         }
 
         protected void AssertCollectionEndsWith<TActual, TExpected>(IEnumerable<TActual> actual, ICollection<TExpected> expected, Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs)
@@ -1516,7 +1526,9 @@ namespace FluentAssertions.Collections
                     int firstIndexToCompare = a.Count - e.Count;
                     int index = a.Skip(firstIndexToCompare).IndexOfFirstDifferenceWith(e, equalityComparison);
                     return index >= 0 ? index + firstIndexToCompare : index;
-                });
+                })
+                .Then
+                .ClearExpectation();
         }
 
         /// <summary>
@@ -1586,7 +1598,9 @@ namespace FluentAssertions.Collections
                 .Then
                 .Given(subject => SuccessorOf(predecessor, subject))
                 .ForCondition(successor => successor.IsSameOrEqualTo(expectation))
-                .FailWith("but found {0}.", successor => successor);
+                .FailWith("but found {0}.", successor => successor)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -1640,7 +1654,9 @@ namespace FluentAssertions.Collections
                 .FailWith("but found a null element.")
                 .Then
                 .ForCondition(subject => subject.All(x => expectedType.GetTypeInfo().IsAssignableFrom(GetType(x).GetTypeInfo())))
-                .FailWith("but found {0}.", subject => $"[{string.Join(", ", subject.Select(x => GetType(x).FullName))}]");
+                .FailWith("but found {0}.", subject => $"[{string.Join(", ", subject.Select(x => GetType(x).FullName))}]")
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -1682,7 +1698,9 @@ namespace FluentAssertions.Collections
                 .FailWith("but found a null element.")
                 .Then
                 .ForCondition(subject => subject.All(x => expectedType == GetType(x)))
-                .FailWith("but found {0}.", subject => $"[{string.Join(", ", subject.Select(x => GetType(x).FullName))}]");
+                .FailWith("but found {0}.", subject => $"[{string.Join(", ", subject.Select(x => GetType(x).FullName))}]")
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -419,7 +419,9 @@ namespace FluentAssertions.Collections
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
                     .WithExpectation("Expected {context:collection} to satisfy all inspectors{reason}, but some inspectors are not satisfied:")
-                    .FailWithPreFormatted(failureMessage);
+                    .FailWithPreFormatted(failureMessage)
+                    .Then
+                    .ClearExpectation();
             }
 
             return new AndConstraint<GenericCollectionAssertions<T>>(this);

--- a/Src/FluentAssertions/Execution/GivenSelectorExtensions.cs
+++ b/Src/FluentAssertions/Execution/GivenSelectorExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using FluentAssertions.Common;
 
@@ -59,13 +60,46 @@ namespace FluentAssertions.Execution
                 .AssertCollectionHasNotTooManyItems(length);
         }
 
-        public static void AssertCollectionsHaveSameItems<TActual, TExpected>(this GivenSelector<ICollection<TActual>> givenSelector,
+        public static ContinuationOfGiven<ICollection<TActual>> AssertCollectionsHaveSameItems<TActual, TExpected>(this GivenSelector<ICollection<TActual>> givenSelector,
             ICollection<TExpected> expected, Func<ICollection<TActual>, ICollection<TExpected>, int> findIndex)
         {
-            givenSelector
-                .Given(actual => new { Items = actual, Index = findIndex(actual, expected) })
-                .ForCondition(diff => diff.Index == -1)
-                .FailWith("but {0} differs at index {1}.", diff => diff.Items, diff => diff.Index);
+            return givenSelector
+                .Given<ICollection<TActual>>(actual => new CollectionWithIndex<TActual>(actual, findIndex(actual, expected)))
+                .ForCondition(diff => diff.As<CollectionWithIndex<TActual>>().Index == -1)
+                .FailWith("but {0} differs at index {1}.",
+                    diff => diff.As<CollectionWithIndex<TActual>>().Items,
+                    diff => diff.As<CollectionWithIndex<TActual>>().Index);
+        }
+
+        private sealed class CollectionWithIndex<T> : ICollection<T>
+        {
+            public ICollection<T> Items { get; }
+
+            public int Index { get; }
+
+            public CollectionWithIndex(ICollection<T> items, int index)
+            {
+                Items = items;
+                Index = index;
+            }
+
+            public int Count => Items.Count;
+
+            public bool IsReadOnly => Items.IsReadOnly;
+
+            public void Add(T item) => Items.Add(item);
+
+            public void Clear() => Items.Clear();
+
+            public bool Contains(T item) => Items.Contains(item);
+
+            public void CopyTo(T[] array, int arrayIndex) => Items.CopyTo(array, arrayIndex);
+
+            public IEnumerator<T> GetEnumerator() => Items.GetEnumerator();
+
+            public bool Remove(T item) => Items.Remove(item);
+
+            IEnumerator IEnumerable.GetEnumerator() => Items.GetEnumerator();
         }
     }
 }

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -697,7 +697,8 @@ namespace FluentAssertions.Primitives
                 .ForCondition(Subject.Value.Second != unexpected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(", but it was.")
-                .Then.ClearExpectation();
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeAssertions>(this);
         }

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -390,7 +390,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Year == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("but it was {0}.", Subject.Value.Year);
+                .FailWith("but it was {0}.", Subject.Value.Year)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
@@ -416,7 +418,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Year != unexpected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("but it was.");
+                .FailWith("but it was.")
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
@@ -443,7 +447,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Month == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("but it was {0}.", Subject.Value.Month);
+                .FailWith("but it was {0}.", Subject.Value.Month)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
@@ -469,7 +475,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Month != unexpected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("but it was.");
+                .FailWith("but it was.")
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
@@ -496,7 +504,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Day == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("but it was {0}.", Subject.Value.Day);
+                .FailWith("but it was {0}.", Subject.Value.Day)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
@@ -522,7 +532,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Day != unexpected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("but it was.");
+                .FailWith("but it was.")
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
@@ -549,7 +561,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Hour == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("but it was {0}.", Subject.Value.Hour);
+                .FailWith("but it was {0}.", Subject.Value.Hour)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
@@ -575,7 +589,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Hour != unexpected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("but it was.");
+                .FailWith("but it was.")
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
@@ -602,7 +618,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Minute == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("but it was {0}.", Subject.Value.Minute);
+                .FailWith("but it was {0}.", Subject.Value.Minute)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
@@ -629,7 +647,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Minute != unexpected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("but it was.");
+                .FailWith("but it was.")
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
@@ -656,7 +676,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Second == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("but it was {0}.", Subject.Value.Second);
+                .FailWith("but it was {0}.", Subject.Value.Second)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
@@ -683,7 +705,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Second != unexpected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("but it was.");
+                .FailWith("but it was.")
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
@@ -710,7 +734,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Offset == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("but it was {0}.", Subject.Value.Offset);
+                .FailWith("but it was {0}.", Subject.Value.Offset)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
@@ -737,7 +763,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Offset != unexpected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("but it was.");
+                .FailWith("but it was.")
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
@@ -827,7 +855,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Date == expectedDate)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("but it was {0}.", Subject.Value);
+                .FailWith("but it was {0}.", Subject.Value)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }
@@ -856,7 +886,9 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ForCondition(Subject.Value.Date != unexpectedDate)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("but it was.");
+                .FailWith("but it was.")
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
         }


### PR DESCRIPTION
When using `WithExpectation` it should most often be matched by a `ClearExpectation`.
Not calling `ClearExpectation` can cause the `expectation` to appear in the failure message of subsequent assertions inside an `AssertionScope`.

To make `AssertCollectionsHaveSameItems` return a chainable `ContinuationOfGiven<T>` I made `CollectionWithIndex<T>`. 
It might not be very elegant, but it was the only way I could come up with.