### PR TITLE
Catch exceptions from DetermineCallerIdentity

### DIFF
--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -21,17 +21,29 @@ namespace FluentAssertions
         {
             string caller = null;
 
-            StackTrace stack = new StackTrace(true);
-
-            foreach (StackFrame frame in stack.GetFrames())
+            try
             {
-                logger(frame.ToString());
+                StackTrace stack = new StackTrace(true);
 
-                if (!IsDynamic(frame) && !IsDotNet(frame) && !IsCurrentAssembly(frame) && !IsCustomAssertion(frame))
+                foreach (StackFrame frame in stack.GetFrames())
                 {
-                    caller = ExtractVariableNameFrom(frame) ?? caller;
-                    break;
+                    logger(frame.ToString());
+
+                    if (frame.GetMethod() is object
+                        && !IsDynamic(frame)
+                        && !IsDotNet(frame)
+                        && !IsCurrentAssembly(frame)
+                        && !IsCustomAssertion(frame))
+                    {
+                        caller = ExtractVariableNameFrom(frame) ?? caller;
+                        break;
+                    }
                 }
+            }
+            catch (Exception e)
+            {
+                // Ignore exceptions, as determination of caller identity is only a nice-to-have
+                logger(e.ToString());
             }
 
             return caller;


### PR DESCRIPTION
Apparently when compiling an UWP project with .NET Native
`StackFrame.GetMethod` can return `null`. As determination
of caller identity is just a nice-to-have and not a need-to-have
I think we should wrap it in a `try/catch` instead of throwing
exceptions.
Related to #1149