### PR TITLE
Grammar correction for readability

### DIFF
--- a/docs/_pages/exceptions.md
+++ b/docs/_pages/exceptions.md
@@ -7,7 +7,7 @@ sidebar:
   nav: "sidebar"
 ---
 
-The following example verifies that the `Foo()` method throws an `InvalidOperationException` which `Message` property has a specific value.
+The following example verifies that the `Foo()` method throws an `InvalidOperationException` whose `Message` property has a specific value.
 
 ```csharp
 subject.Invoking(y => y.Foo("Hello"))


### PR DESCRIPTION
Didn't understand the sentence on first read.

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/_pages/documentation.md) in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com).
