### PR TITLE
Chain assertions

### DIFF
--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -379,13 +379,12 @@ namespace FluentAssertions.Primitives
         public AndConstraint<DateTimeAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the year part of {context:the date} to be {0}{reason}", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found <null>.")
                 .Then
                 .ForCondition(Subject.Value.Year == expected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found {0}.", Subject.Value.Year)
                 .Then
                 .ClearExpectation();
@@ -407,12 +406,11 @@ namespace FluentAssertions.Primitives
         public AndConstraint<DateTimeAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject.HasValue)
                 .FailWith("Did not expect the year part of {context:the date} to be {0}{reason}, but found a <null> DateTime.", unexpected)
                 .Then
                 .ForCondition(Subject.Value.Year != unexpected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect the year part of {context:the date} to be {0}{reason}, but it was.", unexpected,
                     Subject.Value.Year);
 
@@ -433,13 +431,12 @@ namespace FluentAssertions.Primitives
         public AndConstraint<DateTimeAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the month part of {context:the date} to be {0}{reason}", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
                 .ForCondition(Subject.Value.Month == expected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found {0}.", Subject.Value.Month)
                 .Then
                 .ClearExpectation();
@@ -461,13 +458,12 @@ namespace FluentAssertions.Primitives
         public AndConstraint<DateTimeAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the month part of {context:the date} to be {0}{reason}", unexpected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
                 .ForCondition(Subject.Value.Month != unexpected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but it was.")
                 .Then
                 .ClearExpectation();
@@ -489,13 +485,12 @@ namespace FluentAssertions.Primitives
         public AndConstraint<DateTimeAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the day part of {context:the date} to be {0}{reason}", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
                 .ForCondition(Subject.Value.Day == expected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found {0}.", Subject.Value.Day)
                 .Then
                 .ClearExpectation();
@@ -517,13 +512,12 @@ namespace FluentAssertions.Primitives
         public AndConstraint<DateTimeAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the day part of {context:the date} to be {0}{reason}", unexpected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
                 .ForCondition(Subject.Value.Day != unexpected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but it was.")
                 .Then
                 .ClearExpectation();
@@ -545,13 +539,12 @@ namespace FluentAssertions.Primitives
         public AndConstraint<DateTimeAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the hour part of {context:the time} to be {0}{reason}", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
                 .ForCondition(Subject.Value.Hour == expected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found {0}.", Subject.Value.Hour)
                 .Then
                 .ClearExpectation();
@@ -573,13 +566,12 @@ namespace FluentAssertions.Primitives
         public AndConstraint<DateTimeAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the hour part of {context:the time} to be {0}{reason}", unexpected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found a <null> DateTime.", unexpected)
                 .Then
                 .ForCondition(Subject.Value.Hour != unexpected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but it was.", unexpected, Subject.Value.Hour)
                 .Then
                 .ClearExpectation();
@@ -602,13 +594,12 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the minute part of {context:the time} to be {0}{reason}", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
                 .ForCondition(Subject.Value.Minute == expected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found {0}.", Subject.Value.Minute)
                 .Then
                 .ClearExpectation();
@@ -631,13 +622,12 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the minute part of {context:the time} to be {0}{reason}", unexpected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found a <null> DateTime.", unexpected)
                 .Then
                 .ForCondition(Subject.Value.Minute != unexpected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but it was.", unexpected, Subject.Value.Minute)
                 .Then
                 .ClearExpectation();
@@ -660,13 +650,12 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the seconds part of {context:the time} to be {0}{reason}", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
                 .ForCondition(Subject.Value.Second == expected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found {0}.", Subject.Value.Second)
                 .Then
                 .ClearExpectation();
@@ -689,13 +678,12 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the seconds part of {context:the time} to be {0}{reason}", unexpected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
                 .ForCondition(Subject.Value.Second != unexpected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but it was.")
                 .Then
                 .ClearExpectation();
@@ -781,13 +769,12 @@ namespace FluentAssertions.Primitives
             DateTime expectedDate = expected.Date;
 
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the date part of {context:the date and time} to be {0}{reason}", expectedDate)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found a <null> DateTime.", expectedDate)
                 .Then
                 .ForCondition(Subject.Value.Date == expectedDate)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found {1}.", expectedDate, Subject.Value)
                 .Then
                 .ClearExpectation();
@@ -812,13 +799,12 @@ namespace FluentAssertions.Primitives
             DateTime unexpectedDate = unexpected.Date;
 
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the date part of {context:the date and time} to be {0}{reason}", unexpectedDate)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
                 .ForCondition(Subject.Value.Date != unexpectedDate)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but it was.")
                 .Then
                 .ClearExpectation();
@@ -905,13 +891,12 @@ namespace FluentAssertions.Primitives
         public AndConstraint<DateTimeAssertions> BeIn(DateTimeKind expectedKind, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:the date and time} to be in {0}{reason}", expectedKind)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
                 .ForCondition(Subject.Value.Kind == expectedKind)
-                .BecauseOf(because, becauseArgs)
                 .FailWith(", but found {0}.", Subject.Value.Kind)
                 .Then
                 .ClearExpectation();

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -383,13 +383,12 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the year part of {context:the date} to be {0}{reason}, ", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
                 .ForCondition(Subject.Value.Year == expected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but it was {0}.", Subject.Value.Year)
                 .Then
                 .ClearExpectation();
@@ -411,13 +410,12 @@ namespace FluentAssertions.Primitives
         public AndConstraint<DateTimeOffsetAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the year part of {context:the date} to be {0}{reason}, ", unexpected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
                 .ForCondition(Subject.Value.Year != unexpected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but it was.")
                 .Then
                 .ClearExpectation();
@@ -440,13 +438,12 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the month part of {context:the date} to be {0}{reason}, ", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
                 .ForCondition(Subject.Value.Month == expected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but it was {0}.", Subject.Value.Month)
                 .Then
                 .ClearExpectation();
@@ -468,13 +465,12 @@ namespace FluentAssertions.Primitives
         public AndConstraint<DateTimeOffsetAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the month part of {context:the date} to be {0}{reason}, ", unexpected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
                 .ForCondition(Subject.Value.Month != unexpected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but it was.")
                 .Then
                 .ClearExpectation();
@@ -497,13 +493,12 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the day part of {context:the date} to be {0}{reason}, ", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
                 .ForCondition(Subject.Value.Day == expected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but it was {0}.", Subject.Value.Day)
                 .Then
                 .ClearExpectation();
@@ -525,13 +520,12 @@ namespace FluentAssertions.Primitives
         public AndConstraint<DateTimeOffsetAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the day part of {context:the date} to be {0}{reason}, ", unexpected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
                 .ForCondition(Subject.Value.Day != unexpected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but it was.")
                 .Then
                 .ClearExpectation();
@@ -554,13 +548,12 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the hour part of {context:the time} to be {0}{reason}, ", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
                 .ForCondition(Subject.Value.Hour == expected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but it was {0}.", Subject.Value.Hour)
                 .Then
                 .ClearExpectation();
@@ -582,13 +575,12 @@ namespace FluentAssertions.Primitives
         public AndConstraint<DateTimeOffsetAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the hour part of {context:the time} to be {0}{reason}, ", unexpected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
                 .ForCondition(Subject.Value.Hour != unexpected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but it was.")
                 .Then
                 .ClearExpectation();
@@ -611,13 +603,12 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the minute part of {context:the time} to be {0}{reason}, ", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
                 .ForCondition(Subject.Value.Minute == expected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but it was {0}.", Subject.Value.Minute)
                 .Then
                 .ClearExpectation();
@@ -640,13 +631,12 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the minute part of {context:the time} to be {0}{reason}, ", unexpected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
                 .ForCondition(Subject.Value.Minute != unexpected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but it was.")
                 .Then
                 .ClearExpectation();
@@ -669,13 +659,12 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the seconds part of {context:the time} to be {0}{reason}, ", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
                 .ForCondition(Subject.Value.Second == expected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but it was {0}.", Subject.Value.Second)
                 .Then
                 .ClearExpectation();
@@ -698,13 +687,12 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the seconds part of {context:the time} to be {0}{reason}, ", unexpected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
                 .ForCondition(Subject.Value.Second != unexpected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but it was.")
                 .Then
                 .ClearExpectation();
@@ -727,13 +715,12 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the offset of {context:the date} to be {0}{reason}, ", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
                 .ForCondition(Subject.Value.Offset == expected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but it was {0}.", Subject.Value.Offset)
                 .Then
                 .ClearExpectation();
@@ -756,13 +743,12 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the offset of {context:the date} to be {0}{reason}, ", unexpected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
                 .ForCondition(Subject.Value.Offset != unexpected)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but it was.")
                 .Then
                 .ClearExpectation();
@@ -848,13 +834,12 @@ namespace FluentAssertions.Primitives
             DateTime expectedDate = expected.Date;
 
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the date part of {context:the date and time} to be {0}{reason}, ", expectedDate)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but found a <null> DateTimeOffset.", expectedDate)
                 .Then
                 .ForCondition(Subject.Value.Date == expectedDate)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but it was {0}.", Subject.Value)
                 .Then
                 .ClearExpectation();
@@ -879,13 +864,12 @@ namespace FluentAssertions.Primitives
             DateTime unexpectedDate = unexpected.Date;
 
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the date part of {context:the date and time} to be {0}{reason}, ", unexpectedDate)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
                 .ForCondition(Subject.Value.Date != unexpectedDate)
-                .BecauseOf(because, becauseArgs)
                 .FailWith("but it was.")
                 .Then
                 .ClearExpectation();

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -37,14 +37,15 @@ namespace FluentAssertions.Primitives
         public AndConstraint<SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:time} to be positive{reason}, ")
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:time} to be positive{reason}, but found <null>.");
-
-            Execute.Assertion
+                .FailWith("but found <null>.")
+                .Then
                 .ForCondition(Subject.Value.CompareTo(TimeSpan.Zero) > 0)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:time} to be positive{reason}, but found {0}.", Subject.Value);
+                .FailWith("but found {0}.", Subject.Value)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
         }
@@ -62,14 +63,15 @@ namespace FluentAssertions.Primitives
         public AndConstraint<SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:time} to be negative{reason}, ")
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:time} to be negative{reason}, but found <null>.");
-
-            Execute.Assertion
+                .FailWith("but found <null>.")
+                .Then
                 .ForCondition(Subject.Value.CompareTo(TimeSpan.Zero) < 0)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:time} to be negative{reason}, but found {0}.", Subject.Value);
+                .FailWith("but found {0}.", Subject.Value)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
         }
@@ -89,14 +91,15 @@ namespace FluentAssertions.Primitives
         public AndConstraint<SimpleTimeSpanAssertions> Be(TimeSpan expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {0}{reason}, ", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {0}{reason}, but found <null>.", expected);
-
-            Execute.Assertion
+                .FailWith("but found <null>.")
+                .Then
                 .ForCondition(Subject.Value.CompareTo(expected) == 0)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {0}{reason}, but found {1}.", expected, Subject.Value);
+                .FailWith("but found {0}.", Subject.Value)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
         }
@@ -138,14 +141,15 @@ namespace FluentAssertions.Primitives
         public AndConstraint<SimpleTimeSpanAssertions> BeLessThan(TimeSpan expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:time} to be less than {0}{reason}, ", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:time} to be less than {0}{reason}, but found <null>.", expected);
-
-            Execute.Assertion
+                .FailWith("but found <null>.")
+                .Then
                 .ForCondition(Subject.Value.CompareTo(expected) < 0)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:time} to be less than {0}{reason}, but found {1}.", expected, Subject.Value);
+                .FailWith("but found {0}.", Subject.Value)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
         }
@@ -165,14 +169,15 @@ namespace FluentAssertions.Primitives
         public AndConstraint<SimpleTimeSpanAssertions> BeLessOrEqualTo(TimeSpan expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:time} to be less or equal to {0}{reason}, ", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:time} to be less or equal to {0}{reason}, but found <null>.", expected);
-
-            Execute.Assertion
+                .FailWith("but found <null>.")
+                .Then
                 .ForCondition(Subject.Value.CompareTo(expected) <= 0)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:time} to be less or equal to {0}{reason}, but found {1}.", expected, Subject.Value);
+                .FailWith("but found {0}.", Subject.Value)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
         }
@@ -192,14 +197,15 @@ namespace FluentAssertions.Primitives
         public AndConstraint<SimpleTimeSpanAssertions> BeGreaterThan(TimeSpan expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:time} to be greater than {0}{reason}, ", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:time} to be greater than {0}{reason}, but found <null>.", expected);
-
-            Execute.Assertion
+                .FailWith("but found <null>.")
+                .Then
                 .ForCondition(Subject.Value.CompareTo(expected) > 0)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:time} to be greater than {0}{reason}, but found {1}.", expected, Subject.Value);
+                .FailWith("but found {0}.", Subject.Value)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
         }
@@ -220,14 +226,15 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:time} to be greater or equal to {0}{reason}, ", expected)
                 .ForCondition(Subject.HasValue)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:time} to be greater or equal to {0}{reason}, but found <null>.", expected);
