### PR TITLE
Add missing paren to object graphs doc

### DIFF
--- a/docs/_pages/objectgraphs.md
+++ b/docs/_pages/objectgraphs.md
@@ -169,7 +169,7 @@ If you want to do this for all members of a certain type, you can shorten the ab
 ```csharp
 orderDto.Should().BeEquivalentTo(order, options => options 
     .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1000))
-    .WhenTypeIs<DateTime>();
+    .WhenTypeIs<DateTime>());
 ```
 
 ### Enums ###


### PR DESCRIPTION
Fixed typo