### PR TITLE
Add index to XPath information of XDocument equivalence failure message

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -69,6 +69,7 @@ dotnet_naming_symbols.constant_fields.required_modifiers = const
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
 # Code style defaults
+csharp_using_directive_placement = outside_namespace:warning
 dotnet_sort_system_directives_first = true
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = false

--- a/Src/FluentAssertions/Xml/XmlReaderValidator.cs
+++ b/Src/FluentAssertions/Xml/XmlReaderValidator.cs
@@ -244,7 +244,7 @@ namespace FluentAssertions.Xml
 
             public string Value { get; }
 
-            public string Prefix { get; }
+            private string Prefix { get; }
 
             public string QualifiedName
             {
@@ -273,64 +273,64 @@ namespace FluentAssertions.Xml
                 this.reader.MoveToContent();
             }
 
-            public XmlNodeType NodeType => this.reader.NodeType;
+            public XmlNodeType NodeType => reader.NodeType;
 
-            public string LocalName => this.reader.LocalName;
+            public string LocalName => reader.LocalName;
 
-            public string NamespaceURI => this.reader.NamespaceURI;
+            public string NamespaceURI => reader.NamespaceURI;
 
-            public string Value => this.reader.Value;
+            public string Value => reader.Value;
 
-            public bool IsEmptyElement => this.reader.IsEmptyElement;
+            public bool IsEmptyElement => reader.IsEmptyElement;
 
-            public bool EOF => this.reader.EOF;
+            public bool EOF => reader.EOF;
 
             public bool Read()
             {
-                if (this.skipOnce)
+                if (skipOnce)
                 {
-                    this.skipOnce = false;
+                    skipOnce = false;
                     return true;
                 }
 
-                if (!this.reader.Read())
+                if (!reader.Read())
                 {
                     return false;
                 }
 
-                this.reader.MoveToContent();
+                reader.MoveToContent();
                 return true;
             }
 
             public void MoveToEndElement()
             {
-                this.reader.Read();
-                if (this.reader.NodeType != XmlNodeType.EndElement)
+                reader.Read();
+                if (reader.NodeType != XmlNodeType.EndElement)
                 {
                     // advancing failed
                     // skip reading on next attempt to "simulate" rewind reader
-                    this.skipOnce = true;
+                    skipOnce = true;
                 }
 
-                this.reader.MoveToContent();
+                reader.MoveToContent();
             }
 
             public IList<AttributeData> GetAttributes()
             {
                 var attributes = new List<AttributeData>();
 
-                if (this.reader.MoveToFirstAttribute())
+                if (reader.MoveToFirstAttribute())
                 {
                     do
                     {
                         if (reader.NamespaceURI != "http://www.w3.org/2000/xmlns/")
                         {
-                            attributes.Add(new AttributeData(this.reader.NamespaceURI, this.reader.LocalName, this.reader.Value, this.reader.Prefix));
+                            attributes.Add(new AttributeData(reader.NamespaceURI, reader.LocalName, reader.Value, reader.Prefix));
                         }
                     }
-                    while (this.reader.MoveToNextAttribute());
+                    while (reader.MoveToNextAttribute());
 
-                    this.reader.MoveToElement();
+                    reader.MoveToElement();
                 }
 
                 return attributes;

--- a/Tests/Shared.Specs/XDocumentAssertionSpecs.cs
+++ b/Tests/Shared.Specs/XDocumentAssertionSpecs.cs
@@ -480,7 +480,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void when_an_xml_element_has_attributes_and_is_self_closing_it_should_succeed()
+        public void When_asserting_equivalence_of_an_xml_document_but_has_different_attribute_value_it_should_fail_with_xpath_to_difference()
         {
             // Arrange
             XDocument actual = XDocument.Parse("<xml><a attr=\"x\"/><b id=\"foo\"/></xml>");
@@ -490,8 +490,23 @@ namespace FluentAssertions.Specs
             Action act = () => actual.Should().BeEquivalentTo(expected);
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*\"/xml/b\"*");
+            act.Should().Throw<XunitException>().WithMessage("*\"/xml/b\"*");
+        }
+
+        [Fact]
+        public void When_asserting_equivalence_of_document_with_repeating_element_names_but_differs_it_should_fail_with_index_xpath_to_difference()
+        {
+            // Arrange
+            XDocument actual = XDocument.Parse(
+                "<xml><xml2 /><xml2 /><xml2><a x=\"y\"/><b><sub /></b><a x=\"y\"/></xml2></xml>");
+            XDocument expected = XDocument.Parse(
+                "<xml><xml2 /><xml2 /><xml2><a x=\"y\"/><b><sub /></b><a x=\"z\"/></xml2></xml>");
+
+            // Arrange
+            Action act = () => actual.Should().BeEquivalentTo(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("*\"/xml/xml2[3]/a[2]\"*");
         }
 
         #endregion

--- a/Tests/Shared.Specs/XDocumentAssertionSpecs.cs
+++ b/Tests/Shared.Specs/XDocumentAssertionSpecs.cs
@@ -529,7 +529,7 @@ namespace FluentAssertions.Specs
             XDocument actual = XDocument.Parse("<xml><a attr=\"x\"/><b id=\"foo\"/></xml>");
             XDocument expected = XDocument.Parse("<xml><a attr=\"x\"/><b id=\"bar\"/></xml>");
 
-            // Arrange
+            // Act
             Action act = () => actual.Should().BeEquivalentTo(expected);
 
             // Assert
@@ -545,7 +545,7 @@ namespace FluentAssertions.Specs
             XDocument expected = XDocument.Parse(
                 "<xml><xml2 /><xml2 /><xml2><a x=\"y\"/><b><sub /></b><a x=\"z\"/></xml2></xml>");
 
-            // Arrange
+            // Act
             Action act = () => actual.Should().BeEquivalentTo(expected);
 
             // Assert

--- a/Tests/Shared.Specs/XDocumentAssertionSpecs.cs
+++ b/Tests/Shared.Specs/XDocumentAssertionSpecs.cs
@@ -552,6 +552,22 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>().WithMessage("*\"/xml/xml2[3]/a[2]\"*");
         }
 
+        [Fact]
+        public void When_asserting_equivalence_of_document_with_repeating_element_names_on_different_levels_but_differs_it_should_fail_with_index_xpath_to_difference()
+        {
+            // Arrange
+            XDocument actual = XDocument.Parse(
+                "<xml><xml /><xml /><xml><xml x=\"y\"/><xml2><xml /></xml2><xml x=\"y\"/></xml></xml>");
+            XDocument expected = XDocument.Parse(
+                "<xml><xml /><xml /><xml><xml x=\"y\"/><xml2><xml /></xml2><xml x=\"z\"/></xml></xml>");
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("*\"/xml/xml[3]/xml[2]\"*");
+        }
+
         #endregion
 
         #region BeNull / NotBeNull


### PR DESCRIPTION
I think, the XDocument equivalence failure message is not helpful when comparing documents with repeating element names, like HTML documents. By just providing the simple XPath it may be very difficult to identify the element with difference:
`/html/body/table/tr/td`

This PR is a proposal to improve the failure message by writing index number (according XPath syntax) when a specific element was found at least second time on same level:
`/html/body/table[2]/tr[17]/td[5]`

Additionally
* I recommend a new setting for `editorconfig` according to the current code style
* I changed a test name according to the test content