### PR TITLE
Increase mutation score

### DIFF
--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -276,22 +276,19 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} to match regex {0}{reason}, but it was <null>.", regularExpression);
 
-            bool isMatch = false;
             try
             {
-                isMatch = Regex.IsMatch(Subject, regularExpression);
+                Execute.Assertion
+                .ForCondition(Regex.IsMatch(Subject, regularExpression))
+                .BecauseOf(because, becauseArgs)
+                .UsingLineBreaks
+                .FailWith("Expected {context:string} to match regex {0}{reason}, but {1} does not match.", regularExpression, Subject);
             }
             catch (ArgumentException)
             {
                 Execute.Assertion
                     .FailWith("Cannot match {context:string} against {0} because it is not a valid regular expression.", regularExpression);
             }
-
-            Execute.Assertion
-                .ForCondition(isMatch)
-                .BecauseOf(because, becauseArgs)
-                .UsingLineBreaks
-                .FailWith("Expected {context:string} to match regex {0}{reason}, but {1} does not match.", regularExpression, Subject);
 
             return new AndConstraint<StringAssertions>(this);
         }
@@ -319,22 +316,19 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} to not match regex {0}{reason}, but it was <null>.", regularExpression);
 
-            bool isMatch = false;
             try
             {
-                isMatch = Regex.IsMatch(Subject, regularExpression);
+                Execute.Assertion
+                    .ForCondition(!Regex.IsMatch(Subject, regularExpression))
+                    .BecauseOf(because, becauseArgs)
+                    .UsingLineBreaks
+                    .FailWith("Did not expect {context:string} to match regex {0}{reason}, but {1} matches.", regularExpression, Subject);
             }
             catch (ArgumentException)
             {
                 Execute.Assertion.FailWith("Cannot match {context:string} against {0} because it is not a valid regular expression.",
                     regularExpression);
             }
-
-            Execute.Assertion
-                .ForCondition(!isMatch)
-                .BecauseOf(because, becauseArgs)
-                .UsingLineBreaks
-                .FailWith("Did not expect {context:string} to match regex {0}{reason}, but {1} matches.", regularExpression, Subject);
 
             return new AndConstraint<StringAssertions>(this);
         }

