### PR TITLE
Changed Be/NotBe on IComparable to use Object.Equals and added BeRankedEquallyTo

### DIFF
--- a/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
@@ -19,12 +19,11 @@ namespace FluentAssertions.Numeric
         {
         }
 
+
         /// <summary>
-        /// Asserts that the subject is considered equal to another object according to the implementation of <see cref="IComparable{T}"/>.
+        /// Asserts that an object equals another object using its <see cref="object.Equals(object)" /> implementation.
         /// </summary>
-        /// <param name="expected">
-        /// The object to pass to the subject's <see cref="IComparable{T}.CompareTo"/> method.
-        /// </param>
+        /// <param name="expected">The expected value</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -35,7 +34,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(ReferenceEquals(Subject, expected) || (Subject.CompareTo(expected) == Equal))
+                .ForCondition(Subject.IsSameOrEqualTo(expected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:object} to be equal to {0}{reason}, but found {1}.", expected, Subject);
 
@@ -110,22 +109,20 @@ namespace FluentAssertions.Numeric
         }
 
         /// <summary>
-        /// Asserts that the subject is not equal to another object according to its implementation of <see cref="IComparable{T}"/>.
+        /// Asserts that an object does not equal another object using its <see cref="object.Equals(object)" /> method.
         /// </summary>
-        /// <param name="unexpected">
-        /// The object to pass to the subject's <see cref="IComparable{T}.CompareTo"/> method.
-        /// </param>
+        /// <param name="unexpected">The unexpected value</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
         /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="because"/>.
+        /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
         /// </param>
         public AndConstraint<ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.CompareTo(unexpected) != Equal)
+                .ForCondition(!Subject.IsSameOrEqualTo(unexpected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:object} to be equal to {0}{reason}.", unexpected);
 

--- a/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
@@ -152,7 +152,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) == Equal)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:object} {0} to be be ranked as equal to {1}{reason}.", Subject, expected);
+                .FailWith("Expected {context:object} {0} to be ranked as equal to {1}{reason}.", Subject, expected);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
         }

--- a/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
@@ -176,7 +176,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(unexpected) != Equal)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:object} {0} not to be be ranked as equal to {1}{reason}.", Subject, unexpected);
+                .FailWith("Expected {context:object} {0} not to be ranked as equal to {1}{reason}.", Subject, unexpected);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
         }

--- a/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
@@ -161,7 +161,7 @@ namespace FluentAssertions.Numeric
         /// Asserts that the subject is not ranked equal to another object. I.e. the result of <see cref="IComparable{T}.CompareTo"/>returns non-zero.
         /// To verify whether the objects are not equal according to <see cref="object.Equals(object)"/> you must use <see cref="NotBe(T, string, object[])"/>.
         /// </summary>
-        /// <param name="expected">
+        /// <param name="unexpected">
         /// The object to pass to the subject's <see cref="IComparable{T}.CompareTo"/> method.
         /// </param>
         /// <param name="because">
@@ -171,12 +171,12 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.CompareTo(expected) != Equal)
+                .ForCondition(Subject.CompareTo(unexpected) != Equal)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:object} {0} not to be be ranked as equal to {1}{reason}.", Subject, expected);
+                .FailWith("Expected {context:object} {0} not to be be ranked as equal to {1}{reason}.", Subject, unexpected);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
         }

--- a/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
@@ -23,7 +23,7 @@ namespace FluentAssertions.Numeric
         /// <summary>
         /// Asserts that an object equals another object using its <see cref="object.Equals(object)" /> implementation.<br/>
         /// Verification whether <see cref="IComparable{T}.CompareTo(T)"/> returns 0 is not done here, you should use
-        /// <see cref="BeRankedAsEqualTo(T, string, object[])"/> to verify this. 
+        /// <see cref="BeRankedEquallyTo(T, string, object[])"/> to verify this. 
         /// </summary>
         /// <param name="expected">The expected value</param>
         /// <param name="because">
@@ -113,7 +113,7 @@ namespace FluentAssertions.Numeric
         /// <summary>
         /// Asserts that an object does not equal another object using its <see cref="object.Equals(object)" /> method.<br/>
         /// Verification whether <see cref="IComparable{T}.CompareTo(T)"/> returns non-zero is not done here, you should use
-        /// <see cref="NotBeRankedAsEqualTo(T, string, object[])"/> to verify this.
+        /// <see cref="NotBeRankedEquallyTo(T, string, object[])"/> to verify this.
         /// </summary>
         /// <param name="unexpected">The unexpected value</param>
         /// <param name="because">
