### PR TITLE
Use explicit interface member when respecting declared types

### DIFF
--- a/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
@@ -25,7 +25,7 @@ namespace FluentAssertions.Equivalency.Matching
                     .FindField(expectedMember.Name, expectedMember.MemberType));
             }
 
-            if ((compareeSelectedMemberInfoInfo is null) && ExpectationImplementsMemberExplicitly(subject, expectedMember))
+            if ((compareeSelectedMemberInfoInfo is null || !config.UseRuntimeTyping) && ExpectationImplementsMemberExplicitly(subject, expectedMember))
             {
                 compareeSelectedMemberInfoInfo = expectedMember;
             }

--- a/Tests/Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/BasicEquivalencySpecs.cs
@@ -1396,6 +1396,230 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_respecting_declared_types_explicit_interface_member_on_interfaced_subject_should_be_used()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IVehicle expected = new Vehicle
+            {
+                VehicleId = 1
+            };
+
+            IVehicle subject = new ExplicitVehicle
+            {
+                VehicleId = 2 // instance member
+            };
+            subject.VehicleId = 1; // interface member
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => subject.Should().BeEquivalentTo(expected, opt => opt.RespectingDeclaredTypes());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_respecting_declared_types_explicit_interface_member_on_interfaced_expectation_should_be_used()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IVehicle expected = new ExplicitVehicle
+            {
+                VehicleId = 2 // instance member
+            };
+            expected.VehicleId = 1; // interface member
+
+            IVehicle subject = new Vehicle
+            {
+                VehicleId = 1
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => subject.Should().BeEquivalentTo(expected, opt => opt.RespectingDeclaredTypes());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_respecting_runtime_types_explicit_interface_member_on_interfaced_subject_should_not_be_used()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IVehicle expected = new Vehicle
+            {
+                VehicleId = 1
+            };
+
+            IVehicle subject = new ExplicitVehicle
+            {
+                VehicleId = 2 // instance member
+            };
+            subject.VehicleId = 1; // interface member
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => subject.Should().BeEquivalentTo(expected, opt => opt.RespectingRuntimeTypes());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_respecting_runtime_types_explicit_interface_member_on_interfaced_expectation_should_not_be_used()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            IVehicle expected = new ExplicitVehicle
+            {
+                VehicleId = 2 // instance member
+            };
+            expected.VehicleId = 1; // interface member
+
+            IVehicle subject = new Vehicle
+            {
+                VehicleId = 1
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => subject.Should().BeEquivalentTo(expected, opt => opt.RespectingRuntimeTypes());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_respecting_declared_types_explicit_interface_member_on_subject_should_not_be_used()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var expected = new Vehicle
+            {
+                VehicleId = 1
+            };
+
+            var subject = new ExplicitVehicle
+            {
+                VehicleId = 2
+            };
+            ((IVehicle)subject).VehicleId = 1;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => subject.Should().BeEquivalentTo(expected, opt => opt.RespectingDeclaredTypes());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_respecting_declared_types_explicit_interface_member_on_expectation_should_not_be_used()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var expected = new ExplicitVehicle
+            {
+                VehicleId = 2
+            };
+            ((IVehicle)expected).VehicleId = 1;
+
+            var subject = new Vehicle
+            {
+                VehicleId = 1
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => subject.Should().BeEquivalentTo(expected, opt => opt.RespectingDeclaredTypes());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_respecting_runtime_types_explicit_interface_member_on_subject_should_not_be_used()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var expected = new Vehicle
+            {
+                VehicleId = 1
+            };
+
+            var subject = new ExplicitVehicle
+            {
+                VehicleId = 2
+            };
+            ((IVehicle)subject).VehicleId = 1;
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => subject.Should().BeEquivalentTo(expected, opt => opt.RespectingRuntimeTypes());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_respecting_runtime_types_explicit_interface_member_on_expectation_should_not_be_used()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var expected = new ExplicitVehicle
+            {
+                VehicleId = 2
+            };
+            ((IVehicle)expected).VehicleId = 1;
+
+            var subject = new Vehicle
+            {
+                VehicleId = 1
+            };
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action action = () => subject.Should().BeEquivalentTo(expected, opt => opt.RespectingRuntimeTypes());
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
         public void When_a_deeply_nested_property_with_a_value_mismatch_is_excluded_it_should_not_throw()
         {
             //-----------------------------------------------------------------------------------------------------------
@@ -4585,6 +4809,8 @@ namespace FluentAssertions.Specs
     public class ExplicitVehicle : IVehicle
     {
         int IVehicle.VehicleId { get; set; }
+
+        public int VehicleId { get; set; }
     }
 
     public interface ICar : IVehicle


### PR DESCRIPTION
Allows selecting an explicit interface member over a regular instance member when using `RespectingDeclaredTypes` and expectation type is interface.

Fixes #1130 