### PR TITLE
Add Have/NotHaveSameCount for Dictionaries

### DIFF
--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -238,6 +239,87 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} {0} to have a count {1}{reason}, but count is {2}.",
                         Subject, countPredicate.Body, actualCount);
             }
+
+            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+        }
+
+        /// <summary>
+        /// Assert that the current dictionary has the same number of elements as <paramref name="otherCollection" />.
+        /// </summary>
+        /// <param name="otherCollection">The other collection with the same expected number of elements</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> HaveSameCount(IEnumerable otherCollection, string because = "",
+            params object[] becauseArgs)
+        {
+            Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot compare dictionary count against a <null> collection.");
+
+            if (ReferenceEquals(Subject, null))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:dictionary} to have the same count as {0}{reason}, but found {1}.",
+                        otherCollection,
+                        Subject);
+            }
+
+            int actualCount = Subject.Count;
+            int expectedCount = otherCollection.Cast<object>().Count();
+
+            Execute.Assertion
+                .ForCondition(actualCount == expectedCount)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:dictionary} to have {0} item(s){reason}, but count is {1}.", expectedCount, actualCount);
+
+            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+        }
+
+        /// <summary>
+        /// Assert that the current collection does not have the same number of elements as <paramref name="otherCollection" />.
+        /// </summary>
+        /// <param name="otherCollection">The other collection with the unexpected number of elements</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotHaveSameCount(IEnumerable otherCollection, string because = "",
+            params object[] becauseArgs)
+        {
+            Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot compare dictionary count against a <null> collection.");
+
+            if (ReferenceEquals(Subject, null))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:dictionary} to not have the same count as {0}{reason}, but found {1}.",
+                        otherCollection,
+                        Subject);
+            }
+
+            if (ReferenceEquals(Subject, otherCollection))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:dictionary} {0} to not have the same count as {1}{reason}, but they both reference the same object.",
+                        Subject,
+                        otherCollection);
+            }
+
+            int actualCount = Subject.Count;
+            int expectedCount = otherCollection.Cast<object>().Count();
+
+            Execute.Assertion
+                .ForCondition(actualCount != expectedCount)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:dictionary} to not have {0} item(s){reason}, but count is {1}.", expectedCount, actualCount);
 
             return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
         }

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -259,7 +259,7 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot compare dictionary count against a <null> collection.");
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -295,7 +295,7 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot compare dictionary count against a <null> collection.");
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)

--- a/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
@@ -611,6 +611,219 @@ namespace FluentAssertions.Specs
 
         #endregion
 
