### PR TITLE
Styling

### DIFF
--- a/Rules.ruleset
+++ b/Rules.ruleset
@@ -14,6 +14,18 @@
     <Rule Id="CS1718" Action="Error" />
     <Rule Id="CS1720" Action="Error" />
   </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Common" RuleNamespace="Microsoft.CodeAnalysis.Common">
+    <Rule Id="CA1031" Action="None" />
+    <Rule Id="CA1303" Action="None" />
+    <Rule Id="CA1819" Action="None" />
+    <Rule Id="CA1825" Action="None" />
+    <Rule Id="CA2225" Action="None" />
+    <Rule Id="CA2007" Action="None" />
+    <Rule Id="CA1724" Action="None" />
+    <Rule Id="CA1710" Action="None" />
+    <Rule Id="CA1720" Action="None" />
+    <Rule Id="CA1724" Action="None" />
+  </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
     <Rule Id="IDE0035" Action="Error" />
 	<Rule Id="IDE0007" Action="None" />
@@ -23,6 +35,8 @@
     <Rule Id="IDE0033" Action="Info" />
   </Rules>
   <Rules AnalyzerId="Roslynator.CSharp.Analyzers" RuleNamespace="Roslynator.CSharp.Analyzers">
+    <Rule Id="RCS1029" Action="None" />
+	<Rule Id="RCS1090" Action="None" />
     <Rule Id="RCS1080" Action="None" />
     <Rule Id="RCS1102" Action="None" />
     <Rule Id="RCS1119" Action="None" />
@@ -44,5 +58,6 @@
     <Rule Id="U2U1108" Action="None" />
     <Rule Id="U2U1201" Action="Hidden" />
     <Rule Id="U2U1202" Action="None" />
+    <Rule Id="U2U1212" Action="None" />
   </Rules>
 </RuleSet>

--- a/Src/FluentAssertions/AggregateExceptionExtractor.cs
+++ b/Src/FluentAssertions/AggregateExceptionExtractor.cs
@@ -26,7 +26,7 @@ namespace FluentAssertions
 
             if (actualException is AggregateException aggregateException)
             {
-                var flattenedExceptions = aggregateException.Flatten();
+                AggregateException flattenedExceptions = aggregateException.Flatten();
 
                 exceptions.AddRange(flattenedExceptions.InnerExceptions.OfType<T>());
             }

--- a/Src/FluentAssertions/AndConstraint.cs
+++ b/Src/FluentAssertions/AndConstraint.cs
@@ -8,7 +8,7 @@ namespace FluentAssertions
         public T And { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:System.Object"/> class.
+        /// Initializes a new instance of the <see cref="System.Object"/> class.
         /// </summary>
         public AndConstraint(T parentConstraint)
         {

--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -717,7 +717,7 @@ namespace FluentAssertions
         [Pure]
         public static TTo As<TTo>(this object subject)
         {
-            return subject is TTo ? (TTo)subject : default(TTo);
+            return subject is TTo ? (TTo)subject : default;
         }
 
         /// <summary>

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -126,7 +126,7 @@ namespace FluentAssertions
 
         private static bool IsStringLiteral(string candidate)
         {
-            return candidate.StartsWith("\"");
+            return candidate.StartsWith("\"", StringComparison.Ordinal);
         }
 
         private static bool IsNumeric(string candidate)

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -11,7 +11,9 @@ namespace FluentAssertions
     /// </summary>
     public static class CallerIdentifier
     {
+#pragma warning disable CA2211 // TODO: fix in 6.0
         public static Action<string> logger = str => { };
+#pragma warning restore CA2211
 
 #if !NETSTANDARD1_3 && !NETSTANDARD1_6
 

--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -255,7 +255,7 @@ namespace FluentAssertions.Collections
 
             ICollection<TExpected> expectedItems = expectation.ConvertOrCastToCollection<TExpected>();
 
-            IAssertionScope assertion = Execute.Assertion.BecauseOf(because, becauseArgs);
+            AssertionScope assertion = Execute.Assertion.BecauseOf(because, becauseArgs);
             if (subjectIsNull)
             {
                 assertion.FailWith("Expected {context:collection} to be equal to {0}{reason}, but found <null>.", expectedItems);
@@ -599,7 +599,7 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:collection} to contain equivalent of {0}{reason}, but found <null>.", expectation);
             }
 
-            IEquivalencyAssertionOptions options = config(AssertionOptions.CloneDefaults<TExpectation>());
+            EquivalencyAssertionOptions<TExpectation> options = config(AssertionOptions.CloneDefaults<TExpectation>());
             IEnumerable<object> actualItems = Subject.Cast<object>();
 
             using (var scope = new AssertionScope())

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -343,7 +343,7 @@ namespace FluentAssertions.Collections
             // from O(n^2) to O(n). For bigger tables it is necessary in order to achieve acceptable
             // execution times.
             Func<EquivalencyAssertionOptions<TExpectation>, EquivalencyAssertionOptions<TExpectation>> forceStringOrderingConfig =
-                x => config(x).WithStrictOrderingFor(s => s.SelectedMemberPath == "");
+                x => config(x).WithStrictOrderingFor(s => string.IsNullOrEmpty(s.SelectedMemberPath));
 
             BeEquivalentTo(repeatedExpectation, forceStringOrderingConfig, because, becauseArgs);
         }

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -45,7 +45,7 @@ namespace FluentAssertions.Collections
 
             Func<T, TKey> compiledPredicate = predicate.Compile();
 
-            var values = Subject
+            T[] values = Subject
                 .Where(e => compiledPredicate(e) is null)
                 .ToArray();
 

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -777,7 +777,7 @@ namespace FluentAssertions.Collections
         /// Returns an enumerable consisting of all items in the first collection also appearing in the second.
         /// </summary>
         /// <remarks>Enumerable.Intersect is not suitable because it drops any repeated elements.</remarks>
-        private IEnumerable<TValue> RepetitionPreservingIntersect(
+        private static IEnumerable<TValue> RepetitionPreservingIntersect(
             IEnumerable<TValue> first, IEnumerable<TValue> second)
         {
             var secondSet = new HashSet<TValue>(second);

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -548,7 +548,7 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} to contain keys {0}{reason}, but found {1}.", expected, Subject);
             }
 
-            var missingKeys = expectedKeys.Where(key => !Subject.ContainsKey(key));
+            IEnumerable<TKey> missingKeys = expectedKeys.Where(key => !Subject.ContainsKey(key));
 
             if (missingKeys.Any())
             {
@@ -648,7 +648,7 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} to contain keys {0}{reason}, but found {1}.", unexpected, Subject);
             }
 
-            var foundKeys = unexpectedKeys.Intersect(Subject.Keys);
+            IEnumerable<TKey> foundKeys = unexpectedKeys.Intersect(Subject.Keys);
 
             if (foundKeys.Any())
             {
@@ -746,7 +746,8 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} to contain value {0}{reason}, but found {1}.", expected, Subject);
             }
 
-            var missingValues = expectedValues.Except(Subject.Values);
+            IEnumerable<TValue> missingValues = expectedValues.Except(Subject.Values);
+
             if (missingValues.Any())
             {
                 if (expectedValues.Count > 1)
@@ -860,7 +861,8 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} to not contain value {0}{reason}, but found {1}.", unexpected, Subject);
             }
 
-            var foundValues = unexpectedValues.Intersect(Subject.Values);
+            IEnumerable<TValue> foundValues = unexpectedValues.Intersect(Subject.Values);
+
             if (foundValues.Any())
             {
                 if (unexpectedValues.Count > 1)
@@ -928,8 +930,8 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} to contain key/value pairs {0}{reason}, but dictionary is {1}.", expected, Subject);
             }
 
-            var expectedKeys = expectedKeyValuePairs.Select(keyValuePair => keyValuePair.Key).ToArray();
-            var missingKeys = expectedKeys.Where(key => !Subject.ContainsKey(key));
+            TKey[] expectedKeys = expectedKeyValuePairs.Select(keyValuePair => keyValuePair.Key).ToArray();
+            IEnumerable<TKey> missingKeys = expectedKeys.Where(key => !Subject.ContainsKey(key));
 
             if (missingKeys.Any())
             {
@@ -962,7 +964,7 @@ namespace FluentAssertions.Collections
                 }
                 else
                 {
-                    var expectedKeyValuePair = keyValuePairsNotSameOrEqualInSubject[0];
+                    KeyValuePair<TKey, TValue> expectedKeyValuePair = keyValuePairsNotSameOrEqualInSubject[0];
                     TValue actual = Subject[expectedKeyValuePair.Key];
 
                     Execute.Assertion
@@ -1080,11 +1082,12 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} to not contain key/value pairs {0}{reason}, but dictionary is {1}.", items, Subject);
             }
 
