### PR TITLE
Doc: Fix incorrect rending of inline-code-block and update message

### DIFF
--- a/docs/_pages/introduction.md
+++ b/docs/_pages/introduction.md
@@ -85,7 +85,7 @@ username.Should().Be("jonas");
 
 This will throw a test framework-specific exception with the following message:
 
-`Expected username to be "jonas", but "dennis" differs near 'd' (index 0)`.`
+`Expected username to be "jonas" with a length of 5, but "dennis" has a length of 6, differs near "den" (index 0).`
 
 The way this works is that Fluent Assertions will try to traverse the current stack trace to find the line and column numbers as well as the full path to the source file. Since it needs the debug symbols for that, this will require you to compile the unit tests in debug mode, even on your build servers. Also, since only .NET Standard 2.0 and the full .NET Framework support getting direct access to the current stack trace, subject identification only works for the platforms targeting those frameworks.
 


### PR DESCRIPTION
* [ ] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/_pages/documentation.md) in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com).

I couldn't find the `documentation.md` file, so this just provides the "fix". 
Please let me know if and what has to be done additionally.