### PR TITLE
Only mention Match assertion once per overload

### DIFF
--- a/Src/FluentAssertions/Numeric/NullableNumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableNumericAssertions.cs
@@ -103,7 +103,7 @@ namespace FluentAssertions.Numeric
             params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
-            
+
             Execute.Assertion
                 .ForCondition(predicate.Compile()((T?)Subject))
                 .BecauseOf(because, becauseArgs)

--- a/docs/_pages/nullabletypes.md
+++ b/docs/_pages/nullabletypes.md
@@ -18,7 +18,6 @@ theShort.Should().Match(x => !x.HasValue || x > 0);
 int? theInt = 3;
 theInt.Should().HaveValue();
 theInt.Should().NotBeNull();
-theInt.Should().Match(x => x.HasValue && x > 0);
 
 DateTime? theDate = null;
 theDate.Should().NotHaveValue();

--- a/docs/_pages/numerictypes.md
+++ b/docs/_pages/numerictypes.md
@@ -19,7 +19,7 @@ theInt.Should().Be(5);
 theInt.Should().NotBe(10);
 theInt.Should().BeInRange(1, 10);
 theInt.Should().NotBeInRange(6, 10);
-theInt.Should().Match(x => x > 4 && x < 6);
+theInt.Should().Match(x => x % 2 == 1);
 
 theInt = 0;
 //theInt.Should().BePositive(); => Expected positive value, but found 0
@@ -29,7 +29,6 @@ theInt = -8;
 theInt.Should().BeNegative();
 int? nullableInt = 3;
 nullableInt.Should().Be(3);
-nullableInt.Should().Match(x => x.HasValue && x > 0);
 
 double theDouble = 5.1;
 theDouble.Should().BeGreaterThan(5);


### PR DESCRIPTION
Only mention the new `Match` assertion once per overload and use examples, that can't be more idiomatically expressed with existing assertions.