--- a/Tests/Shared.Specs/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/AsyncFunctionExceptionAssertionSpecs.cs
@@ -1033,6 +1033,24 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_wait_time_is_zero_for_async_func_executed_with_wait_it_should_not_throw()
+        {
+            // Arrange
+            var waitTime = 0.Milliseconds();
+            var pollInterval = 10.Milliseconds();
+
+            var clock = new FakeClock();
+            var asyncObject = new AsyncClass();
+            Func<Task> someFunc = () => asyncObject.SucceedAsync();
+
+            // Act
+            Action act = () => someFunc.Should(clock).NotThrowAfter(waitTime, pollInterval);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
         public void When_poll_interval_is_negative_for_async_func_executed_with_wait_it_should_throw()
         {
             // Arrange
@@ -1048,6 +1066,24 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<ArgumentOutOfRangeException>()
                 .WithMessage("* value of pollInterval must be non-negative*");
+        }
+
+        [Fact]
+        public void When_poll_interval_is_zero_for_async_func_executed_with_wait_it_should_not_throw()
+        {
+            // Arrange
+            var waitTime = 10.Milliseconds();
+            var pollInterval = 0.Milliseconds();
+
+            var clock = new FakeClock();
+            var asyncObject = new AsyncClass();
+            Func<Task> someFunc = () => asyncObject.SucceedAsync();
+
+            // Act
+            Action act = () => someFunc.Should(clock).NotThrowAfter(waitTime, pollInterval);
+
+            // Assert
+            act.Should().NotThrow();
         }
 
         [Fact]

--- a/Tests/Shared.Specs/CollectionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/CollectionAssertionSpecs.cs
@@ -198,6 +198,32 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_collection_count_is_matched_against_a_predicate_it_should_not_throw()
+        {
+            // Arrange
+            IEnumerable collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().HaveCount(c => c % 2 == 1);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_collection_count_is_matched_against_a_predicate_it_should_throw()
+        {
+            // Arrange
+            IEnumerable collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().HaveCount(c => c % 2 == 0);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
         public void When_counting_nongeneric_enumerable_it_should_enumerate()
         {
             // Arrange

--- a/Tests/Shared.Specs/DateTimeOffsetValueFormatterSpecs.cs
+++ b/Tests/Shared.Specs/DateTimeOffsetValueFormatterSpecs.cs
@@ -73,6 +73,27 @@ namespace FluentAssertions.Specs
             result.Should().Be("<08:20:01>");
         }
 
+        [InlineData("0001-01-02 04:05:06", "<0001-01-02 04:05:06>")]
+        [InlineData("0001-02-01 04:05:06", "<0001-02-01 04:05:06>")]
+        [InlineData("0002-01-01 04:05:06", "<0002-01-01 04:05:06>")]
+        [InlineData("0001-02-02 04:05:06", "<0001-02-02 04:05:06>")]
+        [InlineData("0002-01-02 04:05:06", "<0002-01-02 04:05:06>")]
+        [InlineData("0002-02-01 04:05:06", "<0002-02-01 04:05:06>")]
+        [InlineData("0002-02-02 04:05:06", "<0002-02-02 04:05:06>")]
+        [Theory]
+        public void When_date_is_relevant_it_should_be_included_in_the_output(string actual, string expected)
+        {
+            // Arrange
+            var formatter = new DateTimeOffsetValueFormatter();
+            var value = DateTime.Parse(actual, CultureInfo.InvariantCulture);
+
+            // Act
+            string result = formatter.Format(value, new FormattingContext(), null);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
         [Fact]
         public void When_a_full_date_and_time_is_specified_all_parts_should_be_included_in_the_output()
         {

--- a/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/Shared.Specs/GenericDictionaryAssertionSpecs.cs
@@ -1526,6 +1526,24 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_a_dictionary_contains_exactly_one_of_the_keys_it_should_throw_with_clear_explanation()
+        {
+            // Arrange
+            var dictionary = new Dictionary<int, string>
+            {
+                [1] = "One",
+                [2] = "Two"
+            };
+
+            // Act
+            Action act = () => dictionary.Should().NotContainKeys(new[] { 2 }, "because {0}", "we do");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected dictionary {[1, One], [2, Two]} to not contain key 2 because we do.");
+        }
+
+        [Fact]
         public void When_the_noncontents_of_a_dictionary_are_checked_against_an_empty_list_of_keys_it_should_throw_clear_explanation()
         {
             // Arrange
@@ -1761,6 +1779,24 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().NotThrow<XunitException>();
+        }
+
+        [Fact]
+        public void When_a_dictionary_contains_a_exactly_one_of_the_values_it_should_throw_with_clear_explanation()
+        {
+            // Arrange
+            var dictionary = new Dictionary<int, string>
+            {
+                [1] = "One",
+                [2] = "Two"
+            };
+
+            // Act
+            Action act = () => dictionary.Should().NotContainValues(new[] { "Two" }, "because {0}", "we do");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected dictionary {[1, One], [2, Two]} to not contain value \"Two\" because we do.");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/Shared.Specs/ReferenceTypeAssertionsSpecs.cs
@@ -230,6 +230,32 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_generic_object_is_not_of_the_unexpected_type_it_should_not_throw()
+        {
+            // Arrange
+            var aList = new System.Collections.Generic.List<string>();
+
+            // Act
+            Action action = () => aList.Should().NotBeOfType<string>();
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_non_generic_object_is_not_of_the_unexpected_open_generic_type_it_should_not_throw()
+        {
+            // Arrange
+            var aString = "blah";
+
+            // Act
+            Action action = () => aString.Should().NotBeOfType(typeof(System.Collections.Generic.Dictionary<,>));
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
         public void When_asserting_object_is_not_of_type_and_it_is_null_it_should_throw()
         {
             // Arrange

--- a/Tests/Shared.Specs/StringAssertionSpecs.cs
+++ b/Tests/Shared.Specs/StringAssertionSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -458,6 +459,19 @@ namespace FluentAssertions.Specs
             act.Should().NotThrow();
         }
 
+        [Fact]
+        public void When_a_string_with_newline_matches_the_equivalent_of_a_wildcard_pattern_it_should_not_throw()
+        {
+            // Arrange
+            string subject = "hello\r\nworld!";
+
+            // Act
+            Action act = () => subject.Should().MatchEquivalentOf("helloworld!");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
         #endregion
 
         #region Not Match Equivalent Of
@@ -494,6 +508,19 @@ namespace FluentAssertions.Specs
                 .WithMessage("Did not expect subject to match the equivalent of*\"*world*\" because that's illegal, " +
                 "but*\"hello WORLD\" matches.");
 #endif
+        }
+
+        [Fact]
+        public void When_a_string_with_newlines_does_match_the_equivalent_of_a_pattern_but_it_shouldnt_it_should_throw()
+        {
+            // Arrange
+            string subject = "hello\r\nworld!";
+
+            // Act
+            Action act = () => subject.Should().NotMatchEquivalentOf("helloworld!");
+
+            // Assert
+            act.Should().Throw<XunitException>();
         }
 
         #endregion
@@ -585,6 +612,28 @@ namespace FluentAssertions.Specs
 #endif
         }
 
+        [Fact]
+        public void When_a_string_is_matched_against_an_invalid_regex_it_should_only_have_one_failure_message()
+        {
+            // Arrange
+            string subject = "hello world!";
+            string invalidRegex = ".**"; // Use local variable for this invalid regex to avoid static R# analysis errors
+
+            // Act
+            Action act = () =>
+            {
+                using (new AssertionScope())
+                {
+                    subject.Should().MatchRegex(invalidRegex);
+                }
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .Which.Message.Should().Contain("is not a valid regular expression")
+                    .And.NotContain("does not match");
+        }
+
         #endregion
 
         #region Not Match Regex
@@ -670,6 +719,28 @@ namespace FluentAssertions.Specs
 #else
              .WithMessage("Cannot match subject against \".**\" because it is not a valid regular expression.*");
 #endif
+        }
+
+        [Fact]
+        public void When_a_string_is_negatively_matched_against_an_invalid_regex_it_only_contain_one_failure_message()
+        {
+            // Arrange
+            string subject = "hello world!";
+            string invalidRegex = ".**"; // Use local variable for this invalid regex to avoid static R# analysis errors
+
+            // Act
+            Action act = () =>
+            {
+                using (new AssertionScope())
+                {
+                    subject.Should().NotMatchRegex(invalidRegex);
+                }
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .Which.Message.Should().Contain("is not a valid regular expression")
+                    .And.NotContain("matches");
         }
 
         #endregion

--- a/Tests/Shared.Specs/TypeAssertionSpecs.cs
+++ b/Tests/Shared.Specs/TypeAssertionSpecs.cs
@@ -1429,6 +1429,40 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_a_selection_of_types_do_inherit_unexpected_attribute_with_the_expected_properties_it_succeeds()
+        {
+            // Arrange
+            var types = new TypeSelector(typeof(ClassWithInheritedAttribute));
+
+            // Act
+            Action act = () => types.Should()
+                .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => ((a.Name == "Expected") && a.IsEnabled),
+                    "because we {0}", "do");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected all types to not be decorated with or inherit *DummyClassAttribute*" +
+                    " that matches ((a.Name == \"Expected\")*a.IsEnabled) because we do," +
+                    " but a matching attribute was found on the following types:*" +
+                    "*ClassWithInheritedAttribute*.");
+        }
+
+        [Fact]
+        public void When_a_selection_of_types_do_not_inherit_unexpected_attribute_with_the_expected_properties_it_succeeds()
+        {
+            // Arrange
+            var types = new TypeSelector(typeof(ClassWithoutAttribute));
+
+            // Act
+            Action act = () => types.Should()
+                .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => ((a.Name == "Expected") && a.IsEnabled),
+                    "because we {0}", "do");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
         public void When_injecting_a_null_predicate_into_TypeSelector_NotBeDecoratedWithOrInherit_it_should_throw()
         {
             // Arrange


### PR DESCRIPTION
I installed a new version of Stryker, gave it a spin and added test cases for some low-hanging fruit.

Highlights:
* `TypeSelectorAssertions.NotBeDecoratedWithOrInherit(predicate)` only had a test verifying null check of the predicate, but no positive/negative test of the logic.
* `[Not]MatchRegex` would include two failure messages if used inside an `AssertionScope`
* No tests for `NonGenericCollectionAssertions.HaveCount(predicate)`
* No tests for `NotContainKeys` and `NotContainValues` when there is a single unexpected key/value

For anyone interessted here's the [mutation report](https://github.com/fluentassertions/fluentassertions/files/4009395/mutation-report.zip)

Part of #1068 