### PR TITLE
(GH-577) Add 'Whose' and 'That' aliases for 'Which'

### DIFF
--- a/Src/FluentAssertions/AndWhichConstraint.cs
+++ b/Src/FluentAssertions/AndWhichConstraint.cs
@@ -66,5 +66,21 @@ namespace FluentAssertions
         /// Just a convenience property that returns the same value as <see cref="Which"/>.
         /// </remarks>
         public TMatchedElement Subject => Which;
+
+        /// <summary>
+        /// Returns the single result of a prior assertion that is used to select a nested or collection item.
+        /// </summary>
+        /// <remarks>
+        /// Just a convenience property that returns the same value as <see cref="Which"/>.
+        /// </remarks>
+        public TMatchedElement Whose => Which;
+
+        /// <summary>
+        /// Returns the single result of a prior assertion that is used to select a nested or collection item.
+        /// </summary>
+        /// <remarks>
+        /// Just a convenience property that returns the same value as <see cref="Which"/>.
+        /// </remarks>
+        public TMatchedElement That => Which;
     }
 }

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -38,7 +38,26 @@ namespace FluentAssertions.Specialized
         /// <summary>
         /// Gets the exception object of the exception thrown.
         /// </summary>
+        /// <remarks>
+        /// Just a convenience property that returns the same value as <see cref="And"/>.
+        /// </remarks>
         public TException Which => And;
+
+        /// <summary>
+        /// Gets the exception object of the exception thrown.
+        /// </summary>
+        /// <remarks>
+        /// Just a convenience property that returns the same value as <see cref="And"/>.
+        /// </remarks>
+        public TException Whose => And;
+
+        /// <summary>
+        /// Gets the exception object of the exception thrown.
+        /// </summary>
+        /// <remarks>
+        /// Just a convenience property that returns the same value as <see cref="And"/>.
+        /// </remarks>
+        public TException That => And;
 
         /// <summary>
         /// Returns the type of the subject the assertion applies on.

--- a/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
@@ -1798,7 +1798,7 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => dictionary.Should().ContainValue(myClass).Which.SomeProperty.Should().BeGreaterThan(0);
+            Action act = () => dictionary.Should().ContainValue(myClass).Whose.SomeProperty.Should().BeGreaterThan(0);
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert

--- a/Tests/Shared.Specs/XElementAssertionSpecs.cs
+++ b/Tests/Shared.Specs/XElementAssertionSpecs.cs
@@ -1278,6 +1278,25 @@ namespace FluentAssertions.Specs
             matchedElement.Name.Should().Be(XName.Get("child"));
         }
 
+        [Fact]
+        public void When_asserting_element_has_child_element_it_should_return_the_matched_element_in_the_that_property()
+        {
+            //-------------------------------------------------------------------------------------------------------------------
+            // Act
+            //-------------------------------------------------------------------------------------------------------------------
+            var element = XElement.Parse(
+                @"<parent>
+                    <child attr='1' />
+                  </parent>");
+
+            //-------------------------------------------------------------------------------------------------------------------
+            // Assert
+            //-------------------------------------------------------------------------------------------------------------------
+            element.Should().HaveElement("child")
+                .That.Should().BeOfType<XElement>()
+                .And.HaveAttribute("attr", "1");
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Small PR to add `Whose` and `That` aliases of `Which` in the `AndWhichConstraint` and `ExceptionAssertions` classes.

Fix #577 
