### PR TITLE
update .net core sdk

### DIFF
--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace></RootNamespace>
     <IsPackable>False</IsPackable>
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageDownload Include="GitVersion.CommandLine.DotNetCore" Version="[5.0.1]" />
+    <PackageDownload Include="GitVersion.Tool" Version="[5.1.2]" />
     <PackageDownload Include="NSpec" Version="[1.0.13]" />
     <PackageDownload Include="NSpec" Version="[2.0.1]" />
     <PackageDownload Include="NSpec" Version="[3.1.0]" />
     <PackageDownload Include="nunit.runners" Version="[2.7.1]" />
     <PackageDownload Include="xunit.runner.console" Version="[2.4.1]" />
-    <PackageReference Include="Nuke.Common" Version="0.22.2" />
+    <PackageReference Include="Nuke.Common" Version="0.23.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -11,9 +11,7 @@
 
   <ItemGroup>
     <PackageDownload Include="GitVersion.Tool" Version="[5.1.2]" />
-    <PackageDownload Include="NSpec" Version="[1.0.13]" />
-    <PackageDownload Include="NSpec" Version="[2.0.1]" />
-    <PackageDownload Include="NSpec" Version="[3.1.0]" />
+    <PackageDownload Include="NSpec" Version="[1.0.13];[2.0.1];[3.1.0]" />
     <PackageDownload Include="nunit.runners" Version="[2.7.1]" />
     <PackageDownload Include="xunit.runner.console" Version="[2.4.1]" />
     <PackageReference Include="Nuke.Common" Version="0.23.4" />

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
     "sdk": {
-        "version": "3.0.100-preview7-012821"
+        "version": "3.0.100"
     }
 }


### PR DESCRIPTION
`<PackageIcon>` was included with [nuget 5.3.0/dotnet core 3.0.100](https://docs.microsoft.com/en-us/nuget/release-notes/nuget-5.3).
It does not specify if it is available in any preview version of .Net Core 3.0, but the feature was merged at [August 23](https://github.com/NuGet/NuGet.Client/pull/3006) in .Net Core 3.0-preview7 was released at [July 23](https://dotnet.microsoft.com/download/dotnet-core/3.0#3.0.0-preview7).
So I hope this solves #1186