### PR TITLE
Improve documentation on execution time assertions

### DIFF
--- a/docs/_pages/executiontime.md
+++ b/docs/_pages/executiontime.md
@@ -50,7 +50,7 @@ someAction.ExecutionTime().Should().BeCloseTo(150.Milliseconds(), 50.Millisecond
 If you're dealing with a `Task`, you can also assert that it completed within a specified period of time:
 
 ```csharp
-Func<Task> someAsyncWork = SomethingReturningATask();
+Func<Task> someAsyncWork = () => SomethingReturningATask();
 someAsyncWork.Should().CompleteWithin(100.Milliseconds());
 ```
 
@@ -65,7 +65,7 @@ If the `Task` is generic and returns a value, you can use that to write a contin
 ```csharp
 Func<Task<int>> someAsyncFunc;
 
-func.Should().CompleteWithin(100.Milliseconds()).Which.Should().Be(42);
+someAsyncFunc.Should().CompleteWithin(100.Milliseconds()).Which.Should().Be(42);
 ```
 
 A fully `async` version is available as well.


### PR DESCRIPTION
Clarify that the CompleteWithin works on `Func<Task>` and not on `Task` directly.

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/_pages/documentation.md) in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com).
