### PR TITLE
Add missing failure messages

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -538,6 +538,7 @@ namespace FluentAssertions.Collections
 
             Execute.Assertion
                 .ForCondition(failures.Length > 0)
+                .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} {0} not to be equivalent to collection {1}{reason}.", Subject,
                     unexpected);
 
@@ -632,7 +633,7 @@ namespace FluentAssertions.Collections
 
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} {0} to contain equivalent of {1}.", Subject, expectation);
+                    .FailWith("Expected {context:collection} {0} to contain equivalent of {1}{reason}.", Subject, expectation);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -622,7 +622,7 @@ namespace FluentAssertions.Collections
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(elementsCount == inspectorsCount)
-                .FailWith("Expected {context:collection} to contain exactly {0} items, but it contains {1} items",
+                .FailWith("Expected {context:collection} to contain exactly {0} items{reason}, but it contains {1} items",
                     inspectorsCount, elementsCount);
 
             string[] failuresFromInspectors = CollectFailuresFromInspectors(elementInspectors);

--- a/Src/FluentAssertions/Equivalency/CyclicReferenceDetector.cs
+++ b/Src/FluentAssertions/Equivalency/CyclicReferenceDetector.cs
@@ -30,7 +30,7 @@ namespace FluentAssertions.Equivalency
         /// The behavior of a cyclic reference is determined by the <see cref="CyclicReferenceHandling"/> constructor
         /// parameter.
         /// </remarks>
-        public bool IsCyclicReference(ObjectReference reference)
+        public bool IsCyclicReference(ObjectReference reference, string because = "", params object[] becauseArgs)
         {
             bool isCyclic = false;
 
@@ -41,7 +41,9 @@ namespace FluentAssertions.Equivalency
                     isCyclic = true;
                     if (handling == CyclicReferenceHandling.ThrowException)
                     {
-                        AssertionScope.Current.FailWith(
+                        AssertionScope.Current
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith(
                             "Expected {context:subject} to be {expectation}{reason}, but it contains a cyclic reference.");
                     }
                 }

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -91,7 +91,8 @@ namespace FluentAssertions.Equivalency
 
             bool isComplexType = IsComplexType(context.Expectation);
 
-            return objectTracker.IsCyclicReference(new ObjectReference(context.Expectation, context.SelectedMemberPath, isComplexType));
+            var reference = new ObjectReference(context.Expectation, context.SelectedMemberPath, isComplexType);
+            return objectTracker.IsCyclicReference(reference, context.Because, context.BecauseArgs);
         }
 
         private bool IsComplexType(object expectation)

--- a/Src/FluentAssertions/Equivalency/StructuralEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/StructuralEqualityEquivalencyStep.cs
@@ -19,17 +19,18 @@ namespace FluentAssertions.Equivalency
         {
             bool expectationIsNotNull = AssertionScope.Current
                 .ForCondition(!(context.Expectation is null))
+                .BecauseOf(context.Because, context.BecauseArgs)
                 .FailWith(
-                    "Expected {context:subject} to be <null>, but found {0}.",
+                    "Expected {context:subject} to be <null>{reason}, but found {0}.",
                     context.Subject);
 
-            bool subjectIsNotNull =
-                AssertionScope.Current.ForCondition(
-                    !(context.Subject is null))
-                    .FailWith(
-                        "Expected {context:object} to be {0}{reason}, but found {1}.",
-                        context.Expectation,
-                        context.Subject);
+            bool subjectIsNotNull = AssertionScope.Current
+                .ForCondition(!(context.Subject is null))
+                .BecauseOf(context.Because, context.BecauseArgs)
+                .FailWith(
+                    "Expected {context:object} to be {0}{reason}, but found {1}.",
+                    context.Expectation,
+                    context.Subject);
 
             if (expectationIsNotNull && subjectIsNotNull)
             {

--- a/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
@@ -100,10 +100,11 @@ namespace FluentAssertions.Reflection
         {
             Type foundType = Subject.GetTypes().SingleOrDefault(t => t.Namespace == @namespace && t.Name == name);
 
-            Execute.Assertion.ForCondition(foundType != null)
+            Execute.Assertion
+                .ForCondition(foundType != null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected assembly {0} to define type {1}.{2}, but it does not.", Subject.FullName,
-                    @namespace, name);
+                .FailWith("Expected assembly {0} to define type {1}.{2}{reason}, but it does not.",
+                    Subject.FullName, @namespace, name);
 
             return new AndWhichConstraint<AssemblyAssertions, Type>(this, foundType);
         }

--- a/Tests/Shared.Specs/AssemblyAssertionSpecs.cs
+++ b/Tests/Shared.Specs/AssemblyAssertionSpecs.cs
@@ -123,14 +123,16 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => thisAssembly.Should().DefineType("FakeNamespace", "FakeName");
+            Action act = () => thisAssembly.Should().DefineType("FakeNamespace", "FakeName",
+                "because we want to test the failure {0}", "message");
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
                 .WithMessage(string.Format("Expected assembly \"{0}\" " +
-                             "to define type \"FakeNamespace\".\"FakeName\", but it does not.", thisAssembly.FullName));
+                             "to define type \"FakeNamespace\".\"FakeName\" " +
+                             "because we want to test the failure message, but it does not.", thisAssembly.FullName));
         }
 
         [Fact]