-            var keyValuePairsFound = keyValuePairs.Where(keyValuePair => Subject.ContainsKey(keyValuePair.Key)).ToArray();
+            KeyValuePair<TKey, TValue>[] keyValuePairsFound = keyValuePairs.Where(keyValuePair => Subject.ContainsKey(keyValuePair.Key)).ToArray();
 
             if (keyValuePairsFound.Any())
             {
-                var keyValuePairsSameOrEqualInSubject = keyValuePairsFound.Where(keyValuePair => Subject[keyValuePair.Key].IsSameOrEqualTo(keyValuePair.Value)).ToArray();
+                KeyValuePair<TKey, TValue>[] keyValuePairsSameOrEqualInSubject = keyValuePairsFound
+                    .Where(keyValuePair => Subject[keyValuePair.Key].IsSameOrEqualTo(keyValuePair.Value)).ToArray();
 
                 if (keyValuePairsSameOrEqualInSubject.Any())
                 {
@@ -1096,7 +1099,7 @@ namespace FluentAssertions.Collections
                     }
                     else
                     {
-                        var keyValuePair = keyValuePairsSameOrEqualInSubject[0];
+                        KeyValuePair<TKey, TValue> keyValuePair = keyValuePairsSameOrEqualInSubject[0];
 
                         Execute.Assertion
                             .BecauseOf(because, becauseArgs)

--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -40,7 +40,7 @@ namespace FluentAssertions.Common
         {
             Guard.ThrowIfArgumentIsNull(expression, nameof(expression), "Expected a property expression, but found <null>.");
 
-            var memberInfo = AttemptToGetMemberInfoFromCastExpression(expression) ??
+            MemberInfo memberInfo = AttemptToGetMemberInfoFromCastExpression(expression) ??
                              AttemptToGetMemberInfoFromMemberExpression(expression);
 
             if (!(memberInfo is PropertyInfo propertyInfo))
@@ -92,7 +92,9 @@ namespace FluentAssertions.Common
 
             while (node != null)
             {
+#pragma warning disable IDE0010 // System.Linq.Expressions.ExpressionType has many members we do not care about
                 switch (node.NodeType)
+#pragma warning restore IDE0010
                 {
                     case ExpressionType.Lambda:
                         node = ((LambdaExpression)node).Body;

--- a/Src/FluentAssertions/Common/MethodInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/MethodInfoExtensions.cs
@@ -31,7 +31,7 @@ namespace FluentAssertions.Common
 
             if (typeof(TAttribute) == typeof(MethodImplAttribute) && memberInfo is MethodBase methodBase)
             {
-                var (success, methodImplAttribute) = RecreateMethodImplAttribute(methodBase);
+                (bool success, MethodImplAttribute methodImplAttribute) = RecreateMethodImplAttribute(methodBase);
 
                 if (success)
                 {

--- a/Src/FluentAssertions/Common/NullConfigurationStore.cs
+++ b/Src/FluentAssertions/Common/NullConfigurationStore.cs
@@ -1,3 +1,4 @@
+#if NETSTANDARD1_3 || NETSTANDARD1_6
 namespace FluentAssertions.Common
 {
     internal class NullConfigurationStore : IConfigurationStore
@@ -8,3 +9,4 @@ namespace FluentAssertions.Common
         }
     }
 }
+#endif

--- a/Src/FluentAssertions/Common/NullReflector.cs
+++ b/Src/FluentAssertions/Common/NullReflector.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if NETSTANDARD1_3
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -12,3 +13,4 @@ namespace FluentAssertions.Common
         }
     }
 }
+#endif

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -300,7 +300,7 @@ namespace FluentAssertions.Common
         /// <returns></returns>
         public static bool IsCSharpAbstract(this Type type)
         {
-            var typeInfo = type.GetTypeInfo();
+            TypeInfo typeInfo = type.GetTypeInfo();
             return typeInfo.IsAbstract && !typeInfo.IsSealed;
         }
 
@@ -311,7 +311,7 @@ namespace FluentAssertions.Common
         /// <returns></returns>
         public static bool IsCSharpSealed(this Type type)
         {
-            var typeInfo = type.GetTypeInfo();
+            TypeInfo typeInfo = type.GetTypeInfo();
             return typeInfo.IsSealed && !typeInfo.IsAbstract;
         }
 
@@ -322,7 +322,7 @@ namespace FluentAssertions.Common
         /// <returns></returns>
         public static bool IsCSharpStatic(this Type type)
         {
-            var typeInfo = type.GetTypeInfo();
+            TypeInfo typeInfo = type.GetTypeInfo();
             return typeInfo.IsSealed && typeInfo.IsAbstract;
         }
 

--- a/Src/FluentAssertions/Equivalency/AssertionContext.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionContext.cs
@@ -24,7 +24,7 @@ namespace FluentAssertions.Equivalency
 
         internal static AssertionContext<TSubject> CreateFromEquivalencyValidationContext(IEquivalencyValidationContext context)
         {
-            var expectation = (context.Expectation != null) ? (TSubject)context.Expectation : default(TSubject);
+            TSubject expectation = (context.Expectation != null) ? (TSubject)context.Expectation : default;
 
             var assertionContext = new AssertionContext<TSubject>(
                 context.SelectedMemberInfo,

--- a/Src/FluentAssertions/Equivalency/CollectionMemberAssertionRuleDecorator.cs
+++ b/Src/FluentAssertions/Equivalency/CollectionMemberAssertionRuleDecorator.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Equivalency
             IEquivalencyValidator parent,
             IEquivalencyAssertionOptions config)
         {
-            var equivalencyValidationContext = CreateAdjustedCopy(context);
+            EquivalencyValidationContext equivalencyValidationContext = CreateAdjustedCopy(context);
 
             return equivalencyStep.Handle(equivalencyValidationContext, parent, config);
         }

--- a/Src/FluentAssertions/Equivalency/ConversionSelector.cs
+++ b/Src/FluentAssertions/Equivalency/ConversionSelector.cs
@@ -64,12 +64,12 @@ namespace FluentAssertions.Equivalency
 
             StringBuilder descriptionBuilder = new StringBuilder();
 
-            foreach (var inclusion in inclusions)
+            foreach (ConversionSelectorRule inclusion in inclusions)
             {
                 descriptionBuilder.Append(inclusion.Description);
             }
 
-            foreach (var exclusion in exclusions)
+            foreach (ConversionSelectorRule exclusion in exclusions)
             {
                 descriptionBuilder.Append(exclusion.Description);
             }

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
@@ -51,7 +51,7 @@ namespace FluentAssertions.Equivalency
             }
         }
 
-        private bool AssertIsNotNull(object expectation, object[] subject)
+        private static bool AssertIsNotNull(object expectation, object[] subject)
         {
             return AssertionScope.Current
                 .ForCondition(!(expectation is null))

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -82,7 +82,7 @@ namespace FluentAssertions.Equivalency
 
         private bool IsCyclicReference(IEquivalencyValidationContext context)
         {
-            var objectTracker = AssertionScope.Current.Get<CyclicReferenceDetector>("cyclic_reference_detector");
+            CyclicReferenceDetector objectTracker = AssertionScope.Current.Get<CyclicReferenceDetector>("cyclic_reference_detector");
             if (objectTracker is null)
             {
                 objectTracker = new CyclicReferenceDetector(config.CyclicReferenceHandling);
@@ -114,7 +114,7 @@ namespace FluentAssertions.Equivalency
 
         private void RunStepsUntilEquivalencyIsProven(IEquivalencyValidationContext context)
         {
-            foreach (var step in AssertionOptions.EquivalencySteps)
+            foreach (IEquivalencyStep step in AssertionOptions.EquivalencySteps)
             {
                 if (step.CanHandle(context, config) && step.Handle(context, this, config))
                 {

--- a/Src/FluentAssertions/Equivalency/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericEnumerableEquivalencyStep.cs
@@ -46,7 +46,7 @@ namespace FluentAssertions.Equivalency
                     "to use for asserting the equivalency of the collection. ",
                     interfaceTypes.Select(type => "IEnumerable<" + type.GetGenericArguments().Single() + ">")));
 
-            if (AssertSubjectIsCollection(context.Expectation, context.Subject))
+            if (AssertSubjectIsCollection(context.Subject))
             {
                 var validator = new EnumerableEquivalencyValidator(parent, context)
                 {
@@ -74,7 +74,7 @@ namespace FluentAssertions.Equivalency
         private static void HandleImpl<T>(EnumerableEquivalencyValidator validator, object[] subject, IEnumerable<T> expectation)
             => validator.Execute(subject, expectation?.ToArray());
 
-        private static bool AssertSubjectIsCollection(object expectation, object subject)
+        private static bool AssertSubjectIsCollection(object subject)
         {
             bool conditionMet = AssertionScope.Current
                 .ForCondition(!(subject is null))

--- a/Src/FluentAssertions/Equivalency/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericEnumerableEquivalencyStep.cs
@@ -18,7 +18,7 @@ namespace FluentAssertions.Equivalency
         /// </summary>
         public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
         {
-            var expectationType = config.GetExpectationType(context);
+            Type expectationType = config.GetExpectationType(context);
 
             return (context.Expectation != null) && IsGenericCollection(expectationType);
         }
@@ -38,7 +38,7 @@ namespace FluentAssertions.Equivalency
         {
             Type expectedType = config.GetExpectationType(context);
 
-            var interfaceTypes = GetIEnumerableInterfaces(expectedType);
+            Type[] interfaceTypes = GetIEnumerableInterfaces(expectedType);
 
             AssertionScope.Current
                 .ForCondition(interfaceTypes.Length == 1)
@@ -97,7 +97,7 @@ namespace FluentAssertions.Equivalency
 
         private static bool IsGenericCollection(Type type)
         {
-            var enumerableInterfaces = GetIEnumerableInterfaces(type);
+            Type[] enumerableInterfaces = GetIEnumerableInterfaces(type);
 
             return (!typeof(string).IsAssignableFrom(type)) && enumerableInterfaces.Any();
         }

--- a/Src/FluentAssertions/Equivalency/MemberInfoSelectedMemberInfo.cs
+++ b/Src/FluentAssertions/Equivalency/MemberInfoSelectedMemberInfo.cs
@@ -36,7 +36,7 @@ namespace FluentAssertions.Equivalency
                 return true;
             }
 
-            if (obj.GetType() != this.GetType())
+            if (obj.GetType() != GetType())
             {
                 return false;
             }

--- a/Src/FluentAssertions/Equivalency/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/ObjectReference.cs
@@ -22,12 +22,12 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="T:System.Object"/> is equal to the current <see cref="T:System.Object"/>.
+        /// Determines whether the specified <see cref="System.Object"/> is equal to the current <see cref="System.Object"/>.
         /// </summary>
         /// <returns>
-        /// true if the specified <see cref="T:System.Object"/> is equal to the current <see cref="T:System.Object"/>; otherwise, false.
+        /// true if the specified <see cref="System.Object"/> is equal to the current <see cref="System.Object"/>; otherwise, false.
         /// </returns>
-        /// <param name="obj">The <see cref="T:System.Object"/> to compare with the current <see cref="T:System.Object"/>. </param><filterpriority>2</filterpriority>
+        /// <param name="obj">The <see cref="System.Object"/> to compare with the current <see cref="System.Object"/>. </param><filterpriority>2</filterpriority>
         public override bool Equals(object obj)
         {
             if (!(obj is ObjectReference other))
@@ -52,7 +52,7 @@ namespace FluentAssertions.Equivalency
         /// Serves as a hash function for a particular type.
         /// </summary>
         /// <returns>
-        /// A hash code for the current <see cref="T:System.Object"/>.
+        /// A hash code for the current <see cref="System.Object"/>.
         /// </returns>
         /// <filterpriority>2</filterpriority>
         public override int GetHashCode()

--- a/Src/FluentAssertions/Equivalency/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/ObjectReference.cs
@@ -39,7 +39,7 @@ namespace FluentAssertions.Equivalency
         }
 
         private string[] GetPathElements() => pathElements
-            ?? (pathElements = path.ToLowerInvariant().Replace("][", "].[").Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries));
+            ?? (pathElements = path.ToUpperInvariant().Replace("][", "].[").Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries));
 
         private bool IsParentOf(ObjectReference other)
         {

--- a/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
@@ -48,7 +48,7 @@ namespace FluentAssertions.Equivalency.Ordering
 
             if (!indexQualifierRegex.IsMatch(path))
             {
-                var match = indexQualifierRegex.Match(sourcePath);
+                Match match = indexQualifierRegex.Match(sourcePath);
                 if (match.Success)
                 {
                     sourcePath = sourcePath.Substring(match.Length);

--- a/Src/FluentAssertions/Equivalency/OrderingRuleCollection.cs
+++ b/Src/FluentAssertions/Equivalency/OrderingRuleCollection.cs
@@ -31,7 +31,7 @@ namespace FluentAssertions.Equivalency
         /// Returns an enumerator that iterates through the collection.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.Collections.Generic.IEnumerator`1"/> that can be used to iterate through the collection.
+        /// A <see cref="System.Collections.Generic.IEnumerator{T}"/> that can be used to iterate through the collection.
         /// </returns>
         /// <filterpriority>1</filterpriority>
         public IEnumerator<IOrderingRule> GetEnumerator()
@@ -43,7 +43,7 @@ namespace FluentAssertions.Equivalency
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Collections.IEnumerator"/> object that can be used to iterate through the collection.
+        /// An <see cref="System.Collections.IEnumerator"/> object that can be used to iterate through the collection.
         /// </returns>
         /// <filterpriority>2</filterpriority>
         IEnumerator IEnumerable.GetEnumerator()

--- a/Src/FluentAssertions/Equivalency/Selection/ExcludeMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/ExcludeMemberByPathSelectionRule.cs
@@ -15,7 +15,7 @@ namespace FluentAssertions.Equivalency.Selection
         public ExcludeMemberByPathSelectionRule(MemberPath pathToExclude)
             : base(pathToExclude.ToString())
         {
-            this.memberToExclude = pathToExclude;
+            memberToExclude = pathToExclude;
         }
 
         protected override IEnumerable<SelectedMemberInfo> OnSelectMembers(IEnumerable<SelectedMemberInfo> selectedMembers,

--- a/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
@@ -23,7 +23,7 @@ namespace FluentAssertions.Equivalency.Selection
         protected override IEnumerable<SelectedMemberInfo> OnSelectMembers(IEnumerable<SelectedMemberInfo> selectedMembers,
             string currentPath, IMemberInfo context)
         {
-            var matchingMembers =
+            IEnumerable<SelectedMemberInfo> matchingMembers =
                 from member in context.RuntimeType.GetNonPrivateMembers()
                 let memberPath = new MemberPath(member.DeclaringType, currentPath.Combine(member.Name))
                 where memberToInclude.IsSameAs(memberPath) ||

--- a/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
@@ -39,7 +39,7 @@ namespace FluentAssertions.Equivalency.Selection
 
             if (!indexQualifierRegex.IsMatch(selectedPath))
             {
-                var match = indexQualifierRegex.Match(propertyPath);
+                Match match = indexQualifierRegex.Match(propertyPath);
                 if (match.Success)
                 {
                     propertyPath = propertyPath.Substring(match.Length);

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -33,7 +33,9 @@ namespace FluentAssertions.Equivalency
         private CyclicReferenceHandling cyclicReferenceHandling = CyclicReferenceHandling.ThrowException;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+#pragma warning disable CA1051 // TODO: fix in 6.0
         protected readonly OrderingRuleCollection orderingRules = new OrderingRuleCollection();
+#pragma warning restore CA1051
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private bool isRecursive;

--- a/Src/FluentAssertions/Equivalency/StructuralEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/StructuralEqualityEquivalencyStep.cs
@@ -41,7 +41,7 @@ namespace FluentAssertions.Equivalency
 
             if (expectationIsNotNull && subjectIsNotNull)
             {
-                foreach (var selectedMemberInfo in selectedMembers)
+                foreach (SelectedMemberInfo selectedMemberInfo in selectedMembers)
                 {
                     AssertMemberEquality(context, parent, selectedMemberInfo, config);
                 }
@@ -67,7 +67,7 @@ namespace FluentAssertions.Equivalency
 
         private static SelectedMemberInfo FindMatchFor(SelectedMemberInfo selectedMemberInfo, IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
         {
-            var query =
+            IEnumerable<SelectedMemberInfo> query =
                 from rule in config.MatchingRules
                 let match = rule.Match(selectedMemberInfo, context.Subject, context.SelectedMemberDescription, config)
                 where match != null
@@ -81,7 +81,7 @@ namespace FluentAssertions.Equivalency
         {
             IEnumerable<SelectedMemberInfo> members = Enumerable.Empty<SelectedMemberInfo>();
 
-            foreach (var selectionRule in config.SelectionRules)
+            foreach (IMemberSelectionRule selectionRule in config.SelectionRules)
             {
                 members = selectionRule.SelectMembers(members, context, config);
             }

--- a/Src/FluentAssertions/Equivalency/TryConversionStep.cs
+++ b/Src/FluentAssertions/Equivalency/TryConversionStep.cs
@@ -57,7 +57,7 @@ namespace FluentAssertions.Equivalency
             {
                 context.TraceSingle(path => $"Converted subject {context.Subject} at {path} to {expectationType}");
 
-                var newContext = context.CreateWithDifferentSubject(convertedSubject, expectationType);
+                IEquivalencyValidationContext newContext = context.CreateWithDifferentSubject(convertedSubject, expectationType);
 
                 structuralEqualityValidator.AssertEqualityUsing(newContext);
                 return true;

--- a/Src/FluentAssertions/Events/EventHandlerFactory.cs
+++ b/Src/FluentAssertions/Events/EventHandlerFactory.cs
@@ -84,7 +84,7 @@ namespace FluentAssertions.Events
         /// </summary>
         private static Type GetDelegateReturnType(Type d)
         {
-            var invoke = DelegateInvokeMethod(d);
+            MethodInfo invoke = DelegateInvokeMethod(d);
             return invoke.ReturnType;
         }
 
@@ -93,9 +93,9 @@ namespace FluentAssertions.Events
         /// </summary>
         private static Type[] GetDelegateParameterTypes(Type d)
         {
-            var invoke = DelegateInvokeMethod(d);
+            MethodInfo invoke = DelegateInvokeMethod(d);
 
-            var parameterInfo = invoke.GetParameters();
+            ParameterInfo[] parameterInfo = invoke.GetParameters();
             var parameters = new Type[parameterInfo.Length];
 
             for (var index = 0; index < parameterInfo.Length; index++)
@@ -134,7 +134,7 @@ namespace FluentAssertions.Events
                 return false;
             }
 
-            var invoke = d.GetMethod("Invoke");
+            MethodInfo invoke = d.GetMethod("Invoke");
             return invoke != null;
         }
 
@@ -148,7 +148,7 @@ namespace FluentAssertions.Events
                 throw new ArgumentException("Type is not a Delegate!", nameof(d));
             }
 
-            var invoke = d.GetMethod("Invoke");
+            MethodInfo invoke = d.GetMethod("Invoke");
             return invoke;
         }
     }

--- a/Src/FluentAssertions/Events/EventMonitor.cs
+++ b/Src/FluentAssertions/Events/EventMonitor.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Common;
@@ -43,7 +44,7 @@ namespace FluentAssertions.Events
         {
             get
             {
-                var query =
+                IEnumerable<OccurredEvent> query =
                     from mapItem in recorderMap.ToArray()
                     let eventName = mapItem.Key
                     let recorder = mapItem.Value
@@ -86,7 +87,7 @@ namespace FluentAssertions.Events
                 throw new InvalidOperationException($"Type {typeDefiningEventsToMonitor.Name} does not expose any events.");
             }
 
-            foreach (var eventInfo in events)
+            foreach (EventInfo eventInfo in events)
             {
                 AttachEventHandler(eventInfo, utcNow);
             }

--- a/Src/FluentAssertions/Execution/AssertionFailedException.cs
+++ b/Src/FluentAssertions/Execution/AssertionFailedException.cs
@@ -13,7 +13,9 @@ namespace FluentAssertions.Execution
     [Serializable]
 #endif
 
+#pragma warning disable CA1032, RCS1194 // AssertionFailedException should never be constructed with an empty message
     public class AssertionFailedException : Exception
+#pragma warning restore CA1032, RCS1194
     {
         public AssertionFailedException(string message)
             : base(message)

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -141,7 +141,7 @@ namespace FluentAssertions.Execution
         /// <param name="args">Optional arguments to any numbered placeholders.</param>
         public AssertionScope WithExpectation(string message, params object[] args)
         {
-            var localReason = reason;
+            Func<string> localReason = reason;
             expectation = () =>
             {
                 var messageBuilder = new MessageBuilder(useLineBreaks);

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -88,7 +88,9 @@ namespace FluentAssertions.Execution
         /// </summary>
         public static AssertionScope Current
         {
+#pragma warning disable CA2000 // AssertionScope should not be disposed here
             get => GetCurrentAssertionScope() ?? new AssertionScope(new DefaultAssertionStrategy());
+#pragma warning restore CA2000
             private set => SetCurrentAssertionScope(value);
         }
 

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -42,12 +42,12 @@ namespace FluentAssertions.Execution
         /// <summary>
         /// Starts a new scope based on the given assertion strategy.
         /// </summary>
-        /// <param name="_assertionStrategy">The assertion strategy for this scope.</param>
+        /// <param name="assertionStrategy">The assertion strategy for this scope.</param>
         /// <exception cref="ArgumentNullException">Thrown when trying to use a null strategy.</exception>
-        public AssertionScope(IAssertionStrategy _assertionStrategy)
+        public AssertionScope(IAssertionStrategy assertionStrategy)
         {
-            assertionStrategy = _assertionStrategy
-                ?? throw new ArgumentNullException(nameof(_assertionStrategy));
+            this.assertionStrategy = assertionStrategy
+                ?? throw new ArgumentNullException(nameof(assertionStrategy));
             parent = null;
         }
 

--- a/Src/FluentAssertions/Execution/ContextDataItems.cs
+++ b/Src/FluentAssertions/Execution/ContextDataItems.cs
@@ -34,7 +34,7 @@ namespace FluentAssertions.Execution
 
         public void Add(ContextDataItems contextDataItems)
         {
-            foreach (var item in contextDataItems.items)
+            foreach (DataItem item in contextDataItems.items)
             {
                 Add(item.Clone());
             }
@@ -42,7 +42,7 @@ namespace FluentAssertions.Execution
 
         public void Add(DataItem item)
         {
-            var existingItem = items.SingleOrDefault(i => i.Key == item.Key);
+            DataItem existingItem = items.SingleOrDefault(i => i.Key == item.Key);
             if (existingItem != null)
             {
                 items.Remove(existingItem);

--- a/Src/FluentAssertions/Execution/ContinuedAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/ContinuedAssertionScope.cs
@@ -25,7 +25,7 @@ namespace FluentAssertions.Execution
 
         public GivenSelector<T> Given<T>(Func<T> selector)
         {
-            return predecessor.Given<T>(selector);
+            return predecessor.Given(selector);
         }
 
         public IAssertionScope ForCondition(bool condition)

--- a/Src/FluentAssertions/Execution/GallioTestFramework.cs
+++ b/Src/FluentAssertions/Execution/GallioTestFramework.cs
@@ -30,20 +30,20 @@ namespace FluentAssertions.Execution
 
             if (testContext != null)
             {
-                var method = testContextType.GetRuntimeMethod("IncrementAssertCount", new Type[0]);
+                MethodInfo method = testContextType.GetRuntimeMethod("IncrementAssertCount", new Type[0]);
                 method.Invoke(testContext, null);
             }
 
             object assertionFailureBuilder = Activator.CreateInstance(assertionFailureBuilderType, message);
             object assertionFailure;
-            var setMessageMethod = assertionFailureBuilderType.GetRuntimeMethod("SetMessage", new[] { typeof(string) });
+            MethodInfo setMessageMethod = assertionFailureBuilderType.GetRuntimeMethod("SetMessage", new[] { typeof(string) });
             setMessageMethod.Invoke(assertionFailureBuilder, new object[] { message });
 
-            var toAssertionFailureMethod = assertionFailureBuilderType.GetRuntimeMethod("ToAssertionFailure", new Type[0]);
+            MethodInfo toAssertionFailureMethod = assertionFailureBuilderType.GetRuntimeMethod("ToAssertionFailure", new Type[0]);
             assertionFailure = toAssertionFailureMethod.Invoke(assertionFailureBuilder, null);
             try
             {
-                var failMethod = assertionHelperType.GetRuntimeMethods().First(m => m.Name == "Fail");
+                MethodInfo failMethod = assertionHelperType.GetRuntimeMethods().First(m => m.Name == "Fail");
                 failMethod.Invoke(null, new[] { assertionFailure });
             }
             catch (TargetInvocationException ex)

--- a/Src/FluentAssertions/Execution/GallioTestFramework.cs
+++ b/Src/FluentAssertions/Execution/GallioTestFramework.cs
@@ -79,6 +79,6 @@ namespace FluentAssertions.Execution
             }
         }
 
-        private string AssemblyName => "Gallio";
+        private static string AssemblyName => "Gallio";
     }
 }

--- a/Src/FluentAssertions/Execution/GivenSelector.cs
+++ b/Src/FluentAssertions/Execution/GivenSelector.cs
@@ -26,7 +26,7 @@ namespace FluentAssertions.Execution
             this.predecessorSucceeded = predecessorSucceeded;
             this.predecessor = predecessor;
 
-            subject = predecessorSucceeded ? selector() : default(T);
+            subject = predecessorSucceeded ? selector() : default;
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Execution/MessageBuilder.cs
+++ b/Src/FluentAssertions/Execution/MessageBuilder.cs
@@ -42,7 +42,7 @@ namespace FluentAssertions.Execution
             return message;
         }
 
-        private string SubstituteIdentifier(string message, string identifier, string fallbackIdentifier)
+        private static string SubstituteIdentifier(string message, string identifier, string fallbackIdentifier)
         {
             const string pattern = @"(\s|^)\{context(?:\:(?<default>[a-z|A-Z|\s]+))?\}";
 
@@ -72,7 +72,7 @@ namespace FluentAssertions.Execution
             return message.TrimStart();
         }
 
-        private string SubstituteContextualTags(string message, ContextDataItems contextData)
+        private static string SubstituteContextualTags(string message, ContextDataItems contextData)
         {
             const string pattern = @"(?<!\{)\{(?<key>[a-z|A-Z]+)(?:\:(?<default>[a-z|A-Z|\s]+))?\}(?!\})";
 

--- a/Src/FluentAssertions/Extensions/FluentTimeSpanExtensions.cs
+++ b/Src/FluentAssertions/Extensions/FluentTimeSpanExtensions.cs
@@ -24,12 +24,12 @@ namespace FluentAssertions.Extensions
         /// <summary>
         /// Represents the number of ticks that are in 1 microsecond.
         /// </summary>
-        public const Int64 TicksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
+        public const long TicksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
 
         /// <summary>
         /// Represents the number of ticks that are in 1 nanosecond.
         /// </summary>
-        public const Double TicksPerNanosecond = TicksPerMicrosecond / 1000d;
+        public const double TicksPerNanosecond = TicksPerMicrosecond / 1000d;
 
         /// <summary>
         /// Returns a <see cref="TimeSpan" /> based on a number of ticks.

--- a/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
@@ -70,7 +70,7 @@ namespace FluentAssertions.Formatting
             }
         }
 
-        private MethodInfo[] FindCustomFormatters()
+        private static MethodInfo[] FindCustomFormatters()
         {
             IEnumerable<MethodInfo> query =
                 from type in Services.Reflector.GetAllTypesFromAppDomain(Applicable)

--- a/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
@@ -71,7 +72,7 @@ namespace FluentAssertions.Formatting
 
         private MethodInfo[] FindCustomFormatters()
         {
-            var query =
+            IEnumerable<MethodInfo> query =
                 from type in Services.Reflector.GetAllTypesFromAppDomain(Applicable)
                 where type != null
                 from method in type.GetMethods(BindingFlags.Static | BindingFlags.Public)
@@ -85,7 +86,7 @@ namespace FluentAssertions.Formatting
 
         private static bool Applicable(Assembly assembly)
         {
-            var configuration = Configuration.Current;
+            Configuration configuration = Configuration.Current;
             ValueFormatterDetectionMode mode = configuration.ValueFormatterDetectionMode;
 
             return ((mode == ValueFormatterDetectionMode.Scan) || (

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -66,12 +66,12 @@ namespace FluentAssertions.Formatting
                 builder.AppendLine();
             }
 
-            var type = obj.GetType();
+            Type type = obj.GetType();
             builder.AppendLine(type.FullName);
             builder.Append(CreateWhitespaceForLevel(context.Depth)).Append('{').AppendLine();
 
             IEnumerable<SelectedMemberInfo> properties = type.GetNonPrivateMembers();
-            foreach (var propertyInfo in properties.OrderBy(pi => pi.Name))
+            foreach (SelectedMemberInfo propertyInfo in properties.OrderBy(pi => pi.Name))
             {
                 string propertyValueText = GetPropertyValueTextFor(obj, propertyInfo, context, formatChild);
                 builder.AppendLine(propertyValueText);

--- a/Src/FluentAssertions/Formatting/MultidimensionalArrayFormatter.cs
+++ b/Src/FluentAssertions/Formatting/MultidimensionalArrayFormatter.cs
@@ -45,7 +45,7 @@ namespace FluentAssertions.Formatting
 
                 if (IsFirstIteration(arr, currentDimensionIndex, currentLoopIndex))
                 {
-                    sb.Append("{");
+                    sb.Append('{');
                 }
 
                 if (IsInnerMostLoop(arr, currentLoopIndex))
@@ -65,7 +65,7 @@ namespace FluentAssertions.Formatting
 
                 while (IsLastIteration(arr, currentDimensionIndex, currentLoopIndex))
                 {
-                    sb.Append("}");
+                    sb.Append('}');
                     // Reset current loop's variable to start value ...and move to outer loop
                     dimensionIndices[currentLoopIndex] = arr.GetLowerBound(currentLoopIndex);
                     --currentLoopIndex;

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -778,7 +778,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<DateTimeAssertions> BeSameDateAs(DateTime expected, string because = "",
             params object[] becauseArgs)
         {
-            var expectedDate = expected.Date;
+            DateTime expectedDate = expected.Date;
 
             Execute.Assertion
                 .WithExpectation("Expected the date part of {context:the date and time} to be {0}{reason}", expectedDate)

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -845,7 +845,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<DateTimeOffsetAssertions> BeSameDateAs(DateTimeOffset expected, string because = "",
             params object[] becauseArgs)
         {
-            var expectedDate = expected.Date;
+            DateTime expectedDate = expected.Date;
 
             Execute.Assertion
                 .WithExpectation("Expected the date part of {context:the date and time} to be {0}{reason}, ", expectedDate)
@@ -876,7 +876,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<DateTimeOffsetAssertions> NotBeSameDateAs(DateTimeOffset unexpected, string because = "",
             params object[] becauseArgs)
         {
-            var unexpectedDate = unexpected.Date;
+            DateTime unexpectedDate = unexpected.Date;
 
             Execute.Assertion
                 .WithExpectation("Did not expect the date part of {context:the date and time} to be {0}{reason}, ", unexpectedDate)

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -134,7 +134,7 @@ namespace FluentAssertions.Primitives
 
             T typedSubject = (Subject is T type)
                 ? type
-                : default(T);
+                : default;
 
             return new AndWhichConstraint<TAssertions, T>((TAssertions)this, typedSubject);
         }
@@ -244,7 +244,7 @@ namespace FluentAssertions.Primitives
 
             T typedSubject = (Subject is T type)
                 ? type
-                : default(T);
+                : default;
 
             return new AndWhichConstraint<TAssertions, T>((TAssertions)this, typedSubject);
         }

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -283,8 +283,8 @@ namespace FluentAssertions.Primitives
         public AndConstraint<SimpleTimeSpanAssertions> BeCloseTo(TimeSpan nearbyTime, TimeSpan precision, string because = "",
             params object[] becauseArgs)
         {
-            var minimumValue = nearbyTime - precision;
-            var maximumValue = nearbyTime + precision;
+            TimeSpan minimumValue = nearbyTime - precision;
+            TimeSpan maximumValue = nearbyTime + precision;
 
             Execute.Assertion
                 .ForCondition(Subject.HasValue && (Subject.Value >= minimumValue) && (Subject.Value <= maximumValue))
@@ -347,8 +347,8 @@ namespace FluentAssertions.Primitives
         public AndConstraint<SimpleTimeSpanAssertions> NotBeCloseTo(TimeSpan distantTime, TimeSpan precision, string because = "",
             params object[] becauseArgs)
         {
-            var minimumValue = distantTime - precision;
-            var maximumValue = distantTime + precision;
+            TimeSpan minimumValue = distantTime - precision;
+            TimeSpan maximumValue = distantTime + precision;
 
             Execute.Assertion
                 .ForCondition(Subject.HasValue && !((Subject.Value >= minimumValue) && (Subject.Value <= maximumValue)))

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -16,7 +16,7 @@ namespace FluentAssertions.Primitives
     public class StringAssertions : ReferenceTypeAssertions<string, StringAssertions>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:System.Object" /> class.
+        /// Initializes a new instance of the <see cref="System.Object" /> class.
         /// </summary>
         public StringAssertions(string value) : base(value)
         {

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -796,7 +796,7 @@ namespace FluentAssertions.Primitives
         {
             ThrowIfValuesNullOrEmpty(values);
 
-            var matches = values.Where(v => Contains(Subject, v, StringComparison.Ordinal));
+            IEnumerable<string> matches = values.Where(v => Contains(Subject, v, StringComparison.Ordinal));
 
             Execute.Assertion
                 .ForCondition(!matches.Any())

--- a/Src/FluentAssertions/Primitives/StringValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringValidator.cs
@@ -58,7 +58,7 @@ namespace FluentAssertions.Primitives
             return true;
         }
 
-        private bool IsLongOrMultiline(string value)
+        private static bool IsLongOrMultiline(string value)
         {
             return (value.Length > HumanReadableLength) || value.Contains(Environment.NewLine);
         }

--- a/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
@@ -29,7 +29,7 @@ namespace FluentAssertions.Primitives
 
         private bool IsMatch()
         {
-            var options = IgnoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
+            RegexOptions options = IgnoreCase ? RegexOptions.IgnoreCase : RegexOptions.None;
 
             string input = CleanNewLines(subject);
             string pattern = ConvertWildcardToRegEx(CleanNewLines(expected));

--- a/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
@@ -37,7 +37,7 @@ namespace FluentAssertions.Primitives
             return Regex.IsMatch(input, pattern, options | RegexOptions.Singleline);
         }
 
-        private string ConvertWildcardToRegEx(string wildcardExpression)
+        private static string ConvertWildcardToRegEx(string wildcardExpression)
         {
             return "^" + Regex.Escape(wildcardExpression).Replace("\\*", ".*").Replace("\\?", ".") + "$";
         }

--- a/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Execution;
@@ -45,7 +46,7 @@ namespace FluentAssertions.Reflection
             var subjectName = Subject.GetName().Name;
             var assemblyName = assembly.GetName().Name;
 
-            var references = Subject.GetReferencedAssemblies().Select(x => x.Name);
+            IEnumerable<string> references = Subject.GetReferencedAssemblies().Select(x => x.Name);
 
             Execute.Assertion
                    .BecauseOf(because, becauseArgs)
@@ -78,7 +79,7 @@ namespace FluentAssertions.Reflection
             var subjectName = Subject.GetName().Name;
             var assemblyName = assembly.GetName().Name;
 
-            var references = Subject.GetReferencedAssemblies().Select(x => x.Name);
+            IEnumerable<string> references = Subject.GetReferencedAssemblies().Select(x => x.Name);
 
             Execute.Assertion
                    .BecauseOf(because, becauseArgs)
@@ -97,7 +98,7 @@ namespace FluentAssertions.Reflection
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
         public AndWhichConstraint<AssemblyAssertions, Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs)
         {
-            var foundType = Subject.GetTypes().SingleOrDefault(t => t.Namespace == @namespace && t.Name == name);
+            Type foundType = Subject.GetTypes().SingleOrDefault(t => t.Namespace == @namespace && t.Name == name);
 
             Execute.Assertion.ForCondition(foundType != null)
                 .BecauseOf(because, becauseArgs)

--- a/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
@@ -93,7 +93,7 @@ namespace FluentAssertions.Reflection
         /// </summary>
         /// <param name="namespace">The namespace of the class.</param>
         /// <param name="name">The name of the class.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<AssemblyAssertions, Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs)

--- a/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
@@ -93,9 +93,9 @@ namespace FluentAssertions.Reflection
         /// </summary>
         /// <param name="namespace">The namespace of the class.</param>
         /// <param name="name">The name of the class.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<AssemblyAssertions, Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs)
         {
             Type foundType = Subject.GetTypes().SingleOrDefault(t => t.Namespace == @namespace && t.Name == name);

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -176,7 +176,7 @@ namespace FluentAssertions.Specialized
             {
                 TimeSpan? invocationEndTime = null;
                 Exception exception = null;
-                var timer = clock.StartTimer();
+                ITimer timer = clock.StartTimer();
 
                 while (invocationEndTime is null || invocationEndTime < waitTime)
                 {

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -162,7 +162,7 @@ namespace FluentAssertions.Specialized
 
             TimeSpan? invocationEndTime = null;
             Exception exception = null;
-            var timer = clock.StartTimer();
+            ITimer timer = clock.StartTimer();
 
             while (invocationEndTime is null || invocationEndTime < waitTime)
             {
@@ -213,7 +213,7 @@ namespace FluentAssertions.Specialized
 
         protected void NotThrow<TException>(Exception exception, string because, object[] becauseArgs) where TException : Exception
         {
-            var exceptions = extractor.OfType<TException>(exception);
+            IEnumerable<TException> exceptions = extractor.OfType<TException>(exception);
             Execute.Assertion
                 .ForCondition(!exceptions.Any())
                 .BecauseOf(because, becauseArgs)

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -61,7 +61,7 @@ namespace FluentAssertions.Specialized
         public virtual ExceptionAssertions<TException> WithMessage(string expectedWildcardPattern, string because = "",
             params object[] becauseArgs)
         {
-            IAssertionScope assertion = Execute.Assertion.BecauseOf(because, becauseArgs).UsingLineBreaks;
+            AssertionScope assertion = Execute.Assertion.BecauseOf(because, becauseArgs).UsingLineBreaks;
 
             assertion
                 .ForCondition(Subject.Any())

--- a/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
@@ -71,7 +71,7 @@ namespace FluentAssertions.Specialized
         public void BeLessOrEqualTo(TimeSpan maxDuration, string because = "", params object[] becauseArgs)
         {
             bool Condition(TimeSpan duration) => duration.CompareTo(maxDuration) <= 0;
-            var (isRunning, elapsed) = PollUntil(Condition, expectedResult: false, rate: maxDuration);
+            (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: false, rate: maxDuration);
 
             Execute.Assertion
                 .ForCondition(Condition(elapsed))
@@ -99,7 +99,7 @@ namespace FluentAssertions.Specialized
         public void BeLessThan(TimeSpan maxDuration, string because = "", params object[] becauseArgs)
         {
             bool Condition(TimeSpan duration) => duration.CompareTo(maxDuration) < 0;
-            var (isRunning, elapsed) = PollUntil(Condition, expectedResult: false, rate: maxDuration);
+            (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: false, rate: maxDuration);
 
             Execute.Assertion
                 .ForCondition(Condition(execution.ElapsedTime))
@@ -127,7 +127,7 @@ namespace FluentAssertions.Specialized
         public void BeGreaterOrEqualTo(TimeSpan minDuration, string because = "", params object[] becauseArgs)
         {
             bool Condition(TimeSpan duration) => duration.CompareTo(minDuration) >= 0;
-            var (isRunning, elapsed) = PollUntil(Condition, expectedResult: true, rate: minDuration);
+            (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: true, rate: minDuration);
 
             Execute.Assertion
                 .ForCondition(Condition(elapsed))
@@ -155,7 +155,7 @@ namespace FluentAssertions.Specialized
         public void BeGreaterThan(TimeSpan minDuration, string because = "", params object[] becauseArgs)
         {
             bool Condition(TimeSpan duration) => duration.CompareTo(minDuration) > 0;
-            var (isRunning, elapsed) = PollUntil(Condition, expectedResult: true, rate: minDuration);
+            (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: true, rate: minDuration);
 
             Execute.Assertion
                 .ForCondition(Condition(elapsed))
@@ -186,15 +186,15 @@ namespace FluentAssertions.Specialized
         /// </param>
         public void BeCloseTo(TimeSpan expectedDuration, TimeSpan precision, string because = "", params object[] becauseArgs)
         {
-            var minimumValue = expectedDuration - precision;
-            var maximumValue = expectedDuration + precision;
+            TimeSpan minimumValue = expectedDuration - precision;
+            TimeSpan maximumValue = expectedDuration + precision;
 
             bool MaxCondition(TimeSpan duration) => duration <= maximumValue;
             bool MinCondition(TimeSpan duration) => duration >= minimumValue;
 
             // for polling we only use max condition, we don't want poll to stop if
             // elapsed time didn't even get to the acceptable range
-            var (isRunning, elapsed) = PollUntil(MaxCondition, expectedResult: false, rate: maximumValue);
+            (bool isRunning, TimeSpan elapsed) = PollUntil(MaxCondition, expectedResult: false, rate: maximumValue);
 
             Execute.Assertion
                 .ForCondition(MinCondition(elapsed) && MaxCondition(elapsed))

--- a/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Specialized
         /// <param name="executionTime">The execution on which time must be asserted.</param>
         public ExecutionTimeAssertions(ExecutionTime executionTime)
         {
-            this.execution = executionTime;
+            execution = executionTime;
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Specialized/FunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/FunctionAssertions.cs
@@ -97,7 +97,7 @@ namespace FluentAssertions.Specialized
 
             TimeSpan? invocationEndTime = null;
             Exception exception = null;
-            var timer = clock.StartTimer();
+            ITimer timer = clock.StartTimer();
 
             while (invocationEndTime is null || invocationEndTime < waitTime)
             {

--- a/Src/FluentAssertions/Types/MemberInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MemberInfoAssertions.cs
@@ -40,7 +40,7 @@ namespace FluentAssertions.Types
             string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
-            return BeDecoratedWith<TAttribute>(attr => true, because, becauseArgs);
+            return BeDecoratedWith<TAttribute>(_ => true, because, becauseArgs);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace FluentAssertions.Types
             string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
-            return NotBeDecoratedWith<TAttribute>(attr => true, because, becauseArgs);
+            return NotBeDecoratedWith<TAttribute>(_ => true, because, becauseArgs);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Types/MethodBaseAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodBaseAssertions.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -71,7 +73,7 @@ namespace FluentAssertions.Types
 
         internal static string GetParameterString(MethodBase methodBase)
         {
-            var parameterTypes = methodBase.GetParameters().Select(p => p.ParameterType);
+            IEnumerable<Type> parameterTypes = methodBase.GetParameters().Select(p => p.ParameterType);
 
             return string.Join(", ", parameterTypes.Select(p => p.FullName));
         }

--- a/Src/FluentAssertions/Types/MethodInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoAssertions.cs
@@ -70,9 +70,9 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the selected method is async.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs)
         {
             string failureMessage = "Expected method " +
@@ -90,9 +90,9 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the selected method is not async.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<MethodInfoAssertions> NotBeAsync(string because = "", params object[] becauseArgs)
         {
             string failureMessage = "Expected method " + SubjectDescription + " not to be async{reason}, but it is.";

--- a/Src/FluentAssertions/Types/MethodInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoAssertions.cs
@@ -70,7 +70,7 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the selected method is async.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs)
@@ -90,7 +90,7 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the selected method is not async.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<MethodInfoAssertions> NotBeAsync(string because = "", params object[] becauseArgs)

--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -147,7 +147,7 @@ namespace FluentAssertions.Types
         /// Returns an enumerator that iterates through the collection.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.Collections.Generic.IEnumerator`1"/> that can be used to iterate through the collection.
+        /// A <see cref="System.Collections.Generic.IEnumerator{T}"/> that can be used to iterate through the collection.
         /// </returns>
         /// <filterpriority>1</filterpriority>
         public IEnumerator<MethodInfo> GetEnumerator()
@@ -159,7 +159,7 @@ namespace FluentAssertions.Types
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Collections.IEnumerator"/> object that can be used to iterate through the collection.
+        /// An <see cref="System.Collections.IEnumerator"/> object that can be used to iterate through the collection.
         /// </returns>
         /// <filterpriority>2</filterpriority>
         IEnumerator IEnumerable.GetEnumerator()

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -116,7 +116,7 @@ namespace FluentAssertions.Types
         public AndConstraint<MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
-            return BeDecoratedWith<TAttribute>(attr => true, because, becauseArgs);
+            return BeDecoratedWith<TAttribute>(_ => true, because, becauseArgs);
         }
 
         /// <summary>
@@ -167,7 +167,7 @@ namespace FluentAssertions.Types
         public AndConstraint<MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
-            return NotBeDecoratedWith<TAttribute>(attr => true, because, becauseArgs);
+            return NotBeDecoratedWith<TAttribute>(_ => true, because, becauseArgs);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -226,6 +226,8 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Returns the type of the subject the assertion applies on.
         /// </summary>
+#pragma warning disable CA1822 // Do not change signature of a public member
         protected string Context => "method";
+#pragma warning restore CA1822
     }
 }

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -85,7 +85,7 @@ namespace FluentAssertions.Types
 
         private MethodInfo[] GetAllNonVirtualMethodsFromSelection()
         {
-            var query =
+            IEnumerable<MethodInfo> query =
                 from method in SubjectMethods
                 where method.IsNonVirtual()
                 select method;
@@ -95,7 +95,7 @@ namespace FluentAssertions.Types
 
         private MethodInfo[] GetAllVirtualMethodsFromSelection()
         {
-            var query =
+            IEnumerable<MethodInfo> query =
                 from method in SubjectMethods
                 where !method.IsNonVirtual()
                 select method;
@@ -139,7 +139,7 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate, nameof(isMatchingAttributePredicate));
 
-            IEnumerable<MethodInfo> methodsWithoutAttribute = GetMethodsWithout<TAttribute>(isMatchingAttributePredicate);
+            IEnumerable<MethodInfo> methodsWithoutAttribute = GetMethodsWithout(isMatchingAttributePredicate);
 
             string failureMessage =
                 "Expected all selected methods to be decorated with {0}{reason}, but the following methods are not:" +
@@ -190,7 +190,7 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate, nameof(isMatchingAttributePredicate));
 
-            IEnumerable<MethodInfo> methodsWithAttribute = GetMethodsWith<TAttribute>(isMatchingAttributePredicate);
+            IEnumerable<MethodInfo> methodsWithAttribute = GetMethodsWith(isMatchingAttributePredicate);
 
             string failureMessage =
                 "Expected all selected methods to not be decorated with {0}{reason}, but the following methods are:" +

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -68,7 +68,7 @@ namespace FluentAssertions.Types
         /// </param>
         public AndConstraint<MethodInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs)
         {
-            IEnumerable<MethodInfo> virtualMethods = GetAllVirtualMethodsFromSelection();
+            MethodInfo[] virtualMethods = GetAllVirtualMethodsFromSelection();
 
             string failureMessage =
                 "Expected all selected methods not to be virtual{reason}, but the following methods are virtual:" +
@@ -139,7 +139,7 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate, nameof(isMatchingAttributePredicate));
 
-            IEnumerable<MethodInfo> methodsWithoutAttribute = GetMethodsWithout(isMatchingAttributePredicate);
+            MethodInfo[] methodsWithoutAttribute = GetMethodsWithout(isMatchingAttributePredicate);
 
             string failureMessage =
                 "Expected all selected methods to be decorated with {0}{reason}, but the following methods are not:" +
@@ -190,7 +190,7 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate, nameof(isMatchingAttributePredicate));
 
-            IEnumerable<MethodInfo> methodsWithAttribute = GetMethodsWith(isMatchingAttributePredicate);
+            MethodInfo[] methodsWithAttribute = GetMethodsWith(isMatchingAttributePredicate);
 
             string failureMessage =
                 "Expected all selected methods to not be decorated with {0}{reason}, but the following methods are:" +

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -119,7 +119,7 @@ namespace FluentAssertions.Types
         /// Returns an enumerator that iterates through the collection.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.Collections.Generic.IEnumerator`1"/> that can be used to iterate through the collection.
+        /// A <see cref="System.Collections.Generic.IEnumerator{T}"/> that can be used to iterate through the collection.
         /// </returns>
         /// <filterpriority>1</filterpriority>
         public IEnumerator<PropertyInfo> GetEnumerator()
@@ -131,7 +131,7 @@ namespace FluentAssertions.Types
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Collections.IEnumerator"/> object that can be used to iterate through the collection.
+        /// An <see cref="System.Collections.IEnumerator"/> object that can be used to iterate through the collection.
         /// </returns>
         /// <filterpriority>2</filterpriority>
         IEnumerator IEnumerable.GetEnumerator()

--- a/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
@@ -211,6 +211,8 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Returns the type of the subject the assertion applies on.
         /// </summary>
+#pragma warning disable CA1822 // Do not change signature of a public member
         protected string Context => "property info";
+#pragma warning restore CA1822
     }
 }

--- a/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
@@ -116,7 +116,7 @@ namespace FluentAssertions.Types
 
         private PropertyInfo[] GetAllNonVirtualPropertiesFromSelection()
         {
-            var query =
+            IEnumerable<PropertyInfo> query =
                 from property in SubjectProperties
                 where !property.IsVirtual()
                 select property;
@@ -126,7 +126,7 @@ namespace FluentAssertions.Types
 
         private PropertyInfo[] GetAllVirtualPropertiesFromSelection()
         {
-            var query =
+            IEnumerable<PropertyInfo> query =
                 from property in SubjectProperties
                 where property.IsVirtual()
                 select property;

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -1389,7 +1389,7 @@ namespace FluentAssertions.Types
 
         private void AssertThatSubjectIsClass()
         {
-            var typeInfo = Subject.GetTypeInfo();
+            TypeInfo typeInfo = Subject.GetTypeInfo();
             if (typeInfo.IsInterface || typeInfo.IsValueType || typeof(Delegate).IsAssignableFrom(typeInfo.BaseType))
             {
                 throw new InvalidOperationException($"{Subject} must be a class.");

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -1079,7 +1079,7 @@ namespace FluentAssertions.Types
             return NotHaveConstructor(new Type[] { }, because, becauseArgs);
         }
 
-        private string GetParameterString(IEnumerable<Type> parameterTypes)
+        private static string GetParameterString(IEnumerable<Type> parameterTypes)
         {
             return string.Join(", ", parameterTypes.Select(p => p.FullName));
         }

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -18,7 +18,7 @@ namespace FluentAssertions.Types
     public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:System.Object" /> class.
+        /// Initializes a new instance of the <see cref="System.Object" /> class.
         /// </summary>
         public TypeAssertions(Type type) : base(type)
         {
@@ -421,9 +421,9 @@ namespace FluentAssertions.Types
         /// Asserts that the current <see cref="System.Type"/> implements Interface <paramref name="interfaceType"/>.
         /// </summary>
         /// <param name="interfaceType">The interface that should be implemented.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> Implement(Type interfaceType, string because = "", params object[] becauseArgs)
         {
             if (!interfaceType.GetTypeInfo().IsInterface)
@@ -442,9 +442,9 @@ namespace FluentAssertions.Types
         /// Asserts that the current <see cref="System.Type"/> implements Interface <typeparamref name="TInterface"/>.
         /// </summary>
         /// <typeparam name="TInterface">The interface that should be implemented.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> Implement<TInterface>(string because = "", params object[] becauseArgs)
             where TInterface : class
         {
@@ -455,9 +455,9 @@ namespace FluentAssertions.Types
         /// Asserts that the current <see cref="System.Type"/> does not implement Interface <paramref name="interfaceType"/>.
         /// </summary>
         /// <param name="interfaceType">The interface that should be not implemented.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotImplement(Type interfaceType, string because = "", params object[] becauseArgs)
         {
             if (!interfaceType.GetTypeInfo().IsInterface)
@@ -476,9 +476,9 @@ namespace FluentAssertions.Types
         /// Asserts that the current <see cref="System.Type"/> does not implement Interface <typeparamref name="TInterface"/>.
         /// </summary>
         /// <typeparam name="TInterface">The interface that should not be implemented.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotImplement<TInterface>(string because = "", params object[] becauseArgs)
             where TInterface : class
         {
@@ -489,9 +489,9 @@ namespace FluentAssertions.Types
         /// Asserts that the current <see cref="System.Type"/> is derived from <see cref="System.Type"/> <paramref name="baseType"/>.
         /// </summary>
         /// <param name="baseType">The Type that should be derived from.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> BeDerivedFrom(Type baseType, string because = "", params object[] becauseArgs)
         {
             if (baseType.GetTypeInfo().IsInterface)
@@ -520,9 +520,9 @@ namespace FluentAssertions.Types
         /// Asserts that the current <see cref="System.Type"/> is derived from <typeparamref name="TBaseClass"/>.
         /// </summary>
         /// <typeparam name="TBaseClass">The Type that should be derived from.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> BeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
             where TBaseClass : class
         {
@@ -533,9 +533,9 @@ namespace FluentAssertions.Types
         /// Asserts that the current <see cref="System.Type"/> is not derived from <see cref="System.Type"/> <paramref name="baseType"/>.
         /// </summary>
         /// <param name="baseType">The Type that should not be derived from.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotBeDerivedFrom(Type baseType, string because = "", params object[] becauseArgs)
         {
             if (baseType.GetTypeInfo().IsInterface)
@@ -565,9 +565,9 @@ namespace FluentAssertions.Types
         /// Asserts that the current <see cref="System.Type"/> is not derived from <typeparamref name="TBaseClass"/>.
         /// </summary>
         /// <typeparam name="TBaseClass">The Type that should not be derived from.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotBeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
             where TBaseClass : class
         {
@@ -577,9 +577,9 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current <see cref="System.Type"/> is sealed.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         /// <returns></returns>
         public AndConstraint<TypeAssertions> BeSealed(string because = "", params object[] becauseArgs)
         {
@@ -596,9 +596,9 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current <see cref="System.Type"/> is not sealed.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         /// <returns></returns>
         public AndConstraint<TypeAssertions> NotBeSealed(string because = "", params object[] becauseArgs)
         {
@@ -615,9 +615,9 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current <see cref="System.Type"/> is abstract.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         /// <returns></returns>
         public AndConstraint<TypeAssertions> BeAbstract(string because = "", params object[] becauseArgs)
         {
@@ -634,9 +634,9 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current <see cref="System.Type"/> is not abstract.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         /// <returns></returns>
         public AndConstraint<TypeAssertions> NotBeAbstract(string because = "", params object[] becauseArgs)
         {
@@ -653,9 +653,9 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current <see cref="System.Type"/> is static.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         /// <returns></returns>
         public AndConstraint<TypeAssertions> BeStatic(string because = "", params object[] becauseArgs)
         {
@@ -672,9 +672,9 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current <see cref="System.Type"/> is not static.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         /// <returns></returns>
         public AndConstraint<TypeAssertions> NotBeStatic(string because = "", params object[] becauseArgs)
         {
@@ -691,11 +691,11 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current type has a property of type <paramref name="propertyType"/> named <paramref name="name"/>.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
         /// <param name="propertyType">The type of the property.</param>
         /// <param name="name">The name of the property.</param>
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveProperty(Type propertyType, string name, string because = "", params object[] becauseArgs)
         {
             PropertyInfo propertyInfo = Subject.GetPropertyByName(name);
@@ -724,9 +724,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TProperty">The type of the property.</typeparam>
         /// <param name="name">The name of the property.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveProperty<TProperty>(string name, string because = "", params object[] becauseArgs)
         {
             return HaveProperty(typeof(TProperty), name, because, becauseArgs);
@@ -736,9 +736,9 @@ namespace FluentAssertions.Types
         /// Asserts that the current type does not have a property named <paramref name="name"/>.
         /// </summary>
         /// <param name="name">The name of the property.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveProperty(string name, string because = "", params object[] becauseArgs)
         {
             PropertyInfo propertyInfo = Subject.GetPropertyByName(name);
@@ -763,9 +763,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="interfaceType">The type of the interface.</param>
         /// <param name="name">The name of the property.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> HaveExplicitProperty(Type interfaceType, string name, string because = "", params object[] becauseArgs)
         {
             Subject.Should().Implement(interfaceType, because, becauseArgs);
@@ -786,9 +786,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TInterface">The interface whose member is being explicitly implemented.</typeparam>
         /// <param name="name">The name of the property.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> HaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
             where TInterface : class
         {
@@ -801,9 +801,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="interfaceType">The type of the interface.</param>
         /// <param name="name">The name of the property.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveExplicitProperty(Type interfaceType, string name, string because = "", params object[] becauseArgs)
         {
             Subject.Should().Implement(interfaceType, because, becauseArgs);
@@ -824,9 +824,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TInterface">The interface whose member is not being explicitly implemented.</typeparam>
         /// <param name="name">The name of the property.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
             where TInterface : class
         {
@@ -840,9 +840,9 @@ namespace FluentAssertions.Types
         /// <param name="interfaceType">The type of the interface.</param>
         /// <param name="name">The name of the method.</param>
         /// <param name="parameterTypes">The expected types of the method parameters.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> HaveExplicitMethod(Type interfaceType, string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             Subject.Should().Implement(interfaceType, because, becauseArgs);
@@ -864,9 +864,9 @@ namespace FluentAssertions.Types
         /// <typeparam name="TInterface">The interface whose member is being explicitly implemented.</typeparam>
         /// <param name="name">The name of the method.</param>
         /// <param name="parameterTypes">The expected types of the method parameters.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> HaveExplicitMethod<TInterface>(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
             where TInterface : class
         {
@@ -880,9 +880,9 @@ namespace FluentAssertions.Types
         /// <param name="interfaceType">The type of the interface.</param>
         /// <param name="name">The name of the method.</param>
         /// <param name="parameterTypes">The expected types of the method parameters.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveExplicitMethod(Type interfaceType, string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             Subject.Should().Implement(interfaceType, because, becauseArgs);
@@ -904,9 +904,9 @@ namespace FluentAssertions.Types
         /// <typeparam name="TInterface">The interface whose member is not being explicitly implemented.</typeparam>
         /// <param name="name">The name of the method.</param>
         /// <param name="parameterTypes">The expected types of the method parameters.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveExplicitMethod<TInterface>(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
             where TInterface : class
         {
@@ -919,9 +919,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="indexerType">The type of the indexer.</param>
         /// <param name="parameterTypes">The parameter types for the indexer.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveIndexer(Type indexerType, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             PropertyInfo propertyInfo = Subject.GetIndexerByParameterTypes(parameterTypes);
@@ -950,10 +950,10 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current type does not have an indexer that takes parameter types <paramref name="parameterTypes"/>.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
         /// <param name="parameterTypes">The expected indexer's parameter types.</param>
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveIndexer(IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             PropertyInfo propertyInfo = Subject.GetIndexerByParameterTypes(parameterTypes);
@@ -970,11 +970,11 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current type has a method named <paramref name="name"/>with parameter types <paramref name="parameterTypes"/>.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
         /// <param name="name">The name of the method.</param>
         /// <param name="parameterTypes">The parameter types for the indexer.</param>
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, MethodInfo> HaveMethod(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             MethodInfo methodInfo = Subject.GetMethod(name, parameterTypes);
@@ -994,9 +994,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="name">The name of the method.</param>
         /// <param name="parameterTypes">The method parameter types.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveMethod(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             MethodInfo methodInfo = Subject.GetMethod(name, parameterTypes);
@@ -1019,10 +1019,10 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current type has a constructor with parameter types <paramref name="parameterTypes"/>.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
         /// <param name="parameterTypes">The parameter types for the indexer.</param>
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, ConstructorInfo> HaveConstructor(IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             ConstructorInfo constructorInfo = Subject.GetConstructor(parameterTypes);
@@ -1039,9 +1039,9 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current type has a default constructor.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, ConstructorInfo> HaveDefaultConstructor(string because = "", params object[] becauseArgs)
         {
             return HaveConstructor(new Type[] { }, because, becauseArgs);
@@ -1050,10 +1050,10 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current type does not have a constructor with parameter types <paramref name="parameterTypes"/>.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
         /// <param name="parameterTypes">The parameter types for the indexer.</param>
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, ConstructorInfo> NotHaveConstructor(IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             ConstructorInfo constructorInfo = Subject.GetConstructor(parameterTypes);
@@ -1071,9 +1071,9 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current type does not have a default constructor.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, ConstructorInfo> NotHaveDefaultConstructor(string because = "", params object[] becauseArgs)
         {
             return NotHaveConstructor(new Type[] { }, because, becauseArgs);
@@ -1135,9 +1135,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         [Obsolete("This method is deprecated in favor of 'HaveImplicitConversionOperator' and will be removed in v6.X.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public AndWhichConstraint<TypeAssertions, MethodInfo> HaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
@@ -1150,9 +1150,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, MethodInfo> HaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
         {
             return HaveImplicitConversionOperator(typeof(TSource), typeof(TTarget), because, becauseArgs);
@@ -1163,9 +1163,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         [Obsolete("This method is deprecated in favor of 'HaveImplicitConversionOperator' and will be removed in v6.X.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public AndWhichConstraint<TypeAssertions, MethodInfo> HaveImplictConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
@@ -1178,9 +1178,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, MethodInfo> HaveImplicitConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
         {
             MethodInfo methodInfo = Subject.GetImplicitConversionOperator(sourceType, targetType);
@@ -1198,9 +1198,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         [Obsolete("This method is deprecated in favor of 'NotHaveImplicitConversionOperator' and will be removed in v6.X.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public AndConstraint<TypeAssertions> NotHaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
@@ -1213,9 +1213,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
         {
             return NotHaveImplicitConversionOperator(typeof(TSource), typeof(TTarget), because, becauseArgs);
@@ -1226,9 +1226,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         [Obsolete("This method is deprecated in favor of 'NotHaveImplicitConversionOperator' and will be removed in v6.X.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public AndConstraint<TypeAssertions> NotHaveImplictConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
@@ -1241,9 +1241,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveImplicitConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
         {
             MethodInfo methodInfo = Subject.GetImplicitConversionOperator(sourceType, targetType);
@@ -1261,9 +1261,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         [Obsolete("This method is deprecated in favor of 'HaveExplicitConversionOperator' and will be removed in v6.X.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public AndWhichConstraint<TypeAssertions, MethodInfo> HaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
@@ -1276,9 +1276,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, MethodInfo> HaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
         {
             return HaveExplicitConversionOperator(typeof(TSource), typeof(TTarget), because, becauseArgs);
@@ -1289,9 +1289,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         [Obsolete("This method is deprecated in favor of 'HaveExplicitConversionOperator' and will be removed in v6.X.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public AndWhichConstraint<TypeAssertions, MethodInfo> HaveExplictConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
@@ -1304,9 +1304,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, MethodInfo> HaveExplicitConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
         {
             MethodInfo methodInfo = Subject.GetExplicitConversionOperator(sourceType, targetType);
@@ -1324,9 +1324,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         [Obsolete("This method is deprecated in favor of 'NotHaveExplicitConversionOperator' and will be removed in v6.X.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public AndConstraint<TypeAssertions> NotHaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
@@ -1339,9 +1339,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
         {
             return NotHaveExplicitConversionOperator(typeof(TSource), typeof(TTarget), because, becauseArgs);
@@ -1352,9 +1352,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         [Obsolete("This method is deprecated in favor of 'NotHaveExplicitConversionOperator' and will be removed in v6.X.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public AndConstraint<TypeAssertions> NotHaveExplictConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
@@ -1367,9 +1367,9 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="!:because"/>.</param>
+        /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveExplicitConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
         {
             MethodInfo methodInfo = Subject.GetExplicitConversionOperator(sourceType, targetType);

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -421,7 +421,7 @@ namespace FluentAssertions.Types
         /// Asserts that the current <see cref="System.Type"/> implements Interface <paramref name="interfaceType"/>.
         /// </summary>
         /// <param name="interfaceType">The interface that should be implemented.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> Implement(Type interfaceType, string because = "", params object[] becauseArgs)
@@ -442,7 +442,7 @@ namespace FluentAssertions.Types
         /// Asserts that the current <see cref="System.Type"/> implements Interface <typeparamref name="TInterface"/>.
         /// </summary>
         /// <typeparam name="TInterface">The interface that should be implemented.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> Implement<TInterface>(string because = "", params object[] becauseArgs)
@@ -455,7 +455,7 @@ namespace FluentAssertions.Types
         /// Asserts that the current <see cref="System.Type"/> does not implement Interface <paramref name="interfaceType"/>.
         /// </summary>
         /// <param name="interfaceType">The interface that should be not implemented.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotImplement(Type interfaceType, string because = "", params object[] becauseArgs)
@@ -476,7 +476,7 @@ namespace FluentAssertions.Types
         /// Asserts that the current <see cref="System.Type"/> does not implement Interface <typeparamref name="TInterface"/>.
         /// </summary>
         /// <typeparam name="TInterface">The interface that should not be implemented.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotImplement<TInterface>(string because = "", params object[] becauseArgs)
@@ -489,7 +489,7 @@ namespace FluentAssertions.Types
         /// Asserts that the current <see cref="System.Type"/> is derived from <see cref="System.Type"/> <paramref name="baseType"/>.
         /// </summary>
         /// <param name="baseType">The Type that should be derived from.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> BeDerivedFrom(Type baseType, string because = "", params object[] becauseArgs)
@@ -520,7 +520,7 @@ namespace FluentAssertions.Types
         /// Asserts that the current <see cref="System.Type"/> is derived from <typeparamref name="TBaseClass"/>.
         /// </summary>
         /// <typeparam name="TBaseClass">The Type that should be derived from.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> BeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
@@ -533,7 +533,7 @@ namespace FluentAssertions.Types
         /// Asserts that the current <see cref="System.Type"/> is not derived from <see cref="System.Type"/> <paramref name="baseType"/>.
         /// </summary>
         /// <param name="baseType">The Type that should not be derived from.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotBeDerivedFrom(Type baseType, string because = "", params object[] becauseArgs)
@@ -565,7 +565,7 @@ namespace FluentAssertions.Types
         /// Asserts that the current <see cref="System.Type"/> is not derived from <typeparamref name="TBaseClass"/>.
         /// </summary>
         /// <typeparam name="TBaseClass">The Type that should not be derived from.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotBeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
@@ -577,7 +577,7 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current <see cref="System.Type"/> is sealed.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         /// <returns></returns>
@@ -596,7 +596,7 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current <see cref="System.Type"/> is not sealed.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         /// <returns></returns>
@@ -615,7 +615,7 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current <see cref="System.Type"/> is abstract.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         /// <returns></returns>
@@ -634,7 +634,7 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current <see cref="System.Type"/> is not abstract.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         /// <returns></returns>
@@ -653,7 +653,7 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current <see cref="System.Type"/> is static.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         /// <returns></returns>
@@ -672,7 +672,7 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current <see cref="System.Type"/> is not static.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         /// <returns></returns>
@@ -693,7 +693,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="propertyType">The type of the property.</param>
         /// <param name="name">The name of the property.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveProperty(Type propertyType, string name, string because = "", params object[] becauseArgs)
@@ -724,7 +724,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TProperty">The type of the property.</typeparam>
         /// <param name="name">The name of the property.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveProperty<TProperty>(string name, string because = "", params object[] becauseArgs)
@@ -736,7 +736,7 @@ namespace FluentAssertions.Types
         /// Asserts that the current type does not have a property named <paramref name="name"/>.
         /// </summary>
         /// <param name="name">The name of the property.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveProperty(string name, string because = "", params object[] becauseArgs)
@@ -763,7 +763,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="interfaceType">The type of the interface.</param>
         /// <param name="name">The name of the property.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> HaveExplicitProperty(Type interfaceType, string name, string because = "", params object[] becauseArgs)
@@ -786,7 +786,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TInterface">The interface whose member is being explicitly implemented.</typeparam>
         /// <param name="name">The name of the property.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> HaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
@@ -801,7 +801,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="interfaceType">The type of the interface.</param>
         /// <param name="name">The name of the property.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveExplicitProperty(Type interfaceType, string name, string because = "", params object[] becauseArgs)
@@ -824,7 +824,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TInterface">The interface whose member is not being explicitly implemented.</typeparam>
         /// <param name="name">The name of the property.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
@@ -840,7 +840,7 @@ namespace FluentAssertions.Types
         /// <param name="interfaceType">The type of the interface.</param>
         /// <param name="name">The name of the method.</param>
         /// <param name="parameterTypes">The expected types of the method parameters.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> HaveExplicitMethod(Type interfaceType, string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
@@ -864,7 +864,7 @@ namespace FluentAssertions.Types
         /// <typeparam name="TInterface">The interface whose member is being explicitly implemented.</typeparam>
         /// <param name="name">The name of the method.</param>
         /// <param name="parameterTypes">The expected types of the method parameters.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> HaveExplicitMethod<TInterface>(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
@@ -880,7 +880,7 @@ namespace FluentAssertions.Types
         /// <param name="interfaceType">The type of the interface.</param>
         /// <param name="name">The name of the method.</param>
         /// <param name="parameterTypes">The expected types of the method parameters.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveExplicitMethod(Type interfaceType, string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
@@ -904,7 +904,7 @@ namespace FluentAssertions.Types
         /// <typeparam name="TInterface">The interface whose member is not being explicitly implemented.</typeparam>
         /// <param name="name">The name of the method.</param>
         /// <param name="parameterTypes">The expected types of the method parameters.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveExplicitMethod<TInterface>(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
@@ -919,7 +919,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="indexerType">The type of the indexer.</param>
         /// <param name="parameterTypes">The parameter types for the indexer.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveIndexer(Type indexerType, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
@@ -951,7 +951,7 @@ namespace FluentAssertions.Types
         /// Asserts that the current type does not have an indexer that takes parameter types <paramref name="parameterTypes"/>.
         /// </summary>
         /// <param name="parameterTypes">The expected indexer's parameter types.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveIndexer(IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
@@ -972,7 +972,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="name">The name of the method.</param>
         /// <param name="parameterTypes">The parameter types for the indexer.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, MethodInfo> HaveMethod(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
@@ -994,7 +994,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="name">The name of the method.</param>
         /// <param name="parameterTypes">The method parameter types.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveMethod(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
@@ -1020,7 +1020,7 @@ namespace FluentAssertions.Types
         /// Asserts that the current type has a constructor with parameter types <paramref name="parameterTypes"/>.
         /// </summary>
         /// <param name="parameterTypes">The parameter types for the indexer.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, ConstructorInfo> HaveConstructor(IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
@@ -1039,7 +1039,7 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current type has a default constructor.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, ConstructorInfo> HaveDefaultConstructor(string because = "", params object[] becauseArgs)
@@ -1051,7 +1051,7 @@ namespace FluentAssertions.Types
         /// Asserts that the current type does not have a constructor with parameter types <paramref name="parameterTypes"/>.
         /// </summary>
         /// <param name="parameterTypes">The parameter types for the indexer.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, ConstructorInfo> NotHaveConstructor(IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
@@ -1071,7 +1071,7 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the current type does not have a default constructor.
         /// </summary>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, ConstructorInfo> NotHaveDefaultConstructor(string because = "", params object[] becauseArgs)
@@ -1135,7 +1135,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         [Obsolete("This method is deprecated in favor of 'HaveImplicitConversionOperator' and will be removed in v6.X.")]
@@ -1150,7 +1150,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, MethodInfo> HaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
@@ -1163,7 +1163,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         [Obsolete("This method is deprecated in favor of 'HaveImplicitConversionOperator' and will be removed in v6.X.")]
@@ -1178,7 +1178,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, MethodInfo> HaveImplicitConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
@@ -1198,7 +1198,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         [Obsolete("This method is deprecated in favor of 'NotHaveImplicitConversionOperator' and will be removed in v6.X.")]
@@ -1213,7 +1213,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
@@ -1226,7 +1226,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         [Obsolete("This method is deprecated in favor of 'NotHaveImplicitConversionOperator' and will be removed in v6.X.")]
@@ -1241,7 +1241,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveImplicitConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
@@ -1261,7 +1261,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         [Obsolete("This method is deprecated in favor of 'HaveExplicitConversionOperator' and will be removed in v6.X.")]
@@ -1276,7 +1276,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, MethodInfo> HaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
@@ -1289,7 +1289,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         [Obsolete("This method is deprecated in favor of 'HaveExplicitConversionOperator' and will be removed in v6.X.")]
@@ -1304,7 +1304,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndWhichConstraint<TypeAssertions, MethodInfo> HaveExplicitConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
@@ -1324,7 +1324,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         [Obsolete("This method is deprecated in favor of 'NotHaveExplicitConversionOperator' and will be removed in v6.X.")]
@@ -1339,7 +1339,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
@@ -1352,7 +1352,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         [Obsolete("This method is deprecated in favor of 'NotHaveExplicitConversionOperator' and will be removed in v6.X.")]
@@ -1367,7 +1367,7 @@ namespace FluentAssertions.Types
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
-        /// <param name="because">A formatted phrase as is supported by <see cref="System.String.Format(System.String,System.Object[])"/> explaining why the assertion
+        /// <param name="because">A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <see cref="because" />.</param>
         public AndConstraint<TypeAssertions> NotHaveExplicitConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -169,7 +169,7 @@ namespace FluentAssertions.Types
         /// Returns an enumerator that iterates through the collection.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.Collections.Generic.IEnumerator`1"/> that can be used to iterate through the collection.
+        /// A <see cref="System.Collections.Generic.IEnumerator{T}"/> that can be used to iterate through the collection.
         /// </returns>
         /// <filterpriority>1</filterpriority>
         public IEnumerator<Type> GetEnumerator()
@@ -181,7 +181,7 @@ namespace FluentAssertions.Types
         /// Returns an enumerator that iterates through a collection.
         /// </summary>
         /// <returns>
-        /// An <see cref="T:System.Collections.IEnumerator"/> object that can be used to iterate through the collection.
+        /// An <see cref="System.Collections.IEnumerator"/> object that can be used to iterate through the collection.
         /// </returns>
         /// <filterpriority>2</filterpriority>
         IEnumerator IEnumerable.GetEnumerator()

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -16,7 +16,7 @@ namespace FluentAssertions.Types
     public class TypeSelectorAssertions
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:System.Object" /> class.
+        /// Initializes a new instance of the <see cref="System.Object" /> class.
         /// </summary>
         public TypeSelectorAssertions(params Type[] types)
         {

--- a/Src/FluentAssertions/Xml/XmlReaderValidator.cs
+++ b/Src/FluentAssertions/Xml/XmlReaderValidator.cs
@@ -8,7 +8,7 @@ namespace FluentAssertions.Xml
 {
     internal class XmlReaderValidator
     {
-        private readonly IAssertionScope assertion;
+        private readonly AssertionScope assertion;
         private readonly XmlReader subjectReader;
         private readonly XmlReader otherReader;
 

--- a/Src/FluentAssertions/Xml/XmlReaderValidator.cs
+++ b/Src/FluentAssertions/Xml/XmlReaderValidator.cs
@@ -66,7 +66,9 @@ namespace FluentAssertions.Xml
 
                 ValidationResult validationResult = null;
 
+#pragma warning disable IDE0010 // System.Xml.XmlNodeType has many members we do not care about
                 switch (subjectReader.NodeType)
+#pragma warning restore IDE0010
                 {
                     case XmlNodeType.Element:
                         validationResult = ValidateStartElement();

--- a/Src/FluentAssertions/Xml/XmlReaderValidator.cs
+++ b/Src/FluentAssertions/Xml/XmlReaderValidator.cs
@@ -195,7 +195,7 @@ namespace FluentAssertions.Xml
             return null;
         }
 
-        private IList<AttributeData> GetAttributes(XmlReader reader)
+        private static IList<AttributeData> GetAttributes(XmlReader reader)
         {
             var attributes = new List<AttributeData>();
 

--- a/Src/JetBrainsAnnotations.cs
+++ b/Src/JetBrainsAnnotations.cs
@@ -422,6 +422,7 @@ namespace JetBrains.Annotations
     /// which should not be removed and so is treated as used.
     /// </summary>
     [MeansImplicitUse(ImplicitUseTargetFlags.WithMembers)]
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = false)]
     internal sealed class PublicAPIAttribute : Attribute
     {
         public PublicAPIAttribute() { }

--- a/Tests/Shared.Specs/AssertionScopeSpecs.cs
+++ b/Tests/Shared.Specs/AssertionScopeSpecs.cs
@@ -763,7 +763,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().ThrowExactly<ArgumentNullException>()
-                .Which.ParamName.Should().Be("_assertionStrategy");
+                .Which.ParamName.Should().Be("assertionStrategy");
         }
 
         internal class FailWithStupidMessageAssertionStrategy : IAssertionStrategy


### PR DESCRIPTION
The vast majority is changing implicit types to explicit, but I've put the changes into several commits, to make reviewing easier.

bea6b63 renames a parameter in a public `AssertionScope` ctor, but that ctor was made public after the latests release, so the change does not break the public API.