### PR TITLE
Simplify ProjectReference to FluentAssertions

### DIFF
--- a/Tests/NetStandard13.Specs/NetStandard13.Specs.csproj
+++ b/Tests/NetStandard13.Specs/NetStandard13.Specs.csproj
@@ -19,12 +19,9 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions">
-      <!-- If both Release and Debug version of FluentAssertions.dll exists, Debug will be selected -->
-      <HintPath Condition="'$(Configuration)' == 'Debug' and Exists('..\..\Artifacts\Release\netstandard1.3\FluentAssertions.dll')">..\..\Artifacts\Release\netstandard1.3\FluentAssertions.dll</HintPath>
-      <HintPath Condition="'$(Configuration)' == 'Debug' and Exists('..\..\Artifacts\Debug\netstandard1.3\FluentAssertions.dll')">..\..\Artifacts\Debug\netstandard1.3\FluentAssertions.dll</HintPath>
-      <HintPath Condition="'$(Configuration)' == 'Release'">..\..\Artifacts\Release\netstandard1.3\FluentAssertions.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\..\Src\FluentAssertions\FluentAssertions.csproj">
+      <SetTargetFramework>TargetFramework=netstandard1.3</SetTargetFramework>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="..\Shared.Specs\Shared.Specs.projitems" Label="Shared" />
 </Project>


### PR DESCRIPTION
Instead of referencing the FluentAssertions.dll targeting netstandard1.3 directly,
we can use the `<SetTargetFramework>`, which lets us specify it explicitly.