### PR TITLE
BeEquivalentTo on normal tuples should use structural equivalency

### DIFF
--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -531,7 +531,15 @@ namespace FluentAssertions.Common
                    || openType == typeof(ValueTuple<,,,,>)
                    || openType == typeof(ValueTuple<,,,,,>)
                    || openType == typeof(ValueTuple<,,,,,,>)
-                   || (openType == typeof(ValueTuple<,,,,,,,>) && IsTuple(type.GetGenericArguments()[7]));
+                   || (openType == typeof(ValueTuple<,,,,,,,>) && IsTuple(type.GetGenericArguments()[7]))
+                   || openType == typeof(Tuple<>)
+                   || openType == typeof(Tuple<,>)
+                   || openType == typeof(Tuple<,,>)
+                   || openType == typeof(Tuple<,,,>)
+                   || openType == typeof(Tuple<,,,,>)
+                   || openType == typeof(Tuple<,,,,,>)
+                   || openType == typeof(Tuple<,,,,,,>)
+                   || (openType == typeof(Tuple<,,,,,,,>) && IsTuple(type.GetGenericArguments()[7]));
         }
 
         internal static bool IsAssignableToOpenGeneric(this Type type, Type definition)

--- a/Tests/Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/BasicEquivalencySpecs.cs
@@ -3134,6 +3134,20 @@ namespace FluentAssertions.Specs
             act.Should().NotThrow();
         }
 
+        [Fact]
+        public void When_a_tuple_is_compared_it_should_compare_its_components()
+        {
+            // Arrange
+            var actual = new Tuple<string, bool, int[]>("Hello", true, new int[] { 3, 2, 1 });
+            var expected = new Tuple<string, bool, int[]>("Hello", true, new int[] { 1, 2, 3 });
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
         #endregion
 
         #region Enums


### PR DESCRIPTION
Unlinke ValueTuple<>, the older Tuple<> was treated as a value type instead of something that requires a structural equality check.

Fixed #999