+        #region Have Same Count
+
+        [Fact]
+        public void When_dictionary_and_collection_have_the_same_number_elements_it_should_succeed()
+        {
+            // Arrange
+            var dictionary = new Dictionary<int, string>
+            {
+                [1] = "One",
+                [2] = "Two",
+                [3] = "Three"
+            };
+            IEnumerable collection = new[] { 4, 5, 6 };
+
+            // Act / Assert
+            dictionary.Should().HaveSameCount(collection);
+        }
+
+        [Fact]
+        public void When_dictionary_and_collection_do_not_have_the_same_number_of_elements_it_should_fail()
+        {
+            // Arrange
+            var dictionary = new Dictionary<int, string>
+            {
+                [1] = "One",
+                [2] = "Two",
+                [3] = "Three"
+            };
+            IEnumerable collection = new[] { 4, 6 };
+
+            // Act
+            Action act = () => dictionary.Should().HaveSameCount(collection);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected dictionary to have 2 item(s), but count is 3.");
+        }
+
+        [Fact]
+        public void When_comparing_item_counts_and_a_reason_is_specified_it_should_it_in_the_exception()
+        {
+            // Arrange
+            var dictionary = new Dictionary<int, string>
+            {
+                [1] = "One",
+                [2] = "Two",
+                [3] = "Three"
+            };
+            IEnumerable collection = new[] { 4, 6 };
+
+            // Act
+            Action act = () => dictionary.Should().HaveSameCount(collection, "we want to test the {0}", "reason");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected dictionary to have 2 item(s) because we want to test the reason, but count is 3.");
+        }
+
+        [Fact]
+        public void When_asserting_dictionary_and_collection_have_same_count_against_null_dictionary_it_should_throw()
+        {
+            // Arrange
+            Dictionary<string, int> dictionary = null;
+            IEnumerable collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => dictionary.Should().HaveSameCount(collection,
+                "because we want to test the behaviour with a null subject");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected dictionary to have the same count as {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_dictionary_and_collection_have_same_count_against_a_null_collection_it_should_throw()
+        {
+            // Arrange
+            var dictionary = new Dictionary<int, string>
+            {
+                [1] = "One",
+                [2] = "Two",
+                [3] = "Three"
+            };
+            IEnumerable collection = null;
+
+            // Act
+            Action act = () => dictionary.Should().HaveSameCount(collection);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithMessage(
+                "Cannot compare dictionary count against a <null> collection.*");
+        }
+
+        #endregion
+
+        #region Not Have Same Count
+
+        [Fact]
+        public void When_asserting_not_same_count_and_collections_have_different_number_elements_it_should_succeed()
+        {
+            // Arrange
+            var dictionary = new Dictionary<int, string>
+            {
+                [1] = "One",
+                [2] = "Two",
+                [3] = "Three"
+            };
+            IEnumerable collection = new[] { 4, 6 };
+
+            // Act / Assert
+            dictionary.Should().NotHaveSameCount(collection);
+        }
+
+        [Fact]
+        public void When_asserting_not_same_count_and_both_collections_have_the_same_number_elements_it_should_fail()
+        {
+            // Arrange
+            var dictionary = new Dictionary<int, string>
+            {
+                [1] = "One",
+                [2] = "Two",
+                [3] = "Three"
+            };
+            IEnumerable collection = new[] { 4, 5, 6 };
+
+            // Act
+            Action act = () => dictionary.Should().NotHaveSameCount(collection);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected dictionary to not have 3 item(s), but count is 3.");
+        }
+
+        [Fact]
+        public void When_comparing_not_same_item_counts_and_a_reason_is_specified_it_should_it_in_the_exception()
+        {
+            // Arrange
+            var dictionary = new Dictionary<int, string>
+            {
+                [1] = "One",
+                [2] = "Two",
+                [3] = "Three"
+            };
+            IEnumerable collection = new[] { 4, 5, 6 };
+
+            // Act
+            Action act = () => dictionary.Should().NotHaveSameCount(collection, "we want to test the {0}", "reason");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected dictionary to not have 3 item(s) because we want to test the reason, but count is 3.");
+        }
+
+        [Fact]
+        public void When_asserting_dictionary_and_collection_to_not_have_same_count_against_null_dictionary_it_should_throw()
+        {
+            // Arrange
+            Dictionary<int, string> dictionary = null;
+            IEnumerable collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => dictionary.Should().NotHaveSameCount(collection,
+                "because we want to test the behaviour with a null subject");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected dictionary to not have the same count as {1, 2, 3} because we want to test the behaviour with a null subject, but found <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_dictionary_and_collection_to_not_have_same_count_against_a_null_collection_it_should_throw()
+        {
+            // Arrange
+            var dictionary = new Dictionary<int, string>
+            {
+                [1] = "One",
+                [2] = "Two",
+                [3] = "Three"
+            };
+            IEnumerable collection = null;
+
+            // Act
+            Action act = () => dictionary.Should().NotHaveSameCount(collection);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithMessage(
+                "Cannot compare dictionary count against a <null> collection.*");
+        }
+
+        [Fact]
+        public void When_asserting_dictionary_and_collection_to_not_have_same_count_but_both_reference_the_same_object_it_should_throw()
+        {
+            // Arrange
+            var dictionary = new Dictionary<int, string>
+            {
+                [1] = "One",
+                [2] = "Two",
+                [3] = "Three"
+            };
+            IEnumerable collection = dictionary;
+
+            // Act
+            Action act = () => dictionary.Should().NotHaveSameCount(collection,
+                "because we want to test the behaviour with same objects");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*not have the same count*because we want to test the behaviour with same objects*but they both reference the same object.");
+        }
+
+        #endregion
+
         #region Be Empty
 
         [Fact]

--- a/docs/_pages/dictionaries.md
+++ b/docs/_pages/dictionaries.md
@@ -65,6 +65,12 @@ You can also assert that the dictionary has a certain number of items:
 ```csharp
 dictionary.Should().HaveCount(2);
 dictionary.Should().NotHaveCount(3);
+
+dictionary1.Should().HaveSameCount(dictionary2);
+dictionary1.Should().NotHaveSameCount(dictionary3);
+
+dictionary1.Should().HaveSameCount(dictionary2.Keys);
+dictionary1.Should().NotHaveSameCount(dictionary3.Keys);
 ```
 
 And finally you can assert that the dictionary contains a specific key/value pair or not:
@@ -81,7 +87,7 @@ dictionary.Should().NotContain(item1, item2);
 dictionary.Should().NotContain(9, "Nine");
 ```
 
-Chaining additional assertion is supported as well.
+Chaining additional assertions is supported as well.
 
 ```csharp
 dictionary.Should().ContainValue(myClass)


### PR DESCRIPTION
Adding support for `HaveSameCount` and `NotHaveSameCount` for dictionaries.  This was almost directly cribbed from the existing `CollectionAssertions` (including test cases).

Resolves #1176 

## IMPORTANT 

* [X] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [X] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [X] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/_pages/documentation.md) in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com).
