### PR TITLE
Intercept Reflection exceptions from `AppSettingsConfigurationStore`

### DIFF
--- a/Src/FluentAssertions/Common/ConfigurationStoreExceptionInterceptor.cs
+++ b/Src/FluentAssertions/Common/ConfigurationStoreExceptionInterceptor.cs
@@ -1,0 +1,36 @@
+﻿#if !NETSTANDARD1_3 && !NETSTANDARD1_6
+
+namespace FluentAssertions.Common
+{
+    internal class ConfigurationStoreExceptionInterceptor : IConfigurationStore
+    {
+        private bool underlyingStoreUnavailable;
+
+        private readonly IConfigurationStore configurationStore;
+
+        public ConfigurationStoreExceptionInterceptor(IConfigurationStore configurationStore)
+        {
+            this.configurationStore = configurationStore;
+        }
+
+        public string GetSetting(string name)
+        {
+            if (underlyingStoreUnavailable)
+            {
+                return null;
+            }
+
+            try
+            {
+                return configurationStore.GetSetting(name);
+            }
+            catch
+            {
+                underlyingStoreUnavailable = true;
+                return null;
+            }
+        }
+    }
+}
+
+#endif

--- a/Src/FluentAssertions/Common/Services.cs
+++ b/Src/FluentAssertions/Common/Services.cs
@@ -48,7 +48,7 @@ namespace FluentAssertions.Common
             ConfigurationStore = new NullConfigurationStore();
 #else
             Reflector = new FullFrameworkReflector();
-            ConfigurationStore = new AppSettingsConfigurationStore();
+            ConfigurationStore = new ConfigurationStoreExceptionInterceptor(new AppSettingsConfigurationStore());
 #endif
 
             ThrowException = TestFrameworkProvider.Throw;


### PR DESCRIPTION
Some platforms throw reflection exceptions when trying to use `ConfigurationManager`.
This does not fix the underlying problem of not being unable to use `ConfigurationManager`, but returns `null` instead of an exception.

Relates to #1207 and #1151