### PR TITLE
Fix unexpected IsDotNet behavior for non-dotnet namespaces

### DIFF
--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -66,8 +66,11 @@ namespace FluentAssertions
 
         private static bool IsDotNet(StackFrame frame)
         {
-            return frame.GetMethod().DeclaringType.Namespace
-                ?.StartsWith("system", StringComparison.InvariantCultureIgnoreCase) == true;
+            var frameNamespace = frame.GetMethod().DeclaringType.Namespace;
+            var comparisonType = StringComparison.InvariantCultureIgnoreCase;
+
+            return frameNamespace?.StartsWith("system.", comparisonType) == true ||
+                frameNamespace?.Equals("system", comparisonType) == true;
         }
 
         private static string ExtractVariableNameFrom(StackFrame frame)

--- a/Tests/Shared.Specs/CallerIdentifierSpecs.cs
+++ b/Tests/Shared.Specs/CallerIdentifierSpecs.cs
@@ -1,0 +1,81 @@
+﻿#if !NETCOREAPP1_1 && !NETSTANDARD1_3 && !NETSTANDARD1_6 && !NETSTANDARD2_0
+
+using Xunit;
+using Xunit.Sdk;
+using FluentAssertions;
+using System;
+using FluentAssertions.Primitives;
+
+namespace FluentAssertions.Specs
+{
+    public class CallerIdentifierSpecs
+    {
+        [Fact]
+        public void When_namespace_is_exactly_System_caller_should_be_unknown()
+        {
+            // Act
+            Action act = () => System.SystemNamespaceClass.DetermineCallerIdentityInNamespace();
+
+            //Assert
+            act.Should().Throw<XunitException>().WithMessage("Expected function to be*");
+        }
+
+        [Fact]
+        public void When_namespace_is_nested_under_System_caller_should_be_unknown()
+        {
+            // Act
+            Action act = () => System.Data.NestedSystemNamespaceClass.DetermineCallerIdentityInNamespace();
+
+            //Assert
+            act.Should().Throw<XunitException>().WithMessage("Expected function to be*");
+        }
+
+        [Fact]
+        public void When_namespace_is_prefixed_with_System_caller_should_be_known()
+        {
+            // Act
+            Action act = () => SystemPrefixed.SystemPrefixedNamespaceClass.DetermineCallerIdentityInNamespace();
+
+            //Assert
+            act.Should().Throw<XunitException>().WithMessage("Expected actualCaller to be*");
+        }
+    }
+}
+
+namespace System
+{
+    public class SystemNamespaceClass
+    {
+        public static void DetermineCallerIdentityInNamespace()
+        {
+            Func<string> actualCaller = () => CallerIdentifier.DetermineCallerIdentity();
+            actualCaller.Should().BeNull("we want this check to fail for the test");
+        }
+    }
+}
+
+namespace SystemPrefixed
+{
+    public class SystemPrefixedNamespaceClass
+    {
+        public static void DetermineCallerIdentityInNamespace()
+        {
+            Func<string> actualCaller = () => CallerIdentifier.DetermineCallerIdentity();
+            actualCaller.Should().BeNull("we want this check to fail for the test");
+        }
+    }
+}
+
+namespace System.Data
+{
+    public class NestedSystemNamespaceClass
+    {
+        public static void DetermineCallerIdentityInNamespace()
+        {
+            Func<string> actualCaller = () => CallerIdentifier.DetermineCallerIdentity();
+            actualCaller.Should().BeNull("we want this check to fail for the test");
+        }
+    }
+}
+
+#endif

--- a/Tests/Shared.Specs/Shared.Specs.projitems
+++ b/Tests/Shared.Specs/Shared.Specs.projitems
@@ -18,6 +18,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AssertionScopeSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AsyncFunctionExceptionAssertionSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)BasicNonEquivalencySpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CallerIdentifierSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DelegateAssertionSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FluentActionsSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FunctionExceptionAssertionSpecs.cs" />


### PR DESCRIPTION
The check in `IsDotNet` only checks if the namespace starts with "System" which can cause non-dotnet namespaces like `SystemSomething.RestApi` to return true unexpectedly.

I struggled with this one at work today for a few hours as our product name (and therefor our namespaces) are `SystemProductName.RestApi`. I noticed it because the variable names were missing from our failing asserts even when building in debug mode.

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/_pages/documentation.md) in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com).