-
-            Execute.Assertion
+                .FailWith("but found <null>.")
+                .Then
                 .ForCondition(Subject.Value.CompareTo(expected) >= 0)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:time} to be greater or equal to {0}{reason}, but found {1}.", expected, Subject.Value);
+                .FailWith("but found {0}.", Subject.Value)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
         }

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -212,18 +212,18 @@ namespace FluentAssertions.Specialized
             TException[] expectedExceptions = extractor.OfType<TException>(exception).ToArray();
 
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected a <{0}> to be thrown{reason}, ", typeof(TException))
                 .ForCondition(exception != null)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected a <{0}> to be thrown{reason}, but no exception was thrown.", typeof(TException));
-
-            Execute.Assertion
+                .FailWith("but no exception was thrown.")
+                .Then
                 .ForCondition(expectedExceptions.Any())
-                .BecauseOf(because, becauseArgs)
-                .FailWith(
-                    "Expected a <{0}> to be thrown{reason}, but found <{1}>: {2}{3}.",
-                    typeof(TException), exception?.GetType(),
+                .FailWith("but found <{0}>: {1}{2}.",
+                    exception?.GetType(),
                     Environment.NewLine,
-                    exception);
+                    exception)
+                .Then
+                .ClearExpectation();
 
             return new ExceptionAssertions<TException>(expectedExceptions);
         }

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -83,15 +83,15 @@ namespace FluentAssertions.Specialized
             where TInnerException : Exception
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected inner {0}{reason}, but ", typeof(TInnerException))
                 .ForCondition(Subject != null)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected inner {0}{reason}, but no exception was thrown.", typeof(TInnerException));