@@ -147,7 +147,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> BeRankedAsEqualTo(T expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<ComparableTypeAssertions<T>> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) == Equal)
@@ -171,7 +171,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because"/>.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> NotBeRankedAsEqualTo(T expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) != Equal)

--- a/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
@@ -21,7 +21,9 @@ namespace FluentAssertions.Numeric
 
 
         /// <summary>
-        /// Asserts that an object equals another object using its <see cref="object.Equals(object)" /> implementation.
+        /// Asserts that an object equals another object using its <see cref="object.Equals(object)" /> implementation.<br/>
+        /// Verification whether <see cref="IComparable{T}.CompareTo(T)"/> returns 0 is not done here, you should use
+        /// <see cref="BeRankedAsEqualTo(T, string, object[])"/> to verify this. 
         /// </summary>
         /// <param name="expected">The expected value</param>
         /// <param name="because">
@@ -109,7 +111,9 @@ namespace FluentAssertions.Numeric
         }
 
         /// <summary>
-        /// Asserts that an object does not equal another object using its <see cref="object.Equals(object)" /> method.
+        /// Asserts that an object does not equal another object using its <see cref="object.Equals(object)" /> method.<br/>
+        /// Verification whether <see cref="IComparable{T}.CompareTo(T)"/> returns non-zero is not done here, you should use
+        /// <see cref="NotBeRankedAsEqualTo(T, string, object[])"/> to verify this.
         /// </summary>
         /// <param name="unexpected">The unexpected value</param>
         /// <param name="because">
@@ -125,6 +129,54 @@ namespace FluentAssertions.Numeric
                 .ForCondition(!Subject.IsSameOrEqualTo(unexpected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:object} to be equal to {0}{reason}.", unexpected);
+
+            return new AndConstraint<ComparableTypeAssertions<T>>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the subject is ranked equal to another object. I.e. the result of <see cref="IComparable{T}.CompareTo"/> returns 0.
+        /// To verify whether the objects are equal you must use <see cref="Be(T, string, object[])"/>.
+        /// </summary>
+        /// <param name="expected">
+        /// The object to pass to the subject's <see cref="IComparable{T}.CompareTo"/> method.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
+        /// </param>
+        public AndConstraint<ComparableTypeAssertions<T>> BeRankedAsEqualTo(T expected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(Subject.CompareTo(expected) == Equal)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:object} {0} to be be ranked as equal to {1}{reason}.", Subject, expected);
+
+            return new AndConstraint<ComparableTypeAssertions<T>>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the subject is not ranked equal to another object. I.e. the result of <see cref="IComparable{T}.CompareTo"/>returns non-zero.
+        /// To verify whether the objects are not equal according to <see cref="object.Equals(object)"/> you must use <see cref="NotBe(T, string, object[])"/>.
+        /// </summary>
+        /// <param name="expected">
+        /// The object to pass to the subject's <see cref="IComparable{T}.CompareTo"/> method.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because"/>.
+        /// </param>
+        public AndConstraint<ComparableTypeAssertions<T>> NotBeRankedAsEqualTo(T expected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(Subject.CompareTo(expected) != Equal)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:object} {0} not to be be ranked as equal to {1}{reason}.", Subject, expected);
 
             return new AndConstraint<ComparableTypeAssertions<T>>(this);
         }

--- a/Tests/Shared.Specs/ComparableSpecs.cs
+++ b/Tests/Shared.Specs/ComparableSpecs.cs
@@ -371,9 +371,9 @@ namespace FluentAssertions.Specs
             act
                 .Should().Throw<XunitException>()
 #if NETCOREAPP1_1
-                .WithMessage("Expected object*42*to be be ranked as equal to*Forty two*because they represent the same number.");
+                .WithMessage("Expected object*42*to be ranked as equal to*Forty two*because they represent the same number.");
 #else
-                .WithMessage("Expected subject*42*to be be ranked as equal to*Forty two*because they represent the same number.");
+                .WithMessage("Expected subject*42*to be ranked as equal to*Forty two*because they represent the same number.");
 #endif
         }
 
@@ -408,9 +408,9 @@ namespace FluentAssertions.Specs
             act
                 .Should().Throw<XunitException>()
 #if NETCOREAPP1_1
-                .WithMessage("Expected object*Lead*not to be be ranked as equal to*Lead*because they represent different concepts.");
+                .WithMessage("Expected object*Lead*not to be ranked as equal to*Lead*because they represent different concepts.");
 #else
