### PR TITLE
Netcore3 preparation

### DIFF
--- a/Tests/Shared.Specs/ExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/ExceptionAssertionSpecs.cs
@@ -395,7 +395,7 @@ namespace FluentAssertions.Specs
                 // Assert
                 //-----------------------------------------------------------------------------------------------------------
                 ex.Message.Should().Match(
-                    "Expected exception message to match the equivalent of*\"message2\", but*\"message2*: someParam\"*");
+                    "Expected exception message to match the equivalent of*\"message2\", but*message2*someParam*");
             }
         }
 

--- a/build.ps1
+++ b/build.ps1
@@ -82,7 +82,7 @@ function MD5HashFile([string] $filePath)
 
 Write-Host "Ensuring .NET Core is installed"
 
-$minVersion = "3.0.100-preview5-011568"
+$minVersion = "3.0.100-preview7-012821"
 $version = . dotnet --version
 Write-Host "Found .NET Core SDK version $version"
 


### PR DESCRIPTION
In .Net Core 3 preview 7, the formatting of `ArgumentException` [changed](https://github.com/dotnet/coreclr/pull/25185/files#diff-6044f205b677cd7711072c893ce07a6a).
This PR relaxes the expected formatting to also match the upcoming formatting.