### PR TITLE
Cleanup parameter xml summaries

### DIFF
--- a/Src/FluentAssertions/Common/IClock.cs
+++ b/Src/FluentAssertions/Common/IClock.cs
@@ -12,14 +12,14 @@ namespace FluentAssertions.Common
         /// <summary>
         /// Will block the current thread until a time delay has passed.
         /// </summary>
-        /// <param name="delay">The time span to wait before completing the returned task</param>
+        /// <param name="timeToDelay">The time span to wait before completing the returned task</param>
         void Delay(TimeSpan timeToDelay);
 
         /// <summary>
         /// Creates a task that will complete after a time delay.
         /// </summary>
         /// <param name="delay">The time span to wait before completing the returned task</param>
-        /// <param name="timeoutCancellationTokenSource"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns>A task that represents the time delay.</returns>
         /// <seealso cref="Task.Delay(TimeSpan)"/>
         Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken);

--- a/Src/FluentAssertions/Equivalency/IMemberSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/IMemberSelectionRule.cs
@@ -21,9 +21,6 @@ namespace FluentAssertions.Equivalency
         /// A collection of members that was prepopulated by other selection rules. Can be empty.</param>
         /// <param name="context"></param>
         /// <param name="config"></param>
-        /// <param name="info">
-        /// Type info about the subject.
-        /// </param>
         /// <returns>
         /// The collection of members after applying this rule. Can contain less or more than was passed in.
         /// </returns>

--- a/Src/FluentAssertions/Events/EventAssertions.cs
+++ b/Src/FluentAssertions/Events/EventAssertions.cs
@@ -27,7 +27,6 @@ namespace FluentAssertions.Events
         /// <summary>
         /// Asserts that an object has raised a particular event at least once.
         /// </summary>
-        /// <param name="eventSource">The object exposing the event.</param>
         /// <param name="eventName">
         /// The name of the event that should have been raised.
         /// </param>
@@ -59,7 +58,6 @@ namespace FluentAssertions.Events
         /// <summary>
         /// Asserts that an object has not raised a particular event.
         /// </summary>
-        /// <param name="eventSource">The object exposing the event.</param>
         /// <param name="eventName">
         /// The name of the event that should not be raised.
         /// </param>
@@ -88,7 +86,6 @@ namespace FluentAssertions.Events
         /// <summary>
         /// Asserts that an object has raised the <see cref="INotifyPropertyChanged.PropertyChanged"/> event for a particular property.
         /// </summary>
-        /// <param name="eventSource">The object exposing the event.</param>
         /// <param name="propertyExpression">
         /// A lambda expression referring to the property for which the property changed event should have been raised, or
         /// <c>null</c> to refer to all properties.
@@ -124,7 +121,6 @@ namespace FluentAssertions.Events
         /// <summary>
         /// Asserts that an object has not raised the <see cref="INotifyPropertyChanged.PropertyChanged"/> event for a particular property.
         /// </summary>
-        /// <param name="eventSource">The object exposing the event.</param>
         /// <param name="propertyExpression">
         /// A lambda expression referring to the property for which the property changed event should have been raised.
         /// </param>

--- a/Src/FluentAssertions/Execution/IAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/IAssertionScope.cs
@@ -84,7 +84,7 @@ namespace FluentAssertions.Execution
         /// If an expectation was set through a prior call to <see cref="AssertionScope.WithExpectation"/>, then the failure message is appended to that
         /// expectation.
         /// </remarks>
-        /// <param name="expectation">The format string that represents the failure message.</param>
+        /// <param name="message">The format string that represents the failure message.</param>
         /// <param name="args">Optional arguments to any numbered placeholders.</param>
         IAssertionScope WithExpectation(string message, params object[] args);
 

--- a/Src/FluentAssertions/Formatting/AggregateExceptionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AggregateExceptionValueFormatter.cs
@@ -17,22 +17,7 @@ namespace FluentAssertions.Formatting
             return value is AggregateException;
         }
 
-        /// <summary>
-        /// Returns a <see cref="System.String" /> that represents this instance.
-        /// </summary>
-        /// <param name="value">The value for which to create a <see cref="System.String"/>.</param>
-        /// <param name="context"> </param>
-        /// <param name="formatChild"></param>
-        /// <param name="processedObjects">
-        /// A collection of objects that
-        /// </param>
-        /// <param name="nestedPropertyLevel">
-        /// The level of nesting for the supplied value. This is used for indenting the format string for objects that have
-        /// no <see cref="object.ToString()"/> override.
-        /// </param>
-        /// <returns>
-        /// A <see cref="System.String" /> that represents this instance.
-        /// </returns>
+        /// <inheritdoc />
         public string Format(object value, FormattingContext context, FormatChild formatChild)
         {
             var exception = (AggregateException)value;

--- a/Src/FluentAssertions/Formatting/ByteValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ByteValueFormatter.cs
@@ -14,21 +14,7 @@
             return value is byte;
         }
 
-        /// <summary>
-        /// Returns a <see cref="System.String" /> that represents this instance.
-        /// </summary>
-        /// <param name="value">The value for which to create a <see cref="System.String"/>.</param>
-        /// <param name="useLineBreaks"> </param>
-        /// <param name="processedObjects">
-        /// A collection of objects that
-        /// </param>
-        /// <param name="nestedPropertyLevel">
-        /// The level of nesting for the supplied value. This is used for indenting the format string for objects that have
-        /// no <see cref="object.ToString()"/> override.
-        /// </param>
-        /// <returns>
-        /// A <see cref="System.String" /> that represents this instance.
-        /// </returns>
+        /// <inheritdoc />
         public string Format(object value, FormattingContext context, FormatChild formatChild)
         {
             return "0x" + ((byte)value).ToString("X2");

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -18,7 +18,7 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Initializes a new instance of the <see cref="MethodInfoSelectorAssertions"/> class.
         /// </summary>
-        /// <param name="methodInfo">The methods to assert.</param>
+        /// <param name="methods">The methods to assert.</param>
         public MethodInfoSelectorAssertions(params MethodInfo[] methods)
         {
             SubjectMethods = methods;


### PR DESCRIPTION
Some xml summaries were broken due to either:
* non-existing parameters (probably leftovers from pre-v5 API), or
* typos in `name` attribute.