-                .WithMessage("Expected subject*Lead*not to be be ranked as equal to*Lead*because they represent different concepts.");
+                .WithMessage("Expected subject*Lead*not to be ranked as equal to*Lead*because they represent different concepts.");
 #endif
         }
 

--- a/Tests/Shared.Specs/ComparableSpecs.cs
+++ b/Tests/Shared.Specs/ComparableSpecs.cs
@@ -68,7 +68,6 @@ namespace FluentAssertions.Specs
             act.Should().NotThrow();
         }
 
-
         [Fact]
         public void When_two_equal_objects_should_not_be_equal_it_should_throw()
         {
@@ -338,6 +337,81 @@ namespace FluentAssertions.Specs
 
             // Assert
             action.Should().Throw<XunitException>();
+        }
+
+        #endregion
+
+        #region Be Ranked As Equal To
+
+        [Fact]
+        public void When_subect_is_ranked_equal_to_another_subject_and_that_is_expected_it_should_not_throw()
+        {
+            // Arrange
+            var subject = new ComparableOfString("Hello");
+            var other = new ComparableOfString("Hello");
+
+            // Act
+            Action act = () => subject.Should().BeRankedAsEqualTo(other);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_subject_is_not_ranked_equal_to_another_subject_but_that_is_expected_it_should_throw()
+        {
+            // Arrange
+            var subject = new ComparableOfString("42");
+            var other = new ComparableOfString("Forty two");
+
+            // Act
+            Action act = () => subject.Should().BeRankedAsEqualTo(other, "they represent the same number");
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+#if NETCOREAPP1_1
+                .WithMessage("Expected object*42*to be be ranked as equal to*Forty two*because they represent the same number.");
+#else
+                .WithMessage("Expected subject*42*to be be ranked as equal to*Forty two*because they represent the same number.");
+#endif
+        }
+
+        #endregion
+
+        #region Not Be Ranked As Equal To
+
+        [Fact]
+        public void When_subect_is_not_ranked_equal_to_another_subject_and_that_is_expected_it_should_not_throw()
+        {
+            // Arrange
+            var subject = new ComparableOfString("Hello");
+            var other = new ComparableOfString("Hi");
+
+            // Act
+            Action act = () => subject.Should().NotBeRankedAsEqualTo(other);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_subject_is_ranked_equal_to_another_subject_but_that_is_not_expected_it_should_throw()
+        {
+            // Arrange
+            var subject = new ComparableOfString("Lead");
+            var other = new ComparableOfString("Lead");
+
+            // Act
+            Action act = () => subject.Should().NotBeRankedAsEqualTo(other, "they represent different concepts");
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+#if NETCOREAPP1_1
+                .WithMessage("Expected object*Lead*not to be be ranked as equal to*Lead*because they represent different concepts.");
+#else
+                .WithMessage("Expected subject*Lead*not to be be ranked as equal to*Lead*because they represent different concepts.");
+#endif
         }
 
         #endregion

--- a/Tests/Shared.Specs/ComparableSpecs.cs
+++ b/Tests/Shared.Specs/ComparableSpecs.cs
@@ -12,19 +12,19 @@ namespace FluentAssertions.Specs
         public void When_two_instances_are_equal_it_should_succeed()
         {
             // Arrange
-            var subject = new ComparableOfString("Hello");
-            var other = new ComparableOfString("Hello");
+            var subject = new EquatableOfInt(1);
+            var other = new EquatableOfInt(1);
 
             // Act / Assert
             subject.Should().Be(other);
         }
 
         [Fact]
-        public void When_two_instances_are_not_equal_it_should_throw()
+        public void When_two_instances_are_the_same_reference_but_are_not_considered_equal_it_should_not_succeed()
         {
             // Arrange
-            var subject = new ComparableOfString("Hello");
-            var other = new ComparableOfString("Hi");
+            var subject = new SameInstanceIsNotEqualClass();
+            var other = subject;
 
             // Act
             Action act = () => subject.Should().Be(other, "they have the same property values");
@@ -33,15 +33,48 @@ namespace FluentAssertions.Specs
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected*Hi*because they have the same property values, but found*Hello*.");
+                    "Expected*SameInstanceIsNotEqualClass*because they have the same property values, but found*SameInstanceIsNotEqualClass*.");
         }
+
+
+        [Fact]
+        public void When_two_instances_are_not_equal_it_should_throw()
+        {
+            // Arrange
+            var subject = new EquatableOfInt(1);
+            var other = new EquatableOfInt(2);
+
+            // Act
+            Action act = () => subject.Should().Be(other, "they have the same property values");
+
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected*2*because they have the same property values, but found*1*.");
+        }
+
+        [Fact]
+        public void When_two_references_to_the_same_instance_are_not_equal_it_should_succeed()
+        {
+            // Arrange
+            var subject = new SameInstanceIsNotEqualClass();
+            var other = subject;
+
+            // Act
+            Action act = () => subject.Should().NotBe(other);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
 
         [Fact]
         public void When_two_equal_objects_should_not_be_equal_it_should_throw()
         {
             // Arrange
-            var subject = new ComparableOfString("Hello");
-            var other = new ComparableOfString("Hello");
+            var subject = new EquatableOfInt(1);
+            var other = new EquatableOfInt(1);
 
             // Act
             Action act = () => subject.Should().NotBe(other, "they represent different things");
@@ -51,9 +84,9 @@ namespace FluentAssertions.Specs
                 .Should().Throw<XunitException>()
                 .WithMessage(
 #if NETCOREAPP1_1
-                    "*Did not expect object to be equal to*Hello*because they represent different things.*");
+                    "*Did not expect object to be equal to*1*because they represent different things.*");
 #else
-                    "*Did not expect subject to be equal to*Hello*because they represent different things.*");
+                    "*Did not expect subject to be equal to*1*because they represent different things.*");
 #endif
         }
 