--- a/Tests/Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/BasicEquivalencySpecs.cs
@@ -2563,7 +2563,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_subject_has_a_valid_property_that_is_compared_with_a_null_property_it_should_throw()
+        public void When_subject_has_a_valid_property_that_is_compared_with_a_null_property_it_should_throw_with_descriptive_message()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -2581,13 +2581,13 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => subject.Should().BeEquivalentTo(other);
+            Action act = () => subject.Should().BeEquivalentTo(other, "we want to test the failure {0}", "message");
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected member Name to be <null>, but found \"Dennis\"*");
+                "Expected member Name to be <null>*we want to test the failure message*, but found \"Dennis\"*");
         }
 
         [Fact]
@@ -3766,12 +3766,14 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => actual.Should().BeEquivalentTo(new SelfReturningEnumerable(), new SelfReturningEnumerable());
+            Action act = () => actual.Should().BeEquivalentTo(
+                new[] { new SelfReturningEnumerable(), new SelfReturningEnumerable() },
+                "we want to test the failure {0}", "message");
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            act.Should().Throw<XunitException>().WithMessage("*cyclic*");
+            act.Should().Throw<XunitException>().WithMessage("*we want to test the failure message*cyclic reference*");
         }
 
         public class SelfReturningEnumerable : IEnumerable<SelfReturningEnumerable>
@@ -4154,7 +4156,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_asserting_instance_of_object_is_equivalent_to_null_it_should_fail()
+        public void When_asserting_instance_of_object_is_equivalent_to_null_it_should_fail_with_a_descriptive_message()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -4165,13 +4167,13 @@ namespace FluentAssertions.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Act
             //-----------------------------------------------------------------------------------------------------------
-            Action act = () => actual.Should().BeEquivalentTo(expected);
+            Action act = () => actual.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
-                .WithMessage("*Expected*to be <null>, but found System.Object*");
+                .WithMessage("*Expected*to be <null>*we want to test the failure message*, but found System.Object*");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/CollectionAssertionSpecs.cs
@@ -2422,6 +2422,27 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_string_collection_does_contain_same_string_it_should_throw_with_a_useful_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            string[] collection = new[] { "a" };
+            string item = "b";
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().ContainEquivalentOf(item, "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
+        }
+
+        [Fact]
         public void When_collection_does_not_contain_object_equivalent_of_another_it_should_throw()
         {
             //-----------------------------------------------------------------------------------------------------------

--- a/Tests/Shared.Specs/EnumAssertionSpecs.cs
+++ b/Tests/Shared.Specs/EnumAssertionSpecs.cs
@@ -107,7 +107,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_expectation_is_null_and_subject_enum_has_some_value_it_should_throw()
+        public void When_expectation_is_null_and_subject_enum_has_some_value_it_should_throw_with_a_useful_message()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -125,7 +125,7 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*to be <null>, but found UInt64Max*");
+                .WithMessage("Expected*to be <null> because comparing enums should throw, but found UInt64Max*");
         }
     }
 }

--- a/Tests/Shared.Specs/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/Shared.Specs/GenericCollectionAssertionsSpecs.cs
@@ -2250,7 +2250,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_inspectors_count_does_not_equal_asserting_collection_length_it_should_throw()
+        public void When_inspectors_count_does_not_equal_asserting_collection_length_it_should_throw_with_a_useful_message()
         {
             //-----------------------------------------------------------------------------------------------------------
             // Arrange
@@ -2271,7 +2271,30 @@ namespace FluentAssertions.Specs
             // Assert
             //-----------------------------------------------------------------------------------------------------------
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain exactly 2 items, but it contains 3 items");
+                "Expected collection to contain exactly 2 items*we want to test the failure message*, but it contains 3 items");
+        }
+
+        [Fact]
+        public void When_inspectors_count_does_not_equal_asserting_collection_length_it_should_fail_with_a_useful_message()
+        {
+            //-----------------------------------------------------------------------------------------------------------
+            // Arrange
+            //-----------------------------------------------------------------------------------------------------------
+            var collection = new int[0];
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Act
+            //-----------------------------------------------------------------------------------------------------------
+            Action act = () => collection.Should().SatisfyRespectively(
+                new Action<int>[]
+                {
+                    value => value.Should().Be(1),
+                }, "because we want to test the failure {0}", "message");
+
+            //-----------------------------------------------------------------------------------------------------------
+            // Assert
+            //-----------------------------------------------------------------------------------------------------------
+            act.Should().Throw<XunitException>().WithMessage("*because we want to test the failure*");
         }
         #endregion
     }


### PR DESCRIPTION
Some assertions did not include failure reason either because it:
* did not add `BecauseOf` before invoking `FailWith`, or
* did not have {reason} inside the failure message.
I added two optional because parameters to `IsCyclicReference` to achieve this.
That class is internal, so no breaking change, but if it can be done
prettier I'm all ear.