### PR TITLE
Make `ThatAreUnderNamespace` respect null namespaces and prefixes

### DIFF
--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -588,5 +588,17 @@ namespace FluentAssertions.Common
 
             return false;
         }
+
+        internal static bool IsUnderNamespace(this Type type, string @namespace)
+        {
+            return IsGlobalNamespace()
+                || IsExactNamespace()
+                || IsParentNamespace();
+
+            bool IsGlobalNamespace() => @namespace is null;
+            bool IsExactNamespace() => IsNamespacePrefix() && type.Namespace.Length == @namespace.Length;
+            bool IsParentNamespace() => IsNamespacePrefix() && type.Namespace[@namespace.Length] == '.';
+            bool IsNamespacePrefix() => type.Namespace?.StartsWith(@namespace, StringComparison.Ordinal) == true;
+        }
     }
 }

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -153,7 +153,7 @@ namespace FluentAssertions.Types
         /// </summary>
         public TypeSelector ThatAreUnderNamespace(string @namespace)
         {
-            types = types.Where(t => t.Namespace?.StartsWith(@namespace) == true).ToList();
+            types = types.Where(t => t.IsUnderNamespace(@namespace)).ToList();
             return this;
         }
 
@@ -162,7 +162,7 @@ namespace FluentAssertions.Types
         /// </summary>
         public TypeSelector ThatAreNotUnderNamespace(string @namespace)
         {
-            types = types.Where(t => t.Namespace?.StartsWith(@namespace) != true).ToList();
+            types = types.Where(t => !t.IsUnderNamespace(@namespace)).ToList();
             return this;
         }
 

--- a/Tests/Shared.Specs/TypeSelectorSpecs.cs
+++ b/Tests/Shared.Specs/TypeSelectorSpecs.cs
@@ -337,6 +337,84 @@ namespace FluentAssertions.Specs
             // Assert
             types.Should().ContainSingle();
         }
+
+        [Fact]
+        public void When_selecting_global_types_from_global_namespace_it_should_succeed()
+        {
+            // Arrange
+            TypeSelector types = new[] { typeof(ClassInGlobalNamespace) }.Types();
+
+            // Act
+            TypeSelector filteredTypes = types.ThatAreUnderNamespace(null);
+
+            // Assert
+            filteredTypes.As<IEnumerable<Type>>().Should().ContainSingle();
+        }
+
+        [Fact]
+        public void When_selecting_global_types_not_from_global_namespace_it_should_succeed()
+        {
+            // Arrange
+            TypeSelector types = new[] { typeof(ClassInGlobalNamespace) }.Types();
+
+            // Act
+            TypeSelector filteredTypes = types.ThatAreNotUnderNamespace(null);
+
+            // Assert
+            filteredTypes.As<IEnumerable<Type>>().Should().BeEmpty();
+        }
+
+        [Fact]
+        public void When_selecting_local_types_from_global_namespace_it_should_succeed()
+        {
+            // Arrange
+            TypeSelector types = new[] { typeof(SomeBaseClass) }.Types();
+
+            // Act
+            TypeSelector filteredTypes = types.ThatAreUnderNamespace(null);
+
+            // Assert
+            filteredTypes.As<IEnumerable<Type>>().Should().ContainSingle();
+        }
+
+        [Fact]
+        public void When_selecting_local_types_not_from_global_namespace_it_should_succeed()
+        {
+            // Arrange
+            TypeSelector types = new[] { typeof(SomeBaseClass) }.Types();
+
+            // Act
+            TypeSelector filteredTypes = types.ThatAreNotUnderNamespace(null);
+
+            // Assert
+            filteredTypes.As<IEnumerable<Type>>().Should().BeEmpty();
+        }
+
+        [Fact]
+        public void When_selecting_a_prefix_of_a_namespace_it_should_not_match()
+        {
+            // Arrange
+            TypeSelector types = new[] { typeof(SomeBaseClass) }.Types();
+
+            // Act
+            TypeSelector filteredTypes = types.ThatAreUnderNamespace("Internal.Main.Tes");
+
+            // Assert
+            filteredTypes.As<IEnumerable<Type>>().Should().BeEmpty();
+        }
+
+        [Fact]
+        public void When_deselecting_a_prefix_of_a_namespace_it_should_not_match()
+        {
+            // Arrange
+            TypeSelector types = new[] { typeof(SomeBaseClass) }.Types();
+
+            // Act
+            TypeSelector filteredTypes = types.ThatAreNotUnderNamespace("Internal.Main.Tes");
+
+            // Assert
+            filteredTypes.As<IEnumerable<Type>>().Should().ContainSingle();
+        }
     }
 }
 
@@ -431,5 +509,9 @@ namespace Internal.Other.Test.Common
     {
     }
 }
+
+#pragma warning disable RCS1110 // Declare type inside namespace.
+internal class ClassInGlobalNamespace { }
+#pragma warning restore RCS1110
 
 #endregion


### PR DESCRIPTION
The namespace of a type not inside any namespace is `null`.
As all types are *under* the global namespace, `ThatAreUnderNamespace` should be able to gracefully handle `null` namespaces.

This also fixes that `ThatAreUnderNamespace` would incorrectly match the
namespace of a type against a partial prefix.

This fixes #1185 and #1196