@@ -61,8 +94,8 @@ namespace FluentAssertions.Specs
         public void When_two_unequal_objects_should_not_be_equal_it_should_not_throw()
         {
             // Arrange
-            var subject = new ComparableOfString("Hello");
-            var other = new ComparableOfString("Hi");
+            var subject = new EquatableOfInt(1);
+            var other = new EquatableOfInt(2);
 
             // Act
             Action act = () => subject.Should().NotBe(other);
@@ -535,6 +568,43 @@ namespace FluentAssertions.Specs
         public override string ToString()
         {
             return Value;
+        }
+    }
+
+    public class SameInstanceIsNotEqualClass
+    {
+        public SameInstanceIsNotEqualClass()
+        {
+        }
+        public override bool Equals(object obj)
+        {
+            return false;
+        }
+        public override int GetHashCode()
+        {
+            return 1;
+        }
+    }
+
+    public class EquatableOfInt
+    {
+        public int Value { get; set; }
+        public EquatableOfInt(int value)
+        {
+            Value = value;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Value == ((EquatableOfInt)obj).Value;
+        }
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+        public override string ToString()
+        {
+            return Value.ToString();
         }
     }
 

--- a/Tests/Shared.Specs/ComparableSpecs.cs
+++ b/Tests/Shared.Specs/ComparableSpecs.cs
@@ -351,7 +351,7 @@ namespace FluentAssertions.Specs
             var other = new ComparableOfString("Hello");
 
             // Act
-            Action act = () => subject.Should().BeRankedAsEqualTo(other);
+            Action act = () => subject.Should().BeRankedEquallyTo(other);
 
             // Assert
             act.Should().NotThrow();
@@ -365,7 +365,7 @@ namespace FluentAssertions.Specs
             var other = new ComparableOfString("Forty two");
 
             // Act
-            Action act = () => subject.Should().BeRankedAsEqualTo(other, "they represent the same number");
+            Action act = () => subject.Should().BeRankedEquallyTo(other, "they represent the same number");
 
             // Assert
             act
@@ -389,7 +389,7 @@ namespace FluentAssertions.Specs
             var other = new ComparableOfString("Hi");
 
             // Act
-            Action act = () => subject.Should().NotBeRankedAsEqualTo(other);
+            Action act = () => subject.Should().NotBeRankedEquallyTo(other);
 
             // Assert
             act.Should().NotThrow();
@@ -403,7 +403,7 @@ namespace FluentAssertions.Specs
             var other = new ComparableOfString("Lead");
 
             // Act
-            Action act = () => subject.Should().NotBeRankedAsEqualTo(other, "they represent different concepts");
+            Action act = () => subject.Should().NotBeRankedEquallyTo(other, "they represent different concepts");
             // Assert
             act
                 .Should().Throw<XunitException>()


### PR DESCRIPTION
A new pull request for #172 in which all commits have been cleaned up. I struggled with getting Git to behave the way I wanted, but I think this should be it. 

Just to reiterate, this might be a breaking change when released since it does not check CompareTo == 0 anymore. This might be something people depend upon.  