-
-            Execute.Assertion
+                .FailWith("no exception was thrown.")
+                .Then
                 .ForCondition(Subject.Any(e => e.InnerException != null))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected inner {0}{reason}, but the thrown exception has no inner exception.",
-                    typeof(TInnerException));
+                .FailWith("the thrown exception has no inner exception.")
+                .Then
+                .ClearExpectation();
 
             TInnerException[] expectedInnerExceptions = Subject
                 .Select(e => e.InnerException)

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -707,12 +707,12 @@ namespace FluentAssertions.Types
                 propertyInfoDescription = PropertyInfoAssertions.GetDescriptionFor(propertyInfo);
             }
 
-            Execute.Assertion.ForCondition(propertyInfo != null)
+            Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith($"Expected {propertyType.Name} {Subject.FullName}.{name} to exist{{reason}}, but it does not.");
-
-            Execute.Assertion.ForCondition(propertyInfo.PropertyType == propertyType)
-                .BecauseOf(because, becauseArgs)
+                .ForCondition(propertyInfo != null)
+                .FailWith($"Expected {propertyType.Name} {Subject.FullName}.{name} to exist{{reason}}, but it does not.")
+                .Then
+                .ForCondition(propertyInfo.PropertyType == propertyType)
                 .FailWith(string.Format("Expected {0} to be of type {1}{{reason}}, but it is not.",
                     propertyInfoDescription, propertyType));
 

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -79,13 +79,11 @@ namespace FluentAssertions.Xml
         public AndConstraint<XDocumentAssertions> NotBe(XDocument unexpected, string because, params object[] becauseArgs)
         {
             Execute.Assertion
+                .BecauseOf(because, becauseArgs)
                 .ForCondition(!(Subject is null))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect XML document to be {0}, but found <null>.", unexpected);
-
-            Execute.Assertion
+                .FailWith("Did not expect XML document to be {0}, but found <null>.", unexpected)
+                .Then
                 .ForCondition(!Subject.Equals(unexpected))
-                .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect XML document to be {0}{reason}.", unexpected);
 
             return new AndConstraint<XDocumentAssertions>(this);


### PR DESCRIPTION
We have great support for chaining assertions and by using `WithExpectation` we can ensure that failure messages from assertions with a shared prefix are in sync.
E.g. instead of writing
```c#
Execute.Assertion
    .ForCondition(condition1)
    .BeCauseOf(because, becauseArgs)
    .FailWith("Expected collection to be something, but found <null>.");

Execute.Assertion
    .ForCondition(condition2)
    .BeCauseOf(because, becauseArgs)
    .FailWith("Expected collection to be something, but it was empty.");
```
we can
```c#
Execute.Assertion
    .BeCauseOf(because, becauseArgs)
    .WithExpectation("Expected collection to be something, ")
    .ForCondition(condition1)
    .FailWith("but found <null>.")
    .Then
    .ForCondition(condition2)
    .FailWith("but it was empty.")
    .Then
    .ClearExpectation();
```

Also this PR remove unnecessary extra calls to `BecauseOf` for chained assertions.