### PR TITLE
Add API approval tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,6 @@ docs/_site
 docs/codekit-config.json
 docs/Gemfile.lock
 docs/node_modules
+
+# Approval Tests
+*.received.txt

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -120,6 +120,11 @@ class Build : NukeBuild
             NSpec1(TestFrameworkDirectory / "NSpec.Net45.Specs" / "bin" / "Debug" / "net451" / "NSpec.Specs.dll");
             NSpec2(TestFrameworkDirectory / "NSpec2.Net45.Specs" / "bin" / "Debug" / "net451" / "NSpec2.Specs.dll");
             NSpec3(TestFrameworkDirectory / "NSpec3.Net45.Specs" / "bin" / "Debug" / "net451" / "NSpec3.Specs.dll");
+
+            DotNetTest(s => s
+                .SetConfiguration(Configuration.Debug)
+                .CombineWith(
+                    cc => cc.SetProjectFile(Solution.GetProject("Approval.Tests"))));
         });
 
     Target Pack => _ => _

--- a/FluentAssertions.sln
+++ b/FluentAssertions.sln
@@ -66,6 +66,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetCore30.Specs", "Tests\Ne
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetCore21.Specs", "Tests\NetCore21.Specs\NetCore21.Specs.csproj", "{C4CC9B52-5800-4E32-AE37-F62FA682B10D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Approval.Tests", "Tests\Approval.Tests\Approval.Tests.csproj", "{F5115158-A038-4D14-A04E-46E7863E40B9}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Tests\Shared.Specs\Shared.Specs.projitems*{0c23c12c-899f-4ad1-b737-b967a9910c08}*SharedItemsImports = 13
@@ -158,6 +160,10 @@ Global
 		{C4CC9B52-5800-4E32-AE37-F62FA682B10D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C4CC9B52-5800-4E32-AE37-F62FA682B10D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C4CC9B52-5800-4E32-AE37-F62FA682B10D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F5115158-A038-4D14-A04E-46E7863E40B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F5115158-A038-4D14-A04E-46E7863E40B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F5115158-A038-4D14-A04E-46E7863E40B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F5115158-A038-4D14-A04E-46E7863E40B9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -184,6 +190,7 @@ Global
 		{FCAFB0F1-79EA-4D49-813B-188D4BC4BE71} = {963262D0-9FD5-4741-8C0E-E2F34F110EF3}
 		{05727385-DA56-4FC1-B44A-79DFECC3198A} = {963262D0-9FD5-4741-8C0E-E2F34F110EF3}
 		{C4CC9B52-5800-4E32-AE37-F62FA682B10D} = {963262D0-9FD5-4741-8C0E-E2F34F110EF3}
+		{F5115158-A038-4D14-A04E-46E7863E40B9} = {963262D0-9FD5-4741-8C0E-E2F34F110EF3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {75DDA3D8-9D6F-4865-93F4-DDE11DEE8290}

--- a/Tests/Approval.Tests/ApiApproval.cs
+++ b/Tests/Approval.Tests/ApiApproval.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using ApprovalTests;
+using ApprovalTests.Core;
+using ApprovalTests.Reporters;
+using ApprovalTests.Writers;
+using PublicApiGenerator;
+using Xunit;
+
+namespace Approval.Tests
+{
+    public class ApiApproval
+    {
+        [Theory]
+        [InlineData("FluentAssertions", "net45")]
+        [InlineData("FluentAssertions", "net47")]
+        [InlineData("FluentAssertions", "netstandard1.3")]
+        [InlineData("FluentAssertions", "netstandard1.6")]
+        [InlineData("FluentAssertions", "netstandard2.0")]
+        [InlineData("FluentAssertions", "netstandard2.1")]
+        [InlineData("FluentAssertions", "netcoreapp2.0")]
+        [InlineData("FluentAssertions", "netcoreapp2.1")]
+        [UseReporter(typeof(DiffReporter))]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void ApproveApi(string projectName, string frameworkVersion)
+        {
+            string codeBase = Assembly.GetExecutingAssembly().CodeBase;
+            UriBuilder uri = new UriBuilder(new Uri(codeBase));
+            string assemblyPath = Uri.UnescapeDataString(uri.Path);
+            var containingDirectory = Path.GetDirectoryName(assemblyPath);
+            var configurationName = new DirectoryInfo(containingDirectory).Parent.Name;
+            var assemblyFile = Path.GetFullPath(
+                Path.Combine(
+                    GetSourceDirectory(),
+                    $"../../Artifacts/{configurationName}/{frameworkVersion}/{projectName}.dll"));
+
+            var assembly = Assembly.LoadFile(Path.GetFullPath(assemblyFile));
+            var publicApi = ApiGenerator.GeneratePublicApi(assembly, options: null);
+
+            Approvals.Verify(
+                WriterFactory.CreateTextWriter(publicApi),
+                new ApprovalNamer(projectName, frameworkVersion),
+                Approvals.GetReporter());
+        }
+
+        private class ApprovalNamer : IApprovalNamer
+        {
+            public ApprovalNamer(string projectName, string frameworkVersion)
+            {
+                Name = frameworkVersion;
+                SourcePath = Path.Combine(GetSourceDirectory(), "ApprovedApi", projectName);
+            }
+
+            public string SourcePath { get; }
+
+            public string Name { get; }
+        }
+
+        private static string GetSourceDirectory([CallerFilePath] string path = "") => Path.GetDirectoryName(path);
+    }
+}

--- a/Tests/Approval.Tests/Approval.Tests.csproj
+++ b/Tests/Approval.Tests/Approval.Tests.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="ApprovalTests" Version="4.4.0" />
+    <PackageReference Include="PublicApiGenerator" Version="10.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net45.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net45.approved.txt
@@ -1,0 +1,2155 @@
+﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.5", FrameworkDisplayName=".NET Framework 4.5")]
+namespace FluentAssertions
+{
+    public class AggregateExceptionExtractor : FluentAssertions.Specialized.IExtractExceptions
+    {
+        public AggregateExceptionExtractor() { }
+        public System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception { }
+    }
+    public class AndConstraint<T>
+    {
+        public AndConstraint(T parentConstraint) { }
+        public T And { get; }
+    }
+    public class AndWhichConstraint<TParentConstraint, TMatchedElement> : FluentAssertions.AndConstraint<TParentConstraint>
+    {
+        public AndWhichConstraint(TParentConstraint parentConstraint, System.Collections.Generic.IEnumerable<TMatchedElement> matchedConstraint) { }
+        public AndWhichConstraint(TParentConstraint parentConstraint, TMatchedElement matchedConstraint) { }
+        public TMatchedElement Subject { get; }
+        public TMatchedElement Which { get; }
+    }
+    public static class AssertionExtensions
+    {
+        public static TTo As<TTo>(this object subject) { }
+        public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.Task<TResult>> action) { }
+        public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+        public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
+        public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
+        public static FluentAssertions.Events.IMonitor<T> Monitor<T>(this T eventSource, System.Func<System.DateTime> utcNow = null) { }
+        public static FluentAssertions.Specialized.ExecutionTimeAssertions Should(this FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        public static FluentAssertions.Types.MethodInfoSelectorAssertions Should(this FluentAssertions.Types.MethodInfoSelector methodSelector) { }
+        public static FluentAssertions.Types.PropertyInfoSelectorAssertions Should(this FluentAssertions.Types.PropertyInfoSelector propertyInfoSelector) { }
+        public static FluentAssertions.Types.TypeSelectorAssertions Should(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
+        public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
+        public static FluentAssertions.Collections.NonGenericCollectionAssertions Should(this System.Collections.IEnumerable actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
+        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
+        public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
+        public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
+        public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
+        public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
+        public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
+        public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
+        public static FluentAssertions.Xml.XAttributeAssertions Should(this System.Xml.Linq.XAttribute actualValue) { }
+        public static FluentAssertions.Xml.XDocumentAssertions Should(this System.Xml.Linq.XDocument actualValue) { }
+        public static FluentAssertions.Xml.XElementAssertions Should(this System.Xml.Linq.XElement actualValue) { }
+        public static FluentAssertions.Primitives.BooleanAssertions Should(this bool actualValue) { }
+        public static FluentAssertions.Primitives.NullableBooleanAssertions Should(this bool? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<byte> Should(this byte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<byte> Should(this byte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<decimal> Should(this decimal actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<decimal> Should(this decimal? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<double> Should(this double actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<double> Should(this double? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<float> Should(this float actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<float> Should(this float? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<int> Should(this int actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<int> Should(this int? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<long> Should(this long actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<long> Should(this long? actualValue) { }
+        public static FluentAssertions.Primitives.ObjectAssertions Should(this object actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<sbyte> Should(this sbyte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<sbyte> Should(this sbyte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<short> Should(this short actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<short> Should(this short? actualValue) { }
+        public static FluentAssertions.Primitives.StringAssertions Should(this string actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<uint> Should(this uint actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<uint> Should(this uint? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ulong> Should(this ulong actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ulong> Should(this ulong? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ushort> Should(this ushort actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ushort> Should(this ushort? actualValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
+        public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public static class AssertionOptions
+    {
+        public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
+        public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
+        public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
+    }
+    public static class AtLeast
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class AtMost
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class CallerIdentifier
+    {
+        public static System.Action<string> logger;
+        public static string DetermineCallerIdentity() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
+    public class CustomAssertionAttribute : System.Attribute
+    {
+        public CustomAssertionAttribute() { }
+    }
+    public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
+    {
+        public EquivalencyStepCollection() { }
+        public void Add<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void AddAfter<TPredecessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Clear() { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IEquivalencyStep> GetEnumerator() { }
+        public void Insert<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void InsertBefore<TSuccessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Remove<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep { }
+        public void Reset() { }
+    }
+    public static class EventRaisingExtensions
+    {
+        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, params System.Linq.Expressions.Expression<>[] predicates) { }
+        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
+        public static FluentAssertions.Events.IEventRecorder WithSender(this FluentAssertions.Events.IEventRecorder eventRecorder, object expectedSender) { }
+    }
+    public static class Exactly
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class FluentActions
+    {
+        public static System.Func<System.Threading.Tasks.Task> Awaiting(System.Func<System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task<T>> Awaiting<T>(System.Func<System.Threading.Tasks.Task<T>> func) { }
+        public static System.Action Enumerating(System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static System.Action Invoking(System.Action action) { }
+        public static System.Func<T> Invoking<T>(System.Func<T> func) { }
+    }
+    public static class LessThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class MoreThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class NumericAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+    }
+    public static class ObjectAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeXmlSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class OccurrenceConstraint
+    {
+        protected OccurrenceConstraint(int expectedCount) { }
+    }
+    public static class TypeEnumerableExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreInNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreUnderNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatDeriveFrom<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatImplement<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+    }
+    public static class TypeExtensions
+    {
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this System.Type type) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this System.Type type) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Type type) { }
+    }
+    public static class XmlAssertionExtensions
+    {
+        public static FluentAssertions.Xml.XmlElementAssertions Should(this System.Xml.XmlElement actualValue) { }
+        public static FluentAssertions.Xml.XmlNodeAssertions Should(this System.Xml.XmlNode actualValue) { }
+    }
+}
+namespace FluentAssertions.Collections
+{
+    public abstract class CollectionAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Collections.IEnumerable
+        where TAssertions : FluentAssertions.Collections.CollectionAssertions<TSubject, TAssertions>
+    {
+        protected CollectionAssertions() { }
+        protected CollectionAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeOfType<T>(string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionEndsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actual, System.Collections.Generic.ICollection<TExpected> expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionEndsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actual, TExpected[] expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionStartsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actualItems, System.Collections.Generic.ICollection<TExpected> expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionStartsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actualItems, TExpected[] expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertSubjectEquality<TActual, TExpected>(System.Collections.IEnumerable expectation, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params object[] expectations) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.IEnumerable expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.IEnumerable expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.IEnumerable>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.IEnumerable>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSubsetOf(System.Collections.IEnumerable expectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params object[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainItemsAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(object element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params object[] elements) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, object> HaveElementAt(int index, object element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(object successor, object expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(object predecessor, object expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInAscendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAscendingInOrder(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInAscendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAscendingInOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInDescendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDescendingInOrder(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInDescendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDescendingInOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSubsetOf(System.Collections.IEnumerable unexpectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotIntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(object element, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
+    {
+        public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+            where TKey :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(params TKey[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(params TValue[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(params TKey[] unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(params TValue[] unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+    }
+    public class NonGenericCollectionAssertions : FluentAssertions.Collections.CollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
+    {
+        public NonGenericCollectionAssertions(System.Collections.IEnumerable collection) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
+    {
+        public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params T[] elements) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpectedItemsList, params T[] additionalUnexpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(params System.Action<>[] elementInspectors) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(System.Collections.Generic.IEnumerable<System.Action<T>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+    }
+    public class StringCollectionAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<string, FluentAssertions.Collections.StringCollectionAssertions>
+    {
+        public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(params string[] expectation) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(params string[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+    }
+    public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public WhichValueConstraint(FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> parentConstraint, TValue value) { }
+        public TValue WhichValue { get; }
+    }
+}
+namespace FluentAssertions.Common
+{
+    public enum CSharpAccessModifier
+    {
+        Public = 0,
+        Private = 1,
+        Protected = 2,
+        Internal = 3,
+        ProtectedInternal = 4,
+        InvalidForCSharp = 5,
+        PrivateProtected = 6,
+    }
+    public static class CSharpAccessModifierExtensions { }
+    public class Configuration
+    {
+        public Configuration(FluentAssertions.Common.IConfigurationStore store) { }
+        public string TestFrameworkName { get; set; }
+        public string ValueFormatterAssembly { get; set; }
+        public FluentAssertions.Common.ValueFormatterDetectionMode ValueFormatterDetectionMode { get; set; }
+        public static FluentAssertions.Common.Configuration Current { get; }
+    }
+    public static class DateTimeExtensions
+    {
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime) { }
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime, System.TimeSpan offset) { }
+    }
+    public interface IClock
+    {
+        void Delay(System.TimeSpan timeToDelay);
+        System.Threading.Tasks.Task DelayAsync(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken);
+        FluentAssertions.Common.ITimer StartTimer();
+        bool Wait(System.Threading.Tasks.Task task, System.TimeSpan timeout);
+    }
+    public interface IConfigurationStore
+    {
+        string GetSetting(string name);
+    }
+    public interface IReflector
+    {
+        System.Collections.Generic.IEnumerable<System.Type> GetAllTypesFromAppDomain(System.Func<System.Reflection.Assembly, bool> predicate);
+    }
+    public interface ITimer
+    {
+        System.TimeSpan Elapsed { get; }
+    }
+    public static class MethodInfoExtensions { }
+    public static class ObjectExtensions
+    {
+        public static bool IsSameOrEqualTo(this object actual, object expected) { }
+    }
+    public static class PropertyInfoExtensions { }
+    public static class Services
+    {
+        public static FluentAssertions.Common.Configuration Configuration { get; }
+        public static FluentAssertions.Common.IConfigurationStore ConfigurationStore { get; set; }
+        public static FluentAssertions.Common.IReflector Reflector { get; set; }
+        public static System.Action<string> ThrowException { get; set; }
+        public static void ResetToDefaults() { }
+    }
+    public static class TypeExtensions
+    {
+        public static System.Reflection.FieldInfo FindField(this System.Type type, string fieldName, System.Type preferredType) { }
+        public static FluentAssertions.Equivalency.SelectedMemberInfo FindMember(this System.Type type, string memberName, System.Type preferredType) { }
+        public static System.Reflection.PropertyInfo FindProperty(this System.Type type, string propertyName, System.Type preferredType) { }
+        public static System.Reflection.ConstructorInfo GetConstructor(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.PropertyInfo GetIndexerByParameterTypes(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Reflection.MethodInfo GetMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> GetNonPrivateFields(this System.Type typeToReflect) { }
+        public static System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetNonPrivateMembers(this System.Type typeToReflect) { }
+        public static System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> GetNonPrivateProperties(this System.Type typeToReflect, System.Collections.Generic.IEnumerable<string> filter = null) { }
+        public static System.Reflection.MethodInfo GetParameterlessMethod(this System.Type type, string methodName) { }
+        public static System.Reflection.PropertyInfo GetPropertyByName(this System.Type type, string propertyName) { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWithOrInherits> instead.")]
+        public static bool HasAttribute<TAttribute>(this System.Reflection.MemberInfo method)
+            where TAttribute : System.Attribute { }
+        public static bool HasExplicitlyImplementedProperty(this System.Type type, System.Type interfaceType, string propertyName) { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWith> instead.")]
+        public static bool HasMatchingAttribute<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
+        public static bool HasMatchingAttribute<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, bool inherit = false)
+            where TAttribute : System.Attribute { }
+        public static bool HasMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static bool HasParameterlessMethod(this System.Type type, string methodName) { }
+        public static bool HasValueSemantics(this System.Type type) { }
+        public static bool Implements(this System.Type type, System.Type expectedBaseType) { }
+        public static bool IsCSharpAbstract(this System.Type type) { }
+        public static bool IsCSharpSealed(this System.Type type) { }
+        public static bool IsCSharpStatic(this System.Type type) { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        [System.Obsolete("This overload is deprecated and will be removed on the next major version. Please" +
+            " use <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type, bool inherit = false)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsEquivalentTo(this FluentAssertions.Equivalency.SelectedMemberInfo property, FluentAssertions.Equivalency.SelectedMemberInfo otherProperty) { }
+        public static bool IsIndexer(this System.Reflection.PropertyInfo member) { }
+        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
+        public static bool OverridesEquals(this System.Type type) { }
+    }
+    public enum ValueFormatterDetectionMode
+    {
+        Disabled = 0,
+        Specific = 1,
+        Scan = 2,
+    }
+}
+namespace FluentAssertions.Equivalency
+{
+    public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class ConversionSelector
+    {
+        public ConversionSelector() { }
+        public FluentAssertions.Equivalency.ConversionSelector Clone() { }
+        public void Exclude(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void Include(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void IncludeAll() { }
+        public bool RequiresConversion(FluentAssertions.Equivalency.IMemberInfo info) { }
+        public override string ToString() { }
+    }
+    public enum CyclicReferenceHandling
+    {
+        Ignore = 0,
+        ThrowException = 1,
+    }
+    public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DictionaryEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public virtual bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class EnumEqualityStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumEqualityStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public enum EnumEquivalencyHandling
+    {
+        ByValue = 0,
+        ByName = 1,
+    }
+    public class EnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumerableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public enum EqualityStrategy
+    {
+        Equals = 0,
+        Members = 1,
+        ForceEquals = 2,
+        ForceMembers = 3,
+    }
+    public class EquivalencyAssertionOptions : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions>
+    {
+        public EquivalencyAssertionOptions() { }
+    }
+    [System.Obsolete("This class is deprecated and will be removed in version 6.X.")]
+    public static class EquivalencyAssertionOptionsExtentions
+    {
+        public static System.Type GetExpectationType(this FluentAssertions.Equivalency.IEquivalencyAssertionOptions config, FluentAssertions.Equivalency.IMemberInfo context) { }
+    }
+    public class EquivalencyAssertionOptions<TExpectation> : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>>
+    {
+        public EquivalencyAssertionOptions() { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+    }
+    public class EquivalencyValidationContext : FluentAssertions.Equivalency.IEquivalencyValidationContext, FluentAssertions.Equivalency.IMemberInfo
+    {
+        public EquivalencyValidationContext() { }
+        public string Because { get; set; }
+        public object[] BecauseArgs { get; set; }
+        public System.Type CompileTimeType { get; set; }
+        public object Expectation { get; set; }
+        public bool IsRoot { get; }
+        public bool RootIsCollection { get; set; }
+        public System.Type RuntimeType { get; }
+        public string SelectedMemberDescription { get; set; }
+        public FluentAssertions.Equivalency.SelectedMemberInfo SelectedMemberInfo { get; set; }
+        public string SelectedMemberPath { get; set; }
+        public object Subject { get; set; }
+        public FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
+        public override string ToString() { }
+        public System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getTraceMessage) { }
+        public void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getTraceMessage) { }
+    }
+    public class EquivalencyValidator : FluentAssertions.Equivalency.IEquivalencyValidator
+    {
+        public EquivalencyValidator(FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public void AssertEquality(FluentAssertions.Equivalency.EquivalencyValidationContext context) { }
+        public void AssertEqualityUsing(FluentAssertions.Equivalency.IEquivalencyValidationContext context) { }
+    }
+    public class GenericDictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericDictionaryEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class GenericEnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericEnumerableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public delegate string GetTraceMessage(string path);
+    public interface IAssertionContext<TSubject>
+    {
+        string Because { get; set; }
+        object[] BecauseArgs { get; set; }
+        TSubject Expectation { get; }
+        TSubject Subject { get; }
+        FluentAssertions.Equivalency.SelectedMemberInfo SubjectProperty { get; }
+    }
+    public interface IAssertionRule
+    {
+        bool AssertEquality(FluentAssertions.Equivalency.IEquivalencyValidationContext context);
+    }
+    public interface IEquivalencyAssertionOptions
+    {
+        bool AllowInfiniteRecursion { get; }
+        FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
+        FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool IncludeFields { get; }
+        bool IncludeProperties { get; }
+        bool IsRecursive { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberMatchingRule> MatchingRules { get; }
+        FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
+        FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
+        bool UseRuntimeTyping { get; }
+        FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> GetUserEquivalencySteps(FluentAssertions.Equivalency.ConversionSelector conversionSelector);
+    }
+    public interface IEquivalencyStep
+    {
+        bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+        bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IEquivalencyValidationContext : FluentAssertions.Equivalency.IMemberInfo
+    {
+        string Because { get; }
+        object[] BecauseArgs { get; }
+        object Expectation { get; }
+        bool IsRoot { get; }
+        bool RootIsCollection { get; set; }
+        object Subject { get; }
+        FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
+        System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getMessage);
+        void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getMessage);
+    }
+    public interface IEquivalencyValidator
+    {
+        void AssertEqualityUsing(FluentAssertions.Equivalency.IEquivalencyValidationContext context);
+    }
+    public interface IMemberInfo
+    {
+        System.Type CompileTimeType { get; }
+        System.Type RuntimeType { get; }
+        string SelectedMemberDescription { get; }
+        FluentAssertions.Equivalency.SelectedMemberInfo SelectedMemberInfo { get; }
+        string SelectedMemberPath { get; }
+    }
+    public interface IMemberMatchingRule
+    {
+        FluentAssertions.Equivalency.SelectedMemberInfo Match(FluentAssertions.Equivalency.SelectedMemberInfo expectedMember, object subject, string memberPath, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IMemberSelectionRule
+    {
+        bool IncludesMembers { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> SelectMembers(System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> selectedMembers, FluentAssertions.Equivalency.IMemberInfo context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IOrderingRule
+    {
+        FluentAssertions.Equivalency.OrderStrictness Evaluate(FluentAssertions.Equivalency.IMemberInfo memberInfo);
+    }
+    public interface ITraceWriter
+    {
+        System.IDisposable AddBlock(string trace);
+        void AddSingle(string trace);
+        string ToString();
+    }
+    public enum OrderStrictness
+    {
+        Strict = 0,
+        NotStrict = 1,
+        Irrelevant = 2,
+    }
+    public class OrderingRuleCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule>, System.Collections.IEnumerable
+    {
+        public OrderingRuleCollection() { }
+        public OrderingRuleCollection(System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule> orderingRules) { }
+        public void Add(FluentAssertions.Equivalency.IOrderingRule rule) { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IOrderingRule> GetEnumerator() { }
+        public bool IsOrderingStrictFor(FluentAssertions.Equivalency.IMemberInfo memberInfo) { }
+    }
+    public class ReferenceEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ReferenceEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public virtual bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class RunAllUserStepsEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public RunAllUserStepsEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public abstract class SelectedMemberInfo
+    {
+        protected SelectedMemberInfo() { }
+        public abstract System.Type DeclaringType { get; }
+        public abstract System.Type MemberType { get; }
+        public abstract string Name { get; }
+        public abstract object GetValue(object obj, object[] index);
+        public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.FieldInfo fieldInfo) { }
+        public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.PropertyInfo propertyInfo) { }
+    }
+    public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
+        where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
+    {
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        protected readonly FluentAssertions.Equivalency.OrderingRuleCollection orderingRules;
+        protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
+        public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        public FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
+        protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public TSelf AllowingInfiniteRecursion() { }
+        public TSelf ComparingByMembers<T>() { }
+        public TSelf ComparingByValue<T>() { }
+        public TSelf ComparingEnumsByName() { }
+        public TSelf ComparingEnumsByValue() { }
+        public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf ExcludingFields() { }
+        public TSelf ExcludingMissingMembers() { }
+        public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingProperties() { }
+        public TSelf IgnoringCyclicReferences() { }
+        public TSelf IncludingAllDeclaredProperties() { }
+        public TSelf IncludingAllRuntimeProperties() { }
+        public TSelf IncludingFields() { }
+        public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingProperties() { }
+        protected void RemoveSelectionRule<T>()
+            where T : FluentAssertions.Equivalency.IMemberSelectionRule { }
+        public TSelf RespectingDeclaredTypes() { }
+        public TSelf RespectingRuntimeTypes() { }
+        public TSelf ThrowingOnMissingMembers() { }
+        public override string ToString() { }
+        public TSelf Using(FluentAssertions.Equivalency.IAssertionRule assertionRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IEquivalencyStep equivalencyStep) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
+        public TSelf WithAutoConversion() { }
+        public TSelf WithAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf WithStrictOrdering() { }
+        public TSelf WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf WithTracing(FluentAssertions.Equivalency.ITraceWriter writer = null) { }
+        public TSelf WithoutAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void WithoutMatchingRules() { }
+        public void WithoutSelectionRules() { }
+        public TSelf WithoutStrictOrdering() { }
+        public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public class Restriction<TMember>
+        {
+            public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
+            public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+            public TSelf WhenTypeIs<TMemberType>() { }
+        }
+    }
+    public class SimpleEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public SimpleEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class StringBuilderTraceWriter : FluentAssertions.Equivalency.ITraceWriter
+    {
+        public StringBuilderTraceWriter() { }
+        public System.IDisposable AddBlock(string trace) { }
+        public void AddSingle(string trace) { }
+        public override string ToString() { }
+    }
+    public class StringEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StringEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class StructuralEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StructuralEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public static class SubjectInfoExtensions
+    {
+        public static bool WhichGetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichGetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+    }
+    public class TryConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public TryConversionStep(FluentAssertions.Equivalency.ConversionSelector selector) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ValueTypeEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+}
+namespace FluentAssertions.Events
+{
+    public class EventAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<T, FluentAssertions.Events.EventAssertions<T>>
+    {
+        protected EventAssertions(FluentAssertions.Events.IMonitor<T> monitor) { }
+        protected override string Identifier { get; }
+        public void NotRaise(string eventName, string because = "", params object[] becauseArgs) { }
+        public void NotRaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecorder Raise(string eventName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecorder RaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
+    }
+    public class EventMetadata
+    {
+        public EventMetadata(string eventName, System.Type handlerType) { }
+        public string EventName { get; }
+        public System.Type HandlerType { get; }
+    }
+    public class EventRecorder : FluentAssertions.Events.IEventRecorder, System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
+    {
+        public EventRecorder(object eventRaiser, string eventName, System.Func<System.DateTime> utcNow) { }
+        public System.Type EventHandlerType { get; }
+        public string EventName { get; }
+        public object EventObject { get; }
+        public void Attach(System.WeakReference subject, System.Reflection.EventInfo eventInfo) { }
+        public void Dispose() { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Events.RecordedEvent> GetEnumerator() { }
+        public void RecordEvent(params object[] parameters) { }
+        public void Reset() { }
+    }
+    public interface IEventRecorder : System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
+    {
+        System.Type EventHandlerType { get; }
+        string EventName { get; }
+        object EventObject { get; }
+        void RecordEvent(params object[] parameters);
+        void Reset();
+    }
+    public interface IMonitor<T> : System.IDisposable
+    {
+        FluentAssertions.Events.EventMetadata[] MonitoredEvents { get; }
+        FluentAssertions.Events.OccurredEvent[] OccurredEvents { get; }
+        T Subject { get; }
+        void Clear();
+        FluentAssertions.Events.IEventRecorder GetEventRecorder(string eventName);
+        FluentAssertions.Events.EventAssertions<T> Should();
+    }
+    public class OccurredEvent
+    {
+        public OccurredEvent() { }
+        public string EventName { get; set; }
+        public object[] Parameters { get; set; }
+        public System.DateTime TimestampUtc { get; set; }
+    }
+    public class RecordedEvent
+    {
+        public RecordedEvent(System.DateTime utcNow, object monitoredObject, params object[] parameters) { }
+        public System.Collections.Generic.IEnumerable<object> Parameters { get; }
+        public System.DateTime TimestampUtc { get; set; }
+    }
+}
+namespace FluentAssertions.Execution
+{
+    public class AssertionFailedException : System.Exception
+    {
+        public AssertionFailedException(string message) { }
+        protected AssertionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public class AssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public AssertionScope() { }
+        public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
+        public AssertionScope(string context) { }
+        public string Context { get; set; }
+        public bool Succeeded { get; }
+        public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
+        public static FluentAssertions.Execution.AssertionScope Current { get; }
+        public void AddNonReportable(string key, object value) { }
+        public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, string value) { }
+        public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
+        public T Get<T>(string key) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public bool HasFailures() { }
+        public FluentAssertions.Execution.AssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.AssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public class Continuation
+    {
+        public Continuation(FluentAssertions.Execution.AssertionScope sourceScope, bool sourceSucceeded) { }
+        public bool SourceSucceeded { get; }
+        public FluentAssertions.Execution.IAssertionScope Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.Continuation continuation) { }
+    }
+    public class ContinuationOfGiven<TSubject>
+    {
+        public ContinuationOfGiven(FluentAssertions.Execution.GivenSelector<TSubject> parent, bool succeeded) { }
+        public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
+    }
+    public class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public ContinuedAssertionScope(FluentAssertions.Execution.AssertionScope predecessor, bool predecessorSucceeded) { }
+        public bool Succeeded { get; }
+        public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.IAssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public static class Execute
+    {
+        public static FluentAssertions.Execution.AssertionScope Assertion { get; }
+    }
+    public class FailReason
+    {
+        public FailReason(string message, params object[] args) { }
+        public object[] Args { get; }
+        public string Message { get; }
+    }
+    public class GivenSelector<T>
+    {
+        public GivenSelector(System.Func<T> selector, bool predecessorSucceeded, FluentAssertions.Execution.AssertionScope predecessor) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> ClearExpectation() { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<, >[] args) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
+        public FluentAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
+    }
+    public interface IAssertionScope : System.IDisposable
+    {
+        bool Succeeded { get; }
+        FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
+        FluentAssertions.Execution.Continuation ClearExpectation();
+        string[] Discard();
+        FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc);
+        FluentAssertions.Execution.Continuation FailWith(string message, params object[] args);
+        FluentAssertions.Execution.IAssertionScope ForCondition(bool condition);
+        FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector);
+        FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier);
+        FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args);
+    }
+    public interface IAssertionStrategy
+    {
+        System.Collections.Generic.IEnumerable<string> FailureMessages { get; }
+        System.Collections.Generic.IEnumerable<string> DiscardFailures();
+        void HandleFailure(string message);
+        void ThrowIfAny(System.Collections.Generic.IDictionary<string, object> context);
+    }
+    public interface ICloneable2
+    {
+        object Clone();
+    }
+}
+namespace FluentAssertions.Extensions
+{
+    public static class FluentDateTimeExtensions
+    {
+        public static System.DateTime AddMicroseconds(this System.DateTime self, long microseconds) { }
+        public static System.DateTimeOffset AddMicroseconds(this System.DateTimeOffset self, long microseconds) { }
+        public static System.DateTime AddNanoseconds(this System.DateTime self, long nanoseconds) { }
+        public static System.DateTimeOffset AddNanoseconds(this System.DateTimeOffset self, long nanoseconds) { }
+        public static System.DateTime After(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime April(this int day, int year) { }
+        public static System.DateTime AsLocal(this System.DateTime dateTime) { }
+        public static System.DateTime AsUtc(this System.DateTime dateTime) { }
+        public static System.DateTime At(this System.DateTime date, System.TimeSpan time) { }
+        public static System.DateTime At(this System.DateTime date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTimeOffset At(this System.DateTimeOffset date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTime August(this int day, int year) { }
+        public static System.DateTime Before(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime December(this int day, int year) { }
+        public static System.DateTime February(this int day, int year) { }
+        public static System.DateTime January(this int day, int year) { }
+        public static System.DateTime July(this int day, int year) { }
+        public static System.DateTime June(this int day, int year) { }
+        public static System.DateTime March(this int day, int year) { }
+        public static System.DateTime May(this int day, int year) { }
+        public static int Microsecond(this System.DateTime self) { }
+        public static int Microsecond(this System.DateTimeOffset self) { }
+        public static int Nanosecond(this System.DateTime self) { }
+        public static int Nanosecond(this System.DateTimeOffset self) { }
+        public static System.DateTime November(this int day, int year) { }
+        public static System.DateTime October(this int day, int year) { }
+        public static System.DateTime September(this int day, int year) { }
+    }
+    public static class FluentTimeSpanExtensions
+    {
+        public const long TicksPerMicrosecond = 10;
+        public const double TicksPerNanosecond = 0.01D;
+        public static System.TimeSpan And(this System.TimeSpan sourceTime, System.TimeSpan offset) { }
+        public static System.TimeSpan Days(this double days) { }
+        public static System.TimeSpan Days(this int days) { }
+        public static System.TimeSpan Days(this int days, System.TimeSpan offset) { }
+        public static System.TimeSpan Hours(this double hours) { }
+        public static System.TimeSpan Hours(this int hours) { }
+        public static System.TimeSpan Hours(this int hours, System.TimeSpan offset) { }
+        public static int Microseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Microseconds(this int microseconds) { }
+        public static System.TimeSpan Microseconds(this long microseconds) { }
+        public static System.TimeSpan Milliseconds(this double milliseconds) { }
+        public static System.TimeSpan Milliseconds(this int milliseconds) { }
+        public static System.TimeSpan Minutes(this double minutes) { }
+        public static System.TimeSpan Minutes(this int minutes) { }
+        public static System.TimeSpan Minutes(this int minutes, System.TimeSpan offset) { }
+        public static int Nanoseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Nanoseconds(this int nanoseconds) { }
+        public static System.TimeSpan Nanoseconds(this long nanoseconds) { }
+        public static System.TimeSpan Seconds(this double seconds) { }
+        public static System.TimeSpan Seconds(this int seconds) { }
+        public static System.TimeSpan Seconds(this int seconds, System.TimeSpan offset) { }
+        public static System.TimeSpan Ticks(this int ticks) { }
+        public static System.TimeSpan Ticks(this long ticks) { }
+        public static double TotalMicroseconds(this System.TimeSpan self) { }
+        public static double TotalNanoseconds(this System.TimeSpan self) { }
+    }
+}
+namespace FluentAssertions.Formatting
+{
+    public class AggregateExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AggregateExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class AttributeBasedFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AttributeBasedFormatter() { }
+        public System.Reflection.MethodInfo[] Formatters { get; }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DateTimeOffsetValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DateTimeOffsetValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DecimalValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DecimalValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DefaultValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DoubleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public EnumerableValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExpressionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public delegate string FormatChild(string childPath, object value);
+    public static class Formatter
+    {
+        public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
+        public static void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static string ToString(object value, bool useLineBreaks = false) { }
+    }
+    public class FormattingContext
+    {
+        public FormattingContext() { }
+        public int Depth { get; set; }
+        public bool UseLineBreaks { get; set; }
+    }
+    public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public GuidValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public interface IValueFormatter
+    {
+        bool CanHandle(object value);
+        string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
+    }
+    public class Int16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class MultidimensionalArrayFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public MultidimensionalArrayFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class NullValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public NullValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class PropertyInfoFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public PropertyInfoFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SingleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SingleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class StringValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public StringValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TaskFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TaskFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TimeSpanValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TimeSpanValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
+    public class ValueFormatterAttribute : System.Attribute
+    {
+        public ValueFormatterAttribute() { }
+    }
+    public class XAttributeValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XAttributeValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XDocumentValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XDocumentValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XElementValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XElementValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+}
+namespace FluentAssertions.Numeric
+{
+    public class ComparableTypeAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    {
+        public ComparableTypeAssertions(System.IComparable<T> value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
+        where T :  struct
+    {
+        public NullableNumericAssertions(T? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NumericAssertions<T>
+        where T :  struct
+    {
+        public NumericAssertions(object value) { }
+        public System.IComparable Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(params T[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Primitives
+{
+    public class BooleanAssertions
+    {
+        public BooleanAssertions(bool? value) { }
+        public bool? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeAssertions
+    {
+        public DateTimeAssertions(System.DateTime? value) { }
+        public System.DateTime? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.DateTime[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetAssertions
+    {
+        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
+        public System.DateTimeOffset? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetRangeAssertions
+    {
+        protected DateTimeOffsetRangeAssertions(FluentAssertions.Primitives.DateTimeOffsetAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeRangeAssertions
+    {
+        protected DateTimeRangeAssertions(FluentAssertions.Primitives.DateTimeAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
+    }
+    public class GuidAssertions
+    {
+        public GuidAssertions(System.Guid? value) { }
+        public System.Guid? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableBooleanAssertions : FluentAssertions.Primitives.BooleanAssertions
+    {
+        public NullableBooleanAssertions(bool? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions
+    {
+        public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions
+    {
+        public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableGuidAssertions : FluentAssertions.Primitives.GuidAssertions
+    {
+        public NullableGuidAssertions(System.Guid? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions
+    {
+        public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class ObjectAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
+    {
+        public ObjectAssertions(object value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be(object expected, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> HaveFlag(System.Enum expectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe(object unexpected, string because = "", params object[] becauseArgs) { }
+        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotHaveFlag(System.Enum unexpectedFlag, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
+        where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+    {
+        protected ReferenceTypeAssertions() { }
+        protected ReferenceTypeAssertions(TSubject subject) { }
+        protected abstract string Identifier { get; }
+        public TSubject Subject { get; set; }
+        public FluentAssertions.AndConstraint<TAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameAs(TSubject expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<TSubject, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match<T>(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
+            where T : TSubject { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SimpleTimeSpanAssertions
+    {
+        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public System.TimeSpan? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+    }
+    public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>
+    {
+        public StringAssertions(string value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(params string[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+    }
+    public enum TimeSpanCondition
+    {
+        MoreThan = 0,
+        AtLeast = 1,
+        Exactly = 2,
+        Within = 3,
+        LessThan = 4,
+    }
+}
+namespace FluentAssertions.Reflection
+{
+    public class AssemblyAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Reflection.Assembly, FluentAssertions.Reflection.AssemblyAssertions>
+    {
+        public AssemblyAssertions(System.Reflection.Assembly assembly) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Reflection.AssemblyAssertions, System.Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs) { }
+        public void NotReference(System.Reflection.Assembly assembly) { }
+        public void NotReference(System.Reflection.Assembly assembly, string because, params string[] becauseArgs) { }
+        public void Reference(System.Reflection.Assembly assembly) { }
+        public void Reference(System.Reflection.Assembly assembly, string because, params string[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Specialized
+{
+    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action>
+    {
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Action Subject { get; }
+        protected override void InvokeSubject() { }
+    }
+    public class AsyncFunctionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Func<System.Threading.Tasks.Task>>
+    {
+        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Func<System.Threading.Tasks.Task> Subject { get; }
+        protected override void InvokeSubject() { }
+        public System.Threading.Tasks.Task NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public abstract class DelegateAssertions<TDelegate> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Delegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate>>
+        where TDelegate : System.Delegate
+    {
+        protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public new TDelegate Subject { get; }
+        protected abstract void InvokeSubject();
+        public void NotThrow(string because = "", params object[] becauseArgs) { }
+        protected void NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        protected void NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+        public void NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public class ExceptionAssertions<TException> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IEnumerable<TException>, FluentAssertions.Specialized.ExceptionAssertions<TException>>
+        where TException : System.Exception
+    {
+        public ExceptionAssertions(System.Collections.Generic.IEnumerable<TException> exceptions) { }
+        public TException And { get; }
+        protected override string Identifier { get; }
+        public TException Which { get; }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Where(System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, string because = "", params object[] becauseArgs) { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerException<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerExceptionExactly<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TException> WithMessage(string expectedWildcardPattern, string because = "", params object[] becauseArgs) { }
+    }
+    public class ExecutionTime
+    {
+        public ExecutionTime(System.Action action) { }
+        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action) { }
+        protected ExecutionTime(System.Action action, string actionDescription) { }
+        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription) { }
+    }
+    public class ExecutionTimeAssertions
+    {
+        public ExecutionTimeAssertions(FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        public void BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public void BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public void BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public void BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public void BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+    }
+    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
+    {
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Func<T> Subject { get; }
+        protected override void InvokeSubject() { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions
+    {
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+    public interface IExtractExceptions
+    {
+        System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception;
+    }
+    public class MemberExecutionTime<T> : FluentAssertions.Specialized.ExecutionTime
+    {
+        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+    }
+    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions
+    {
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Types
+{
+    public static class AllTypes
+    {
+        public static FluentAssertions.Types.TypeSelector From(System.Reflection.Assembly assembly) { }
+    }
+    public class ConstructorInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.ConstructorInfo, FluentAssertions.Types.ConstructorInfoAssertions>
+    {
+        public ConstructorInfoAssertions(System.Reflection.ConstructorInfo constructorInfo) { }
+        protected override string Identifier { get; }
+    }
+    public abstract class MemberInfoAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MemberInfo
+        where TAssertions : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+    {
+        protected MemberInfoAssertions() { }
+        protected MemberInfoAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+    }
+    public abstract class MethodBaseAssertions<TSubject, TAssertions> : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MethodBase
+        where TAssertions : FluentAssertions.Types.MethodBaseAssertions<TSubject, TAssertions>
+    {
+        protected MethodBaseAssertions() { }
+        protected MethodBaseAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>
+    {
+        public MethodInfoAssertions() { }
+        public MethodInfoAssertions(System.Reflection.MethodInfo methodInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturnVoid(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> ReturnVoid(string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, System.Collections.IEnumerable
+    {
+        public MethodInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public MethodInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.MethodInfoSelector ThatArePublicOrInternal { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturnVoid { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
+        public System.Reflection.MethodInfo[] ToArray() { }
+    }
+    public class MethodInfoSelectorAssertions
+    {
+        public MethodInfoSelectorAssertions(params System.Reflection.MethodInfo[] methods) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> SubjectMethods { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoAssertions : FluentAssertions.Types.MemberInfoAssertions<System.Reflection.PropertyInfo, FluentAssertions.Types.PropertyInfoAssertions>
+    {
+        public PropertyInfoAssertions(System.Reflection.PropertyInfo propertyInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo>, System.Collections.IEnumerable
+    {
+        public PropertyInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public PropertyInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatArePublicOrInternal { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.PropertyInfo> GetEnumerator() { }
+        public FluentAssertions.Types.PropertyInfoSelector NotOfType<TReturn>() { }
+        public FluentAssertions.Types.PropertyInfoSelector OfType<TReturn>() { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public System.Reflection.PropertyInfo[] ToArray() { }
+    }
+    public class PropertyInfoSelectorAssertions
+    {
+        public PropertyInfoSelectorAssertions(params System.Reflection.PropertyInfo[] properties) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> SubjectProperties { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public class TypeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Type, FluentAssertions.Types.TypeAssertions>
+    {
+        public TypeAssertions(System.Type type) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be(System.Type expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be<TExpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<System.Type> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveExplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveExplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveImplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveImplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveIndexer(System.Type indexerType, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty(System.Type propertyType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty<TProperty>(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe(System.Type unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe<TUnexpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<System.Type> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveExplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveExplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveImplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveImplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveIndexer(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveProperty(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+    }
+    public class TypeSelector : System.Collections.Generic.IEnumerable<System.Type>, System.Collections.IEnumerable
+    {
+        public TypeSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public TypeSelector(System.Type type) { }
+        public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
+        public System.Type[] ToArray() { }
+    }
+    public class TypeSelectorAssertions
+    {
+        public TypeSelectorAssertions(params System.Type[] types) { }
+        public System.Collections.Generic.IEnumerable<System.Type> Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+    }
+}
+namespace FluentAssertions.Xml
+{
+    public class XAttributeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XAttribute, FluentAssertions.Xml.XAttributeAssertions>
+    {
+        public XAttributeAssertions(System.Xml.Linq.XAttribute attribute) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> Be(System.Xml.Linq.XAttribute expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> Be(System.Xml.Linq.XAttribute expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> HaveValue(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> HaveValue(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> NotBe(System.Xml.Linq.XAttribute unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> NotBe(System.Xml.Linq.XAttribute unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XDocumentAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XDocument, FluentAssertions.Xml.XDocumentAssertions>
+    {
+        public XDocumentAssertions(System.Xml.Linq.XDocument document) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> Be(System.Xml.Linq.XDocument expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> Be(System.Xml.Linq.XDocument expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> BeEquivalentTo(System.Xml.Linq.XDocument expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> BeEquivalentTo(System.Xml.Linq.XDocument expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBe(System.Xml.Linq.XDocument unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBe(System.Xml.Linq.XDocument unexpected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBeEquivalentTo(System.Xml.Linq.XDocument unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBeEquivalentTo(System.Xml.Linq.XDocument unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XElementAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XElement, FluentAssertions.Xml.XElementAssertions>
+    {
+        public XElementAssertions(System.Xml.Linq.XElement xElement) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> Be(System.Xml.Linq.XElement expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> Be(System.Xml.Linq.XElement expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveValue(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveValue(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBe(System.Xml.Linq.XElement unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBe(System.Xml.Linq.XElement unexpected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBeEquivalentTo(System.Xml.Linq.XElement unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBeEquivalentTo(System.Xml.Linq.XElement unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XmlElementAssertions : FluentAssertions.Xml.XmlNodeAssertions<System.Xml.XmlElement, FluentAssertions.Xml.XmlElementAssertions>
+    {
+        public XmlElementAssertions(System.Xml.XmlElement xmlElement) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttribute(string expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttributeWithNamespace(string expectedName, string expectedNamespace, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttributeWithNamespace(string expectedName, string expectedNamespace, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElement(string expectedName) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElement(string expectedName, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElementWithNamespace(string expectedName, string expectedNamespace) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElementWithNamespace(string expectedName, string expectedNamespace, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveInnerText(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveInnerText(string expected, string because, params object[] becauseArgs) { }
+    }
+    public class XmlNodeAssertions : FluentAssertions.Xml.XmlNodeAssertions<System.Xml.XmlNode, FluentAssertions.Xml.XmlNodeAssertions>
+    {
+        public XmlNodeAssertions(System.Xml.XmlNode xmlNode) { }
+    }
+    public class XmlNodeAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Xml.XmlNode
+        where TAssertions : FluentAssertions.Xml.XmlNodeAssertions<TSubject, TAssertions>
+    {
+        public XmlNodeAssertions(TSubject xmlNode) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Xml.XmlNode expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Xml.XmlNode expected, string because, params object[] reasonArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Xml.XmlNode unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Xml.XmlNode unexpected, string because, params object[] reasonArgs) { }
+    }
+    public class XmlNodeFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XmlNodeFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+}

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net45.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net45.approved.txt
@@ -1340,8 +1340,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
         where T :  struct

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -1340,8 +1340,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
         where T :  struct

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -1,0 +1,2155 @@
+﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.7", FrameworkDisplayName=".NET Framework 4.7")]
+namespace FluentAssertions
+{
+    public class AggregateExceptionExtractor : FluentAssertions.Specialized.IExtractExceptions
+    {
+        public AggregateExceptionExtractor() { }
+        public System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception { }
+    }
+    public class AndConstraint<T>
+    {
+        public AndConstraint(T parentConstraint) { }
+        public T And { get; }
+    }
+    public class AndWhichConstraint<TParentConstraint, TMatchedElement> : FluentAssertions.AndConstraint<TParentConstraint>
+    {
+        public AndWhichConstraint(TParentConstraint parentConstraint, System.Collections.Generic.IEnumerable<TMatchedElement> matchedConstraint) { }
+        public AndWhichConstraint(TParentConstraint parentConstraint, TMatchedElement matchedConstraint) { }
+        public TMatchedElement Subject { get; }
+        public TMatchedElement Which { get; }
+    }
+    public static class AssertionExtensions
+    {
+        public static TTo As<TTo>(this object subject) { }
+        public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.Task<TResult>> action) { }
+        public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+        public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
+        public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
+        public static FluentAssertions.Events.IMonitor<T> Monitor<T>(this T eventSource, System.Func<System.DateTime> utcNow = null) { }
+        public static FluentAssertions.Specialized.ExecutionTimeAssertions Should(this FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        public static FluentAssertions.Types.MethodInfoSelectorAssertions Should(this FluentAssertions.Types.MethodInfoSelector methodSelector) { }
+        public static FluentAssertions.Types.PropertyInfoSelectorAssertions Should(this FluentAssertions.Types.PropertyInfoSelector propertyInfoSelector) { }
+        public static FluentAssertions.Types.TypeSelectorAssertions Should(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
+        public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
+        public static FluentAssertions.Collections.NonGenericCollectionAssertions Should(this System.Collections.IEnumerable actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
+        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
+        public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
+        public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
+        public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
+        public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
+        public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
+        public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
+        public static FluentAssertions.Xml.XAttributeAssertions Should(this System.Xml.Linq.XAttribute actualValue) { }
+        public static FluentAssertions.Xml.XDocumentAssertions Should(this System.Xml.Linq.XDocument actualValue) { }
+        public static FluentAssertions.Xml.XElementAssertions Should(this System.Xml.Linq.XElement actualValue) { }
+        public static FluentAssertions.Primitives.BooleanAssertions Should(this bool actualValue) { }
+        public static FluentAssertions.Primitives.NullableBooleanAssertions Should(this bool? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<byte> Should(this byte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<byte> Should(this byte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<decimal> Should(this decimal actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<decimal> Should(this decimal? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<double> Should(this double actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<double> Should(this double? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<float> Should(this float actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<float> Should(this float? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<int> Should(this int actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<int> Should(this int? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<long> Should(this long actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<long> Should(this long? actualValue) { }
+        public static FluentAssertions.Primitives.ObjectAssertions Should(this object actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<sbyte> Should(this sbyte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<sbyte> Should(this sbyte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<short> Should(this short actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<short> Should(this short? actualValue) { }
+        public static FluentAssertions.Primitives.StringAssertions Should(this string actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<uint> Should(this uint actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<uint> Should(this uint? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ulong> Should(this ulong actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ulong> Should(this ulong? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ushort> Should(this ushort actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ushort> Should(this ushort? actualValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
+        public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public static class AssertionOptions
+    {
+        public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
+        public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
+        public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
+    }
+    public static class AtLeast
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class AtMost
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class CallerIdentifier
+    {
+        public static System.Action<string> logger;
+        public static string DetermineCallerIdentity() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
+    public class CustomAssertionAttribute : System.Attribute
+    {
+        public CustomAssertionAttribute() { }
+    }
+    public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
+    {
+        public EquivalencyStepCollection() { }
+        public void Add<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void AddAfter<TPredecessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Clear() { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IEquivalencyStep> GetEnumerator() { }
+        public void Insert<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void InsertBefore<TSuccessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Remove<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep { }
+        public void Reset() { }
+    }
+    public static class EventRaisingExtensions
+    {
+        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, params System.Linq.Expressions.Expression<>[] predicates) { }
+        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
+        public static FluentAssertions.Events.IEventRecorder WithSender(this FluentAssertions.Events.IEventRecorder eventRecorder, object expectedSender) { }
+    }
+    public static class Exactly
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class FluentActions
+    {
+        public static System.Func<System.Threading.Tasks.Task> Awaiting(System.Func<System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task<T>> Awaiting<T>(System.Func<System.Threading.Tasks.Task<T>> func) { }
+        public static System.Action Enumerating(System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static System.Action Invoking(System.Action action) { }
+        public static System.Func<T> Invoking<T>(System.Func<T> func) { }
+    }
+    public static class LessThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class MoreThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class NumericAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+    }
+    public static class ObjectAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeXmlSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class OccurrenceConstraint
+    {
+        protected OccurrenceConstraint(int expectedCount) { }
+    }
+    public static class TypeEnumerableExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreInNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreUnderNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatDeriveFrom<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatImplement<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+    }
+    public static class TypeExtensions
+    {
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this System.Type type) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this System.Type type) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Type type) { }
+    }
+    public static class XmlAssertionExtensions
+    {
+        public static FluentAssertions.Xml.XmlElementAssertions Should(this System.Xml.XmlElement actualValue) { }
+        public static FluentAssertions.Xml.XmlNodeAssertions Should(this System.Xml.XmlNode actualValue) { }
+    }
+}
+namespace FluentAssertions.Collections
+{
+    public abstract class CollectionAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Collections.IEnumerable
+        where TAssertions : FluentAssertions.Collections.CollectionAssertions<TSubject, TAssertions>
+    {
+        protected CollectionAssertions() { }
+        protected CollectionAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeOfType<T>(string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionEndsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actual, System.Collections.Generic.ICollection<TExpected> expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionEndsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actual, TExpected[] expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionStartsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actualItems, System.Collections.Generic.ICollection<TExpected> expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionStartsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actualItems, TExpected[] expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertSubjectEquality<TActual, TExpected>(System.Collections.IEnumerable expectation, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params object[] expectations) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.IEnumerable expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.IEnumerable expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.IEnumerable>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.IEnumerable>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSubsetOf(System.Collections.IEnumerable expectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params object[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainItemsAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(object element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params object[] elements) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, object> HaveElementAt(int index, object element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(object successor, object expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(object predecessor, object expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInAscendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAscendingInOrder(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInAscendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAscendingInOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInDescendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDescendingInOrder(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInDescendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDescendingInOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSubsetOf(System.Collections.IEnumerable unexpectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotIntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(object element, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
+    {
+        public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+            where TKey :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(params TKey[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(params TValue[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(params TKey[] unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(params TValue[] unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+    }
+    public class NonGenericCollectionAssertions : FluentAssertions.Collections.CollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
+    {
+        public NonGenericCollectionAssertions(System.Collections.IEnumerable collection) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
+    {
+        public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params T[] elements) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpectedItemsList, params T[] additionalUnexpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(params System.Action<>[] elementInspectors) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(System.Collections.Generic.IEnumerable<System.Action<T>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+    }
+    public class StringCollectionAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<string, FluentAssertions.Collections.StringCollectionAssertions>
+    {
+        public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(params string[] expectation) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(params string[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+    }
+    public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public WhichValueConstraint(FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> parentConstraint, TValue value) { }
+        public TValue WhichValue { get; }
+    }
+}
+namespace FluentAssertions.Common
+{
+    public enum CSharpAccessModifier
+    {
+        Public = 0,
+        Private = 1,
+        Protected = 2,
+        Internal = 3,
+        ProtectedInternal = 4,
+        InvalidForCSharp = 5,
+        PrivateProtected = 6,
+    }
+    public static class CSharpAccessModifierExtensions { }
+    public class Configuration
+    {
+        public Configuration(FluentAssertions.Common.IConfigurationStore store) { }
+        public string TestFrameworkName { get; set; }
+        public string ValueFormatterAssembly { get; set; }
+        public FluentAssertions.Common.ValueFormatterDetectionMode ValueFormatterDetectionMode { get; set; }
+        public static FluentAssertions.Common.Configuration Current { get; }
+    }
+    public static class DateTimeExtensions
+    {
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime) { }
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime, System.TimeSpan offset) { }
+    }
+    public interface IClock
+    {
+        void Delay(System.TimeSpan timeToDelay);
+        System.Threading.Tasks.Task DelayAsync(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken);
+        FluentAssertions.Common.ITimer StartTimer();
+        bool Wait(System.Threading.Tasks.Task task, System.TimeSpan timeout);
+    }
+    public interface IConfigurationStore
+    {
+        string GetSetting(string name);
+    }
+    public interface IReflector
+    {
+        System.Collections.Generic.IEnumerable<System.Type> GetAllTypesFromAppDomain(System.Func<System.Reflection.Assembly, bool> predicate);
+    }
+    public interface ITimer
+    {
+        System.TimeSpan Elapsed { get; }
+    }
+    public static class MethodInfoExtensions { }
+    public static class ObjectExtensions
+    {
+        public static bool IsSameOrEqualTo(this object actual, object expected) { }
+    }
+    public static class PropertyInfoExtensions { }
+    public static class Services
+    {
+        public static FluentAssertions.Common.Configuration Configuration { get; }
+        public static FluentAssertions.Common.IConfigurationStore ConfigurationStore { get; set; }
+        public static FluentAssertions.Common.IReflector Reflector { get; set; }
+        public static System.Action<string> ThrowException { get; set; }
+        public static void ResetToDefaults() { }
+    }
+    public static class TypeExtensions
+    {
+        public static System.Reflection.FieldInfo FindField(this System.Type type, string fieldName, System.Type preferredType) { }
+        public static FluentAssertions.Equivalency.SelectedMemberInfo FindMember(this System.Type type, string memberName, System.Type preferredType) { }
+        public static System.Reflection.PropertyInfo FindProperty(this System.Type type, string propertyName, System.Type preferredType) { }
+        public static System.Reflection.ConstructorInfo GetConstructor(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.PropertyInfo GetIndexerByParameterTypes(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Reflection.MethodInfo GetMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> GetNonPrivateFields(this System.Type typeToReflect) { }
+        public static System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetNonPrivateMembers(this System.Type typeToReflect) { }
+        public static System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> GetNonPrivateProperties(this System.Type typeToReflect, System.Collections.Generic.IEnumerable<string> filter = null) { }
+        public static System.Reflection.MethodInfo GetParameterlessMethod(this System.Type type, string methodName) { }
+        public static System.Reflection.PropertyInfo GetPropertyByName(this System.Type type, string propertyName) { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWithOrInherits> instead.")]
+        public static bool HasAttribute<TAttribute>(this System.Reflection.MemberInfo method)
+            where TAttribute : System.Attribute { }
+        public static bool HasExplicitlyImplementedProperty(this System.Type type, System.Type interfaceType, string propertyName) { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWith> instead.")]
+        public static bool HasMatchingAttribute<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
+        public static bool HasMatchingAttribute<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, bool inherit = false)
+            where TAttribute : System.Attribute { }
+        public static bool HasMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static bool HasParameterlessMethod(this System.Type type, string methodName) { }
+        public static bool HasValueSemantics(this System.Type type) { }
+        public static bool Implements(this System.Type type, System.Type expectedBaseType) { }
+        public static bool IsCSharpAbstract(this System.Type type) { }
+        public static bool IsCSharpSealed(this System.Type type) { }
+        public static bool IsCSharpStatic(this System.Type type) { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        [System.Obsolete("This overload is deprecated and will be removed on the next major version. Please" +
+            " use <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type, bool inherit = false)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsEquivalentTo(this FluentAssertions.Equivalency.SelectedMemberInfo property, FluentAssertions.Equivalency.SelectedMemberInfo otherProperty) { }
+        public static bool IsIndexer(this System.Reflection.PropertyInfo member) { }
+        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
+        public static bool OverridesEquals(this System.Type type) { }
+    }
+    public enum ValueFormatterDetectionMode
+    {
+        Disabled = 0,
+        Specific = 1,
+        Scan = 2,
+    }
+}
+namespace FluentAssertions.Equivalency
+{
+    public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class ConversionSelector
+    {
+        public ConversionSelector() { }
+        public FluentAssertions.Equivalency.ConversionSelector Clone() { }
+        public void Exclude(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void Include(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void IncludeAll() { }
+        public bool RequiresConversion(FluentAssertions.Equivalency.IMemberInfo info) { }
+        public override string ToString() { }
+    }
+    public enum CyclicReferenceHandling
+    {
+        Ignore = 0,
+        ThrowException = 1,
+    }
+    public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DictionaryEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public virtual bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class EnumEqualityStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumEqualityStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public enum EnumEquivalencyHandling
+    {
+        ByValue = 0,
+        ByName = 1,
+    }
+    public class EnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumerableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public enum EqualityStrategy
+    {
+        Equals = 0,
+        Members = 1,
+        ForceEquals = 2,
+        ForceMembers = 3,
+    }
+    public class EquivalencyAssertionOptions : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions>
+    {
+        public EquivalencyAssertionOptions() { }
+    }
+    [System.Obsolete("This class is deprecated and will be removed in version 6.X.")]
+    public static class EquivalencyAssertionOptionsExtentions
+    {
+        public static System.Type GetExpectationType(this FluentAssertions.Equivalency.IEquivalencyAssertionOptions config, FluentAssertions.Equivalency.IMemberInfo context) { }
+    }
+    public class EquivalencyAssertionOptions<TExpectation> : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>>
+    {
+        public EquivalencyAssertionOptions() { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+    }
+    public class EquivalencyValidationContext : FluentAssertions.Equivalency.IEquivalencyValidationContext, FluentAssertions.Equivalency.IMemberInfo
+    {
+        public EquivalencyValidationContext() { }
+        public string Because { get; set; }
+        public object[] BecauseArgs { get; set; }
+        public System.Type CompileTimeType { get; set; }
+        public object Expectation { get; set; }
+        public bool IsRoot { get; }
+        public bool RootIsCollection { get; set; }
+        public System.Type RuntimeType { get; }
+        public string SelectedMemberDescription { get; set; }
+        public FluentAssertions.Equivalency.SelectedMemberInfo SelectedMemberInfo { get; set; }
+        public string SelectedMemberPath { get; set; }
+        public object Subject { get; set; }
+        public FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
+        public override string ToString() { }
+        public System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getTraceMessage) { }
+        public void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getTraceMessage) { }
+    }
+    public class EquivalencyValidator : FluentAssertions.Equivalency.IEquivalencyValidator
+    {
+        public EquivalencyValidator(FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public void AssertEquality(FluentAssertions.Equivalency.EquivalencyValidationContext context) { }
+        public void AssertEqualityUsing(FluentAssertions.Equivalency.IEquivalencyValidationContext context) { }
+    }
+    public class GenericDictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericDictionaryEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class GenericEnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericEnumerableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public delegate string GetTraceMessage(string path);
+    public interface IAssertionContext<TSubject>
+    {
+        string Because { get; set; }
+        object[] BecauseArgs { get; set; }
+        TSubject Expectation { get; }
+        TSubject Subject { get; }
+        FluentAssertions.Equivalency.SelectedMemberInfo SubjectProperty { get; }
+    }
+    public interface IAssertionRule
+    {
+        bool AssertEquality(FluentAssertions.Equivalency.IEquivalencyValidationContext context);
+    }
+    public interface IEquivalencyAssertionOptions
+    {
+        bool AllowInfiniteRecursion { get; }
+        FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
+        FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool IncludeFields { get; }
+        bool IncludeProperties { get; }
+        bool IsRecursive { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberMatchingRule> MatchingRules { get; }
+        FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
+        FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
+        bool UseRuntimeTyping { get; }
+        FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> GetUserEquivalencySteps(FluentAssertions.Equivalency.ConversionSelector conversionSelector);
+    }
+    public interface IEquivalencyStep
+    {
+        bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+        bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IEquivalencyValidationContext : FluentAssertions.Equivalency.IMemberInfo
+    {
+        string Because { get; }
+        object[] BecauseArgs { get; }
+        object Expectation { get; }
+        bool IsRoot { get; }
+        bool RootIsCollection { get; set; }
+        object Subject { get; }
+        FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
+        System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getMessage);
+        void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getMessage);
+    }
+    public interface IEquivalencyValidator
+    {
+        void AssertEqualityUsing(FluentAssertions.Equivalency.IEquivalencyValidationContext context);
+    }
+    public interface IMemberInfo
+    {
+        System.Type CompileTimeType { get; }
+        System.Type RuntimeType { get; }
+        string SelectedMemberDescription { get; }
+        FluentAssertions.Equivalency.SelectedMemberInfo SelectedMemberInfo { get; }
+        string SelectedMemberPath { get; }
+    }
+    public interface IMemberMatchingRule
+    {
+        FluentAssertions.Equivalency.SelectedMemberInfo Match(FluentAssertions.Equivalency.SelectedMemberInfo expectedMember, object subject, string memberPath, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IMemberSelectionRule
+    {
+        bool IncludesMembers { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> SelectMembers(System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> selectedMembers, FluentAssertions.Equivalency.IMemberInfo context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IOrderingRule
+    {
+        FluentAssertions.Equivalency.OrderStrictness Evaluate(FluentAssertions.Equivalency.IMemberInfo memberInfo);
+    }
+    public interface ITraceWriter
+    {
+        System.IDisposable AddBlock(string trace);
+        void AddSingle(string trace);
+        string ToString();
+    }
+    public enum OrderStrictness
+    {
+        Strict = 0,
+        NotStrict = 1,
+        Irrelevant = 2,
+    }
+    public class OrderingRuleCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule>, System.Collections.IEnumerable
+    {
+        public OrderingRuleCollection() { }
+        public OrderingRuleCollection(System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule> orderingRules) { }
+        public void Add(FluentAssertions.Equivalency.IOrderingRule rule) { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IOrderingRule> GetEnumerator() { }
+        public bool IsOrderingStrictFor(FluentAssertions.Equivalency.IMemberInfo memberInfo) { }
+    }
+    public class ReferenceEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ReferenceEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public virtual bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class RunAllUserStepsEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public RunAllUserStepsEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public abstract class SelectedMemberInfo
+    {
+        protected SelectedMemberInfo() { }
+        public abstract System.Type DeclaringType { get; }
+        public abstract System.Type MemberType { get; }
+        public abstract string Name { get; }
+        public abstract object GetValue(object obj, object[] index);
+        public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.FieldInfo fieldInfo) { }
+        public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.PropertyInfo propertyInfo) { }
+    }
+    public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
+        where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
+    {
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        protected readonly FluentAssertions.Equivalency.OrderingRuleCollection orderingRules;
+        protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
+        public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        public FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
+        protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public TSelf AllowingInfiniteRecursion() { }
+        public TSelf ComparingByMembers<T>() { }
+        public TSelf ComparingByValue<T>() { }
+        public TSelf ComparingEnumsByName() { }
+        public TSelf ComparingEnumsByValue() { }
+        public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf ExcludingFields() { }
+        public TSelf ExcludingMissingMembers() { }
+        public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingProperties() { }
+        public TSelf IgnoringCyclicReferences() { }
+        public TSelf IncludingAllDeclaredProperties() { }
+        public TSelf IncludingAllRuntimeProperties() { }
+        public TSelf IncludingFields() { }
+        public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingProperties() { }
+        protected void RemoveSelectionRule<T>()
+            where T : FluentAssertions.Equivalency.IMemberSelectionRule { }
+        public TSelf RespectingDeclaredTypes() { }
+        public TSelf RespectingRuntimeTypes() { }
+        public TSelf ThrowingOnMissingMembers() { }
+        public override string ToString() { }
+        public TSelf Using(FluentAssertions.Equivalency.IAssertionRule assertionRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IEquivalencyStep equivalencyStep) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
+        public TSelf WithAutoConversion() { }
+        public TSelf WithAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf WithStrictOrdering() { }
+        public TSelf WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf WithTracing(FluentAssertions.Equivalency.ITraceWriter writer = null) { }
+        public TSelf WithoutAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void WithoutMatchingRules() { }
+        public void WithoutSelectionRules() { }
+        public TSelf WithoutStrictOrdering() { }
+        public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public class Restriction<TMember>
+        {
+            public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
+            public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+            public TSelf WhenTypeIs<TMemberType>() { }
+        }
+    }
+    public class SimpleEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public SimpleEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class StringBuilderTraceWriter : FluentAssertions.Equivalency.ITraceWriter
+    {
+        public StringBuilderTraceWriter() { }
+        public System.IDisposable AddBlock(string trace) { }
+        public void AddSingle(string trace) { }
+        public override string ToString() { }
+    }
+    public class StringEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StringEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class StructuralEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StructuralEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public static class SubjectInfoExtensions
+    {
+        public static bool WhichGetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichGetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+    }
+    public class TryConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public TryConversionStep(FluentAssertions.Equivalency.ConversionSelector selector) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ValueTypeEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+}
+namespace FluentAssertions.Events
+{
+    public class EventAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<T, FluentAssertions.Events.EventAssertions<T>>
+    {
+        protected EventAssertions(FluentAssertions.Events.IMonitor<T> monitor) { }
+        protected override string Identifier { get; }
+        public void NotRaise(string eventName, string because = "", params object[] becauseArgs) { }
+        public void NotRaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecorder Raise(string eventName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecorder RaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
+    }
+    public class EventMetadata
+    {
+        public EventMetadata(string eventName, System.Type handlerType) { }
+        public string EventName { get; }
+        public System.Type HandlerType { get; }
+    }
+    public class EventRecorder : FluentAssertions.Events.IEventRecorder, System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
+    {
+        public EventRecorder(object eventRaiser, string eventName, System.Func<System.DateTime> utcNow) { }
+        public System.Type EventHandlerType { get; }
+        public string EventName { get; }
+        public object EventObject { get; }
+        public void Attach(System.WeakReference subject, System.Reflection.EventInfo eventInfo) { }
+        public void Dispose() { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Events.RecordedEvent> GetEnumerator() { }
+        public void RecordEvent(params object[] parameters) { }
+        public void Reset() { }
+    }
+    public interface IEventRecorder : System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
+    {
+        System.Type EventHandlerType { get; }
+        string EventName { get; }
+        object EventObject { get; }
+        void RecordEvent(params object[] parameters);
+        void Reset();
+    }
+    public interface IMonitor<T> : System.IDisposable
+    {
+        FluentAssertions.Events.EventMetadata[] MonitoredEvents { get; }
+        FluentAssertions.Events.OccurredEvent[] OccurredEvents { get; }
+        T Subject { get; }
+        void Clear();
+        FluentAssertions.Events.IEventRecorder GetEventRecorder(string eventName);
+        FluentAssertions.Events.EventAssertions<T> Should();
+    }
+    public class OccurredEvent
+    {
+        public OccurredEvent() { }
+        public string EventName { get; set; }
+        public object[] Parameters { get; set; }
+        public System.DateTime TimestampUtc { get; set; }
+    }
+    public class RecordedEvent
+    {
+        public RecordedEvent(System.DateTime utcNow, object monitoredObject, params object[] parameters) { }
+        public System.Collections.Generic.IEnumerable<object> Parameters { get; }
+        public System.DateTime TimestampUtc { get; set; }
+    }
+}
+namespace FluentAssertions.Execution
+{
+    public class AssertionFailedException : System.Exception
+    {
+        public AssertionFailedException(string message) { }
+        protected AssertionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public class AssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public AssertionScope() { }
+        public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
+        public AssertionScope(string context) { }
+        public string Context { get; set; }
+        public bool Succeeded { get; }
+        public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
+        public static FluentAssertions.Execution.AssertionScope Current { get; }
+        public void AddNonReportable(string key, object value) { }
+        public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, string value) { }
+        public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
+        public T Get<T>(string key) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public bool HasFailures() { }
+        public FluentAssertions.Execution.AssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.AssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public class Continuation
+    {
+        public Continuation(FluentAssertions.Execution.AssertionScope sourceScope, bool sourceSucceeded) { }
+        public bool SourceSucceeded { get; }
+        public FluentAssertions.Execution.IAssertionScope Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.Continuation continuation) { }
+    }
+    public class ContinuationOfGiven<TSubject>
+    {
+        public ContinuationOfGiven(FluentAssertions.Execution.GivenSelector<TSubject> parent, bool succeeded) { }
+        public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
+    }
+    public class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public ContinuedAssertionScope(FluentAssertions.Execution.AssertionScope predecessor, bool predecessorSucceeded) { }
+        public bool Succeeded { get; }
+        public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.IAssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public static class Execute
+    {
+        public static FluentAssertions.Execution.AssertionScope Assertion { get; }
+    }
+    public class FailReason
+    {
+        public FailReason(string message, params object[] args) { }
+        public object[] Args { get; }
+        public string Message { get; }
+    }
+    public class GivenSelector<T>
+    {
+        public GivenSelector(System.Func<T> selector, bool predecessorSucceeded, FluentAssertions.Execution.AssertionScope predecessor) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> ClearExpectation() { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<, >[] args) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
+        public FluentAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
+    }
+    public interface IAssertionScope : System.IDisposable
+    {
+        bool Succeeded { get; }
+        FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
+        FluentAssertions.Execution.Continuation ClearExpectation();
+        string[] Discard();
+        FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc);
+        FluentAssertions.Execution.Continuation FailWith(string message, params object[] args);
+        FluentAssertions.Execution.IAssertionScope ForCondition(bool condition);
+        FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector);
+        FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier);
+        FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args);
+    }
+    public interface IAssertionStrategy
+    {
+        System.Collections.Generic.IEnumerable<string> FailureMessages { get; }
+        System.Collections.Generic.IEnumerable<string> DiscardFailures();
+        void HandleFailure(string message);
+        void ThrowIfAny(System.Collections.Generic.IDictionary<string, object> context);
+    }
+    public interface ICloneable2
+    {
+        object Clone();
+    }
+}
+namespace FluentAssertions.Extensions
+{
+    public static class FluentDateTimeExtensions
+    {
+        public static System.DateTime AddMicroseconds(this System.DateTime self, long microseconds) { }
+        public static System.DateTimeOffset AddMicroseconds(this System.DateTimeOffset self, long microseconds) { }
+        public static System.DateTime AddNanoseconds(this System.DateTime self, long nanoseconds) { }
+        public static System.DateTimeOffset AddNanoseconds(this System.DateTimeOffset self, long nanoseconds) { }
+        public static System.DateTime After(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime April(this int day, int year) { }
+        public static System.DateTime AsLocal(this System.DateTime dateTime) { }
+        public static System.DateTime AsUtc(this System.DateTime dateTime) { }
+        public static System.DateTime At(this System.DateTime date, System.TimeSpan time) { }
+        public static System.DateTime At(this System.DateTime date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTimeOffset At(this System.DateTimeOffset date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTime August(this int day, int year) { }
+        public static System.DateTime Before(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime December(this int day, int year) { }
+        public static System.DateTime February(this int day, int year) { }
+        public static System.DateTime January(this int day, int year) { }
+        public static System.DateTime July(this int day, int year) { }
+        public static System.DateTime June(this int day, int year) { }
+        public static System.DateTime March(this int day, int year) { }
+        public static System.DateTime May(this int day, int year) { }
+        public static int Microsecond(this System.DateTime self) { }
+        public static int Microsecond(this System.DateTimeOffset self) { }
+        public static int Nanosecond(this System.DateTime self) { }
+        public static int Nanosecond(this System.DateTimeOffset self) { }
+        public static System.DateTime November(this int day, int year) { }
+        public static System.DateTime October(this int day, int year) { }
+        public static System.DateTime September(this int day, int year) { }
+    }
+    public static class FluentTimeSpanExtensions
+    {
+        public const long TicksPerMicrosecond = 10;
+        public const double TicksPerNanosecond = 0.01D;
+        public static System.TimeSpan And(this System.TimeSpan sourceTime, System.TimeSpan offset) { }
+        public static System.TimeSpan Days(this double days) { }
+        public static System.TimeSpan Days(this int days) { }
+        public static System.TimeSpan Days(this int days, System.TimeSpan offset) { }
+        public static System.TimeSpan Hours(this double hours) { }
+        public static System.TimeSpan Hours(this int hours) { }
+        public static System.TimeSpan Hours(this int hours, System.TimeSpan offset) { }
+        public static int Microseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Microseconds(this int microseconds) { }
+        public static System.TimeSpan Microseconds(this long microseconds) { }
+        public static System.TimeSpan Milliseconds(this double milliseconds) { }
+        public static System.TimeSpan Milliseconds(this int milliseconds) { }
+        public static System.TimeSpan Minutes(this double minutes) { }
+        public static System.TimeSpan Minutes(this int minutes) { }
+        public static System.TimeSpan Minutes(this int minutes, System.TimeSpan offset) { }
+        public static int Nanoseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Nanoseconds(this int nanoseconds) { }
+        public static System.TimeSpan Nanoseconds(this long nanoseconds) { }
+        public static System.TimeSpan Seconds(this double seconds) { }
+        public static System.TimeSpan Seconds(this int seconds) { }
+        public static System.TimeSpan Seconds(this int seconds, System.TimeSpan offset) { }
+        public static System.TimeSpan Ticks(this int ticks) { }
+        public static System.TimeSpan Ticks(this long ticks) { }
+        public static double TotalMicroseconds(this System.TimeSpan self) { }
+        public static double TotalNanoseconds(this System.TimeSpan self) { }
+    }
+}
+namespace FluentAssertions.Formatting
+{
+    public class AggregateExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AggregateExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class AttributeBasedFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AttributeBasedFormatter() { }
+        public System.Reflection.MethodInfo[] Formatters { get; }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DateTimeOffsetValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DateTimeOffsetValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DecimalValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DecimalValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DefaultValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DoubleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public EnumerableValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExpressionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public delegate string FormatChild(string childPath, object value);
+    public static class Formatter
+    {
+        public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
+        public static void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static string ToString(object value, bool useLineBreaks = false) { }
+    }
+    public class FormattingContext
+    {
+        public FormattingContext() { }
+        public int Depth { get; set; }
+        public bool UseLineBreaks { get; set; }
+    }
+    public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public GuidValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public interface IValueFormatter
+    {
+        bool CanHandle(object value);
+        string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
+    }
+    public class Int16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class MultidimensionalArrayFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public MultidimensionalArrayFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class NullValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public NullValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class PropertyInfoFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public PropertyInfoFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SingleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SingleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class StringValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public StringValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TaskFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TaskFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TimeSpanValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TimeSpanValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
+    public class ValueFormatterAttribute : System.Attribute
+    {
+        public ValueFormatterAttribute() { }
+    }
+    public class XAttributeValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XAttributeValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XDocumentValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XDocumentValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XElementValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XElementValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+}
+namespace FluentAssertions.Numeric
+{
+    public class ComparableTypeAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    {
+        public ComparableTypeAssertions(System.IComparable<T> value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
+        where T :  struct
+    {
+        public NullableNumericAssertions(T? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NumericAssertions<T>
+        where T :  struct
+    {
+        public NumericAssertions(object value) { }
+        public System.IComparable Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(params T[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Primitives
+{
+    public class BooleanAssertions
+    {
+        public BooleanAssertions(bool? value) { }
+        public bool? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeAssertions
+    {
+        public DateTimeAssertions(System.DateTime? value) { }
+        public System.DateTime? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.DateTime[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetAssertions
+    {
+        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
+        public System.DateTimeOffset? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetRangeAssertions
+    {
+        protected DateTimeOffsetRangeAssertions(FluentAssertions.Primitives.DateTimeOffsetAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeRangeAssertions
+    {
+        protected DateTimeRangeAssertions(FluentAssertions.Primitives.DateTimeAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
+    }
+    public class GuidAssertions
+    {
+        public GuidAssertions(System.Guid? value) { }
+        public System.Guid? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableBooleanAssertions : FluentAssertions.Primitives.BooleanAssertions
+    {
+        public NullableBooleanAssertions(bool? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions
+    {
+        public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions
+    {
+        public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableGuidAssertions : FluentAssertions.Primitives.GuidAssertions
+    {
+        public NullableGuidAssertions(System.Guid? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions
+    {
+        public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class ObjectAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
+    {
+        public ObjectAssertions(object value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be(object expected, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> HaveFlag(System.Enum expectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe(object unexpected, string because = "", params object[] becauseArgs) { }
+        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotHaveFlag(System.Enum unexpectedFlag, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
+        where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+    {
+        protected ReferenceTypeAssertions() { }
+        protected ReferenceTypeAssertions(TSubject subject) { }
+        protected abstract string Identifier { get; }
+        public TSubject Subject { get; set; }
+        public FluentAssertions.AndConstraint<TAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameAs(TSubject expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<TSubject, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match<T>(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
+            where T : TSubject { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SimpleTimeSpanAssertions
+    {
+        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public System.TimeSpan? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+    }
+    public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>
+    {
+        public StringAssertions(string value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(params string[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+    }
+    public enum TimeSpanCondition
+    {
+        MoreThan = 0,
+        AtLeast = 1,
+        Exactly = 2,
+        Within = 3,
+        LessThan = 4,
+    }
+}
+namespace FluentAssertions.Reflection
+{
+    public class AssemblyAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Reflection.Assembly, FluentAssertions.Reflection.AssemblyAssertions>
+    {
+        public AssemblyAssertions(System.Reflection.Assembly assembly) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Reflection.AssemblyAssertions, System.Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs) { }
+        public void NotReference(System.Reflection.Assembly assembly) { }
+        public void NotReference(System.Reflection.Assembly assembly, string because, params string[] becauseArgs) { }
+        public void Reference(System.Reflection.Assembly assembly) { }
+        public void Reference(System.Reflection.Assembly assembly, string because, params string[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Specialized
+{
+    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action>
+    {
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Action Subject { get; }
+        protected override void InvokeSubject() { }
+    }
+    public class AsyncFunctionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Func<System.Threading.Tasks.Task>>
+    {
+        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Func<System.Threading.Tasks.Task> Subject { get; }
+        protected override void InvokeSubject() { }
+        public System.Threading.Tasks.Task NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public abstract class DelegateAssertions<TDelegate> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Delegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate>>
+        where TDelegate : System.Delegate
+    {
+        protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public new TDelegate Subject { get; }
+        protected abstract void InvokeSubject();
+        public void NotThrow(string because = "", params object[] becauseArgs) { }
+        protected void NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        protected void NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+        public void NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public class ExceptionAssertions<TException> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IEnumerable<TException>, FluentAssertions.Specialized.ExceptionAssertions<TException>>
+        where TException : System.Exception
+    {
+        public ExceptionAssertions(System.Collections.Generic.IEnumerable<TException> exceptions) { }
+        public TException And { get; }
+        protected override string Identifier { get; }
+        public TException Which { get; }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Where(System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, string because = "", params object[] becauseArgs) { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerException<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerExceptionExactly<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TException> WithMessage(string expectedWildcardPattern, string because = "", params object[] becauseArgs) { }
+    }
+    public class ExecutionTime
+    {
+        public ExecutionTime(System.Action action) { }
+        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action) { }
+        protected ExecutionTime(System.Action action, string actionDescription) { }
+        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription) { }
+    }
+    public class ExecutionTimeAssertions
+    {
+        public ExecutionTimeAssertions(FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        public void BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public void BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public void BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public void BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public void BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+    }
+    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
+    {
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Func<T> Subject { get; }
+        protected override void InvokeSubject() { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions
+    {
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+    public interface IExtractExceptions
+    {
+        System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception;
+    }
+    public class MemberExecutionTime<T> : FluentAssertions.Specialized.ExecutionTime
+    {
+        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+    }
+    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions
+    {
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Types
+{
+    public static class AllTypes
+    {
+        public static FluentAssertions.Types.TypeSelector From(System.Reflection.Assembly assembly) { }
+    }
+    public class ConstructorInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.ConstructorInfo, FluentAssertions.Types.ConstructorInfoAssertions>
+    {
+        public ConstructorInfoAssertions(System.Reflection.ConstructorInfo constructorInfo) { }
+        protected override string Identifier { get; }
+    }
+    public abstract class MemberInfoAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MemberInfo
+        where TAssertions : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+    {
+        protected MemberInfoAssertions() { }
+        protected MemberInfoAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+    }
+    public abstract class MethodBaseAssertions<TSubject, TAssertions> : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MethodBase
+        where TAssertions : FluentAssertions.Types.MethodBaseAssertions<TSubject, TAssertions>
+    {
+        protected MethodBaseAssertions() { }
+        protected MethodBaseAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>
+    {
+        public MethodInfoAssertions() { }
+        public MethodInfoAssertions(System.Reflection.MethodInfo methodInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturnVoid(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> ReturnVoid(string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, System.Collections.IEnumerable
+    {
+        public MethodInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public MethodInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.MethodInfoSelector ThatArePublicOrInternal { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturnVoid { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
+        public System.Reflection.MethodInfo[] ToArray() { }
+    }
+    public class MethodInfoSelectorAssertions
+    {
+        public MethodInfoSelectorAssertions(params System.Reflection.MethodInfo[] methods) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> SubjectMethods { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoAssertions : FluentAssertions.Types.MemberInfoAssertions<System.Reflection.PropertyInfo, FluentAssertions.Types.PropertyInfoAssertions>
+    {
+        public PropertyInfoAssertions(System.Reflection.PropertyInfo propertyInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo>, System.Collections.IEnumerable
+    {
+        public PropertyInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public PropertyInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatArePublicOrInternal { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.PropertyInfo> GetEnumerator() { }
+        public FluentAssertions.Types.PropertyInfoSelector NotOfType<TReturn>() { }
+        public FluentAssertions.Types.PropertyInfoSelector OfType<TReturn>() { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public System.Reflection.PropertyInfo[] ToArray() { }
+    }
+    public class PropertyInfoSelectorAssertions
+    {
+        public PropertyInfoSelectorAssertions(params System.Reflection.PropertyInfo[] properties) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> SubjectProperties { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public class TypeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Type, FluentAssertions.Types.TypeAssertions>
+    {
+        public TypeAssertions(System.Type type) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be(System.Type expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be<TExpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<System.Type> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveExplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveExplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveImplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveImplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveIndexer(System.Type indexerType, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty(System.Type propertyType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty<TProperty>(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe(System.Type unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe<TUnexpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<System.Type> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveExplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveExplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveImplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveImplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveIndexer(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveProperty(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+    }
+    public class TypeSelector : System.Collections.Generic.IEnumerable<System.Type>, System.Collections.IEnumerable
+    {
+        public TypeSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public TypeSelector(System.Type type) { }
+        public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
+        public System.Type[] ToArray() { }
+    }
+    public class TypeSelectorAssertions
+    {
+        public TypeSelectorAssertions(params System.Type[] types) { }
+        public System.Collections.Generic.IEnumerable<System.Type> Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+    }
+}
+namespace FluentAssertions.Xml
+{
+    public class XAttributeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XAttribute, FluentAssertions.Xml.XAttributeAssertions>
+    {
+        public XAttributeAssertions(System.Xml.Linq.XAttribute attribute) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> Be(System.Xml.Linq.XAttribute expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> Be(System.Xml.Linq.XAttribute expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> HaveValue(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> HaveValue(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> NotBe(System.Xml.Linq.XAttribute unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> NotBe(System.Xml.Linq.XAttribute unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XDocumentAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XDocument, FluentAssertions.Xml.XDocumentAssertions>
+    {
+        public XDocumentAssertions(System.Xml.Linq.XDocument document) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> Be(System.Xml.Linq.XDocument expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> Be(System.Xml.Linq.XDocument expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> BeEquivalentTo(System.Xml.Linq.XDocument expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> BeEquivalentTo(System.Xml.Linq.XDocument expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBe(System.Xml.Linq.XDocument unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBe(System.Xml.Linq.XDocument unexpected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBeEquivalentTo(System.Xml.Linq.XDocument unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBeEquivalentTo(System.Xml.Linq.XDocument unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XElementAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XElement, FluentAssertions.Xml.XElementAssertions>
+    {
+        public XElementAssertions(System.Xml.Linq.XElement xElement) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> Be(System.Xml.Linq.XElement expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> Be(System.Xml.Linq.XElement expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveValue(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveValue(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBe(System.Xml.Linq.XElement unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBe(System.Xml.Linq.XElement unexpected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBeEquivalentTo(System.Xml.Linq.XElement unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBeEquivalentTo(System.Xml.Linq.XElement unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XmlElementAssertions : FluentAssertions.Xml.XmlNodeAssertions<System.Xml.XmlElement, FluentAssertions.Xml.XmlElementAssertions>
+    {
+        public XmlElementAssertions(System.Xml.XmlElement xmlElement) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttribute(string expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttributeWithNamespace(string expectedName, string expectedNamespace, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttributeWithNamespace(string expectedName, string expectedNamespace, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElement(string expectedName) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElement(string expectedName, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElementWithNamespace(string expectedName, string expectedNamespace) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElementWithNamespace(string expectedName, string expectedNamespace, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveInnerText(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveInnerText(string expected, string because, params object[] becauseArgs) { }
+    }
+    public class XmlNodeAssertions : FluentAssertions.Xml.XmlNodeAssertions<System.Xml.XmlNode, FluentAssertions.Xml.XmlNodeAssertions>
+    {
+        public XmlNodeAssertions(System.Xml.XmlNode xmlNode) { }
+    }
+    public class XmlNodeAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Xml.XmlNode
+        where TAssertions : FluentAssertions.Xml.XmlNodeAssertions<TSubject, TAssertions>
+    {
+        public XmlNodeAssertions(TSubject xmlNode) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Xml.XmlNode expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Xml.XmlNode expected, string because, params object[] reasonArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Xml.XmlNode unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Xml.XmlNode unexpected, string because, params object[] reasonArgs) { }
+    }
+    public class XmlNodeFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XmlNodeFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+}

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.0.approved.txt
@@ -1,0 +1,2156 @@
+﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v2.0", FrameworkDisplayName="")]
+namespace FluentAssertions
+{
+    public class AggregateExceptionExtractor : FluentAssertions.Specialized.IExtractExceptions
+    {
+        public AggregateExceptionExtractor() { }
+        public System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception { }
+    }
+    public class AndConstraint<T>
+    {
+        public AndConstraint(T parentConstraint) { }
+        public T And { get; }
+    }
+    public class AndWhichConstraint<TParentConstraint, TMatchedElement> : FluentAssertions.AndConstraint<TParentConstraint>
+    {
+        public AndWhichConstraint(TParentConstraint parentConstraint, System.Collections.Generic.IEnumerable<TMatchedElement> matchedConstraint) { }
+        public AndWhichConstraint(TParentConstraint parentConstraint, TMatchedElement matchedConstraint) { }
+        public TMatchedElement Subject { get; }
+        public TMatchedElement Which { get; }
+    }
+    public static class AssertionExtensions
+    {
+        public static TTo As<TTo>(this object subject) { }
+        public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.Task<TResult>> action) { }
+        public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask<TResult>> action) { }
+        public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+        public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
+        public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
+        public static FluentAssertions.Events.IMonitor<T> Monitor<T>(this T eventSource, System.Func<System.DateTime> utcNow = null) { }
+        public static FluentAssertions.Specialized.ExecutionTimeAssertions Should(this FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        public static FluentAssertions.Types.MethodInfoSelectorAssertions Should(this FluentAssertions.Types.MethodInfoSelector methodSelector) { }
+        public static FluentAssertions.Types.PropertyInfoSelectorAssertions Should(this FluentAssertions.Types.PropertyInfoSelector propertyInfoSelector) { }
+        public static FluentAssertions.Types.TypeSelectorAssertions Should(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
+        public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
+        public static FluentAssertions.Collections.NonGenericCollectionAssertions Should(this System.Collections.IEnumerable actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
+        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
+        public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
+        public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
+        public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
+        public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
+        public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
+        public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
+        public static FluentAssertions.Xml.XAttributeAssertions Should(this System.Xml.Linq.XAttribute actualValue) { }
+        public static FluentAssertions.Xml.XDocumentAssertions Should(this System.Xml.Linq.XDocument actualValue) { }
+        public static FluentAssertions.Xml.XElementAssertions Should(this System.Xml.Linq.XElement actualValue) { }
+        public static FluentAssertions.Primitives.BooleanAssertions Should(this bool actualValue) { }
+        public static FluentAssertions.Primitives.NullableBooleanAssertions Should(this bool? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<byte> Should(this byte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<byte> Should(this byte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<decimal> Should(this decimal actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<decimal> Should(this decimal? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<double> Should(this double actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<double> Should(this double? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<float> Should(this float actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<float> Should(this float? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<int> Should(this int actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<int> Should(this int? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<long> Should(this long actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<long> Should(this long? actualValue) { }
+        public static FluentAssertions.Primitives.ObjectAssertions Should(this object actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<sbyte> Should(this sbyte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<sbyte> Should(this sbyte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<short> Should(this short actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<short> Should(this short? actualValue) { }
+        public static FluentAssertions.Primitives.StringAssertions Should(this string actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<uint> Should(this uint actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<uint> Should(this uint? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ulong> Should(this ulong actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ulong> Should(this ulong? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ushort> Should(this ushort actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ushort> Should(this ushort? actualValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
+        public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public static class AssertionOptions
+    {
+        public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
+        public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
+        public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
+    }
+    public static class AtLeast
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class AtMost
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class CallerIdentifier
+    {
+        public static System.Action<string> logger;
+        public static string DetermineCallerIdentity() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
+    public class CustomAssertionAttribute : System.Attribute
+    {
+        public CustomAssertionAttribute() { }
+    }
+    public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
+    {
+        public EquivalencyStepCollection() { }
+        public void Add<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void AddAfter<TPredecessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Clear() { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IEquivalencyStep> GetEnumerator() { }
+        public void Insert<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void InsertBefore<TSuccessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Remove<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep { }
+        public void Reset() { }
+    }
+    public static class EventRaisingExtensions
+    {
+        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, params System.Linq.Expressions.Expression<>[] predicates) { }
+        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
+        public static FluentAssertions.Events.IEventRecorder WithSender(this FluentAssertions.Events.IEventRecorder eventRecorder, object expectedSender) { }
+    }
+    public static class Exactly
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class FluentActions
+    {
+        public static System.Func<System.Threading.Tasks.Task> Awaiting(System.Func<System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task<T>> Awaiting<T>(System.Func<System.Threading.Tasks.Task<T>> func) { }
+        public static System.Action Enumerating(System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static System.Action Invoking(System.Action action) { }
+        public static System.Func<T> Invoking<T>(System.Func<T> func) { }
+    }
+    public static class LessThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class MoreThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class NumericAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+    }
+    public static class ObjectAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeXmlSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class OccurrenceConstraint
+    {
+        protected OccurrenceConstraint(int expectedCount) { }
+    }
+    public static class TypeEnumerableExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreInNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreUnderNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatDeriveFrom<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatImplement<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+    }
+    public static class TypeExtensions
+    {
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this System.Type type) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this System.Type type) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Type type) { }
+    }
+    public static class XmlAssertionExtensions
+    {
+        public static FluentAssertions.Xml.XmlElementAssertions Should(this System.Xml.XmlElement actualValue) { }
+        public static FluentAssertions.Xml.XmlNodeAssertions Should(this System.Xml.XmlNode actualValue) { }
+    }
+}
+namespace FluentAssertions.Collections
+{
+    public abstract class CollectionAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Collections.IEnumerable
+        where TAssertions : FluentAssertions.Collections.CollectionAssertions<TSubject, TAssertions>
+    {
+        protected CollectionAssertions() { }
+        protected CollectionAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeOfType<T>(string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionEndsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actual, System.Collections.Generic.ICollection<TExpected> expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionEndsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actual, TExpected[] expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionStartsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actualItems, System.Collections.Generic.ICollection<TExpected> expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionStartsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actualItems, TExpected[] expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertSubjectEquality<TActual, TExpected>(System.Collections.IEnumerable expectation, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params object[] expectations) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.IEnumerable expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.IEnumerable expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.IEnumerable>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.IEnumerable>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSubsetOf(System.Collections.IEnumerable expectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params object[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainItemsAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(object element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params object[] elements) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, object> HaveElementAt(int index, object element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(object successor, object expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(object predecessor, object expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInAscendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAscendingInOrder(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInAscendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAscendingInOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInDescendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDescendingInOrder(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInDescendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDescendingInOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSubsetOf(System.Collections.IEnumerable unexpectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotIntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(object element, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
+    {
+        public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+            where TKey :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(params TKey[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(params TValue[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(params TKey[] unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(params TValue[] unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+    }
+    public class NonGenericCollectionAssertions : FluentAssertions.Collections.CollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
+    {
+        public NonGenericCollectionAssertions(System.Collections.IEnumerable collection) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
+    {
+        public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params T[] elements) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpectedItemsList, params T[] additionalUnexpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(params System.Action<>[] elementInspectors) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(System.Collections.Generic.IEnumerable<System.Action<T>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+    }
+    public class StringCollectionAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<string, FluentAssertions.Collections.StringCollectionAssertions>
+    {
+        public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(params string[] expectation) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(params string[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+    }
+    public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public WhichValueConstraint(FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> parentConstraint, TValue value) { }
+        public TValue WhichValue { get; }
+    }
+}
+namespace FluentAssertions.Common
+{
+    public enum CSharpAccessModifier
+    {
+        Public = 0,
+        Private = 1,
+        Protected = 2,
+        Internal = 3,
+        ProtectedInternal = 4,
+        InvalidForCSharp = 5,
+        PrivateProtected = 6,
+    }
+    public static class CSharpAccessModifierExtensions { }
+    public class Configuration
+    {
+        public Configuration(FluentAssertions.Common.IConfigurationStore store) { }
+        public string TestFrameworkName { get; set; }
+        public string ValueFormatterAssembly { get; set; }
+        public FluentAssertions.Common.ValueFormatterDetectionMode ValueFormatterDetectionMode { get; set; }
+        public static FluentAssertions.Common.Configuration Current { get; }
+    }
+    public static class DateTimeExtensions
+    {
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime) { }
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime, System.TimeSpan offset) { }
+    }
+    public interface IClock
+    {
+        void Delay(System.TimeSpan timeToDelay);
+        System.Threading.Tasks.Task DelayAsync(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken);
+        FluentAssertions.Common.ITimer StartTimer();
+        bool Wait(System.Threading.Tasks.Task task, System.TimeSpan timeout);
+    }
+    public interface IConfigurationStore
+    {
+        string GetSetting(string name);
+    }
+    public interface IReflector
+    {
+        System.Collections.Generic.IEnumerable<System.Type> GetAllTypesFromAppDomain(System.Func<System.Reflection.Assembly, bool> predicate);
+    }
+    public interface ITimer
+    {
+        System.TimeSpan Elapsed { get; }
+    }
+    public static class MethodInfoExtensions { }
+    public static class ObjectExtensions
+    {
+        public static bool IsSameOrEqualTo(this object actual, object expected) { }
+    }
+    public static class PropertyInfoExtensions { }
+    public static class Services
+    {
+        public static FluentAssertions.Common.Configuration Configuration { get; }
+        public static FluentAssertions.Common.IConfigurationStore ConfigurationStore { get; set; }
+        public static FluentAssertions.Common.IReflector Reflector { get; set; }
+        public static System.Action<string> ThrowException { get; set; }
+        public static void ResetToDefaults() { }
+    }
+    public static class TypeExtensions
+    {
+        public static System.Reflection.FieldInfo FindField(this System.Type type, string fieldName, System.Type preferredType) { }
+        public static FluentAssertions.Equivalency.SelectedMemberInfo FindMember(this System.Type type, string memberName, System.Type preferredType) { }
+        public static System.Reflection.PropertyInfo FindProperty(this System.Type type, string propertyName, System.Type preferredType) { }
+        public static System.Reflection.ConstructorInfo GetConstructor(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.PropertyInfo GetIndexerByParameterTypes(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Reflection.MethodInfo GetMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> GetNonPrivateFields(this System.Type typeToReflect) { }
+        public static System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetNonPrivateMembers(this System.Type typeToReflect) { }
+        public static System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> GetNonPrivateProperties(this System.Type typeToReflect, System.Collections.Generic.IEnumerable<string> filter = null) { }
+        public static System.Reflection.MethodInfo GetParameterlessMethod(this System.Type type, string methodName) { }
+        public static System.Reflection.PropertyInfo GetPropertyByName(this System.Type type, string propertyName) { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWithOrInherits> instead.")]
+        public static bool HasAttribute<TAttribute>(this System.Reflection.MemberInfo method)
+            where TAttribute : System.Attribute { }
+        public static bool HasExplicitlyImplementedProperty(this System.Type type, System.Type interfaceType, string propertyName) { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWith> instead.")]
+        public static bool HasMatchingAttribute<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
+        public static bool HasMatchingAttribute<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, bool inherit = false)
+            where TAttribute : System.Attribute { }
+        public static bool HasMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static bool HasParameterlessMethod(this System.Type type, string methodName) { }
+        public static bool HasValueSemantics(this System.Type type) { }
+        public static bool Implements(this System.Type type, System.Type expectedBaseType) { }
+        public static bool IsCSharpAbstract(this System.Type type) { }
+        public static bool IsCSharpSealed(this System.Type type) { }
+        public static bool IsCSharpStatic(this System.Type type) { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        [System.Obsolete("This overload is deprecated and will be removed on the next major version. Please" +
+            " use <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type, bool inherit = false)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsEquivalentTo(this FluentAssertions.Equivalency.SelectedMemberInfo property, FluentAssertions.Equivalency.SelectedMemberInfo otherProperty) { }
+        public static bool IsIndexer(this System.Reflection.PropertyInfo member) { }
+        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
+        public static bool OverridesEquals(this System.Type type) { }
+    }
+    public enum ValueFormatterDetectionMode
+    {
+        Disabled = 0,
+        Specific = 1,
+        Scan = 2,
+    }
+}
+namespace FluentAssertions.Equivalency
+{
+    public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class ConversionSelector
+    {
+        public ConversionSelector() { }
+        public FluentAssertions.Equivalency.ConversionSelector Clone() { }
+        public void Exclude(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void Include(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void IncludeAll() { }
+        public bool RequiresConversion(FluentAssertions.Equivalency.IMemberInfo info) { }
+        public override string ToString() { }
+    }
+    public enum CyclicReferenceHandling
+    {
+        Ignore = 0,
+        ThrowException = 1,
+    }
+    public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DictionaryEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public virtual bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class EnumEqualityStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumEqualityStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public enum EnumEquivalencyHandling
+    {
+        ByValue = 0,
+        ByName = 1,
+    }
+    public class EnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumerableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public enum EqualityStrategy
+    {
+        Equals = 0,
+        Members = 1,
+        ForceEquals = 2,
+        ForceMembers = 3,
+    }
+    public class EquivalencyAssertionOptions : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions>
+    {
+        public EquivalencyAssertionOptions() { }
+    }
+    [System.Obsolete("This class is deprecated and will be removed in version 6.X.")]
+    public static class EquivalencyAssertionOptionsExtentions
+    {
+        public static System.Type GetExpectationType(this FluentAssertions.Equivalency.IEquivalencyAssertionOptions config, FluentAssertions.Equivalency.IMemberInfo context) { }
+    }
+    public class EquivalencyAssertionOptions<TExpectation> : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>>
+    {
+        public EquivalencyAssertionOptions() { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+    }
+    public class EquivalencyValidationContext : FluentAssertions.Equivalency.IEquivalencyValidationContext, FluentAssertions.Equivalency.IMemberInfo
+    {
+        public EquivalencyValidationContext() { }
+        public string Because { get; set; }
+        public object[] BecauseArgs { get; set; }
+        public System.Type CompileTimeType { get; set; }
+        public object Expectation { get; set; }
+        public bool IsRoot { get; }
+        public bool RootIsCollection { get; set; }
+        public System.Type RuntimeType { get; }
+        public string SelectedMemberDescription { get; set; }
+        public FluentAssertions.Equivalency.SelectedMemberInfo SelectedMemberInfo { get; set; }
+        public string SelectedMemberPath { get; set; }
+        public object Subject { get; set; }
+        public FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
+        public override string ToString() { }
+        public System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getTraceMessage) { }
+        public void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getTraceMessage) { }
+    }
+    public class EquivalencyValidator : FluentAssertions.Equivalency.IEquivalencyValidator
+    {
+        public EquivalencyValidator(FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public void AssertEquality(FluentAssertions.Equivalency.EquivalencyValidationContext context) { }
+        public void AssertEqualityUsing(FluentAssertions.Equivalency.IEquivalencyValidationContext context) { }
+    }
+    public class GenericDictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericDictionaryEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class GenericEnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericEnumerableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public delegate string GetTraceMessage(string path);
+    public interface IAssertionContext<TSubject>
+    {
+        string Because { get; set; }
+        object[] BecauseArgs { get; set; }
+        TSubject Expectation { get; }
+        TSubject Subject { get; }
+        FluentAssertions.Equivalency.SelectedMemberInfo SubjectProperty { get; }
+    }
+    public interface IAssertionRule
+    {
+        bool AssertEquality(FluentAssertions.Equivalency.IEquivalencyValidationContext context);
+    }
+    public interface IEquivalencyAssertionOptions
+    {
+        bool AllowInfiniteRecursion { get; }
+        FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
+        FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool IncludeFields { get; }
+        bool IncludeProperties { get; }
+        bool IsRecursive { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberMatchingRule> MatchingRules { get; }
+        FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
+        FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
+        bool UseRuntimeTyping { get; }
+        FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> GetUserEquivalencySteps(FluentAssertions.Equivalency.ConversionSelector conversionSelector);
+    }
+    public interface IEquivalencyStep
+    {
+        bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+        bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IEquivalencyValidationContext : FluentAssertions.Equivalency.IMemberInfo
+    {
+        string Because { get; }
+        object[] BecauseArgs { get; }
+        object Expectation { get; }
+        bool IsRoot { get; }
+        bool RootIsCollection { get; set; }
+        object Subject { get; }
+        FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
+        System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getMessage);
+        void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getMessage);
+    }
+    public interface IEquivalencyValidator
+    {
+        void AssertEqualityUsing(FluentAssertions.Equivalency.IEquivalencyValidationContext context);
+    }
+    public interface IMemberInfo
+    {
+        System.Type CompileTimeType { get; }
+        System.Type RuntimeType { get; }
+        string SelectedMemberDescription { get; }
+        FluentAssertions.Equivalency.SelectedMemberInfo SelectedMemberInfo { get; }
+        string SelectedMemberPath { get; }
+    }
+    public interface IMemberMatchingRule
+    {
+        FluentAssertions.Equivalency.SelectedMemberInfo Match(FluentAssertions.Equivalency.SelectedMemberInfo expectedMember, object subject, string memberPath, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IMemberSelectionRule
+    {
+        bool IncludesMembers { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> SelectMembers(System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> selectedMembers, FluentAssertions.Equivalency.IMemberInfo context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IOrderingRule
+    {
+        FluentAssertions.Equivalency.OrderStrictness Evaluate(FluentAssertions.Equivalency.IMemberInfo memberInfo);
+    }
+    public interface ITraceWriter
+    {
+        System.IDisposable AddBlock(string trace);
+        void AddSingle(string trace);
+        string ToString();
+    }
+    public enum OrderStrictness
+    {
+        Strict = 0,
+        NotStrict = 1,
+        Irrelevant = 2,
+    }
+    public class OrderingRuleCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule>, System.Collections.IEnumerable
+    {
+        public OrderingRuleCollection() { }
+        public OrderingRuleCollection(System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule> orderingRules) { }
+        public void Add(FluentAssertions.Equivalency.IOrderingRule rule) { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IOrderingRule> GetEnumerator() { }
+        public bool IsOrderingStrictFor(FluentAssertions.Equivalency.IMemberInfo memberInfo) { }
+    }
+    public class ReferenceEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ReferenceEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public virtual bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class RunAllUserStepsEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public RunAllUserStepsEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public abstract class SelectedMemberInfo
+    {
+        protected SelectedMemberInfo() { }
+        public abstract System.Type DeclaringType { get; }
+        public abstract System.Type MemberType { get; }
+        public abstract string Name { get; }
+        public abstract object GetValue(object obj, object[] index);
+        public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.FieldInfo fieldInfo) { }
+        public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.PropertyInfo propertyInfo) { }
+    }
+    public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
+        where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
+    {
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        protected readonly FluentAssertions.Equivalency.OrderingRuleCollection orderingRules;
+        protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
+        public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        public FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
+        protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public TSelf AllowingInfiniteRecursion() { }
+        public TSelf ComparingByMembers<T>() { }
+        public TSelf ComparingByValue<T>() { }
+        public TSelf ComparingEnumsByName() { }
+        public TSelf ComparingEnumsByValue() { }
+        public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf ExcludingFields() { }
+        public TSelf ExcludingMissingMembers() { }
+        public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingProperties() { }
+        public TSelf IgnoringCyclicReferences() { }
+        public TSelf IncludingAllDeclaredProperties() { }
+        public TSelf IncludingAllRuntimeProperties() { }
+        public TSelf IncludingFields() { }
+        public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingProperties() { }
+        protected void RemoveSelectionRule<T>()
+            where T : FluentAssertions.Equivalency.IMemberSelectionRule { }
+        public TSelf RespectingDeclaredTypes() { }
+        public TSelf RespectingRuntimeTypes() { }
+        public TSelf ThrowingOnMissingMembers() { }
+        public override string ToString() { }
+        public TSelf Using(FluentAssertions.Equivalency.IAssertionRule assertionRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IEquivalencyStep equivalencyStep) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
+        public TSelf WithAutoConversion() { }
+        public TSelf WithAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf WithStrictOrdering() { }
+        public TSelf WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf WithTracing(FluentAssertions.Equivalency.ITraceWriter writer = null) { }
+        public TSelf WithoutAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void WithoutMatchingRules() { }
+        public void WithoutSelectionRules() { }
+        public TSelf WithoutStrictOrdering() { }
+        public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public class Restriction<TMember>
+        {
+            public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
+            public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+            public TSelf WhenTypeIs<TMemberType>() { }
+        }
+    }
+    public class SimpleEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public SimpleEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class StringBuilderTraceWriter : FluentAssertions.Equivalency.ITraceWriter
+    {
+        public StringBuilderTraceWriter() { }
+        public System.IDisposable AddBlock(string trace) { }
+        public void AddSingle(string trace) { }
+        public override string ToString() { }
+    }
+    public class StringEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StringEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class StructuralEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StructuralEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public static class SubjectInfoExtensions
+    {
+        public static bool WhichGetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichGetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+    }
+    public class TryConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public TryConversionStep(FluentAssertions.Equivalency.ConversionSelector selector) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ValueTypeEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+}
+namespace FluentAssertions.Events
+{
+    public class EventAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<T, FluentAssertions.Events.EventAssertions<T>>
+    {
+        protected EventAssertions(FluentAssertions.Events.IMonitor<T> monitor) { }
+        protected override string Identifier { get; }
+        public void NotRaise(string eventName, string because = "", params object[] becauseArgs) { }
+        public void NotRaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecorder Raise(string eventName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecorder RaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
+    }
+    public class EventMetadata
+    {
+        public EventMetadata(string eventName, System.Type handlerType) { }
+        public string EventName { get; }
+        public System.Type HandlerType { get; }
+    }
+    public class EventRecorder : FluentAssertions.Events.IEventRecorder, System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
+    {
+        public EventRecorder(object eventRaiser, string eventName, System.Func<System.DateTime> utcNow) { }
+        public System.Type EventHandlerType { get; }
+        public string EventName { get; }
+        public object EventObject { get; }
+        public void Attach(System.WeakReference subject, System.Reflection.EventInfo eventInfo) { }
+        public void Dispose() { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Events.RecordedEvent> GetEnumerator() { }
+        public void RecordEvent(params object[] parameters) { }
+        public void Reset() { }
+    }
+    public interface IEventRecorder : System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
+    {
+        System.Type EventHandlerType { get; }
+        string EventName { get; }
+        object EventObject { get; }
+        void RecordEvent(params object[] parameters);
+        void Reset();
+    }
+    public interface IMonitor<T> : System.IDisposable
+    {
+        FluentAssertions.Events.EventMetadata[] MonitoredEvents { get; }
+        FluentAssertions.Events.OccurredEvent[] OccurredEvents { get; }
+        T Subject { get; }
+        void Clear();
+        FluentAssertions.Events.IEventRecorder GetEventRecorder(string eventName);
+        FluentAssertions.Events.EventAssertions<T> Should();
+    }
+    public class OccurredEvent
+    {
+        public OccurredEvent() { }
+        public string EventName { get; set; }
+        public object[] Parameters { get; set; }
+        public System.DateTime TimestampUtc { get; set; }
+    }
+    public class RecordedEvent
+    {
+        public RecordedEvent(System.DateTime utcNow, object monitoredObject, params object[] parameters) { }
+        public System.Collections.Generic.IEnumerable<object> Parameters { get; }
+        public System.DateTime TimestampUtc { get; set; }
+    }
+}
+namespace FluentAssertions.Execution
+{
+    public class AssertionFailedException : System.Exception
+    {
+        public AssertionFailedException(string message) { }
+        protected AssertionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public class AssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public AssertionScope() { }
+        public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
+        public AssertionScope(string context) { }
+        public string Context { get; set; }
+        public bool Succeeded { get; }
+        public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
+        public static FluentAssertions.Execution.AssertionScope Current { get; }
+        public void AddNonReportable(string key, object value) { }
+        public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, string value) { }
+        public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
+        public T Get<T>(string key) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public bool HasFailures() { }
+        public FluentAssertions.Execution.AssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.AssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public class Continuation
+    {
+        public Continuation(FluentAssertions.Execution.AssertionScope sourceScope, bool sourceSucceeded) { }
+        public bool SourceSucceeded { get; }
+        public FluentAssertions.Execution.IAssertionScope Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.Continuation continuation) { }
+    }
+    public class ContinuationOfGiven<TSubject>
+    {
+        public ContinuationOfGiven(FluentAssertions.Execution.GivenSelector<TSubject> parent, bool succeeded) { }
+        public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
+    }
+    public class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public ContinuedAssertionScope(FluentAssertions.Execution.AssertionScope predecessor, bool predecessorSucceeded) { }
+        public bool Succeeded { get; }
+        public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.IAssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public static class Execute
+    {
+        public static FluentAssertions.Execution.AssertionScope Assertion { get; }
+    }
+    public class FailReason
+    {
+        public FailReason(string message, params object[] args) { }
+        public object[] Args { get; }
+        public string Message { get; }
+    }
+    public class GivenSelector<T>
+    {
+        public GivenSelector(System.Func<T> selector, bool predecessorSucceeded, FluentAssertions.Execution.AssertionScope predecessor) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> ClearExpectation() { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<, >[] args) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
+        public FluentAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
+    }
+    public interface IAssertionScope : System.IDisposable
+    {
+        bool Succeeded { get; }
+        FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
+        FluentAssertions.Execution.Continuation ClearExpectation();
+        string[] Discard();
+        FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc);
+        FluentAssertions.Execution.Continuation FailWith(string message, params object[] args);
+        FluentAssertions.Execution.IAssertionScope ForCondition(bool condition);
+        FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector);
+        FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier);
+        FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args);
+    }
+    public interface IAssertionStrategy
+    {
+        System.Collections.Generic.IEnumerable<string> FailureMessages { get; }
+        System.Collections.Generic.IEnumerable<string> DiscardFailures();
+        void HandleFailure(string message);
+        void ThrowIfAny(System.Collections.Generic.IDictionary<string, object> context);
+    }
+    public interface ICloneable2
+    {
+        object Clone();
+    }
+}
+namespace FluentAssertions.Extensions
+{
+    public static class FluentDateTimeExtensions
+    {
+        public static System.DateTime AddMicroseconds(this System.DateTime self, long microseconds) { }
+        public static System.DateTimeOffset AddMicroseconds(this System.DateTimeOffset self, long microseconds) { }
+        public static System.DateTime AddNanoseconds(this System.DateTime self, long nanoseconds) { }
+        public static System.DateTimeOffset AddNanoseconds(this System.DateTimeOffset self, long nanoseconds) { }
+        public static System.DateTime After(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime April(this int day, int year) { }
+        public static System.DateTime AsLocal(this System.DateTime dateTime) { }
+        public static System.DateTime AsUtc(this System.DateTime dateTime) { }
+        public static System.DateTime At(this System.DateTime date, System.TimeSpan time) { }
+        public static System.DateTime At(this System.DateTime date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTimeOffset At(this System.DateTimeOffset date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTime August(this int day, int year) { }
+        public static System.DateTime Before(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime December(this int day, int year) { }
+        public static System.DateTime February(this int day, int year) { }
+        public static System.DateTime January(this int day, int year) { }
+        public static System.DateTime July(this int day, int year) { }
+        public static System.DateTime June(this int day, int year) { }
+        public static System.DateTime March(this int day, int year) { }
+        public static System.DateTime May(this int day, int year) { }
+        public static int Microsecond(this System.DateTime self) { }
+        public static int Microsecond(this System.DateTimeOffset self) { }
+        public static int Nanosecond(this System.DateTime self) { }
+        public static int Nanosecond(this System.DateTimeOffset self) { }
+        public static System.DateTime November(this int day, int year) { }
+        public static System.DateTime October(this int day, int year) { }
+        public static System.DateTime September(this int day, int year) { }
+    }
+    public static class FluentTimeSpanExtensions
+    {
+        public const long TicksPerMicrosecond = 10;
+        public const double TicksPerNanosecond = 0.01D;
+        public static System.TimeSpan And(this System.TimeSpan sourceTime, System.TimeSpan offset) { }
+        public static System.TimeSpan Days(this double days) { }
+        public static System.TimeSpan Days(this int days) { }
+        public static System.TimeSpan Days(this int days, System.TimeSpan offset) { }
+        public static System.TimeSpan Hours(this double hours) { }
+        public static System.TimeSpan Hours(this int hours) { }
+        public static System.TimeSpan Hours(this int hours, System.TimeSpan offset) { }
+        public static int Microseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Microseconds(this int microseconds) { }
+        public static System.TimeSpan Microseconds(this long microseconds) { }
+        public static System.TimeSpan Milliseconds(this double milliseconds) { }
+        public static System.TimeSpan Milliseconds(this int milliseconds) { }
+        public static System.TimeSpan Minutes(this double minutes) { }
+        public static System.TimeSpan Minutes(this int minutes) { }
+        public static System.TimeSpan Minutes(this int minutes, System.TimeSpan offset) { }
+        public static int Nanoseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Nanoseconds(this int nanoseconds) { }
+        public static System.TimeSpan Nanoseconds(this long nanoseconds) { }
+        public static System.TimeSpan Seconds(this double seconds) { }
+        public static System.TimeSpan Seconds(this int seconds) { }
+        public static System.TimeSpan Seconds(this int seconds, System.TimeSpan offset) { }
+        public static System.TimeSpan Ticks(this int ticks) { }
+        public static System.TimeSpan Ticks(this long ticks) { }
+        public static double TotalMicroseconds(this System.TimeSpan self) { }
+        public static double TotalNanoseconds(this System.TimeSpan self) { }
+    }
+}
+namespace FluentAssertions.Formatting
+{
+    public class AggregateExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AggregateExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class AttributeBasedFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AttributeBasedFormatter() { }
+        public System.Reflection.MethodInfo[] Formatters { get; }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DateTimeOffsetValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DateTimeOffsetValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DecimalValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DecimalValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DefaultValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DoubleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public EnumerableValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExpressionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public delegate string FormatChild(string childPath, object value);
+    public static class Formatter
+    {
+        public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
+        public static void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static string ToString(object value, bool useLineBreaks = false) { }
+    }
+    public class FormattingContext
+    {
+        public FormattingContext() { }
+        public int Depth { get; set; }
+        public bool UseLineBreaks { get; set; }
+    }
+    public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public GuidValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public interface IValueFormatter
+    {
+        bool CanHandle(object value);
+        string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
+    }
+    public class Int16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class MultidimensionalArrayFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public MultidimensionalArrayFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class NullValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public NullValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class PropertyInfoFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public PropertyInfoFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SingleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SingleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class StringValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public StringValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TaskFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TaskFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TimeSpanValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TimeSpanValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
+    public class ValueFormatterAttribute : System.Attribute
+    {
+        public ValueFormatterAttribute() { }
+    }
+    public class XAttributeValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XAttributeValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XDocumentValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XDocumentValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XElementValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XElementValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+}
+namespace FluentAssertions.Numeric
+{
+    public class ComparableTypeAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    {
+        public ComparableTypeAssertions(System.IComparable<T> value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
+        where T :  struct
+    {
+        public NullableNumericAssertions(T? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NumericAssertions<T>
+        where T :  struct
+    {
+        public NumericAssertions(object value) { }
+        public System.IComparable Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(params T[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Primitives
+{
+    public class BooleanAssertions
+    {
+        public BooleanAssertions(bool? value) { }
+        public bool? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeAssertions
+    {
+        public DateTimeAssertions(System.DateTime? value) { }
+        public System.DateTime? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.DateTime[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetAssertions
+    {
+        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
+        public System.DateTimeOffset? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetRangeAssertions
+    {
+        protected DateTimeOffsetRangeAssertions(FluentAssertions.Primitives.DateTimeOffsetAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeRangeAssertions
+    {
+        protected DateTimeRangeAssertions(FluentAssertions.Primitives.DateTimeAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
+    }
+    public class GuidAssertions
+    {
+        public GuidAssertions(System.Guid? value) { }
+        public System.Guid? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableBooleanAssertions : FluentAssertions.Primitives.BooleanAssertions
+    {
+        public NullableBooleanAssertions(bool? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions
+    {
+        public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions
+    {
+        public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableGuidAssertions : FluentAssertions.Primitives.GuidAssertions
+    {
+        public NullableGuidAssertions(System.Guid? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions
+    {
+        public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class ObjectAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
+    {
+        public ObjectAssertions(object value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be(object expected, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> HaveFlag(System.Enum expectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe(object unexpected, string because = "", params object[] becauseArgs) { }
+        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotHaveFlag(System.Enum unexpectedFlag, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
+        where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+    {
+        protected ReferenceTypeAssertions() { }
+        protected ReferenceTypeAssertions(TSubject subject) { }
+        protected abstract string Identifier { get; }
+        public TSubject Subject { get; set; }
+        public FluentAssertions.AndConstraint<TAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameAs(TSubject expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<TSubject, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match<T>(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
+            where T : TSubject { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SimpleTimeSpanAssertions
+    {
+        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public System.TimeSpan? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+    }
+    public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>
+    {
+        public StringAssertions(string value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(params string[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+    }
+    public enum TimeSpanCondition
+    {
+        MoreThan = 0,
+        AtLeast = 1,
+        Exactly = 2,
+        Within = 3,
+        LessThan = 4,
+    }
+}
+namespace FluentAssertions.Reflection
+{
+    public class AssemblyAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Reflection.Assembly, FluentAssertions.Reflection.AssemblyAssertions>
+    {
+        public AssemblyAssertions(System.Reflection.Assembly assembly) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Reflection.AssemblyAssertions, System.Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs) { }
+        public void NotReference(System.Reflection.Assembly assembly) { }
+        public void NotReference(System.Reflection.Assembly assembly, string because, params string[] becauseArgs) { }
+        public void Reference(System.Reflection.Assembly assembly) { }
+        public void Reference(System.Reflection.Assembly assembly, string because, params string[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Specialized
+{
+    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action>
+    {
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Action Subject { get; }
+        protected override void InvokeSubject() { }
+    }
+    public class AsyncFunctionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Func<System.Threading.Tasks.Task>>
+    {
+        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Func<System.Threading.Tasks.Task> Subject { get; }
+        protected override void InvokeSubject() { }
+        public System.Threading.Tasks.Task NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public abstract class DelegateAssertions<TDelegate> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Delegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate>>
+        where TDelegate : System.Delegate
+    {
+        protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public new TDelegate Subject { get; }
+        protected abstract void InvokeSubject();
+        public void NotThrow(string because = "", params object[] becauseArgs) { }
+        protected void NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        protected void NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+        public void NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public class ExceptionAssertions<TException> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IEnumerable<TException>, FluentAssertions.Specialized.ExceptionAssertions<TException>>
+        where TException : System.Exception
+    {
+        public ExceptionAssertions(System.Collections.Generic.IEnumerable<TException> exceptions) { }
+        public TException And { get; }
+        protected override string Identifier { get; }
+        public TException Which { get; }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Where(System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, string because = "", params object[] becauseArgs) { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerException<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerExceptionExactly<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TException> WithMessage(string expectedWildcardPattern, string because = "", params object[] becauseArgs) { }
+    }
+    public class ExecutionTime
+    {
+        public ExecutionTime(System.Action action) { }
+        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action) { }
+        protected ExecutionTime(System.Action action, string actionDescription) { }
+        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription) { }
+    }
+    public class ExecutionTimeAssertions
+    {
+        public ExecutionTimeAssertions(FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        public void BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public void BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public void BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public void BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public void BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+    }
+    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
+    {
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Func<T> Subject { get; }
+        protected override void InvokeSubject() { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions
+    {
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+    public interface IExtractExceptions
+    {
+        System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception;
+    }
+    public class MemberExecutionTime<T> : FluentAssertions.Specialized.ExecutionTime
+    {
+        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+    }
+    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions
+    {
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Types
+{
+    public static class AllTypes
+    {
+        public static FluentAssertions.Types.TypeSelector From(System.Reflection.Assembly assembly) { }
+    }
+    public class ConstructorInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.ConstructorInfo, FluentAssertions.Types.ConstructorInfoAssertions>
+    {
+        public ConstructorInfoAssertions(System.Reflection.ConstructorInfo constructorInfo) { }
+        protected override string Identifier { get; }
+    }
+    public abstract class MemberInfoAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MemberInfo
+        where TAssertions : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+    {
+        protected MemberInfoAssertions() { }
+        protected MemberInfoAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+    }
+    public abstract class MethodBaseAssertions<TSubject, TAssertions> : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MethodBase
+        where TAssertions : FluentAssertions.Types.MethodBaseAssertions<TSubject, TAssertions>
+    {
+        protected MethodBaseAssertions() { }
+        protected MethodBaseAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>
+    {
+        public MethodInfoAssertions() { }
+        public MethodInfoAssertions(System.Reflection.MethodInfo methodInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturnVoid(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> ReturnVoid(string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, System.Collections.IEnumerable
+    {
+        public MethodInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public MethodInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.MethodInfoSelector ThatArePublicOrInternal { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturnVoid { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
+        public System.Reflection.MethodInfo[] ToArray() { }
+    }
+    public class MethodInfoSelectorAssertions
+    {
+        public MethodInfoSelectorAssertions(params System.Reflection.MethodInfo[] methods) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> SubjectMethods { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoAssertions : FluentAssertions.Types.MemberInfoAssertions<System.Reflection.PropertyInfo, FluentAssertions.Types.PropertyInfoAssertions>
+    {
+        public PropertyInfoAssertions(System.Reflection.PropertyInfo propertyInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo>, System.Collections.IEnumerable
+    {
+        public PropertyInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public PropertyInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatArePublicOrInternal { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.PropertyInfo> GetEnumerator() { }
+        public FluentAssertions.Types.PropertyInfoSelector NotOfType<TReturn>() { }
+        public FluentAssertions.Types.PropertyInfoSelector OfType<TReturn>() { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public System.Reflection.PropertyInfo[] ToArray() { }
+    }
+    public class PropertyInfoSelectorAssertions
+    {
+        public PropertyInfoSelectorAssertions(params System.Reflection.PropertyInfo[] properties) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> SubjectProperties { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public class TypeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Type, FluentAssertions.Types.TypeAssertions>
+    {
+        public TypeAssertions(System.Type type) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be(System.Type expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be<TExpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<System.Type> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveExplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveExplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveImplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveImplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveIndexer(System.Type indexerType, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty(System.Type propertyType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty<TProperty>(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe(System.Type unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe<TUnexpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<System.Type> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveExplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveExplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveImplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveImplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveIndexer(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveProperty(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+    }
+    public class TypeSelector : System.Collections.Generic.IEnumerable<System.Type>, System.Collections.IEnumerable
+    {
+        public TypeSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public TypeSelector(System.Type type) { }
+        public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
+        public System.Type[] ToArray() { }
+    }
+    public class TypeSelectorAssertions
+    {
+        public TypeSelectorAssertions(params System.Type[] types) { }
+        public System.Collections.Generic.IEnumerable<System.Type> Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+    }
+}
+namespace FluentAssertions.Xml
+{
+    public class XAttributeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XAttribute, FluentAssertions.Xml.XAttributeAssertions>
+    {
+        public XAttributeAssertions(System.Xml.Linq.XAttribute attribute) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> Be(System.Xml.Linq.XAttribute expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> Be(System.Xml.Linq.XAttribute expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> HaveValue(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> HaveValue(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> NotBe(System.Xml.Linq.XAttribute unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> NotBe(System.Xml.Linq.XAttribute unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XDocumentAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XDocument, FluentAssertions.Xml.XDocumentAssertions>
+    {
+        public XDocumentAssertions(System.Xml.Linq.XDocument document) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> Be(System.Xml.Linq.XDocument expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> Be(System.Xml.Linq.XDocument expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> BeEquivalentTo(System.Xml.Linq.XDocument expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> BeEquivalentTo(System.Xml.Linq.XDocument expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBe(System.Xml.Linq.XDocument unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBe(System.Xml.Linq.XDocument unexpected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBeEquivalentTo(System.Xml.Linq.XDocument unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBeEquivalentTo(System.Xml.Linq.XDocument unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XElementAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XElement, FluentAssertions.Xml.XElementAssertions>
+    {
+        public XElementAssertions(System.Xml.Linq.XElement xElement) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> Be(System.Xml.Linq.XElement expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> Be(System.Xml.Linq.XElement expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveValue(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveValue(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBe(System.Xml.Linq.XElement unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBe(System.Xml.Linq.XElement unexpected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBeEquivalentTo(System.Xml.Linq.XElement unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBeEquivalentTo(System.Xml.Linq.XElement unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XmlElementAssertions : FluentAssertions.Xml.XmlNodeAssertions<System.Xml.XmlElement, FluentAssertions.Xml.XmlElementAssertions>
+    {
+        public XmlElementAssertions(System.Xml.XmlElement xmlElement) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttribute(string expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttributeWithNamespace(string expectedName, string expectedNamespace, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttributeWithNamespace(string expectedName, string expectedNamespace, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElement(string expectedName) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElement(string expectedName, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElementWithNamespace(string expectedName, string expectedNamespace) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElementWithNamespace(string expectedName, string expectedNamespace, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveInnerText(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveInnerText(string expected, string because, params object[] becauseArgs) { }
+    }
+    public class XmlNodeAssertions : FluentAssertions.Xml.XmlNodeAssertions<System.Xml.XmlNode, FluentAssertions.Xml.XmlNodeAssertions>
+    {
+        public XmlNodeAssertions(System.Xml.XmlNode xmlNode) { }
+    }
+    public class XmlNodeAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Xml.XmlNode
+        where TAssertions : FluentAssertions.Xml.XmlNodeAssertions<TSubject, TAssertions>
+    {
+        public XmlNodeAssertions(TSubject xmlNode) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Xml.XmlNode expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Xml.XmlNode expected, string because, params object[] reasonArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Xml.XmlNode unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Xml.XmlNode unexpected, string because, params object[] reasonArgs) { }
+    }
+    public class XmlNodeFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XmlNodeFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+}

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.0.approved.txt
@@ -1341,8 +1341,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
         where T :  struct

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -1342,8 +1342,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
         where T :  struct

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -1,0 +1,2157 @@
+﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v2.1", FrameworkDisplayName="")]
+namespace FluentAssertions
+{
+    public class AggregateExceptionExtractor : FluentAssertions.Specialized.IExtractExceptions
+    {
+        public AggregateExceptionExtractor() { }
+        public System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception { }
+    }
+    public class AndConstraint<T>
+    {
+        public AndConstraint(T parentConstraint) { }
+        public T And { get; }
+    }
+    public class AndWhichConstraint<TParentConstraint, TMatchedElement> : FluentAssertions.AndConstraint<TParentConstraint>
+    {
+        public AndWhichConstraint(TParentConstraint parentConstraint, System.Collections.Generic.IEnumerable<TMatchedElement> matchedConstraint) { }
+        public AndWhichConstraint(TParentConstraint parentConstraint, TMatchedElement matchedConstraint) { }
+        public TMatchedElement Subject { get; }
+        public TMatchedElement Which { get; }
+    }
+    public static class AssertionExtensions
+    {
+        public static TTo As<TTo>(this object subject) { }
+        public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask> action) { }
+        public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.Task<TResult>> action) { }
+        public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask<TResult>> action) { }
+        public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+        public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
+        public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
+        public static FluentAssertions.Events.IMonitor<T> Monitor<T>(this T eventSource, System.Func<System.DateTime> utcNow = null) { }
+        public static FluentAssertions.Specialized.ExecutionTimeAssertions Should(this FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        public static FluentAssertions.Types.MethodInfoSelectorAssertions Should(this FluentAssertions.Types.MethodInfoSelector methodSelector) { }
+        public static FluentAssertions.Types.PropertyInfoSelectorAssertions Should(this FluentAssertions.Types.PropertyInfoSelector propertyInfoSelector) { }
+        public static FluentAssertions.Types.TypeSelectorAssertions Should(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
+        public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
+        public static FluentAssertions.Collections.NonGenericCollectionAssertions Should(this System.Collections.IEnumerable actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
+        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
+        public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
+        public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
+        public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
+        public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
+        public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
+        public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
+        public static FluentAssertions.Xml.XAttributeAssertions Should(this System.Xml.Linq.XAttribute actualValue) { }
+        public static FluentAssertions.Xml.XDocumentAssertions Should(this System.Xml.Linq.XDocument actualValue) { }
+        public static FluentAssertions.Xml.XElementAssertions Should(this System.Xml.Linq.XElement actualValue) { }
+        public static FluentAssertions.Primitives.BooleanAssertions Should(this bool actualValue) { }
+        public static FluentAssertions.Primitives.NullableBooleanAssertions Should(this bool? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<byte> Should(this byte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<byte> Should(this byte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<decimal> Should(this decimal actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<decimal> Should(this decimal? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<double> Should(this double actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<double> Should(this double? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<float> Should(this float actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<float> Should(this float? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<int> Should(this int actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<int> Should(this int? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<long> Should(this long actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<long> Should(this long? actualValue) { }
+        public static FluentAssertions.Primitives.ObjectAssertions Should(this object actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<sbyte> Should(this sbyte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<sbyte> Should(this sbyte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<short> Should(this short actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<short> Should(this short? actualValue) { }
+        public static FluentAssertions.Primitives.StringAssertions Should(this string actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<uint> Should(this uint actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<uint> Should(this uint? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ulong> Should(this ulong actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ulong> Should(this ulong? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ushort> Should(this ushort actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ushort> Should(this ushort? actualValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
+        public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public static class AssertionOptions
+    {
+        public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
+        public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
+        public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
+    }
+    public static class AtLeast
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class AtMost
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class CallerIdentifier
+    {
+        public static System.Action<string> logger;
+        public static string DetermineCallerIdentity() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
+    public class CustomAssertionAttribute : System.Attribute
+    {
+        public CustomAssertionAttribute() { }
+    }
+    public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
+    {
+        public EquivalencyStepCollection() { }
+        public void Add<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void AddAfter<TPredecessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Clear() { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IEquivalencyStep> GetEnumerator() { }
+        public void Insert<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void InsertBefore<TSuccessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Remove<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep { }
+        public void Reset() { }
+    }
+    public static class EventRaisingExtensions
+    {
+        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, params System.Linq.Expressions.Expression<>[] predicates) { }
+        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
+        public static FluentAssertions.Events.IEventRecorder WithSender(this FluentAssertions.Events.IEventRecorder eventRecorder, object expectedSender) { }
+    }
+    public static class Exactly
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class FluentActions
+    {
+        public static System.Func<System.Threading.Tasks.Task> Awaiting(System.Func<System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task<T>> Awaiting<T>(System.Func<System.Threading.Tasks.Task<T>> func) { }
+        public static System.Action Enumerating(System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static System.Action Invoking(System.Action action) { }
+        public static System.Func<T> Invoking<T>(System.Func<T> func) { }
+    }
+    public static class LessThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class MoreThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class NumericAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+    }
+    public static class ObjectAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeXmlSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class OccurrenceConstraint
+    {
+        protected OccurrenceConstraint(int expectedCount) { }
+    }
+    public static class TypeEnumerableExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreInNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreUnderNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatDeriveFrom<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatImplement<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+    }
+    public static class TypeExtensions
+    {
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this System.Type type) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this System.Type type) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Type type) { }
+    }
+    public static class XmlAssertionExtensions
+    {
+        public static FluentAssertions.Xml.XmlElementAssertions Should(this System.Xml.XmlElement actualValue) { }
+        public static FluentAssertions.Xml.XmlNodeAssertions Should(this System.Xml.XmlNode actualValue) { }
+    }
+}
+namespace FluentAssertions.Collections
+{
+    public abstract class CollectionAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Collections.IEnumerable
+        where TAssertions : FluentAssertions.Collections.CollectionAssertions<TSubject, TAssertions>
+    {
+        protected CollectionAssertions() { }
+        protected CollectionAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeOfType<T>(string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionEndsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actual, System.Collections.Generic.ICollection<TExpected> expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionEndsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actual, TExpected[] expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionStartsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actualItems, System.Collections.Generic.ICollection<TExpected> expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionStartsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actualItems, TExpected[] expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertSubjectEquality<TActual, TExpected>(System.Collections.IEnumerable expectation, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params object[] expectations) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.IEnumerable expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.IEnumerable expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.IEnumerable>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.IEnumerable>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSubsetOf(System.Collections.IEnumerable expectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params object[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainItemsAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(object element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params object[] elements) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, object> HaveElementAt(int index, object element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(object successor, object expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(object predecessor, object expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInAscendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAscendingInOrder(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInAscendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAscendingInOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInDescendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDescendingInOrder(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInDescendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDescendingInOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSubsetOf(System.Collections.IEnumerable unexpectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotIntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(object element, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
+    {
+        public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+            where TKey :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(params TKey[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(params TValue[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(params TKey[] unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(params TValue[] unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+    }
+    public class NonGenericCollectionAssertions : FluentAssertions.Collections.CollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
+    {
+        public NonGenericCollectionAssertions(System.Collections.IEnumerable collection) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
+    {
+        public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params T[] elements) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpectedItemsList, params T[] additionalUnexpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(params System.Action<>[] elementInspectors) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(System.Collections.Generic.IEnumerable<System.Action<T>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+    }
+    public class StringCollectionAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<string, FluentAssertions.Collections.StringCollectionAssertions>
+    {
+        public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(params string[] expectation) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(params string[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+    }
+    public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public WhichValueConstraint(FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> parentConstraint, TValue value) { }
+        public TValue WhichValue { get; }
+    }
+}
+namespace FluentAssertions.Common
+{
+    public enum CSharpAccessModifier
+    {
+        Public = 0,
+        Private = 1,
+        Protected = 2,
+        Internal = 3,
+        ProtectedInternal = 4,
+        InvalidForCSharp = 5,
+        PrivateProtected = 6,
+    }
+    public static class CSharpAccessModifierExtensions { }
+    public class Configuration
+    {
+        public Configuration(FluentAssertions.Common.IConfigurationStore store) { }
+        public string TestFrameworkName { get; set; }
+        public string ValueFormatterAssembly { get; set; }
+        public FluentAssertions.Common.ValueFormatterDetectionMode ValueFormatterDetectionMode { get; set; }
+        public static FluentAssertions.Common.Configuration Current { get; }
+    }
+    public static class DateTimeExtensions
+    {
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime) { }
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime, System.TimeSpan offset) { }
+    }
+    public interface IClock
+    {
+        void Delay(System.TimeSpan timeToDelay);
+        System.Threading.Tasks.Task DelayAsync(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken);
+        FluentAssertions.Common.ITimer StartTimer();
+        bool Wait(System.Threading.Tasks.Task task, System.TimeSpan timeout);
+    }
+    public interface IConfigurationStore
+    {
+        string GetSetting(string name);
+    }
+    public interface IReflector
+    {
+        System.Collections.Generic.IEnumerable<System.Type> GetAllTypesFromAppDomain(System.Func<System.Reflection.Assembly, bool> predicate);
+    }
+    public interface ITimer
+    {
+        System.TimeSpan Elapsed { get; }
+    }
+    public static class MethodInfoExtensions { }
+    public static class ObjectExtensions
+    {
+        public static bool IsSameOrEqualTo(this object actual, object expected) { }
+    }
+    public static class PropertyInfoExtensions { }
+    public static class Services
+    {
+        public static FluentAssertions.Common.Configuration Configuration { get; }
+        public static FluentAssertions.Common.IConfigurationStore ConfigurationStore { get; set; }
+        public static FluentAssertions.Common.IReflector Reflector { get; set; }
+        public static System.Action<string> ThrowException { get; set; }
+        public static void ResetToDefaults() { }
+    }
+    public static class TypeExtensions
+    {
+        public static System.Reflection.FieldInfo FindField(this System.Type type, string fieldName, System.Type preferredType) { }
+        public static FluentAssertions.Equivalency.SelectedMemberInfo FindMember(this System.Type type, string memberName, System.Type preferredType) { }
+        public static System.Reflection.PropertyInfo FindProperty(this System.Type type, string propertyName, System.Type preferredType) { }
+        public static System.Reflection.ConstructorInfo GetConstructor(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.PropertyInfo GetIndexerByParameterTypes(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Reflection.MethodInfo GetMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> GetNonPrivateFields(this System.Type typeToReflect) { }
+        public static System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetNonPrivateMembers(this System.Type typeToReflect) { }
+        public static System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> GetNonPrivateProperties(this System.Type typeToReflect, System.Collections.Generic.IEnumerable<string> filter = null) { }
+        public static System.Reflection.MethodInfo GetParameterlessMethod(this System.Type type, string methodName) { }
+        public static System.Reflection.PropertyInfo GetPropertyByName(this System.Type type, string propertyName) { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWithOrInherits> instead.")]
+        public static bool HasAttribute<TAttribute>(this System.Reflection.MemberInfo method)
+            where TAttribute : System.Attribute { }
+        public static bool HasExplicitlyImplementedProperty(this System.Type type, System.Type interfaceType, string propertyName) { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWith> instead.")]
+        public static bool HasMatchingAttribute<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
+        public static bool HasMatchingAttribute<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, bool inherit = false)
+            where TAttribute : System.Attribute { }
+        public static bool HasMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static bool HasParameterlessMethod(this System.Type type, string methodName) { }
+        public static bool HasValueSemantics(this System.Type type) { }
+        public static bool Implements(this System.Type type, System.Type expectedBaseType) { }
+        public static bool IsCSharpAbstract(this System.Type type) { }
+        public static bool IsCSharpSealed(this System.Type type) { }
+        public static bool IsCSharpStatic(this System.Type type) { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        [System.Obsolete("This overload is deprecated and will be removed on the next major version. Please" +
+            " use <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type, bool inherit = false)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsEquivalentTo(this FluentAssertions.Equivalency.SelectedMemberInfo property, FluentAssertions.Equivalency.SelectedMemberInfo otherProperty) { }
+        public static bool IsIndexer(this System.Reflection.PropertyInfo member) { }
+        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
+        public static bool OverridesEquals(this System.Type type) { }
+    }
+    public enum ValueFormatterDetectionMode
+    {
+        Disabled = 0,
+        Specific = 1,
+        Scan = 2,
+    }
+}
+namespace FluentAssertions.Equivalency
+{
+    public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class ConversionSelector
+    {
+        public ConversionSelector() { }
+        public FluentAssertions.Equivalency.ConversionSelector Clone() { }
+        public void Exclude(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void Include(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void IncludeAll() { }
+        public bool RequiresConversion(FluentAssertions.Equivalency.IMemberInfo info) { }
+        public override string ToString() { }
+    }
+    public enum CyclicReferenceHandling
+    {
+        Ignore = 0,
+        ThrowException = 1,
+    }
+    public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DictionaryEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public virtual bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class EnumEqualityStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumEqualityStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public enum EnumEquivalencyHandling
+    {
+        ByValue = 0,
+        ByName = 1,
+    }
+    public class EnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumerableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public enum EqualityStrategy
+    {
+        Equals = 0,
+        Members = 1,
+        ForceEquals = 2,
+        ForceMembers = 3,
+    }
+    public class EquivalencyAssertionOptions : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions>
+    {
+        public EquivalencyAssertionOptions() { }
+    }
+    [System.Obsolete("This class is deprecated and will be removed in version 6.X.")]
+    public static class EquivalencyAssertionOptionsExtentions
+    {
+        public static System.Type GetExpectationType(this FluentAssertions.Equivalency.IEquivalencyAssertionOptions config, FluentAssertions.Equivalency.IMemberInfo context) { }
+    }
+    public class EquivalencyAssertionOptions<TExpectation> : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>>
+    {
+        public EquivalencyAssertionOptions() { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+    }
+    public class EquivalencyValidationContext : FluentAssertions.Equivalency.IEquivalencyValidationContext, FluentAssertions.Equivalency.IMemberInfo
+    {
+        public EquivalencyValidationContext() { }
+        public string Because { get; set; }
+        public object[] BecauseArgs { get; set; }
+        public System.Type CompileTimeType { get; set; }
+        public object Expectation { get; set; }
+        public bool IsRoot { get; }
+        public bool RootIsCollection { get; set; }
+        public System.Type RuntimeType { get; }
+        public string SelectedMemberDescription { get; set; }
+        public FluentAssertions.Equivalency.SelectedMemberInfo SelectedMemberInfo { get; set; }
+        public string SelectedMemberPath { get; set; }
+        public object Subject { get; set; }
+        public FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
+        public override string ToString() { }
+        public System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getTraceMessage) { }
+        public void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getTraceMessage) { }
+    }
+    public class EquivalencyValidator : FluentAssertions.Equivalency.IEquivalencyValidator
+    {
+        public EquivalencyValidator(FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public void AssertEquality(FluentAssertions.Equivalency.EquivalencyValidationContext context) { }
+        public void AssertEqualityUsing(FluentAssertions.Equivalency.IEquivalencyValidationContext context) { }
+    }
+    public class GenericDictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericDictionaryEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class GenericEnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericEnumerableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public delegate string GetTraceMessage(string path);
+    public interface IAssertionContext<TSubject>
+    {
+        string Because { get; set; }
+        object[] BecauseArgs { get; set; }
+        TSubject Expectation { get; }
+        TSubject Subject { get; }
+        FluentAssertions.Equivalency.SelectedMemberInfo SubjectProperty { get; }
+    }
+    public interface IAssertionRule
+    {
+        bool AssertEquality(FluentAssertions.Equivalency.IEquivalencyValidationContext context);
+    }
+    public interface IEquivalencyAssertionOptions
+    {
+        bool AllowInfiniteRecursion { get; }
+        FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
+        FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool IncludeFields { get; }
+        bool IncludeProperties { get; }
+        bool IsRecursive { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberMatchingRule> MatchingRules { get; }
+        FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
+        FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
+        bool UseRuntimeTyping { get; }
+        FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> GetUserEquivalencySteps(FluentAssertions.Equivalency.ConversionSelector conversionSelector);
+    }
+    public interface IEquivalencyStep
+    {
+        bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+        bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IEquivalencyValidationContext : FluentAssertions.Equivalency.IMemberInfo
+    {
+        string Because { get; }
+        object[] BecauseArgs { get; }
+        object Expectation { get; }
+        bool IsRoot { get; }
+        bool RootIsCollection { get; set; }
+        object Subject { get; }
+        FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
+        System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getMessage);
+        void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getMessage);
+    }
+    public interface IEquivalencyValidator
+    {
+        void AssertEqualityUsing(FluentAssertions.Equivalency.IEquivalencyValidationContext context);
+    }
+    public interface IMemberInfo
+    {
+        System.Type CompileTimeType { get; }
+        System.Type RuntimeType { get; }
+        string SelectedMemberDescription { get; }
+        FluentAssertions.Equivalency.SelectedMemberInfo SelectedMemberInfo { get; }
+        string SelectedMemberPath { get; }
+    }
+    public interface IMemberMatchingRule
+    {
+        FluentAssertions.Equivalency.SelectedMemberInfo Match(FluentAssertions.Equivalency.SelectedMemberInfo expectedMember, object subject, string memberPath, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IMemberSelectionRule
+    {
+        bool IncludesMembers { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> SelectMembers(System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> selectedMembers, FluentAssertions.Equivalency.IMemberInfo context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IOrderingRule
+    {
+        FluentAssertions.Equivalency.OrderStrictness Evaluate(FluentAssertions.Equivalency.IMemberInfo memberInfo);
+    }
+    public interface ITraceWriter
+    {
+        System.IDisposable AddBlock(string trace);
+        void AddSingle(string trace);
+        string ToString();
+    }
+    public enum OrderStrictness
+    {
+        Strict = 0,
+        NotStrict = 1,
+        Irrelevant = 2,
+    }
+    public class OrderingRuleCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule>, System.Collections.IEnumerable
+    {
+        public OrderingRuleCollection() { }
+        public OrderingRuleCollection(System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule> orderingRules) { }
+        public void Add(FluentAssertions.Equivalency.IOrderingRule rule) { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IOrderingRule> GetEnumerator() { }
+        public bool IsOrderingStrictFor(FluentAssertions.Equivalency.IMemberInfo memberInfo) { }
+    }
+    public class ReferenceEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ReferenceEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public virtual bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class RunAllUserStepsEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public RunAllUserStepsEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public abstract class SelectedMemberInfo
+    {
+        protected SelectedMemberInfo() { }
+        public abstract System.Type DeclaringType { get; }
+        public abstract System.Type MemberType { get; }
+        public abstract string Name { get; }
+        public abstract object GetValue(object obj, object[] index);
+        public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.FieldInfo fieldInfo) { }
+        public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.PropertyInfo propertyInfo) { }
+    }
+    public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
+        where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
+    {
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        protected readonly FluentAssertions.Equivalency.OrderingRuleCollection orderingRules;
+        protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
+        public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        public FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
+        protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public TSelf AllowingInfiniteRecursion() { }
+        public TSelf ComparingByMembers<T>() { }
+        public TSelf ComparingByValue<T>() { }
+        public TSelf ComparingEnumsByName() { }
+        public TSelf ComparingEnumsByValue() { }
+        public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf ExcludingFields() { }
+        public TSelf ExcludingMissingMembers() { }
+        public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingProperties() { }
+        public TSelf IgnoringCyclicReferences() { }
+        public TSelf IncludingAllDeclaredProperties() { }
+        public TSelf IncludingAllRuntimeProperties() { }
+        public TSelf IncludingFields() { }
+        public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingProperties() { }
+        protected void RemoveSelectionRule<T>()
+            where T : FluentAssertions.Equivalency.IMemberSelectionRule { }
+        public TSelf RespectingDeclaredTypes() { }
+        public TSelf RespectingRuntimeTypes() { }
+        public TSelf ThrowingOnMissingMembers() { }
+        public override string ToString() { }
+        public TSelf Using(FluentAssertions.Equivalency.IAssertionRule assertionRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IEquivalencyStep equivalencyStep) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
+        public TSelf WithAutoConversion() { }
+        public TSelf WithAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf WithStrictOrdering() { }
+        public TSelf WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf WithTracing(FluentAssertions.Equivalency.ITraceWriter writer = null) { }
+        public TSelf WithoutAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void WithoutMatchingRules() { }
+        public void WithoutSelectionRules() { }
+        public TSelf WithoutStrictOrdering() { }
+        public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public class Restriction<TMember>
+        {
+            public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
+            public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+            public TSelf WhenTypeIs<TMemberType>() { }
+        }
+    }
+    public class SimpleEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public SimpleEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class StringBuilderTraceWriter : FluentAssertions.Equivalency.ITraceWriter
+    {
+        public StringBuilderTraceWriter() { }
+        public System.IDisposable AddBlock(string trace) { }
+        public void AddSingle(string trace) { }
+        public override string ToString() { }
+    }
+    public class StringEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StringEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class StructuralEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StructuralEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public static class SubjectInfoExtensions
+    {
+        public static bool WhichGetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichGetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+    }
+    public class TryConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public TryConversionStep(FluentAssertions.Equivalency.ConversionSelector selector) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ValueTypeEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+}
+namespace FluentAssertions.Events
+{
+    public class EventAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<T, FluentAssertions.Events.EventAssertions<T>>
+    {
+        protected EventAssertions(FluentAssertions.Events.IMonitor<T> monitor) { }
+        protected override string Identifier { get; }
+        public void NotRaise(string eventName, string because = "", params object[] becauseArgs) { }
+        public void NotRaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecorder Raise(string eventName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecorder RaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
+    }
+    public class EventMetadata
+    {
+        public EventMetadata(string eventName, System.Type handlerType) { }
+        public string EventName { get; }
+        public System.Type HandlerType { get; }
+    }
+    public class EventRecorder : FluentAssertions.Events.IEventRecorder, System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
+    {
+        public EventRecorder(object eventRaiser, string eventName, System.Func<System.DateTime> utcNow) { }
+        public System.Type EventHandlerType { get; }
+        public string EventName { get; }
+        public object EventObject { get; }
+        public void Attach(System.WeakReference subject, System.Reflection.EventInfo eventInfo) { }
+        public void Dispose() { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Events.RecordedEvent> GetEnumerator() { }
+        public void RecordEvent(params object[] parameters) { }
+        public void Reset() { }
+    }
+    public interface IEventRecorder : System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
+    {
+        System.Type EventHandlerType { get; }
+        string EventName { get; }
+        object EventObject { get; }
+        void RecordEvent(params object[] parameters);
+        void Reset();
+    }
+    public interface IMonitor<T> : System.IDisposable
+    {
+        FluentAssertions.Events.EventMetadata[] MonitoredEvents { get; }
+        FluentAssertions.Events.OccurredEvent[] OccurredEvents { get; }
+        T Subject { get; }
+        void Clear();
+        FluentAssertions.Events.IEventRecorder GetEventRecorder(string eventName);
+        FluentAssertions.Events.EventAssertions<T> Should();
+    }
+    public class OccurredEvent
+    {
+        public OccurredEvent() { }
+        public string EventName { get; set; }
+        public object[] Parameters { get; set; }
+        public System.DateTime TimestampUtc { get; set; }
+    }
+    public class RecordedEvent
+    {
+        public RecordedEvent(System.DateTime utcNow, object monitoredObject, params object[] parameters) { }
+        public System.Collections.Generic.IEnumerable<object> Parameters { get; }
+        public System.DateTime TimestampUtc { get; set; }
+    }
+}
+namespace FluentAssertions.Execution
+{
+    public class AssertionFailedException : System.Exception
+    {
+        public AssertionFailedException(string message) { }
+        protected AssertionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public class AssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public AssertionScope() { }
+        public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
+        public AssertionScope(string context) { }
+        public string Context { get; set; }
+        public bool Succeeded { get; }
+        public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
+        public static FluentAssertions.Execution.AssertionScope Current { get; }
+        public void AddNonReportable(string key, object value) { }
+        public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, string value) { }
+        public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
+        public T Get<T>(string key) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public bool HasFailures() { }
+        public FluentAssertions.Execution.AssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.AssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public class Continuation
+    {
+        public Continuation(FluentAssertions.Execution.AssertionScope sourceScope, bool sourceSucceeded) { }
+        public bool SourceSucceeded { get; }
+        public FluentAssertions.Execution.IAssertionScope Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.Continuation continuation) { }
+    }
+    public class ContinuationOfGiven<TSubject>
+    {
+        public ContinuationOfGiven(FluentAssertions.Execution.GivenSelector<TSubject> parent, bool succeeded) { }
+        public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
+    }
+    public class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public ContinuedAssertionScope(FluentAssertions.Execution.AssertionScope predecessor, bool predecessorSucceeded) { }
+        public bool Succeeded { get; }
+        public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.IAssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public static class Execute
+    {
+        public static FluentAssertions.Execution.AssertionScope Assertion { get; }
+    }
+    public class FailReason
+    {
+        public FailReason(string message, params object[] args) { }
+        public object[] Args { get; }
+        public string Message { get; }
+    }
+    public class GivenSelector<T>
+    {
+        public GivenSelector(System.Func<T> selector, bool predecessorSucceeded, FluentAssertions.Execution.AssertionScope predecessor) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> ClearExpectation() { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<, >[] args) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
+        public FluentAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
+    }
+    public interface IAssertionScope : System.IDisposable
+    {
+        bool Succeeded { get; }
+        FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
+        FluentAssertions.Execution.Continuation ClearExpectation();
+        string[] Discard();
+        FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc);
+        FluentAssertions.Execution.Continuation FailWith(string message, params object[] args);
+        FluentAssertions.Execution.IAssertionScope ForCondition(bool condition);
+        FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector);
+        FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier);
+        FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args);
+    }
+    public interface IAssertionStrategy
+    {
+        System.Collections.Generic.IEnumerable<string> FailureMessages { get; }
+        System.Collections.Generic.IEnumerable<string> DiscardFailures();
+        void HandleFailure(string message);
+        void ThrowIfAny(System.Collections.Generic.IDictionary<string, object> context);
+    }
+    public interface ICloneable2
+    {
+        object Clone();
+    }
+}
+namespace FluentAssertions.Extensions
+{
+    public static class FluentDateTimeExtensions
+    {
+        public static System.DateTime AddMicroseconds(this System.DateTime self, long microseconds) { }
+        public static System.DateTimeOffset AddMicroseconds(this System.DateTimeOffset self, long microseconds) { }
+        public static System.DateTime AddNanoseconds(this System.DateTime self, long nanoseconds) { }
+        public static System.DateTimeOffset AddNanoseconds(this System.DateTimeOffset self, long nanoseconds) { }
+        public static System.DateTime After(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime April(this int day, int year) { }
+        public static System.DateTime AsLocal(this System.DateTime dateTime) { }
+        public static System.DateTime AsUtc(this System.DateTime dateTime) { }
+        public static System.DateTime At(this System.DateTime date, System.TimeSpan time) { }
+        public static System.DateTime At(this System.DateTime date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTimeOffset At(this System.DateTimeOffset date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTime August(this int day, int year) { }
+        public static System.DateTime Before(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime December(this int day, int year) { }
+        public static System.DateTime February(this int day, int year) { }
+        public static System.DateTime January(this int day, int year) { }
+        public static System.DateTime July(this int day, int year) { }
+        public static System.DateTime June(this int day, int year) { }
+        public static System.DateTime March(this int day, int year) { }
+        public static System.DateTime May(this int day, int year) { }
+        public static int Microsecond(this System.DateTime self) { }
+        public static int Microsecond(this System.DateTimeOffset self) { }
+        public static int Nanosecond(this System.DateTime self) { }
+        public static int Nanosecond(this System.DateTimeOffset self) { }
+        public static System.DateTime November(this int day, int year) { }
+        public static System.DateTime October(this int day, int year) { }
+        public static System.DateTime September(this int day, int year) { }
+    }
+    public static class FluentTimeSpanExtensions
+    {
+        public const long TicksPerMicrosecond = 10;
+        public const double TicksPerNanosecond = 0.01D;
+        public static System.TimeSpan And(this System.TimeSpan sourceTime, System.TimeSpan offset) { }
+        public static System.TimeSpan Days(this double days) { }
+        public static System.TimeSpan Days(this int days) { }
+        public static System.TimeSpan Days(this int days, System.TimeSpan offset) { }
+        public static System.TimeSpan Hours(this double hours) { }
+        public static System.TimeSpan Hours(this int hours) { }
+        public static System.TimeSpan Hours(this int hours, System.TimeSpan offset) { }
+        public static int Microseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Microseconds(this int microseconds) { }
+        public static System.TimeSpan Microseconds(this long microseconds) { }
+        public static System.TimeSpan Milliseconds(this double milliseconds) { }
+        public static System.TimeSpan Milliseconds(this int milliseconds) { }
+        public static System.TimeSpan Minutes(this double minutes) { }
+        public static System.TimeSpan Minutes(this int minutes) { }
+        public static System.TimeSpan Minutes(this int minutes, System.TimeSpan offset) { }
+        public static int Nanoseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Nanoseconds(this int nanoseconds) { }
+        public static System.TimeSpan Nanoseconds(this long nanoseconds) { }
+        public static System.TimeSpan Seconds(this double seconds) { }
+        public static System.TimeSpan Seconds(this int seconds) { }
+        public static System.TimeSpan Seconds(this int seconds, System.TimeSpan offset) { }
+        public static System.TimeSpan Ticks(this int ticks) { }
+        public static System.TimeSpan Ticks(this long ticks) { }
+        public static double TotalMicroseconds(this System.TimeSpan self) { }
+        public static double TotalNanoseconds(this System.TimeSpan self) { }
+    }
+}
+namespace FluentAssertions.Formatting
+{
+    public class AggregateExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AggregateExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class AttributeBasedFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AttributeBasedFormatter() { }
+        public System.Reflection.MethodInfo[] Formatters { get; }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DateTimeOffsetValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DateTimeOffsetValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DecimalValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DecimalValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DefaultValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DoubleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public EnumerableValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExpressionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public delegate string FormatChild(string childPath, object value);
+    public static class Formatter
+    {
+        public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
+        public static void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static string ToString(object value, bool useLineBreaks = false) { }
+    }
+    public class FormattingContext
+    {
+        public FormattingContext() { }
+        public int Depth { get; set; }
+        public bool UseLineBreaks { get; set; }
+    }
+    public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public GuidValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public interface IValueFormatter
+    {
+        bool CanHandle(object value);
+        string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
+    }
+    public class Int16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class MultidimensionalArrayFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public MultidimensionalArrayFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class NullValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public NullValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class PropertyInfoFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public PropertyInfoFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SingleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SingleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class StringValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public StringValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TaskFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TaskFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TimeSpanValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TimeSpanValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
+    public class ValueFormatterAttribute : System.Attribute
+    {
+        public ValueFormatterAttribute() { }
+    }
+    public class XAttributeValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XAttributeValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XDocumentValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XDocumentValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XElementValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XElementValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+}
+namespace FluentAssertions.Numeric
+{
+    public class ComparableTypeAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    {
+        public ComparableTypeAssertions(System.IComparable<T> value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
+        where T :  struct
+    {
+        public NullableNumericAssertions(T? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NumericAssertions<T>
+        where T :  struct
+    {
+        public NumericAssertions(object value) { }
+        public System.IComparable Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(params T[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Primitives
+{
+    public class BooleanAssertions
+    {
+        public BooleanAssertions(bool? value) { }
+        public bool? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeAssertions
+    {
+        public DateTimeAssertions(System.DateTime? value) { }
+        public System.DateTime? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.DateTime[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetAssertions
+    {
+        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
+        public System.DateTimeOffset? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetRangeAssertions
+    {
+        protected DateTimeOffsetRangeAssertions(FluentAssertions.Primitives.DateTimeOffsetAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeRangeAssertions
+    {
+        protected DateTimeRangeAssertions(FluentAssertions.Primitives.DateTimeAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
+    }
+    public class GuidAssertions
+    {
+        public GuidAssertions(System.Guid? value) { }
+        public System.Guid? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableBooleanAssertions : FluentAssertions.Primitives.BooleanAssertions
+    {
+        public NullableBooleanAssertions(bool? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions
+    {
+        public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions
+    {
+        public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableGuidAssertions : FluentAssertions.Primitives.GuidAssertions
+    {
+        public NullableGuidAssertions(System.Guid? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions
+    {
+        public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class ObjectAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
+    {
+        public ObjectAssertions(object value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be(object expected, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> HaveFlag(System.Enum expectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe(object unexpected, string because = "", params object[] becauseArgs) { }
+        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotHaveFlag(System.Enum unexpectedFlag, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
+        where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+    {
+        protected ReferenceTypeAssertions() { }
+        protected ReferenceTypeAssertions(TSubject subject) { }
+        protected abstract string Identifier { get; }
+        public TSubject Subject { get; set; }
+        public FluentAssertions.AndConstraint<TAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameAs(TSubject expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<TSubject, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match<T>(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
+            where T : TSubject { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SimpleTimeSpanAssertions
+    {
+        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public System.TimeSpan? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+    }
+    public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>
+    {
+        public StringAssertions(string value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(params string[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+    }
+    public enum TimeSpanCondition
+    {
+        MoreThan = 0,
+        AtLeast = 1,
+        Exactly = 2,
+        Within = 3,
+        LessThan = 4,
+    }
+}
+namespace FluentAssertions.Reflection
+{
+    public class AssemblyAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Reflection.Assembly, FluentAssertions.Reflection.AssemblyAssertions>
+    {
+        public AssemblyAssertions(System.Reflection.Assembly assembly) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Reflection.AssemblyAssertions, System.Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs) { }
+        public void NotReference(System.Reflection.Assembly assembly) { }
+        public void NotReference(System.Reflection.Assembly assembly, string because, params string[] becauseArgs) { }
+        public void Reference(System.Reflection.Assembly assembly) { }
+        public void Reference(System.Reflection.Assembly assembly, string because, params string[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Specialized
+{
+    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action>
+    {
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Action Subject { get; }
+        protected override void InvokeSubject() { }
+    }
+    public class AsyncFunctionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Func<System.Threading.Tasks.Task>>
+    {
+        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Func<System.Threading.Tasks.Task> Subject { get; }
+        protected override void InvokeSubject() { }
+        public System.Threading.Tasks.Task NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public abstract class DelegateAssertions<TDelegate> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Delegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate>>
+        where TDelegate : System.Delegate
+    {
+        protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public new TDelegate Subject { get; }
+        protected abstract void InvokeSubject();
+        public void NotThrow(string because = "", params object[] becauseArgs) { }
+        protected void NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        protected void NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+        public void NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public class ExceptionAssertions<TException> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IEnumerable<TException>, FluentAssertions.Specialized.ExceptionAssertions<TException>>
+        where TException : System.Exception
+    {
+        public ExceptionAssertions(System.Collections.Generic.IEnumerable<TException> exceptions) { }
+        public TException And { get; }
+        protected override string Identifier { get; }
+        public TException Which { get; }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Where(System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, string because = "", params object[] becauseArgs) { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerException<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerExceptionExactly<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TException> WithMessage(string expectedWildcardPattern, string because = "", params object[] becauseArgs) { }
+    }
+    public class ExecutionTime
+    {
+        public ExecutionTime(System.Action action) { }
+        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action) { }
+        protected ExecutionTime(System.Action action, string actionDescription) { }
+        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription) { }
+    }
+    public class ExecutionTimeAssertions
+    {
+        public ExecutionTimeAssertions(FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        public void BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public void BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public void BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public void BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public void BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+    }
+    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
+    {
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Func<T> Subject { get; }
+        protected override void InvokeSubject() { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions
+    {
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+    public interface IExtractExceptions
+    {
+        System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception;
+    }
+    public class MemberExecutionTime<T> : FluentAssertions.Specialized.ExecutionTime
+    {
+        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+    }
+    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions
+    {
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Types
+{
+    public static class AllTypes
+    {
+        public static FluentAssertions.Types.TypeSelector From(System.Reflection.Assembly assembly) { }
+    }
+    public class ConstructorInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.ConstructorInfo, FluentAssertions.Types.ConstructorInfoAssertions>
+    {
+        public ConstructorInfoAssertions(System.Reflection.ConstructorInfo constructorInfo) { }
+        protected override string Identifier { get; }
+    }
+    public abstract class MemberInfoAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MemberInfo
+        where TAssertions : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+    {
+        protected MemberInfoAssertions() { }
+        protected MemberInfoAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+    }
+    public abstract class MethodBaseAssertions<TSubject, TAssertions> : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MethodBase
+        where TAssertions : FluentAssertions.Types.MethodBaseAssertions<TSubject, TAssertions>
+    {
+        protected MethodBaseAssertions() { }
+        protected MethodBaseAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>
+    {
+        public MethodInfoAssertions() { }
+        public MethodInfoAssertions(System.Reflection.MethodInfo methodInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturnVoid(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> ReturnVoid(string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, System.Collections.IEnumerable
+    {
+        public MethodInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public MethodInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.MethodInfoSelector ThatArePublicOrInternal { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturnVoid { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
+        public System.Reflection.MethodInfo[] ToArray() { }
+    }
+    public class MethodInfoSelectorAssertions
+    {
+        public MethodInfoSelectorAssertions(params System.Reflection.MethodInfo[] methods) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> SubjectMethods { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoAssertions : FluentAssertions.Types.MemberInfoAssertions<System.Reflection.PropertyInfo, FluentAssertions.Types.PropertyInfoAssertions>
+    {
+        public PropertyInfoAssertions(System.Reflection.PropertyInfo propertyInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo>, System.Collections.IEnumerable
+    {
+        public PropertyInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public PropertyInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatArePublicOrInternal { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.PropertyInfo> GetEnumerator() { }
+        public FluentAssertions.Types.PropertyInfoSelector NotOfType<TReturn>() { }
+        public FluentAssertions.Types.PropertyInfoSelector OfType<TReturn>() { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public System.Reflection.PropertyInfo[] ToArray() { }
+    }
+    public class PropertyInfoSelectorAssertions
+    {
+        public PropertyInfoSelectorAssertions(params System.Reflection.PropertyInfo[] properties) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> SubjectProperties { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public class TypeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Type, FluentAssertions.Types.TypeAssertions>
+    {
+        public TypeAssertions(System.Type type) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be(System.Type expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be<TExpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<System.Type> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveExplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveExplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveImplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveImplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveIndexer(System.Type indexerType, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty(System.Type propertyType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty<TProperty>(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe(System.Type unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe<TUnexpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<System.Type> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveExplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveExplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveImplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveImplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveIndexer(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveProperty(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+    }
+    public class TypeSelector : System.Collections.Generic.IEnumerable<System.Type>, System.Collections.IEnumerable
+    {
+        public TypeSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public TypeSelector(System.Type type) { }
+        public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
+        public System.Type[] ToArray() { }
+    }
+    public class TypeSelectorAssertions
+    {
+        public TypeSelectorAssertions(params System.Type[] types) { }
+        public System.Collections.Generic.IEnumerable<System.Type> Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+    }
+}
+namespace FluentAssertions.Xml
+{
+    public class XAttributeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XAttribute, FluentAssertions.Xml.XAttributeAssertions>
+    {
+        public XAttributeAssertions(System.Xml.Linq.XAttribute attribute) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> Be(System.Xml.Linq.XAttribute expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> Be(System.Xml.Linq.XAttribute expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> HaveValue(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> HaveValue(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> NotBe(System.Xml.Linq.XAttribute unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> NotBe(System.Xml.Linq.XAttribute unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XDocumentAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XDocument, FluentAssertions.Xml.XDocumentAssertions>
+    {
+        public XDocumentAssertions(System.Xml.Linq.XDocument document) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> Be(System.Xml.Linq.XDocument expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> Be(System.Xml.Linq.XDocument expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> BeEquivalentTo(System.Xml.Linq.XDocument expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> BeEquivalentTo(System.Xml.Linq.XDocument expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBe(System.Xml.Linq.XDocument unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBe(System.Xml.Linq.XDocument unexpected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBeEquivalentTo(System.Xml.Linq.XDocument unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBeEquivalentTo(System.Xml.Linq.XDocument unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XElementAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XElement, FluentAssertions.Xml.XElementAssertions>
+    {
+        public XElementAssertions(System.Xml.Linq.XElement xElement) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> Be(System.Xml.Linq.XElement expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> Be(System.Xml.Linq.XElement expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveValue(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveValue(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBe(System.Xml.Linq.XElement unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBe(System.Xml.Linq.XElement unexpected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBeEquivalentTo(System.Xml.Linq.XElement unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBeEquivalentTo(System.Xml.Linq.XElement unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XmlElementAssertions : FluentAssertions.Xml.XmlNodeAssertions<System.Xml.XmlElement, FluentAssertions.Xml.XmlElementAssertions>
+    {
+        public XmlElementAssertions(System.Xml.XmlElement xmlElement) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttribute(string expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttributeWithNamespace(string expectedName, string expectedNamespace, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttributeWithNamespace(string expectedName, string expectedNamespace, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElement(string expectedName) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElement(string expectedName, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElementWithNamespace(string expectedName, string expectedNamespace) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElementWithNamespace(string expectedName, string expectedNamespace, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveInnerText(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveInnerText(string expected, string because, params object[] becauseArgs) { }
+    }
+    public class XmlNodeAssertions : FluentAssertions.Xml.XmlNodeAssertions<System.Xml.XmlNode, FluentAssertions.Xml.XmlNodeAssertions>
+    {
+        public XmlNodeAssertions(System.Xml.XmlNode xmlNode) { }
+    }
+    public class XmlNodeAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Xml.XmlNode
+        where TAssertions : FluentAssertions.Xml.XmlNodeAssertions<TSubject, TAssertions>
+    {
+        public XmlNodeAssertions(TSubject xmlNode) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Xml.XmlNode expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Xml.XmlNode expected, string because, params object[] reasonArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Xml.XmlNode unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Xml.XmlNode unexpected, string because, params object[] reasonArgs) { }
+    }
+    public class XmlNodeFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XmlNodeFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+}

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard1.3.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard1.3.approved.txt
@@ -1,0 +1,2058 @@
+﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v1.3", FrameworkDisplayName="")]
+namespace FluentAssertions
+{
+    public class AggregateExceptionExtractor : FluentAssertions.Specialized.IExtractExceptions
+    {
+        public AggregateExceptionExtractor() { }
+        public System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception { }
+    }
+    public class AndConstraint<T>
+    {
+        public AndConstraint(T parentConstraint) { }
+        public T And { get; }
+    }
+    public class AndWhichConstraint<TParentConstraint, TMatchedElement> : FluentAssertions.AndConstraint<TParentConstraint>
+    {
+        public AndWhichConstraint(TParentConstraint parentConstraint, System.Collections.Generic.IEnumerable<TMatchedElement> matchedConstraint) { }
+        public AndWhichConstraint(TParentConstraint parentConstraint, TMatchedElement matchedConstraint) { }
+        public TMatchedElement Subject { get; }
+        public TMatchedElement Which { get; }
+    }
+    public static class AssertionExtensions
+    {
+        public static TTo As<TTo>(this object subject) { }
+        public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.Task<TResult>> action) { }
+        public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+        public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
+        public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
+        public static FluentAssertions.Specialized.ExecutionTimeAssertions Should(this FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        public static FluentAssertions.Types.MethodInfoSelectorAssertions Should(this FluentAssertions.Types.MethodInfoSelector methodSelector) { }
+        public static FluentAssertions.Types.PropertyInfoSelectorAssertions Should(this FluentAssertions.Types.PropertyInfoSelector propertyInfoSelector) { }
+        public static FluentAssertions.Types.TypeSelectorAssertions Should(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
+        public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
+        public static FluentAssertions.Collections.NonGenericCollectionAssertions Should(this System.Collections.IEnumerable actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
+        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
+        public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
+        public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
+        public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
+        public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
+        public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
+        public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
+        public static FluentAssertions.Xml.XAttributeAssertions Should(this System.Xml.Linq.XAttribute actualValue) { }
+        public static FluentAssertions.Xml.XDocumentAssertions Should(this System.Xml.Linq.XDocument actualValue) { }
+        public static FluentAssertions.Xml.XElementAssertions Should(this System.Xml.Linq.XElement actualValue) { }
+        public static FluentAssertions.Primitives.BooleanAssertions Should(this bool actualValue) { }
+        public static FluentAssertions.Primitives.NullableBooleanAssertions Should(this bool? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<byte> Should(this byte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<byte> Should(this byte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<decimal> Should(this decimal actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<decimal> Should(this decimal? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<double> Should(this double actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<double> Should(this double? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<float> Should(this float actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<float> Should(this float? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<int> Should(this int actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<int> Should(this int? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<long> Should(this long actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<long> Should(this long? actualValue) { }
+        public static FluentAssertions.Primitives.ObjectAssertions Should(this object actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<sbyte> Should(this sbyte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<sbyte> Should(this sbyte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<short> Should(this short actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<short> Should(this short? actualValue) { }
+        public static FluentAssertions.Primitives.StringAssertions Should(this string actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<uint> Should(this uint actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<uint> Should(this uint? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ulong> Should(this ulong actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ulong> Should(this ulong? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ushort> Should(this ushort actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ushort> Should(this ushort? actualValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
+        public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public static class AssertionOptions
+    {
+        public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
+        public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
+        public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
+    }
+    public static class AtLeast
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class AtMost
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class CallerIdentifier
+    {
+        public static System.Action<string> logger;
+        public static string DetermineCallerIdentity() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
+    public class CustomAssertionAttribute : System.Attribute
+    {
+        public CustomAssertionAttribute() { }
+    }
+    public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
+    {
+        public EquivalencyStepCollection() { }
+        public void Add<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void AddAfter<TPredecessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Clear() { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IEquivalencyStep> GetEnumerator() { }
+        public void Insert<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void InsertBefore<TSuccessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Remove<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep { }
+        public void Reset() { }
+    }
+    public static class EventRaisingExtensions
+    {
+        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, params System.Linq.Expressions.Expression<>[] predicates) { }
+        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
+        public static FluentAssertions.Events.IEventRecorder WithSender(this FluentAssertions.Events.IEventRecorder eventRecorder, object expectedSender) { }
+    }
+    public static class Exactly
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class FluentActions
+    {
+        public static System.Func<System.Threading.Tasks.Task> Awaiting(System.Func<System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task<T>> Awaiting<T>(System.Func<System.Threading.Tasks.Task<T>> func) { }
+        public static System.Action Enumerating(System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static System.Action Invoking(System.Action action) { }
+        public static System.Func<T> Invoking<T>(System.Func<T> func) { }
+    }
+    public static class LessThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class MoreThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class NumericAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class OccurrenceConstraint
+    {
+        protected OccurrenceConstraint(int expectedCount) { }
+    }
+    public static class TypeEnumerableExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreInNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreUnderNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatDeriveFrom<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatImplement<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+    }
+    public static class TypeExtensions
+    {
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this System.Type type) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this System.Type type) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Type type) { }
+    }
+}
+namespace FluentAssertions.Collections
+{
+    public abstract class CollectionAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Collections.IEnumerable
+        where TAssertions : FluentAssertions.Collections.CollectionAssertions<TSubject, TAssertions>
+    {
+        protected CollectionAssertions() { }
+        protected CollectionAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeOfType<T>(string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionEndsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actual, System.Collections.Generic.ICollection<TExpected> expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionEndsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actual, TExpected[] expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionStartsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actualItems, System.Collections.Generic.ICollection<TExpected> expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionStartsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actualItems, TExpected[] expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertSubjectEquality<TActual, TExpected>(System.Collections.IEnumerable expectation, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params object[] expectations) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.IEnumerable expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.IEnumerable expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.IEnumerable>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.IEnumerable>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSubsetOf(System.Collections.IEnumerable expectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params object[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainItemsAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(object element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params object[] elements) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, object> HaveElementAt(int index, object element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(object successor, object expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(object predecessor, object expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInAscendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAscendingInOrder(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInAscendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAscendingInOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInDescendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDescendingInOrder(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInDescendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDescendingInOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSubsetOf(System.Collections.IEnumerable unexpectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotIntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(object element, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
+    {
+        public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+            where TKey :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(params TKey[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(params TValue[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(params TKey[] unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(params TValue[] unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+    }
+    public class NonGenericCollectionAssertions : FluentAssertions.Collections.CollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
+    {
+        public NonGenericCollectionAssertions(System.Collections.IEnumerable collection) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
+    {
+        public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params T[] elements) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpectedItemsList, params T[] additionalUnexpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(params System.Action<>[] elementInspectors) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(System.Collections.Generic.IEnumerable<System.Action<T>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+    }
+    public class StringCollectionAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<string, FluentAssertions.Collections.StringCollectionAssertions>
+    {
+        public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(params string[] expectation) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(params string[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+    }
+    public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public WhichValueConstraint(FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> parentConstraint, TValue value) { }
+        public TValue WhichValue { get; }
+    }
+}
+namespace FluentAssertions.Common
+{
+    public enum CSharpAccessModifier
+    {
+        Public = 0,
+        Private = 1,
+        Protected = 2,
+        Internal = 3,
+        ProtectedInternal = 4,
+        InvalidForCSharp = 5,
+        PrivateProtected = 6,
+    }
+    public static class CSharpAccessModifierExtensions { }
+    public class Configuration
+    {
+        public Configuration(FluentAssertions.Common.IConfigurationStore store) { }
+        public string TestFrameworkName { get; set; }
+        public string ValueFormatterAssembly { get; set; }
+        public FluentAssertions.Common.ValueFormatterDetectionMode ValueFormatterDetectionMode { get; set; }
+        public static FluentAssertions.Common.Configuration Current { get; }
+    }
+    public static class DateTimeExtensions
+    {
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime) { }
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime, System.TimeSpan offset) { }
+    }
+    public interface IClock
+    {
+        void Delay(System.TimeSpan timeToDelay);
+        System.Threading.Tasks.Task DelayAsync(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken);
+        FluentAssertions.Common.ITimer StartTimer();
+        bool Wait(System.Threading.Tasks.Task task, System.TimeSpan timeout);
+    }
+    public interface IConfigurationStore
+    {
+        string GetSetting(string name);
+    }
+    public interface IReflector
+    {
+        System.Collections.Generic.IEnumerable<System.Type> GetAllTypesFromAppDomain(System.Func<System.Reflection.Assembly, bool> predicate);
+    }
+    public interface ITimer
+    {
+        System.TimeSpan Elapsed { get; }
+    }
+    public static class MethodInfoExtensions { }
+    public static class ObjectExtensions
+    {
+        public static bool IsSameOrEqualTo(this object actual, object expected) { }
+    }
+    public static class PropertyInfoExtensions { }
+    public static class Services
+    {
+        public static FluentAssertions.Common.Configuration Configuration { get; }
+        public static FluentAssertions.Common.IConfigurationStore ConfigurationStore { get; set; }
+        public static FluentAssertions.Common.IReflector Reflector { get; set; }
+        public static System.Action<string> ThrowException { get; set; }
+        public static void ResetToDefaults() { }
+    }
+    public static class TypeExtensions
+    {
+        public static System.Reflection.FieldInfo FindField(this System.Type type, string fieldName, System.Type preferredType) { }
+        public static FluentAssertions.Equivalency.SelectedMemberInfo FindMember(this System.Type type, string memberName, System.Type preferredType) { }
+        public static System.Reflection.PropertyInfo FindProperty(this System.Type type, string propertyName, System.Type preferredType) { }
+        public static System.Reflection.ConstructorInfo GetConstructor(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.PropertyInfo GetIndexerByParameterTypes(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Reflection.MethodInfo GetMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> GetNonPrivateFields(this System.Type typeToReflect) { }
+        public static System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetNonPrivateMembers(this System.Type typeToReflect) { }
+        public static System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> GetNonPrivateProperties(this System.Type typeToReflect, System.Collections.Generic.IEnumerable<string> filter = null) { }
+        public static System.Reflection.MethodInfo GetParameterlessMethod(this System.Type type, string methodName) { }
+        public static System.Reflection.PropertyInfo GetPropertyByName(this System.Type type, string propertyName) { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWithOrInherits> instead.")]
+        public static bool HasAttribute<TAttribute>(this System.Reflection.MemberInfo method)
+            where TAttribute : System.Attribute { }
+        public static bool HasExplicitlyImplementedProperty(this System.Type type, System.Type interfaceType, string propertyName) { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWith> instead.")]
+        public static bool HasMatchingAttribute<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
+        public static bool HasMatchingAttribute<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, bool inherit = false)
+            where TAttribute : System.Attribute { }
+        public static bool HasMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static bool HasParameterlessMethod(this System.Type type, string methodName) { }
+        public static bool HasValueSemantics(this System.Type type) { }
+        public static bool Implements(this System.Type type, System.Type expectedBaseType) { }
+        public static bool IsCSharpAbstract(this System.Type type) { }
+        public static bool IsCSharpSealed(this System.Type type) { }
+        public static bool IsCSharpStatic(this System.Type type) { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        [System.Obsolete("This overload is deprecated and will be removed on the next major version. Please" +
+            " use <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type, bool inherit = false)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsEquivalentTo(this FluentAssertions.Equivalency.SelectedMemberInfo property, FluentAssertions.Equivalency.SelectedMemberInfo otherProperty) { }
+        public static bool IsIndexer(this System.Reflection.PropertyInfo member) { }
+        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
+        public static bool OverridesEquals(this System.Type type) { }
+    }
+    public enum ValueFormatterDetectionMode
+    {
+        Disabled = 0,
+        Specific = 1,
+        Scan = 2,
+    }
+}
+namespace FluentAssertions.Equivalency
+{
+    public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class ConversionSelector
+    {
+        public ConversionSelector() { }
+        public FluentAssertions.Equivalency.ConversionSelector Clone() { }
+        public void Exclude(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void Include(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void IncludeAll() { }
+        public bool RequiresConversion(FluentAssertions.Equivalency.IMemberInfo info) { }
+        public override string ToString() { }
+    }
+    public enum CyclicReferenceHandling
+    {
+        Ignore = 0,
+        ThrowException = 1,
+    }
+    public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DictionaryEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public virtual bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class EnumEqualityStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumEqualityStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public enum EnumEquivalencyHandling
+    {
+        ByValue = 0,
+        ByName = 1,
+    }
+    public class EnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumerableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public enum EqualityStrategy
+    {
+        Equals = 0,
+        Members = 1,
+        ForceEquals = 2,
+        ForceMembers = 3,
+    }
+    public class EquivalencyAssertionOptions : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions>
+    {
+        public EquivalencyAssertionOptions() { }
+    }
+    [System.Obsolete("This class is deprecated and will be removed in version 6.X.")]
+    public static class EquivalencyAssertionOptionsExtentions
+    {
+        public static System.Type GetExpectationType(this FluentAssertions.Equivalency.IEquivalencyAssertionOptions config, FluentAssertions.Equivalency.IMemberInfo context) { }
+    }
+    public class EquivalencyAssertionOptions<TExpectation> : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>>
+    {
+        public EquivalencyAssertionOptions() { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+    }
+    public class EquivalencyValidationContext : FluentAssertions.Equivalency.IEquivalencyValidationContext, FluentAssertions.Equivalency.IMemberInfo
+    {
+        public EquivalencyValidationContext() { }
+        public string Because { get; set; }
+        public object[] BecauseArgs { get; set; }
+        public System.Type CompileTimeType { get; set; }
+        public object Expectation { get; set; }
+        public bool IsRoot { get; }
+        public bool RootIsCollection { get; set; }
+        public System.Type RuntimeType { get; }
+        public string SelectedMemberDescription { get; set; }
+        public FluentAssertions.Equivalency.SelectedMemberInfo SelectedMemberInfo { get; set; }
+        public string SelectedMemberPath { get; set; }
+        public object Subject { get; set; }
+        public FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
+        public override string ToString() { }
+        public System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getTraceMessage) { }
+        public void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getTraceMessage) { }
+    }
+    public class EquivalencyValidator : FluentAssertions.Equivalency.IEquivalencyValidator
+    {
+        public EquivalencyValidator(FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public void AssertEquality(FluentAssertions.Equivalency.EquivalencyValidationContext context) { }
+        public void AssertEqualityUsing(FluentAssertions.Equivalency.IEquivalencyValidationContext context) { }
+    }
+    public class GenericDictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericDictionaryEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class GenericEnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericEnumerableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public delegate string GetTraceMessage(string path);
+    public interface IAssertionContext<TSubject>
+    {
+        string Because { get; set; }
+        object[] BecauseArgs { get; set; }
+        TSubject Expectation { get; }
+        TSubject Subject { get; }
+        FluentAssertions.Equivalency.SelectedMemberInfo SubjectProperty { get; }
+    }
+    public interface IAssertionRule
+    {
+        bool AssertEquality(FluentAssertions.Equivalency.IEquivalencyValidationContext context);
+    }
+    public interface IEquivalencyAssertionOptions
+    {
+        bool AllowInfiniteRecursion { get; }
+        FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
+        FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool IncludeFields { get; }
+        bool IncludeProperties { get; }
+        bool IsRecursive { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberMatchingRule> MatchingRules { get; }
+        FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
+        FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
+        bool UseRuntimeTyping { get; }
+        FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> GetUserEquivalencySteps(FluentAssertions.Equivalency.ConversionSelector conversionSelector);
+    }
+    public interface IEquivalencyStep
+    {
+        bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+        bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IEquivalencyValidationContext : FluentAssertions.Equivalency.IMemberInfo
+    {
+        string Because { get; }
+        object[] BecauseArgs { get; }
+        object Expectation { get; }
+        bool IsRoot { get; }
+        bool RootIsCollection { get; set; }
+        object Subject { get; }
+        FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
+        System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getMessage);
+        void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getMessage);
+    }
+    public interface IEquivalencyValidator
+    {
+        void AssertEqualityUsing(FluentAssertions.Equivalency.IEquivalencyValidationContext context);
+    }
+    public interface IMemberInfo
+    {
+        System.Type CompileTimeType { get; }
+        System.Type RuntimeType { get; }
+        string SelectedMemberDescription { get; }
+        FluentAssertions.Equivalency.SelectedMemberInfo SelectedMemberInfo { get; }
+        string SelectedMemberPath { get; }
+    }
+    public interface IMemberMatchingRule
+    {
+        FluentAssertions.Equivalency.SelectedMemberInfo Match(FluentAssertions.Equivalency.SelectedMemberInfo expectedMember, object subject, string memberPath, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IMemberSelectionRule
+    {
+        bool IncludesMembers { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> SelectMembers(System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> selectedMembers, FluentAssertions.Equivalency.IMemberInfo context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IOrderingRule
+    {
+        FluentAssertions.Equivalency.OrderStrictness Evaluate(FluentAssertions.Equivalency.IMemberInfo memberInfo);
+    }
+    public interface ITraceWriter
+    {
+        System.IDisposable AddBlock(string trace);
+        void AddSingle(string trace);
+        string ToString();
+    }
+    public enum OrderStrictness
+    {
+        Strict = 0,
+        NotStrict = 1,
+        Irrelevant = 2,
+    }
+    public class OrderingRuleCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule>, System.Collections.IEnumerable
+    {
+        public OrderingRuleCollection() { }
+        public OrderingRuleCollection(System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule> orderingRules) { }
+        public void Add(FluentAssertions.Equivalency.IOrderingRule rule) { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IOrderingRule> GetEnumerator() { }
+        public bool IsOrderingStrictFor(FluentAssertions.Equivalency.IMemberInfo memberInfo) { }
+    }
+    public class ReferenceEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ReferenceEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public virtual bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class RunAllUserStepsEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public RunAllUserStepsEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public abstract class SelectedMemberInfo
+    {
+        protected SelectedMemberInfo() { }
+        public abstract System.Type DeclaringType { get; }
+        public abstract System.Type MemberType { get; }
+        public abstract string Name { get; }
+        public abstract object GetValue(object obj, object[] index);
+        public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.FieldInfo fieldInfo) { }
+        public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.PropertyInfo propertyInfo) { }
+    }
+    public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
+        where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
+    {
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        protected readonly FluentAssertions.Equivalency.OrderingRuleCollection orderingRules;
+        protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
+        public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        public FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
+        protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public TSelf AllowingInfiniteRecursion() { }
+        public TSelf ComparingByMembers<T>() { }
+        public TSelf ComparingByValue<T>() { }
+        public TSelf ComparingEnumsByName() { }
+        public TSelf ComparingEnumsByValue() { }
+        public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf ExcludingFields() { }
+        public TSelf ExcludingMissingMembers() { }
+        public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingProperties() { }
+        public TSelf IgnoringCyclicReferences() { }
+        public TSelf IncludingAllDeclaredProperties() { }
+        public TSelf IncludingAllRuntimeProperties() { }
+        public TSelf IncludingFields() { }
+        public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingProperties() { }
+        protected void RemoveSelectionRule<T>()
+            where T : FluentAssertions.Equivalency.IMemberSelectionRule { }
+        public TSelf RespectingDeclaredTypes() { }
+        public TSelf RespectingRuntimeTypes() { }
+        public TSelf ThrowingOnMissingMembers() { }
+        public override string ToString() { }
+        public TSelf Using(FluentAssertions.Equivalency.IAssertionRule assertionRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IEquivalencyStep equivalencyStep) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
+        public TSelf WithAutoConversion() { }
+        public TSelf WithAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf WithStrictOrdering() { }
+        public TSelf WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf WithTracing(FluentAssertions.Equivalency.ITraceWriter writer = null) { }
+        public TSelf WithoutAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void WithoutMatchingRules() { }
+        public void WithoutSelectionRules() { }
+        public TSelf WithoutStrictOrdering() { }
+        public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public class Restriction<TMember>
+        {
+            public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
+            public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+            public TSelf WhenTypeIs<TMemberType>() { }
+        }
+    }
+    public class SimpleEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public SimpleEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class StringBuilderTraceWriter : FluentAssertions.Equivalency.ITraceWriter
+    {
+        public StringBuilderTraceWriter() { }
+        public System.IDisposable AddBlock(string trace) { }
+        public void AddSingle(string trace) { }
+        public override string ToString() { }
+    }
+    public class StringEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StringEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class StructuralEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StructuralEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public static class SubjectInfoExtensions
+    {
+        public static bool WhichGetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichGetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+    }
+    public class TryConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public TryConversionStep(FluentAssertions.Equivalency.ConversionSelector selector) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ValueTypeEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+}
+namespace FluentAssertions.Events
+{
+    public interface IEventRecorder : System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
+    {
+        System.Type EventHandlerType { get; }
+        string EventName { get; }
+        object EventObject { get; }
+        void RecordEvent(params object[] parameters);
+        void Reset();
+    }
+    public class RecordedEvent
+    {
+        public RecordedEvent(System.DateTime utcNow, object monitoredObject, params object[] parameters) { }
+        public System.Collections.Generic.IEnumerable<object> Parameters { get; }
+        public System.DateTime TimestampUtc { get; set; }
+    }
+}
+namespace FluentAssertions.Execution
+{
+    public class AssertionFailedException : System.Exception
+    {
+        public AssertionFailedException(string message) { }
+    }
+    public class AssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public AssertionScope() { }
+        public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
+        public AssertionScope(string context) { }
+        public string Context { get; set; }
+        public bool Succeeded { get; }
+        public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
+        public static FluentAssertions.Execution.AssertionScope Current { get; }
+        public void AddNonReportable(string key, object value) { }
+        public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, string value) { }
+        public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
+        public T Get<T>(string key) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public bool HasFailures() { }
+        public FluentAssertions.Execution.AssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.AssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public class Continuation
+    {
+        public Continuation(FluentAssertions.Execution.AssertionScope sourceScope, bool sourceSucceeded) { }
+        public bool SourceSucceeded { get; }
+        public FluentAssertions.Execution.IAssertionScope Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.Continuation continuation) { }
+    }
+    public class ContinuationOfGiven<TSubject>
+    {
+        public ContinuationOfGiven(FluentAssertions.Execution.GivenSelector<TSubject> parent, bool succeeded) { }
+        public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
+    }
+    public class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public ContinuedAssertionScope(FluentAssertions.Execution.AssertionScope predecessor, bool predecessorSucceeded) { }
+        public bool Succeeded { get; }
+        public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.IAssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public static class Execute
+    {
+        public static FluentAssertions.Execution.AssertionScope Assertion { get; }
+    }
+    public class FailReason
+    {
+        public FailReason(string message, params object[] args) { }
+        public object[] Args { get; }
+        public string Message { get; }
+    }
+    public class GivenSelector<T>
+    {
+        public GivenSelector(System.Func<T> selector, bool predecessorSucceeded, FluentAssertions.Execution.AssertionScope predecessor) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> ClearExpectation() { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<, >[] args) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
+        public FluentAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
+    }
+    public interface IAssertionScope : System.IDisposable
+    {
+        bool Succeeded { get; }
+        FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
+        FluentAssertions.Execution.Continuation ClearExpectation();
+        string[] Discard();
+        FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc);
+        FluentAssertions.Execution.Continuation FailWith(string message, params object[] args);
+        FluentAssertions.Execution.IAssertionScope ForCondition(bool condition);
+        FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector);
+        FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier);
+        FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args);
+    }
+    public interface IAssertionStrategy
+    {
+        System.Collections.Generic.IEnumerable<string> FailureMessages { get; }
+        System.Collections.Generic.IEnumerable<string> DiscardFailures();
+        void HandleFailure(string message);
+        void ThrowIfAny(System.Collections.Generic.IDictionary<string, object> context);
+    }
+    public interface ICloneable2
+    {
+        object Clone();
+    }
+}
+namespace FluentAssertions.Extensions
+{
+    public static class FluentDateTimeExtensions
+    {
+        public static System.DateTime AddMicroseconds(this System.DateTime self, long microseconds) { }
+        public static System.DateTimeOffset AddMicroseconds(this System.DateTimeOffset self, long microseconds) { }
+        public static System.DateTime AddNanoseconds(this System.DateTime self, long nanoseconds) { }
+        public static System.DateTimeOffset AddNanoseconds(this System.DateTimeOffset self, long nanoseconds) { }
+        public static System.DateTime After(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime April(this int day, int year) { }
+        public static System.DateTime AsLocal(this System.DateTime dateTime) { }
+        public static System.DateTime AsUtc(this System.DateTime dateTime) { }
+        public static System.DateTime At(this System.DateTime date, System.TimeSpan time) { }
+        public static System.DateTime At(this System.DateTime date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTimeOffset At(this System.DateTimeOffset date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTime August(this int day, int year) { }
+        public static System.DateTime Before(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime December(this int day, int year) { }
+        public static System.DateTime February(this int day, int year) { }
+        public static System.DateTime January(this int day, int year) { }
+        public static System.DateTime July(this int day, int year) { }
+        public static System.DateTime June(this int day, int year) { }
+        public static System.DateTime March(this int day, int year) { }
+        public static System.DateTime May(this int day, int year) { }
+        public static int Microsecond(this System.DateTime self) { }
+        public static int Microsecond(this System.DateTimeOffset self) { }
+        public static int Nanosecond(this System.DateTime self) { }
+        public static int Nanosecond(this System.DateTimeOffset self) { }
+        public static System.DateTime November(this int day, int year) { }
+        public static System.DateTime October(this int day, int year) { }
+        public static System.DateTime September(this int day, int year) { }
+    }
+    public static class FluentTimeSpanExtensions
+    {
+        public const long TicksPerMicrosecond = 10;
+        public const double TicksPerNanosecond = 0.01D;
+        public static System.TimeSpan And(this System.TimeSpan sourceTime, System.TimeSpan offset) { }
+        public static System.TimeSpan Days(this double days) { }
+        public static System.TimeSpan Days(this int days) { }
+        public static System.TimeSpan Days(this int days, System.TimeSpan offset) { }
+        public static System.TimeSpan Hours(this double hours) { }
+        public static System.TimeSpan Hours(this int hours) { }
+        public static System.TimeSpan Hours(this int hours, System.TimeSpan offset) { }
+        public static int Microseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Microseconds(this int microseconds) { }
+        public static System.TimeSpan Microseconds(this long microseconds) { }
+        public static System.TimeSpan Milliseconds(this double milliseconds) { }
+        public static System.TimeSpan Milliseconds(this int milliseconds) { }
+        public static System.TimeSpan Minutes(this double minutes) { }
+        public static System.TimeSpan Minutes(this int minutes) { }
+        public static System.TimeSpan Minutes(this int minutes, System.TimeSpan offset) { }
+        public static int Nanoseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Nanoseconds(this int nanoseconds) { }
+        public static System.TimeSpan Nanoseconds(this long nanoseconds) { }
+        public static System.TimeSpan Seconds(this double seconds) { }
+        public static System.TimeSpan Seconds(this int seconds) { }
+        public static System.TimeSpan Seconds(this int seconds, System.TimeSpan offset) { }
+        public static System.TimeSpan Ticks(this int ticks) { }
+        public static System.TimeSpan Ticks(this long ticks) { }
+        public static double TotalMicroseconds(this System.TimeSpan self) { }
+        public static double TotalNanoseconds(this System.TimeSpan self) { }
+    }
+}
+namespace FluentAssertions.Formatting
+{
+    public class AggregateExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AggregateExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class AttributeBasedFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AttributeBasedFormatter() { }
+        public System.Reflection.MethodInfo[] Formatters { get; }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DateTimeOffsetValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DateTimeOffsetValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DecimalValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DecimalValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DefaultValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DoubleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public EnumerableValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExpressionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public delegate string FormatChild(string childPath, object value);
+    public static class Formatter
+    {
+        public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
+        public static void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static string ToString(object value, bool useLineBreaks = false) { }
+    }
+    public class FormattingContext
+    {
+        public FormattingContext() { }
+        public int Depth { get; set; }
+        public bool UseLineBreaks { get; set; }
+    }
+    public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public GuidValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public interface IValueFormatter
+    {
+        bool CanHandle(object value);
+        string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
+    }
+    public class Int16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class MultidimensionalArrayFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public MultidimensionalArrayFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class NullValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public NullValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class PropertyInfoFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public PropertyInfoFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SingleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SingleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class StringValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public StringValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TaskFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TaskFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TimeSpanValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TimeSpanValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
+    public class ValueFormatterAttribute : System.Attribute
+    {
+        public ValueFormatterAttribute() { }
+    }
+    public class XAttributeValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XAttributeValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XDocumentValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XDocumentValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XElementValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XElementValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+}
+namespace FluentAssertions.Numeric
+{
+    public class ComparableTypeAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    {
+        public ComparableTypeAssertions(System.IComparable<T> value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
+        where T :  struct
+    {
+        public NullableNumericAssertions(T? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NumericAssertions<T>
+        where T :  struct
+    {
+        public NumericAssertions(object value) { }
+        public System.IComparable Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(params T[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Primitives
+{
+    public class BooleanAssertions
+    {
+        public BooleanAssertions(bool? value) { }
+        public bool? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeAssertions
+    {
+        public DateTimeAssertions(System.DateTime? value) { }
+        public System.DateTime? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.DateTime[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetAssertions
+    {
+        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
+        public System.DateTimeOffset? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetRangeAssertions
+    {
+        protected DateTimeOffsetRangeAssertions(FluentAssertions.Primitives.DateTimeOffsetAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeRangeAssertions
+    {
+        protected DateTimeRangeAssertions(FluentAssertions.Primitives.DateTimeAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
+    }
+    public class GuidAssertions
+    {
+        public GuidAssertions(System.Guid? value) { }
+        public System.Guid? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableBooleanAssertions : FluentAssertions.Primitives.BooleanAssertions
+    {
+        public NullableBooleanAssertions(bool? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions
+    {
+        public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions
+    {
+        public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableGuidAssertions : FluentAssertions.Primitives.GuidAssertions
+    {
+        public NullableGuidAssertions(System.Guid? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions
+    {
+        public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class ObjectAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
+    {
+        public ObjectAssertions(object value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be(object expected, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> HaveFlag(System.Enum expectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe(object unexpected, string because = "", params object[] becauseArgs) { }
+        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotHaveFlag(System.Enum unexpectedFlag, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
+        where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+    {
+        protected ReferenceTypeAssertions() { }
+        protected ReferenceTypeAssertions(TSubject subject) { }
+        protected abstract string Identifier { get; }
+        public TSubject Subject { get; set; }
+        public FluentAssertions.AndConstraint<TAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameAs(TSubject expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<TSubject, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match<T>(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
+            where T : TSubject { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SimpleTimeSpanAssertions
+    {
+        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public System.TimeSpan? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+    }
+    public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>
+    {
+        public StringAssertions(string value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(params string[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+    }
+    public enum TimeSpanCondition
+    {
+        MoreThan = 0,
+        AtLeast = 1,
+        Exactly = 2,
+        Within = 3,
+        LessThan = 4,
+    }
+}
+namespace FluentAssertions.Reflection
+{
+    public class AssemblyAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Reflection.Assembly, FluentAssertions.Reflection.AssemblyAssertions>
+    {
+        public AssemblyAssertions(System.Reflection.Assembly assembly) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Reflection.AssemblyAssertions, System.Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Specialized
+{
+    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action>
+    {
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Action Subject { get; }
+        protected override void InvokeSubject() { }
+    }
+    public class AsyncFunctionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Func<System.Threading.Tasks.Task>>
+    {
+        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Func<System.Threading.Tasks.Task> Subject { get; }
+        protected override void InvokeSubject() { }
+        public System.Threading.Tasks.Task NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public abstract class DelegateAssertions<TDelegate> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Delegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate>>
+        where TDelegate : System.Delegate
+    {
+        protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public new TDelegate Subject { get; }
+        protected abstract void InvokeSubject();
+        public void NotThrow(string because = "", params object[] becauseArgs) { }
+        protected void NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        protected void NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+        public void NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public class ExceptionAssertions<TException> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IEnumerable<TException>, FluentAssertions.Specialized.ExceptionAssertions<TException>>
+        where TException : System.Exception
+    {
+        public ExceptionAssertions(System.Collections.Generic.IEnumerable<TException> exceptions) { }
+        public TException And { get; }
+        protected override string Identifier { get; }
+        public TException Which { get; }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Where(System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, string because = "", params object[] becauseArgs) { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerException<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerExceptionExactly<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TException> WithMessage(string expectedWildcardPattern, string because = "", params object[] becauseArgs) { }
+    }
+    public class ExecutionTime
+    {
+        public ExecutionTime(System.Action action) { }
+        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action) { }
+        protected ExecutionTime(System.Action action, string actionDescription) { }
+        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription) { }
+    }
+    public class ExecutionTimeAssertions
+    {
+        public ExecutionTimeAssertions(FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        public void BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public void BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public void BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public void BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public void BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+    }
+    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
+    {
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Func<T> Subject { get; }
+        protected override void InvokeSubject() { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions
+    {
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+    public interface IExtractExceptions
+    {
+        System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception;
+    }
+    public class MemberExecutionTime<T> : FluentAssertions.Specialized.ExecutionTime
+    {
+        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+    }
+    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions
+    {
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Types
+{
+    public static class AllTypes
+    {
+        public static FluentAssertions.Types.TypeSelector From(System.Reflection.Assembly assembly) { }
+    }
+    public class ConstructorInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.ConstructorInfo, FluentAssertions.Types.ConstructorInfoAssertions>
+    {
+        public ConstructorInfoAssertions(System.Reflection.ConstructorInfo constructorInfo) { }
+        protected override string Identifier { get; }
+    }
+    public abstract class MemberInfoAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MemberInfo
+        where TAssertions : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+    {
+        protected MemberInfoAssertions() { }
+        protected MemberInfoAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+    }
+    public abstract class MethodBaseAssertions<TSubject, TAssertions> : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MethodBase
+        where TAssertions : FluentAssertions.Types.MethodBaseAssertions<TSubject, TAssertions>
+    {
+        protected MethodBaseAssertions() { }
+        protected MethodBaseAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>
+    {
+        public MethodInfoAssertions() { }
+        public MethodInfoAssertions(System.Reflection.MethodInfo methodInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturnVoid(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> ReturnVoid(string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, System.Collections.IEnumerable
+    {
+        public MethodInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public MethodInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.MethodInfoSelector ThatArePublicOrInternal { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturnVoid { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
+        public System.Reflection.MethodInfo[] ToArray() { }
+    }
+    public class MethodInfoSelectorAssertions
+    {
+        public MethodInfoSelectorAssertions(params System.Reflection.MethodInfo[] methods) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> SubjectMethods { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoAssertions : FluentAssertions.Types.MemberInfoAssertions<System.Reflection.PropertyInfo, FluentAssertions.Types.PropertyInfoAssertions>
+    {
+        public PropertyInfoAssertions(System.Reflection.PropertyInfo propertyInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo>, System.Collections.IEnumerable
+    {
+        public PropertyInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public PropertyInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatArePublicOrInternal { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.PropertyInfo> GetEnumerator() { }
+        public FluentAssertions.Types.PropertyInfoSelector NotOfType<TReturn>() { }
+        public FluentAssertions.Types.PropertyInfoSelector OfType<TReturn>() { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public System.Reflection.PropertyInfo[] ToArray() { }
+    }
+    public class PropertyInfoSelectorAssertions
+    {
+        public PropertyInfoSelectorAssertions(params System.Reflection.PropertyInfo[] properties) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> SubjectProperties { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public class TypeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Type, FluentAssertions.Types.TypeAssertions>
+    {
+        public TypeAssertions(System.Type type) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be(System.Type expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be<TExpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<System.Type> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveExplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveExplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveImplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveImplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveIndexer(System.Type indexerType, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty(System.Type propertyType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty<TProperty>(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe(System.Type unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe<TUnexpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<System.Type> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveExplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveExplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveImplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveImplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveIndexer(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveProperty(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+    }
+    public class TypeSelector : System.Collections.Generic.IEnumerable<System.Type>, System.Collections.IEnumerable
+    {
+        public TypeSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public TypeSelector(System.Type type) { }
+        public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
+        public System.Type[] ToArray() { }
+    }
+    public class TypeSelectorAssertions
+    {
+        public TypeSelectorAssertions(params System.Type[] types) { }
+        public System.Collections.Generic.IEnumerable<System.Type> Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+    }
+}
+namespace FluentAssertions.Xml
+{
+    public class XAttributeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XAttribute, FluentAssertions.Xml.XAttributeAssertions>
+    {
+        public XAttributeAssertions(System.Xml.Linq.XAttribute attribute) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> Be(System.Xml.Linq.XAttribute expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> Be(System.Xml.Linq.XAttribute expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> HaveValue(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> HaveValue(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> NotBe(System.Xml.Linq.XAttribute unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> NotBe(System.Xml.Linq.XAttribute unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XDocumentAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XDocument, FluentAssertions.Xml.XDocumentAssertions>
+    {
+        public XDocumentAssertions(System.Xml.Linq.XDocument document) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> Be(System.Xml.Linq.XDocument expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> Be(System.Xml.Linq.XDocument expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> BeEquivalentTo(System.Xml.Linq.XDocument expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> BeEquivalentTo(System.Xml.Linq.XDocument expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBe(System.Xml.Linq.XDocument unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBe(System.Xml.Linq.XDocument unexpected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBeEquivalentTo(System.Xml.Linq.XDocument unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBeEquivalentTo(System.Xml.Linq.XDocument unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XElementAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XElement, FluentAssertions.Xml.XElementAssertions>
+    {
+        public XElementAssertions(System.Xml.Linq.XElement xElement) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> Be(System.Xml.Linq.XElement expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> Be(System.Xml.Linq.XElement expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveValue(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveValue(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBe(System.Xml.Linq.XElement unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBe(System.Xml.Linq.XElement unexpected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBeEquivalentTo(System.Xml.Linq.XElement unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBeEquivalentTo(System.Xml.Linq.XElement unexpected, string because, params object[] becauseArgs) { }
+    }
+}

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard1.3.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard1.3.approved.txt
@@ -1282,8 +1282,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
         where T :  struct

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard1.6.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard1.6.approved.txt
@@ -1282,8 +1282,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
         where T :  struct

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard1.6.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard1.6.approved.txt
@@ -1,0 +1,2058 @@
+﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v1.6", FrameworkDisplayName="")]
+namespace FluentAssertions
+{
+    public class AggregateExceptionExtractor : FluentAssertions.Specialized.IExtractExceptions
+    {
+        public AggregateExceptionExtractor() { }
+        public System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception { }
+    }
+    public class AndConstraint<T>
+    {
+        public AndConstraint(T parentConstraint) { }
+        public T And { get; }
+    }
+    public class AndWhichConstraint<TParentConstraint, TMatchedElement> : FluentAssertions.AndConstraint<TParentConstraint>
+    {
+        public AndWhichConstraint(TParentConstraint parentConstraint, System.Collections.Generic.IEnumerable<TMatchedElement> matchedConstraint) { }
+        public AndWhichConstraint(TParentConstraint parentConstraint, TMatchedElement matchedConstraint) { }
+        public TMatchedElement Subject { get; }
+        public TMatchedElement Which { get; }
+    }
+    public static class AssertionExtensions
+    {
+        public static TTo As<TTo>(this object subject) { }
+        public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.Task<TResult>> action) { }
+        public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+        public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
+        public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
+        public static FluentAssertions.Specialized.ExecutionTimeAssertions Should(this FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        public static FluentAssertions.Types.MethodInfoSelectorAssertions Should(this FluentAssertions.Types.MethodInfoSelector methodSelector) { }
+        public static FluentAssertions.Types.PropertyInfoSelectorAssertions Should(this FluentAssertions.Types.PropertyInfoSelector propertyInfoSelector) { }
+        public static FluentAssertions.Types.TypeSelectorAssertions Should(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
+        public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
+        public static FluentAssertions.Collections.NonGenericCollectionAssertions Should(this System.Collections.IEnumerable actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
+        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
+        public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
+        public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
+        public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
+        public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
+        public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
+        public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
+        public static FluentAssertions.Xml.XAttributeAssertions Should(this System.Xml.Linq.XAttribute actualValue) { }
+        public static FluentAssertions.Xml.XDocumentAssertions Should(this System.Xml.Linq.XDocument actualValue) { }
+        public static FluentAssertions.Xml.XElementAssertions Should(this System.Xml.Linq.XElement actualValue) { }
+        public static FluentAssertions.Primitives.BooleanAssertions Should(this bool actualValue) { }
+        public static FluentAssertions.Primitives.NullableBooleanAssertions Should(this bool? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<byte> Should(this byte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<byte> Should(this byte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<decimal> Should(this decimal actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<decimal> Should(this decimal? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<double> Should(this double actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<double> Should(this double? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<float> Should(this float actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<float> Should(this float? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<int> Should(this int actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<int> Should(this int? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<long> Should(this long actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<long> Should(this long? actualValue) { }
+        public static FluentAssertions.Primitives.ObjectAssertions Should(this object actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<sbyte> Should(this sbyte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<sbyte> Should(this sbyte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<short> Should(this short actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<short> Should(this short? actualValue) { }
+        public static FluentAssertions.Primitives.StringAssertions Should(this string actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<uint> Should(this uint actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<uint> Should(this uint? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ulong> Should(this ulong actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ulong> Should(this ulong? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ushort> Should(this ushort actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ushort> Should(this ushort? actualValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
+        public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public static class AssertionOptions
+    {
+        public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
+        public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
+        public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
+    }
+    public static class AtLeast
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class AtMost
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class CallerIdentifier
+    {
+        public static System.Action<string> logger;
+        public static string DetermineCallerIdentity() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
+    public class CustomAssertionAttribute : System.Attribute
+    {
+        public CustomAssertionAttribute() { }
+    }
+    public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
+    {
+        public EquivalencyStepCollection() { }
+        public void Add<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void AddAfter<TPredecessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Clear() { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IEquivalencyStep> GetEnumerator() { }
+        public void Insert<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void InsertBefore<TSuccessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Remove<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep { }
+        public void Reset() { }
+    }
+    public static class EventRaisingExtensions
+    {
+        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, params System.Linq.Expressions.Expression<>[] predicates) { }
+        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
+        public static FluentAssertions.Events.IEventRecorder WithSender(this FluentAssertions.Events.IEventRecorder eventRecorder, object expectedSender) { }
+    }
+    public static class Exactly
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class FluentActions
+    {
+        public static System.Func<System.Threading.Tasks.Task> Awaiting(System.Func<System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task<T>> Awaiting<T>(System.Func<System.Threading.Tasks.Task<T>> func) { }
+        public static System.Action Enumerating(System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static System.Action Invoking(System.Action action) { }
+        public static System.Func<T> Invoking<T>(System.Func<T> func) { }
+    }
+    public static class LessThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class MoreThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class NumericAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class OccurrenceConstraint
+    {
+        protected OccurrenceConstraint(int expectedCount) { }
+    }
+    public static class TypeEnumerableExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreInNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreUnderNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatDeriveFrom<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatImplement<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+    }
+    public static class TypeExtensions
+    {
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this System.Type type) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this System.Type type) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Type type) { }
+    }
+}
+namespace FluentAssertions.Collections
+{
+    public abstract class CollectionAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Collections.IEnumerable
+        where TAssertions : FluentAssertions.Collections.CollectionAssertions<TSubject, TAssertions>
+    {
+        protected CollectionAssertions() { }
+        protected CollectionAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeOfType<T>(string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionEndsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actual, System.Collections.Generic.ICollection<TExpected> expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionEndsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actual, TExpected[] expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionStartsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actualItems, System.Collections.Generic.ICollection<TExpected> expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionStartsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actualItems, TExpected[] expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertSubjectEquality<TActual, TExpected>(System.Collections.IEnumerable expectation, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params object[] expectations) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.IEnumerable expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.IEnumerable expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.IEnumerable>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.IEnumerable>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSubsetOf(System.Collections.IEnumerable expectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params object[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainItemsAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(object element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params object[] elements) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, object> HaveElementAt(int index, object element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(object successor, object expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(object predecessor, object expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInAscendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAscendingInOrder(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInAscendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAscendingInOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInDescendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDescendingInOrder(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInDescendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDescendingInOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSubsetOf(System.Collections.IEnumerable unexpectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotIntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(object element, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
+    {
+        public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+            where TKey :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(params TKey[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(params TValue[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(params TKey[] unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(params TValue[] unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+    }
+    public class NonGenericCollectionAssertions : FluentAssertions.Collections.CollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
+    {
+        public NonGenericCollectionAssertions(System.Collections.IEnumerable collection) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
+    {
+        public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params T[] elements) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpectedItemsList, params T[] additionalUnexpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(params System.Action<>[] elementInspectors) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(System.Collections.Generic.IEnumerable<System.Action<T>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+    }
+    public class StringCollectionAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<string, FluentAssertions.Collections.StringCollectionAssertions>
+    {
+        public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(params string[] expectation) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(params string[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+    }
+    public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public WhichValueConstraint(FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> parentConstraint, TValue value) { }
+        public TValue WhichValue { get; }
+    }
+}
+namespace FluentAssertions.Common
+{
+    public enum CSharpAccessModifier
+    {
+        Public = 0,
+        Private = 1,
+        Protected = 2,
+        Internal = 3,
+        ProtectedInternal = 4,
+        InvalidForCSharp = 5,
+        PrivateProtected = 6,
+    }
+    public static class CSharpAccessModifierExtensions { }
+    public class Configuration
+    {
+        public Configuration(FluentAssertions.Common.IConfigurationStore store) { }
+        public string TestFrameworkName { get; set; }
+        public string ValueFormatterAssembly { get; set; }
+        public FluentAssertions.Common.ValueFormatterDetectionMode ValueFormatterDetectionMode { get; set; }
+        public static FluentAssertions.Common.Configuration Current { get; }
+    }
+    public static class DateTimeExtensions
+    {
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime) { }
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime, System.TimeSpan offset) { }
+    }
+    public interface IClock
+    {
+        void Delay(System.TimeSpan timeToDelay);
+        System.Threading.Tasks.Task DelayAsync(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken);
+        FluentAssertions.Common.ITimer StartTimer();
+        bool Wait(System.Threading.Tasks.Task task, System.TimeSpan timeout);
+    }
+    public interface IConfigurationStore
+    {
+        string GetSetting(string name);
+    }
+    public interface IReflector
+    {
+        System.Collections.Generic.IEnumerable<System.Type> GetAllTypesFromAppDomain(System.Func<System.Reflection.Assembly, bool> predicate);
+    }
+    public interface ITimer
+    {
+        System.TimeSpan Elapsed { get; }
+    }
+    public static class MethodInfoExtensions { }
+    public static class ObjectExtensions
+    {
+        public static bool IsSameOrEqualTo(this object actual, object expected) { }
+    }
+    public static class PropertyInfoExtensions { }
+    public static class Services
+    {
+        public static FluentAssertions.Common.Configuration Configuration { get; }
+        public static FluentAssertions.Common.IConfigurationStore ConfigurationStore { get; set; }
+        public static FluentAssertions.Common.IReflector Reflector { get; set; }
+        public static System.Action<string> ThrowException { get; set; }
+        public static void ResetToDefaults() { }
+    }
+    public static class TypeExtensions
+    {
+        public static System.Reflection.FieldInfo FindField(this System.Type type, string fieldName, System.Type preferredType) { }
+        public static FluentAssertions.Equivalency.SelectedMemberInfo FindMember(this System.Type type, string memberName, System.Type preferredType) { }
+        public static System.Reflection.PropertyInfo FindProperty(this System.Type type, string propertyName, System.Type preferredType) { }
+        public static System.Reflection.ConstructorInfo GetConstructor(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.PropertyInfo GetIndexerByParameterTypes(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Reflection.MethodInfo GetMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> GetNonPrivateFields(this System.Type typeToReflect) { }
+        public static System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetNonPrivateMembers(this System.Type typeToReflect) { }
+        public static System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> GetNonPrivateProperties(this System.Type typeToReflect, System.Collections.Generic.IEnumerable<string> filter = null) { }
+        public static System.Reflection.MethodInfo GetParameterlessMethod(this System.Type type, string methodName) { }
+        public static System.Reflection.PropertyInfo GetPropertyByName(this System.Type type, string propertyName) { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWithOrInherits> instead.")]
+        public static bool HasAttribute<TAttribute>(this System.Reflection.MemberInfo method)
+            where TAttribute : System.Attribute { }
+        public static bool HasExplicitlyImplementedProperty(this System.Type type, System.Type interfaceType, string propertyName) { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWith> instead.")]
+        public static bool HasMatchingAttribute<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
+        public static bool HasMatchingAttribute<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, bool inherit = false)
+            where TAttribute : System.Attribute { }
+        public static bool HasMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static bool HasParameterlessMethod(this System.Type type, string methodName) { }
+        public static bool HasValueSemantics(this System.Type type) { }
+        public static bool Implements(this System.Type type, System.Type expectedBaseType) { }
+        public static bool IsCSharpAbstract(this System.Type type) { }
+        public static bool IsCSharpSealed(this System.Type type) { }
+        public static bool IsCSharpStatic(this System.Type type) { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        [System.Obsolete("This overload is deprecated and will be removed on the next major version. Please" +
+            " use <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type, bool inherit = false)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsEquivalentTo(this FluentAssertions.Equivalency.SelectedMemberInfo property, FluentAssertions.Equivalency.SelectedMemberInfo otherProperty) { }
+        public static bool IsIndexer(this System.Reflection.PropertyInfo member) { }
+        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
+        public static bool OverridesEquals(this System.Type type) { }
+    }
+    public enum ValueFormatterDetectionMode
+    {
+        Disabled = 0,
+        Specific = 1,
+        Scan = 2,
+    }
+}
+namespace FluentAssertions.Equivalency
+{
+    public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class ConversionSelector
+    {
+        public ConversionSelector() { }
+        public FluentAssertions.Equivalency.ConversionSelector Clone() { }
+        public void Exclude(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void Include(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void IncludeAll() { }
+        public bool RequiresConversion(FluentAssertions.Equivalency.IMemberInfo info) { }
+        public override string ToString() { }
+    }
+    public enum CyclicReferenceHandling
+    {
+        Ignore = 0,
+        ThrowException = 1,
+    }
+    public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DictionaryEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public virtual bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class EnumEqualityStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumEqualityStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public enum EnumEquivalencyHandling
+    {
+        ByValue = 0,
+        ByName = 1,
+    }
+    public class EnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumerableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public enum EqualityStrategy
+    {
+        Equals = 0,
+        Members = 1,
+        ForceEquals = 2,
+        ForceMembers = 3,
+    }
+    public class EquivalencyAssertionOptions : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions>
+    {
+        public EquivalencyAssertionOptions() { }
+    }
+    [System.Obsolete("This class is deprecated and will be removed in version 6.X.")]
+    public static class EquivalencyAssertionOptionsExtentions
+    {
+        public static System.Type GetExpectationType(this FluentAssertions.Equivalency.IEquivalencyAssertionOptions config, FluentAssertions.Equivalency.IMemberInfo context) { }
+    }
+    public class EquivalencyAssertionOptions<TExpectation> : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>>
+    {
+        public EquivalencyAssertionOptions() { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+    }
+    public class EquivalencyValidationContext : FluentAssertions.Equivalency.IEquivalencyValidationContext, FluentAssertions.Equivalency.IMemberInfo
+    {
+        public EquivalencyValidationContext() { }
+        public string Because { get; set; }
+        public object[] BecauseArgs { get; set; }
+        public System.Type CompileTimeType { get; set; }
+        public object Expectation { get; set; }
+        public bool IsRoot { get; }
+        public bool RootIsCollection { get; set; }
+        public System.Type RuntimeType { get; }
+        public string SelectedMemberDescription { get; set; }
+        public FluentAssertions.Equivalency.SelectedMemberInfo SelectedMemberInfo { get; set; }
+        public string SelectedMemberPath { get; set; }
+        public object Subject { get; set; }
+        public FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
+        public override string ToString() { }
+        public System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getTraceMessage) { }
+        public void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getTraceMessage) { }
+    }
+    public class EquivalencyValidator : FluentAssertions.Equivalency.IEquivalencyValidator
+    {
+        public EquivalencyValidator(FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public void AssertEquality(FluentAssertions.Equivalency.EquivalencyValidationContext context) { }
+        public void AssertEqualityUsing(FluentAssertions.Equivalency.IEquivalencyValidationContext context) { }
+    }
+    public class GenericDictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericDictionaryEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class GenericEnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericEnumerableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public delegate string GetTraceMessage(string path);
+    public interface IAssertionContext<TSubject>
+    {
+        string Because { get; set; }
+        object[] BecauseArgs { get; set; }
+        TSubject Expectation { get; }
+        TSubject Subject { get; }
+        FluentAssertions.Equivalency.SelectedMemberInfo SubjectProperty { get; }
+    }
+    public interface IAssertionRule
+    {
+        bool AssertEquality(FluentAssertions.Equivalency.IEquivalencyValidationContext context);
+    }
+    public interface IEquivalencyAssertionOptions
+    {
+        bool AllowInfiniteRecursion { get; }
+        FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
+        FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool IncludeFields { get; }
+        bool IncludeProperties { get; }
+        bool IsRecursive { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberMatchingRule> MatchingRules { get; }
+        FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
+        FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
+        bool UseRuntimeTyping { get; }
+        FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> GetUserEquivalencySteps(FluentAssertions.Equivalency.ConversionSelector conversionSelector);
+    }
+    public interface IEquivalencyStep
+    {
+        bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+        bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IEquivalencyValidationContext : FluentAssertions.Equivalency.IMemberInfo
+    {
+        string Because { get; }
+        object[] BecauseArgs { get; }
+        object Expectation { get; }
+        bool IsRoot { get; }
+        bool RootIsCollection { get; set; }
+        object Subject { get; }
+        FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
+        System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getMessage);
+        void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getMessage);
+    }
+    public interface IEquivalencyValidator
+    {
+        void AssertEqualityUsing(FluentAssertions.Equivalency.IEquivalencyValidationContext context);
+    }
+    public interface IMemberInfo
+    {
+        System.Type CompileTimeType { get; }
+        System.Type RuntimeType { get; }
+        string SelectedMemberDescription { get; }
+        FluentAssertions.Equivalency.SelectedMemberInfo SelectedMemberInfo { get; }
+        string SelectedMemberPath { get; }
+    }
+    public interface IMemberMatchingRule
+    {
+        FluentAssertions.Equivalency.SelectedMemberInfo Match(FluentAssertions.Equivalency.SelectedMemberInfo expectedMember, object subject, string memberPath, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IMemberSelectionRule
+    {
+        bool IncludesMembers { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> SelectMembers(System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> selectedMembers, FluentAssertions.Equivalency.IMemberInfo context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IOrderingRule
+    {
+        FluentAssertions.Equivalency.OrderStrictness Evaluate(FluentAssertions.Equivalency.IMemberInfo memberInfo);
+    }
+    public interface ITraceWriter
+    {
+        System.IDisposable AddBlock(string trace);
+        void AddSingle(string trace);
+        string ToString();
+    }
+    public enum OrderStrictness
+    {
+        Strict = 0,
+        NotStrict = 1,
+        Irrelevant = 2,
+    }
+    public class OrderingRuleCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule>, System.Collections.IEnumerable
+    {
+        public OrderingRuleCollection() { }
+        public OrderingRuleCollection(System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule> orderingRules) { }
+        public void Add(FluentAssertions.Equivalency.IOrderingRule rule) { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IOrderingRule> GetEnumerator() { }
+        public bool IsOrderingStrictFor(FluentAssertions.Equivalency.IMemberInfo memberInfo) { }
+    }
+    public class ReferenceEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ReferenceEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public virtual bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class RunAllUserStepsEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public RunAllUserStepsEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public abstract class SelectedMemberInfo
+    {
+        protected SelectedMemberInfo() { }
+        public abstract System.Type DeclaringType { get; }
+        public abstract System.Type MemberType { get; }
+        public abstract string Name { get; }
+        public abstract object GetValue(object obj, object[] index);
+        public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.FieldInfo fieldInfo) { }
+        public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.PropertyInfo propertyInfo) { }
+    }
+    public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
+        where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
+    {
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        protected readonly FluentAssertions.Equivalency.OrderingRuleCollection orderingRules;
+        protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
+        public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        public FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
+        protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public TSelf AllowingInfiniteRecursion() { }
+        public TSelf ComparingByMembers<T>() { }
+        public TSelf ComparingByValue<T>() { }
+        public TSelf ComparingEnumsByName() { }
+        public TSelf ComparingEnumsByValue() { }
+        public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf ExcludingFields() { }
+        public TSelf ExcludingMissingMembers() { }
+        public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingProperties() { }
+        public TSelf IgnoringCyclicReferences() { }
+        public TSelf IncludingAllDeclaredProperties() { }
+        public TSelf IncludingAllRuntimeProperties() { }
+        public TSelf IncludingFields() { }
+        public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingProperties() { }
+        protected void RemoveSelectionRule<T>()
+            where T : FluentAssertions.Equivalency.IMemberSelectionRule { }
+        public TSelf RespectingDeclaredTypes() { }
+        public TSelf RespectingRuntimeTypes() { }
+        public TSelf ThrowingOnMissingMembers() { }
+        public override string ToString() { }
+        public TSelf Using(FluentAssertions.Equivalency.IAssertionRule assertionRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IEquivalencyStep equivalencyStep) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
+        public TSelf WithAutoConversion() { }
+        public TSelf WithAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf WithStrictOrdering() { }
+        public TSelf WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf WithTracing(FluentAssertions.Equivalency.ITraceWriter writer = null) { }
+        public TSelf WithoutAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void WithoutMatchingRules() { }
+        public void WithoutSelectionRules() { }
+        public TSelf WithoutStrictOrdering() { }
+        public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public class Restriction<TMember>
+        {
+            public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
+            public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+            public TSelf WhenTypeIs<TMemberType>() { }
+        }
+    }
+    public class SimpleEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public SimpleEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class StringBuilderTraceWriter : FluentAssertions.Equivalency.ITraceWriter
+    {
+        public StringBuilderTraceWriter() { }
+        public System.IDisposable AddBlock(string trace) { }
+        public void AddSingle(string trace) { }
+        public override string ToString() { }
+    }
+    public class StringEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StringEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class StructuralEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StructuralEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public static class SubjectInfoExtensions
+    {
+        public static bool WhichGetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichGetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+    }
+    public class TryConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public TryConversionStep(FluentAssertions.Equivalency.ConversionSelector selector) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ValueTypeEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+}
+namespace FluentAssertions.Events
+{
+    public interface IEventRecorder : System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
+    {
+        System.Type EventHandlerType { get; }
+        string EventName { get; }
+        object EventObject { get; }
+        void RecordEvent(params object[] parameters);
+        void Reset();
+    }
+    public class RecordedEvent
+    {
+        public RecordedEvent(System.DateTime utcNow, object monitoredObject, params object[] parameters) { }
+        public System.Collections.Generic.IEnumerable<object> Parameters { get; }
+        public System.DateTime TimestampUtc { get; set; }
+    }
+}
+namespace FluentAssertions.Execution
+{
+    public class AssertionFailedException : System.Exception
+    {
+        public AssertionFailedException(string message) { }
+    }
+    public class AssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public AssertionScope() { }
+        public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
+        public AssertionScope(string context) { }
+        public string Context { get; set; }
+        public bool Succeeded { get; }
+        public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
+        public static FluentAssertions.Execution.AssertionScope Current { get; }
+        public void AddNonReportable(string key, object value) { }
+        public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, string value) { }
+        public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
+        public T Get<T>(string key) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public bool HasFailures() { }
+        public FluentAssertions.Execution.AssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.AssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public class Continuation
+    {
+        public Continuation(FluentAssertions.Execution.AssertionScope sourceScope, bool sourceSucceeded) { }
+        public bool SourceSucceeded { get; }
+        public FluentAssertions.Execution.IAssertionScope Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.Continuation continuation) { }
+    }
+    public class ContinuationOfGiven<TSubject>
+    {
+        public ContinuationOfGiven(FluentAssertions.Execution.GivenSelector<TSubject> parent, bool succeeded) { }
+        public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
+    }
+    public class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public ContinuedAssertionScope(FluentAssertions.Execution.AssertionScope predecessor, bool predecessorSucceeded) { }
+        public bool Succeeded { get; }
+        public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.IAssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public static class Execute
+    {
+        public static FluentAssertions.Execution.AssertionScope Assertion { get; }
+    }
+    public class FailReason
+    {
+        public FailReason(string message, params object[] args) { }
+        public object[] Args { get; }
+        public string Message { get; }
+    }
+    public class GivenSelector<T>
+    {
+        public GivenSelector(System.Func<T> selector, bool predecessorSucceeded, FluentAssertions.Execution.AssertionScope predecessor) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> ClearExpectation() { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<, >[] args) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
+        public FluentAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
+    }
+    public interface IAssertionScope : System.IDisposable
+    {
+        bool Succeeded { get; }
+        FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
+        FluentAssertions.Execution.Continuation ClearExpectation();
+        string[] Discard();
+        FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc);
+        FluentAssertions.Execution.Continuation FailWith(string message, params object[] args);
+        FluentAssertions.Execution.IAssertionScope ForCondition(bool condition);
+        FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector);
+        FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier);
+        FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args);
+    }
+    public interface IAssertionStrategy
+    {
+        System.Collections.Generic.IEnumerable<string> FailureMessages { get; }
+        System.Collections.Generic.IEnumerable<string> DiscardFailures();
+        void HandleFailure(string message);
+        void ThrowIfAny(System.Collections.Generic.IDictionary<string, object> context);
+    }
+    public interface ICloneable2
+    {
+        object Clone();
+    }
+}
+namespace FluentAssertions.Extensions
+{
+    public static class FluentDateTimeExtensions
+    {
+        public static System.DateTime AddMicroseconds(this System.DateTime self, long microseconds) { }
+        public static System.DateTimeOffset AddMicroseconds(this System.DateTimeOffset self, long microseconds) { }
+        public static System.DateTime AddNanoseconds(this System.DateTime self, long nanoseconds) { }
+        public static System.DateTimeOffset AddNanoseconds(this System.DateTimeOffset self, long nanoseconds) { }
+        public static System.DateTime After(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime April(this int day, int year) { }
+        public static System.DateTime AsLocal(this System.DateTime dateTime) { }
+        public static System.DateTime AsUtc(this System.DateTime dateTime) { }
+        public static System.DateTime At(this System.DateTime date, System.TimeSpan time) { }
+        public static System.DateTime At(this System.DateTime date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTimeOffset At(this System.DateTimeOffset date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTime August(this int day, int year) { }
+        public static System.DateTime Before(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime December(this int day, int year) { }
+        public static System.DateTime February(this int day, int year) { }
+        public static System.DateTime January(this int day, int year) { }
+        public static System.DateTime July(this int day, int year) { }
+        public static System.DateTime June(this int day, int year) { }
+        public static System.DateTime March(this int day, int year) { }
+        public static System.DateTime May(this int day, int year) { }
+        public static int Microsecond(this System.DateTime self) { }
+        public static int Microsecond(this System.DateTimeOffset self) { }
+        public static int Nanosecond(this System.DateTime self) { }
+        public static int Nanosecond(this System.DateTimeOffset self) { }
+        public static System.DateTime November(this int day, int year) { }
+        public static System.DateTime October(this int day, int year) { }
+        public static System.DateTime September(this int day, int year) { }
+    }
+    public static class FluentTimeSpanExtensions
+    {
+        public const long TicksPerMicrosecond = 10;
+        public const double TicksPerNanosecond = 0.01D;
+        public static System.TimeSpan And(this System.TimeSpan sourceTime, System.TimeSpan offset) { }
+        public static System.TimeSpan Days(this double days) { }
+        public static System.TimeSpan Days(this int days) { }
+        public static System.TimeSpan Days(this int days, System.TimeSpan offset) { }
+        public static System.TimeSpan Hours(this double hours) { }
+        public static System.TimeSpan Hours(this int hours) { }
+        public static System.TimeSpan Hours(this int hours, System.TimeSpan offset) { }
+        public static int Microseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Microseconds(this int microseconds) { }
+        public static System.TimeSpan Microseconds(this long microseconds) { }
+        public static System.TimeSpan Milliseconds(this double milliseconds) { }
+        public static System.TimeSpan Milliseconds(this int milliseconds) { }
+        public static System.TimeSpan Minutes(this double minutes) { }
+        public static System.TimeSpan Minutes(this int minutes) { }
+        public static System.TimeSpan Minutes(this int minutes, System.TimeSpan offset) { }
+        public static int Nanoseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Nanoseconds(this int nanoseconds) { }
+        public static System.TimeSpan Nanoseconds(this long nanoseconds) { }
+        public static System.TimeSpan Seconds(this double seconds) { }
+        public static System.TimeSpan Seconds(this int seconds) { }
+        public static System.TimeSpan Seconds(this int seconds, System.TimeSpan offset) { }
+        public static System.TimeSpan Ticks(this int ticks) { }
+        public static System.TimeSpan Ticks(this long ticks) { }
+        public static double TotalMicroseconds(this System.TimeSpan self) { }
+        public static double TotalNanoseconds(this System.TimeSpan self) { }
+    }
+}
+namespace FluentAssertions.Formatting
+{
+    public class AggregateExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AggregateExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class AttributeBasedFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AttributeBasedFormatter() { }
+        public System.Reflection.MethodInfo[] Formatters { get; }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DateTimeOffsetValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DateTimeOffsetValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DecimalValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DecimalValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DefaultValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DoubleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public EnumerableValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExpressionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public delegate string FormatChild(string childPath, object value);
+    public static class Formatter
+    {
+        public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
+        public static void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static string ToString(object value, bool useLineBreaks = false) { }
+    }
+    public class FormattingContext
+    {
+        public FormattingContext() { }
+        public int Depth { get; set; }
+        public bool UseLineBreaks { get; set; }
+    }
+    public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public GuidValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public interface IValueFormatter
+    {
+        bool CanHandle(object value);
+        string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
+    }
+    public class Int16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class MultidimensionalArrayFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public MultidimensionalArrayFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class NullValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public NullValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class PropertyInfoFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public PropertyInfoFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SingleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SingleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class StringValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public StringValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TaskFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TaskFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TimeSpanValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TimeSpanValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
+    public class ValueFormatterAttribute : System.Attribute
+    {
+        public ValueFormatterAttribute() { }
+    }
+    public class XAttributeValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XAttributeValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XDocumentValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XDocumentValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XElementValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XElementValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+}
+namespace FluentAssertions.Numeric
+{
+    public class ComparableTypeAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    {
+        public ComparableTypeAssertions(System.IComparable<T> value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
+        where T :  struct
+    {
+        public NullableNumericAssertions(T? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NumericAssertions<T>
+        where T :  struct
+    {
+        public NumericAssertions(object value) { }
+        public System.IComparable Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(params T[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Primitives
+{
+    public class BooleanAssertions
+    {
+        public BooleanAssertions(bool? value) { }
+        public bool? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeAssertions
+    {
+        public DateTimeAssertions(System.DateTime? value) { }
+        public System.DateTime? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.DateTime[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetAssertions
+    {
+        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
+        public System.DateTimeOffset? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetRangeAssertions
+    {
+        protected DateTimeOffsetRangeAssertions(FluentAssertions.Primitives.DateTimeOffsetAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeRangeAssertions
+    {
+        protected DateTimeRangeAssertions(FluentAssertions.Primitives.DateTimeAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
+    }
+    public class GuidAssertions
+    {
+        public GuidAssertions(System.Guid? value) { }
+        public System.Guid? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableBooleanAssertions : FluentAssertions.Primitives.BooleanAssertions
+    {
+        public NullableBooleanAssertions(bool? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions
+    {
+        public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions
+    {
+        public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableGuidAssertions : FluentAssertions.Primitives.GuidAssertions
+    {
+        public NullableGuidAssertions(System.Guid? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions
+    {
+        public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class ObjectAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
+    {
+        public ObjectAssertions(object value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be(object expected, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> HaveFlag(System.Enum expectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe(object unexpected, string because = "", params object[] becauseArgs) { }
+        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotHaveFlag(System.Enum unexpectedFlag, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
+        where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+    {
+        protected ReferenceTypeAssertions() { }
+        protected ReferenceTypeAssertions(TSubject subject) { }
+        protected abstract string Identifier { get; }
+        public TSubject Subject { get; set; }
+        public FluentAssertions.AndConstraint<TAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameAs(TSubject expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<TSubject, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match<T>(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
+            where T : TSubject { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SimpleTimeSpanAssertions
+    {
+        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public System.TimeSpan? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+    }
+    public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>
+    {
+        public StringAssertions(string value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(params string[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+    }
+    public enum TimeSpanCondition
+    {
+        MoreThan = 0,
+        AtLeast = 1,
+        Exactly = 2,
+        Within = 3,
+        LessThan = 4,
+    }
+}
+namespace FluentAssertions.Reflection
+{
+    public class AssemblyAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Reflection.Assembly, FluentAssertions.Reflection.AssemblyAssertions>
+    {
+        public AssemblyAssertions(System.Reflection.Assembly assembly) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Reflection.AssemblyAssertions, System.Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Specialized
+{
+    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action>
+    {
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Action Subject { get; }
+        protected override void InvokeSubject() { }
+    }
+    public class AsyncFunctionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Func<System.Threading.Tasks.Task>>
+    {
+        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Func<System.Threading.Tasks.Task> Subject { get; }
+        protected override void InvokeSubject() { }
+        public System.Threading.Tasks.Task NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public abstract class DelegateAssertions<TDelegate> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Delegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate>>
+        where TDelegate : System.Delegate
+    {
+        protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public new TDelegate Subject { get; }
+        protected abstract void InvokeSubject();
+        public void NotThrow(string because = "", params object[] becauseArgs) { }
+        protected void NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        protected void NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+        public void NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public class ExceptionAssertions<TException> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IEnumerable<TException>, FluentAssertions.Specialized.ExceptionAssertions<TException>>
+        where TException : System.Exception
+    {
+        public ExceptionAssertions(System.Collections.Generic.IEnumerable<TException> exceptions) { }
+        public TException And { get; }
+        protected override string Identifier { get; }
+        public TException Which { get; }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Where(System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, string because = "", params object[] becauseArgs) { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerException<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerExceptionExactly<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TException> WithMessage(string expectedWildcardPattern, string because = "", params object[] becauseArgs) { }
+    }
+    public class ExecutionTime
+    {
+        public ExecutionTime(System.Action action) { }
+        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action) { }
+        protected ExecutionTime(System.Action action, string actionDescription) { }
+        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription) { }
+    }
+    public class ExecutionTimeAssertions
+    {
+        public ExecutionTimeAssertions(FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        public void BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public void BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public void BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public void BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public void BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+    }
+    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
+    {
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Func<T> Subject { get; }
+        protected override void InvokeSubject() { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions
+    {
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+    public interface IExtractExceptions
+    {
+        System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception;
+    }
+    public class MemberExecutionTime<T> : FluentAssertions.Specialized.ExecutionTime
+    {
+        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+    }
+    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions
+    {
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Types
+{
+    public static class AllTypes
+    {
+        public static FluentAssertions.Types.TypeSelector From(System.Reflection.Assembly assembly) { }
+    }
+    public class ConstructorInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.ConstructorInfo, FluentAssertions.Types.ConstructorInfoAssertions>
+    {
+        public ConstructorInfoAssertions(System.Reflection.ConstructorInfo constructorInfo) { }
+        protected override string Identifier { get; }
+    }
+    public abstract class MemberInfoAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MemberInfo
+        where TAssertions : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+    {
+        protected MemberInfoAssertions() { }
+        protected MemberInfoAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+    }
+    public abstract class MethodBaseAssertions<TSubject, TAssertions> : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MethodBase
+        where TAssertions : FluentAssertions.Types.MethodBaseAssertions<TSubject, TAssertions>
+    {
+        protected MethodBaseAssertions() { }
+        protected MethodBaseAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>
+    {
+        public MethodInfoAssertions() { }
+        public MethodInfoAssertions(System.Reflection.MethodInfo methodInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturnVoid(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> ReturnVoid(string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, System.Collections.IEnumerable
+    {
+        public MethodInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public MethodInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.MethodInfoSelector ThatArePublicOrInternal { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturnVoid { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
+        public System.Reflection.MethodInfo[] ToArray() { }
+    }
+    public class MethodInfoSelectorAssertions
+    {
+        public MethodInfoSelectorAssertions(params System.Reflection.MethodInfo[] methods) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> SubjectMethods { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoAssertions : FluentAssertions.Types.MemberInfoAssertions<System.Reflection.PropertyInfo, FluentAssertions.Types.PropertyInfoAssertions>
+    {
+        public PropertyInfoAssertions(System.Reflection.PropertyInfo propertyInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo>, System.Collections.IEnumerable
+    {
+        public PropertyInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public PropertyInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatArePublicOrInternal { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.PropertyInfo> GetEnumerator() { }
+        public FluentAssertions.Types.PropertyInfoSelector NotOfType<TReturn>() { }
+        public FluentAssertions.Types.PropertyInfoSelector OfType<TReturn>() { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public System.Reflection.PropertyInfo[] ToArray() { }
+    }
+    public class PropertyInfoSelectorAssertions
+    {
+        public PropertyInfoSelectorAssertions(params System.Reflection.PropertyInfo[] properties) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> SubjectProperties { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public class TypeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Type, FluentAssertions.Types.TypeAssertions>
+    {
+        public TypeAssertions(System.Type type) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be(System.Type expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be<TExpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<System.Type> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveExplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveExplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveImplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveImplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveIndexer(System.Type indexerType, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty(System.Type propertyType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty<TProperty>(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe(System.Type unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe<TUnexpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<System.Type> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveExplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveExplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveImplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveImplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveIndexer(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveProperty(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+    }
+    public class TypeSelector : System.Collections.Generic.IEnumerable<System.Type>, System.Collections.IEnumerable
+    {
+        public TypeSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public TypeSelector(System.Type type) { }
+        public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
+        public System.Type[] ToArray() { }
+    }
+    public class TypeSelectorAssertions
+    {
+        public TypeSelectorAssertions(params System.Type[] types) { }
+        public System.Collections.Generic.IEnumerable<System.Type> Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+    }
+}
+namespace FluentAssertions.Xml
+{
+    public class XAttributeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XAttribute, FluentAssertions.Xml.XAttributeAssertions>
+    {
+        public XAttributeAssertions(System.Xml.Linq.XAttribute attribute) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> Be(System.Xml.Linq.XAttribute expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> Be(System.Xml.Linq.XAttribute expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> HaveValue(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> HaveValue(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> NotBe(System.Xml.Linq.XAttribute unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> NotBe(System.Xml.Linq.XAttribute unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XDocumentAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XDocument, FluentAssertions.Xml.XDocumentAssertions>
+    {
+        public XDocumentAssertions(System.Xml.Linq.XDocument document) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> Be(System.Xml.Linq.XDocument expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> Be(System.Xml.Linq.XDocument expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> BeEquivalentTo(System.Xml.Linq.XDocument expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> BeEquivalentTo(System.Xml.Linq.XDocument expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBe(System.Xml.Linq.XDocument unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBe(System.Xml.Linq.XDocument unexpected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBeEquivalentTo(System.Xml.Linq.XDocument unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBeEquivalentTo(System.Xml.Linq.XDocument unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XElementAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XElement, FluentAssertions.Xml.XElementAssertions>
+    {
+        public XElementAssertions(System.Xml.Linq.XElement xElement) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> Be(System.Xml.Linq.XElement expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> Be(System.Xml.Linq.XElement expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveValue(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveValue(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBe(System.Xml.Linq.XElement unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBe(System.Xml.Linq.XElement unexpected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBeEquivalentTo(System.Xml.Linq.XElement unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBeEquivalentTo(System.Xml.Linq.XElement unexpected, string because, params object[] becauseArgs) { }
+    }
+}

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1296,8 +1296,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
         where T :  struct

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1,0 +1,2111 @@
+﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
+namespace FluentAssertions
+{
+    public class AggregateExceptionExtractor : FluentAssertions.Specialized.IExtractExceptions
+    {
+        public AggregateExceptionExtractor() { }
+        public System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception { }
+    }
+    public class AndConstraint<T>
+    {
+        public AndConstraint(T parentConstraint) { }
+        public T And { get; }
+    }
+    public class AndWhichConstraint<TParentConstraint, TMatchedElement> : FluentAssertions.AndConstraint<TParentConstraint>
+    {
+        public AndWhichConstraint(TParentConstraint parentConstraint, System.Collections.Generic.IEnumerable<TMatchedElement> matchedConstraint) { }
+        public AndWhichConstraint(TParentConstraint parentConstraint, TMatchedElement matchedConstraint) { }
+        public TMatchedElement Subject { get; }
+        public TMatchedElement Which { get; }
+    }
+    public static class AssertionExtensions
+    {
+        public static TTo As<TTo>(this object subject) { }
+        public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.Task<TResult>> action) { }
+        public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+        public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
+        public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
+        public static FluentAssertions.Specialized.ExecutionTimeAssertions Should(this FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        public static FluentAssertions.Types.MethodInfoSelectorAssertions Should(this FluentAssertions.Types.MethodInfoSelector methodSelector) { }
+        public static FluentAssertions.Types.PropertyInfoSelectorAssertions Should(this FluentAssertions.Types.PropertyInfoSelector propertyInfoSelector) { }
+        public static FluentAssertions.Types.TypeSelectorAssertions Should(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
+        public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
+        public static FluentAssertions.Collections.NonGenericCollectionAssertions Should(this System.Collections.IEnumerable actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
+        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
+        public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
+        public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
+        public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
+        public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
+        public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
+        public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
+        public static FluentAssertions.Xml.XAttributeAssertions Should(this System.Xml.Linq.XAttribute actualValue) { }
+        public static FluentAssertions.Xml.XDocumentAssertions Should(this System.Xml.Linq.XDocument actualValue) { }
+        public static FluentAssertions.Xml.XElementAssertions Should(this System.Xml.Linq.XElement actualValue) { }
+        public static FluentAssertions.Primitives.BooleanAssertions Should(this bool actualValue) { }
+        public static FluentAssertions.Primitives.NullableBooleanAssertions Should(this bool? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<byte> Should(this byte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<byte> Should(this byte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<decimal> Should(this decimal actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<decimal> Should(this decimal? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<double> Should(this double actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<double> Should(this double? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<float> Should(this float actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<float> Should(this float? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<int> Should(this int actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<int> Should(this int? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<long> Should(this long actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<long> Should(this long? actualValue) { }
+        public static FluentAssertions.Primitives.ObjectAssertions Should(this object actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<sbyte> Should(this sbyte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<sbyte> Should(this sbyte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<short> Should(this short actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<short> Should(this short? actualValue) { }
+        public static FluentAssertions.Primitives.StringAssertions Should(this string actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<uint> Should(this uint actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<uint> Should(this uint? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ulong> Should(this ulong actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ulong> Should(this ulong? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ushort> Should(this ushort actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ushort> Should(this ushort? actualValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
+        public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public static class AssertionOptions
+    {
+        public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
+        public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
+        public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
+    }
+    public static class AtLeast
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class AtMost
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class CallerIdentifier
+    {
+        public static System.Action<string> logger;
+        public static string DetermineCallerIdentity() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
+    public class CustomAssertionAttribute : System.Attribute
+    {
+        public CustomAssertionAttribute() { }
+    }
+    public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
+    {
+        public EquivalencyStepCollection() { }
+        public void Add<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void AddAfter<TPredecessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Clear() { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IEquivalencyStep> GetEnumerator() { }
+        public void Insert<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void InsertBefore<TSuccessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Remove<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep { }
+        public void Reset() { }
+    }
+    public static class EventRaisingExtensions
+    {
+        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, params System.Linq.Expressions.Expression<>[] predicates) { }
+        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
+        public static FluentAssertions.Events.IEventRecorder WithSender(this FluentAssertions.Events.IEventRecorder eventRecorder, object expectedSender) { }
+    }
+    public static class Exactly
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class FluentActions
+    {
+        public static System.Func<System.Threading.Tasks.Task> Awaiting(System.Func<System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task<T>> Awaiting<T>(System.Func<System.Threading.Tasks.Task<T>> func) { }
+        public static System.Action Enumerating(System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static System.Action Invoking(System.Action action) { }
+        public static System.Func<T> Invoking<T>(System.Func<T> func) { }
+    }
+    public static class LessThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class MoreThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class NumericAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+    }
+    public static class ObjectAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeXmlSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class OccurrenceConstraint
+    {
+        protected OccurrenceConstraint(int expectedCount) { }
+    }
+    public static class TypeEnumerableExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreInNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreUnderNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatDeriveFrom<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatImplement<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+    }
+    public static class TypeExtensions
+    {
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this System.Type type) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this System.Type type) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Type type) { }
+    }
+    public static class XmlAssertionExtensions
+    {
+        public static FluentAssertions.Xml.XmlElementAssertions Should(this System.Xml.XmlElement actualValue) { }
+        public static FluentAssertions.Xml.XmlNodeAssertions Should(this System.Xml.XmlNode actualValue) { }
+    }
+}
+namespace FluentAssertions.Collections
+{
+    public abstract class CollectionAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Collections.IEnumerable
+        where TAssertions : FluentAssertions.Collections.CollectionAssertions<TSubject, TAssertions>
+    {
+        protected CollectionAssertions() { }
+        protected CollectionAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeOfType<T>(string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionEndsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actual, System.Collections.Generic.ICollection<TExpected> expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionEndsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actual, TExpected[] expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionStartsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actualItems, System.Collections.Generic.ICollection<TExpected> expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionStartsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actualItems, TExpected[] expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertSubjectEquality<TActual, TExpected>(System.Collections.IEnumerable expectation, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params object[] expectations) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.IEnumerable expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.IEnumerable expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.IEnumerable>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.IEnumerable>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSubsetOf(System.Collections.IEnumerable expectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params object[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainItemsAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(object element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params object[] elements) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, object> HaveElementAt(int index, object element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(object successor, object expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(object predecessor, object expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInAscendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAscendingInOrder(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInAscendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAscendingInOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInDescendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDescendingInOrder(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInDescendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDescendingInOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSubsetOf(System.Collections.IEnumerable unexpectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotIntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(object element, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
+    {
+        public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+            where TKey :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(params TKey[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(params TValue[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(params TKey[] unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(params TValue[] unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+    }
+    public class NonGenericCollectionAssertions : FluentAssertions.Collections.CollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
+    {
+        public NonGenericCollectionAssertions(System.Collections.IEnumerable collection) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
+    {
+        public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params T[] elements) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpectedItemsList, params T[] additionalUnexpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(params System.Action<>[] elementInspectors) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(System.Collections.Generic.IEnumerable<System.Action<T>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+    }
+    public class StringCollectionAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<string, FluentAssertions.Collections.StringCollectionAssertions>
+    {
+        public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(params string[] expectation) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(params string[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+    }
+    public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public WhichValueConstraint(FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> parentConstraint, TValue value) { }
+        public TValue WhichValue { get; }
+    }
+}
+namespace FluentAssertions.Common
+{
+    public enum CSharpAccessModifier
+    {
+        Public = 0,
+        Private = 1,
+        Protected = 2,
+        Internal = 3,
+        ProtectedInternal = 4,
+        InvalidForCSharp = 5,
+        PrivateProtected = 6,
+    }
+    public static class CSharpAccessModifierExtensions { }
+    public class Configuration
+    {
+        public Configuration(FluentAssertions.Common.IConfigurationStore store) { }
+        public string TestFrameworkName { get; set; }
+        public string ValueFormatterAssembly { get; set; }
+        public FluentAssertions.Common.ValueFormatterDetectionMode ValueFormatterDetectionMode { get; set; }
+        public static FluentAssertions.Common.Configuration Current { get; }
+    }
+    public static class DateTimeExtensions
+    {
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime) { }
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime, System.TimeSpan offset) { }
+    }
+    public interface IClock
+    {
+        void Delay(System.TimeSpan timeToDelay);
+        System.Threading.Tasks.Task DelayAsync(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken);
+        FluentAssertions.Common.ITimer StartTimer();
+        bool Wait(System.Threading.Tasks.Task task, System.TimeSpan timeout);
+    }
+    public interface IConfigurationStore
+    {
+        string GetSetting(string name);
+    }
+    public interface IReflector
+    {
+        System.Collections.Generic.IEnumerable<System.Type> GetAllTypesFromAppDomain(System.Func<System.Reflection.Assembly, bool> predicate);
+    }
+    public interface ITimer
+    {
+        System.TimeSpan Elapsed { get; }
+    }
+    public static class MethodInfoExtensions { }
+    public static class ObjectExtensions
+    {
+        public static bool IsSameOrEqualTo(this object actual, object expected) { }
+    }
+    public static class PropertyInfoExtensions { }
+    public static class Services
+    {
+        public static FluentAssertions.Common.Configuration Configuration { get; }
+        public static FluentAssertions.Common.IConfigurationStore ConfigurationStore { get; set; }
+        public static FluentAssertions.Common.IReflector Reflector { get; set; }
+        public static System.Action<string> ThrowException { get; set; }
+        public static void ResetToDefaults() { }
+    }
+    public static class TypeExtensions
+    {
+        public static System.Reflection.FieldInfo FindField(this System.Type type, string fieldName, System.Type preferredType) { }
+        public static FluentAssertions.Equivalency.SelectedMemberInfo FindMember(this System.Type type, string memberName, System.Type preferredType) { }
+        public static System.Reflection.PropertyInfo FindProperty(this System.Type type, string propertyName, System.Type preferredType) { }
+        public static System.Reflection.ConstructorInfo GetConstructor(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.PropertyInfo GetIndexerByParameterTypes(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Reflection.MethodInfo GetMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> GetNonPrivateFields(this System.Type typeToReflect) { }
+        public static System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetNonPrivateMembers(this System.Type typeToReflect) { }
+        public static System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> GetNonPrivateProperties(this System.Type typeToReflect, System.Collections.Generic.IEnumerable<string> filter = null) { }
+        public static System.Reflection.MethodInfo GetParameterlessMethod(this System.Type type, string methodName) { }
+        public static System.Reflection.PropertyInfo GetPropertyByName(this System.Type type, string propertyName) { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWithOrInherits> instead.")]
+        public static bool HasAttribute<TAttribute>(this System.Reflection.MemberInfo method)
+            where TAttribute : System.Attribute { }
+        public static bool HasExplicitlyImplementedProperty(this System.Type type, System.Type interfaceType, string propertyName) { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWith> instead.")]
+        public static bool HasMatchingAttribute<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
+        public static bool HasMatchingAttribute<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, bool inherit = false)
+            where TAttribute : System.Attribute { }
+        public static bool HasMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static bool HasParameterlessMethod(this System.Type type, string methodName) { }
+        public static bool HasValueSemantics(this System.Type type) { }
+        public static bool Implements(this System.Type type, System.Type expectedBaseType) { }
+        public static bool IsCSharpAbstract(this System.Type type) { }
+        public static bool IsCSharpSealed(this System.Type type) { }
+        public static bool IsCSharpStatic(this System.Type type) { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        [System.Obsolete("This overload is deprecated and will be removed on the next major version. Please" +
+            " use <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type, bool inherit = false)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsEquivalentTo(this FluentAssertions.Equivalency.SelectedMemberInfo property, FluentAssertions.Equivalency.SelectedMemberInfo otherProperty) { }
+        public static bool IsIndexer(this System.Reflection.PropertyInfo member) { }
+        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
+        public static bool OverridesEquals(this System.Type type) { }
+    }
+    public enum ValueFormatterDetectionMode
+    {
+        Disabled = 0,
+        Specific = 1,
+        Scan = 2,
+    }
+}
+namespace FluentAssertions.Equivalency
+{
+    public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class ConversionSelector
+    {
+        public ConversionSelector() { }
+        public FluentAssertions.Equivalency.ConversionSelector Clone() { }
+        public void Exclude(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void Include(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void IncludeAll() { }
+        public bool RequiresConversion(FluentAssertions.Equivalency.IMemberInfo info) { }
+        public override string ToString() { }
+    }
+    public enum CyclicReferenceHandling
+    {
+        Ignore = 0,
+        ThrowException = 1,
+    }
+    public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DictionaryEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public virtual bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class EnumEqualityStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumEqualityStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public enum EnumEquivalencyHandling
+    {
+        ByValue = 0,
+        ByName = 1,
+    }
+    public class EnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumerableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public enum EqualityStrategy
+    {
+        Equals = 0,
+        Members = 1,
+        ForceEquals = 2,
+        ForceMembers = 3,
+    }
+    public class EquivalencyAssertionOptions : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions>
+    {
+        public EquivalencyAssertionOptions() { }
+    }
+    [System.Obsolete("This class is deprecated and will be removed in version 6.X.")]
+    public static class EquivalencyAssertionOptionsExtentions
+    {
+        public static System.Type GetExpectationType(this FluentAssertions.Equivalency.IEquivalencyAssertionOptions config, FluentAssertions.Equivalency.IMemberInfo context) { }
+    }
+    public class EquivalencyAssertionOptions<TExpectation> : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>>
+    {
+        public EquivalencyAssertionOptions() { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+    }
+    public class EquivalencyValidationContext : FluentAssertions.Equivalency.IEquivalencyValidationContext, FluentAssertions.Equivalency.IMemberInfo
+    {
+        public EquivalencyValidationContext() { }
+        public string Because { get; set; }
+        public object[] BecauseArgs { get; set; }
+        public System.Type CompileTimeType { get; set; }
+        public object Expectation { get; set; }
+        public bool IsRoot { get; }
+        public bool RootIsCollection { get; set; }
+        public System.Type RuntimeType { get; }
+        public string SelectedMemberDescription { get; set; }
+        public FluentAssertions.Equivalency.SelectedMemberInfo SelectedMemberInfo { get; set; }
+        public string SelectedMemberPath { get; set; }
+        public object Subject { get; set; }
+        public FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
+        public override string ToString() { }
+        public System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getTraceMessage) { }
+        public void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getTraceMessage) { }
+    }
+    public class EquivalencyValidator : FluentAssertions.Equivalency.IEquivalencyValidator
+    {
+        public EquivalencyValidator(FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public void AssertEquality(FluentAssertions.Equivalency.EquivalencyValidationContext context) { }
+        public void AssertEqualityUsing(FluentAssertions.Equivalency.IEquivalencyValidationContext context) { }
+    }
+    public class GenericDictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericDictionaryEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class GenericEnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericEnumerableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public delegate string GetTraceMessage(string path);
+    public interface IAssertionContext<TSubject>
+    {
+        string Because { get; set; }
+        object[] BecauseArgs { get; set; }
+        TSubject Expectation { get; }
+        TSubject Subject { get; }
+        FluentAssertions.Equivalency.SelectedMemberInfo SubjectProperty { get; }
+    }
+    public interface IAssertionRule
+    {
+        bool AssertEquality(FluentAssertions.Equivalency.IEquivalencyValidationContext context);
+    }
+    public interface IEquivalencyAssertionOptions
+    {
+        bool AllowInfiniteRecursion { get; }
+        FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
+        FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool IncludeFields { get; }
+        bool IncludeProperties { get; }
+        bool IsRecursive { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberMatchingRule> MatchingRules { get; }
+        FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
+        FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
+        bool UseRuntimeTyping { get; }
+        FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> GetUserEquivalencySteps(FluentAssertions.Equivalency.ConversionSelector conversionSelector);
+    }
+    public interface IEquivalencyStep
+    {
+        bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+        bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IEquivalencyValidationContext : FluentAssertions.Equivalency.IMemberInfo
+    {
+        string Because { get; }
+        object[] BecauseArgs { get; }
+        object Expectation { get; }
+        bool IsRoot { get; }
+        bool RootIsCollection { get; set; }
+        object Subject { get; }
+        FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
+        System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getMessage);
+        void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getMessage);
+    }
+    public interface IEquivalencyValidator
+    {
+        void AssertEqualityUsing(FluentAssertions.Equivalency.IEquivalencyValidationContext context);
+    }
+    public interface IMemberInfo
+    {
+        System.Type CompileTimeType { get; }
+        System.Type RuntimeType { get; }
+        string SelectedMemberDescription { get; }
+        FluentAssertions.Equivalency.SelectedMemberInfo SelectedMemberInfo { get; }
+        string SelectedMemberPath { get; }
+    }
+    public interface IMemberMatchingRule
+    {
+        FluentAssertions.Equivalency.SelectedMemberInfo Match(FluentAssertions.Equivalency.SelectedMemberInfo expectedMember, object subject, string memberPath, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IMemberSelectionRule
+    {
+        bool IncludesMembers { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> SelectMembers(System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> selectedMembers, FluentAssertions.Equivalency.IMemberInfo context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IOrderingRule
+    {
+        FluentAssertions.Equivalency.OrderStrictness Evaluate(FluentAssertions.Equivalency.IMemberInfo memberInfo);
+    }
+    public interface ITraceWriter
+    {
+        System.IDisposable AddBlock(string trace);
+        void AddSingle(string trace);
+        string ToString();
+    }
+    public enum OrderStrictness
+    {
+        Strict = 0,
+        NotStrict = 1,
+        Irrelevant = 2,
+    }
+    public class OrderingRuleCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule>, System.Collections.IEnumerable
+    {
+        public OrderingRuleCollection() { }
+        public OrderingRuleCollection(System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule> orderingRules) { }
+        public void Add(FluentAssertions.Equivalency.IOrderingRule rule) { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IOrderingRule> GetEnumerator() { }
+        public bool IsOrderingStrictFor(FluentAssertions.Equivalency.IMemberInfo memberInfo) { }
+    }
+    public class ReferenceEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ReferenceEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public virtual bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class RunAllUserStepsEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public RunAllUserStepsEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public abstract class SelectedMemberInfo
+    {
+        protected SelectedMemberInfo() { }
+        public abstract System.Type DeclaringType { get; }
+        public abstract System.Type MemberType { get; }
+        public abstract string Name { get; }
+        public abstract object GetValue(object obj, object[] index);
+        public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.FieldInfo fieldInfo) { }
+        public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.PropertyInfo propertyInfo) { }
+    }
+    public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
+        where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
+    {
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        protected readonly FluentAssertions.Equivalency.OrderingRuleCollection orderingRules;
+        protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
+        public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        public FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
+        protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public TSelf AllowingInfiniteRecursion() { }
+        public TSelf ComparingByMembers<T>() { }
+        public TSelf ComparingByValue<T>() { }
+        public TSelf ComparingEnumsByName() { }
+        public TSelf ComparingEnumsByValue() { }
+        public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf ExcludingFields() { }
+        public TSelf ExcludingMissingMembers() { }
+        public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingProperties() { }
+        public TSelf IgnoringCyclicReferences() { }
+        public TSelf IncludingAllDeclaredProperties() { }
+        public TSelf IncludingAllRuntimeProperties() { }
+        public TSelf IncludingFields() { }
+        public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingProperties() { }
+        protected void RemoveSelectionRule<T>()
+            where T : FluentAssertions.Equivalency.IMemberSelectionRule { }
+        public TSelf RespectingDeclaredTypes() { }
+        public TSelf RespectingRuntimeTypes() { }
+        public TSelf ThrowingOnMissingMembers() { }
+        public override string ToString() { }
+        public TSelf Using(FluentAssertions.Equivalency.IAssertionRule assertionRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IEquivalencyStep equivalencyStep) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
+        public TSelf WithAutoConversion() { }
+        public TSelf WithAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf WithStrictOrdering() { }
+        public TSelf WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf WithTracing(FluentAssertions.Equivalency.ITraceWriter writer = null) { }
+        public TSelf WithoutAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void WithoutMatchingRules() { }
+        public void WithoutSelectionRules() { }
+        public TSelf WithoutStrictOrdering() { }
+        public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public class Restriction<TMember>
+        {
+            public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
+            public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+            public TSelf WhenTypeIs<TMemberType>() { }
+        }
+    }
+    public class SimpleEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public SimpleEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class StringBuilderTraceWriter : FluentAssertions.Equivalency.ITraceWriter
+    {
+        public StringBuilderTraceWriter() { }
+        public System.IDisposable AddBlock(string trace) { }
+        public void AddSingle(string trace) { }
+        public override string ToString() { }
+    }
+    public class StringEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StringEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class StructuralEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StructuralEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public static class SubjectInfoExtensions
+    {
+        public static bool WhichGetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichGetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+    }
+    public class TryConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public TryConversionStep(FluentAssertions.Equivalency.ConversionSelector selector) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ValueTypeEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+}
+namespace FluentAssertions.Events
+{
+    public interface IEventRecorder : System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
+    {
+        System.Type EventHandlerType { get; }
+        string EventName { get; }
+        object EventObject { get; }
+        void RecordEvent(params object[] parameters);
+        void Reset();
+    }
+    public class RecordedEvent
+    {
+        public RecordedEvent(System.DateTime utcNow, object monitoredObject, params object[] parameters) { }
+        public System.Collections.Generic.IEnumerable<object> Parameters { get; }
+        public System.DateTime TimestampUtc { get; set; }
+    }
+}
+namespace FluentAssertions.Execution
+{
+    public class AssertionFailedException : System.Exception
+    {
+        public AssertionFailedException(string message) { }
+        protected AssertionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public class AssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public AssertionScope() { }
+        public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
+        public AssertionScope(string context) { }
+        public string Context { get; set; }
+        public bool Succeeded { get; }
+        public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
+        public static FluentAssertions.Execution.AssertionScope Current { get; }
+        public void AddNonReportable(string key, object value) { }
+        public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, string value) { }
+        public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
+        public T Get<T>(string key) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public bool HasFailures() { }
+        public FluentAssertions.Execution.AssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.AssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public class Continuation
+    {
+        public Continuation(FluentAssertions.Execution.AssertionScope sourceScope, bool sourceSucceeded) { }
+        public bool SourceSucceeded { get; }
+        public FluentAssertions.Execution.IAssertionScope Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.Continuation continuation) { }
+    }
+    public class ContinuationOfGiven<TSubject>
+    {
+        public ContinuationOfGiven(FluentAssertions.Execution.GivenSelector<TSubject> parent, bool succeeded) { }
+        public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
+    }
+    public class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public ContinuedAssertionScope(FluentAssertions.Execution.AssertionScope predecessor, bool predecessorSucceeded) { }
+        public bool Succeeded { get; }
+        public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.IAssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public static class Execute
+    {
+        public static FluentAssertions.Execution.AssertionScope Assertion { get; }
+    }
+    public class FailReason
+    {
+        public FailReason(string message, params object[] args) { }
+        public object[] Args { get; }
+        public string Message { get; }
+    }
+    public class GivenSelector<T>
+    {
+        public GivenSelector(System.Func<T> selector, bool predecessorSucceeded, FluentAssertions.Execution.AssertionScope predecessor) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> ClearExpectation() { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<, >[] args) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
+        public FluentAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
+    }
+    public interface IAssertionScope : System.IDisposable
+    {
+        bool Succeeded { get; }
+        FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
+        FluentAssertions.Execution.Continuation ClearExpectation();
+        string[] Discard();
+        FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc);
+        FluentAssertions.Execution.Continuation FailWith(string message, params object[] args);
+        FluentAssertions.Execution.IAssertionScope ForCondition(bool condition);
+        FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector);
+        FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier);
+        FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args);
+    }
+    public interface IAssertionStrategy
+    {
+        System.Collections.Generic.IEnumerable<string> FailureMessages { get; }
+        System.Collections.Generic.IEnumerable<string> DiscardFailures();
+        void HandleFailure(string message);
+        void ThrowIfAny(System.Collections.Generic.IDictionary<string, object> context);
+    }
+    public interface ICloneable2
+    {
+        object Clone();
+    }
+}
+namespace FluentAssertions.Extensions
+{
+    public static class FluentDateTimeExtensions
+    {
+        public static System.DateTime AddMicroseconds(this System.DateTime self, long microseconds) { }
+        public static System.DateTimeOffset AddMicroseconds(this System.DateTimeOffset self, long microseconds) { }
+        public static System.DateTime AddNanoseconds(this System.DateTime self, long nanoseconds) { }
+        public static System.DateTimeOffset AddNanoseconds(this System.DateTimeOffset self, long nanoseconds) { }
+        public static System.DateTime After(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime April(this int day, int year) { }
+        public static System.DateTime AsLocal(this System.DateTime dateTime) { }
+        public static System.DateTime AsUtc(this System.DateTime dateTime) { }
+        public static System.DateTime At(this System.DateTime date, System.TimeSpan time) { }
+        public static System.DateTime At(this System.DateTime date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTimeOffset At(this System.DateTimeOffset date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTime August(this int day, int year) { }
+        public static System.DateTime Before(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime December(this int day, int year) { }
+        public static System.DateTime February(this int day, int year) { }
+        public static System.DateTime January(this int day, int year) { }
+        public static System.DateTime July(this int day, int year) { }
+        public static System.DateTime June(this int day, int year) { }
+        public static System.DateTime March(this int day, int year) { }
+        public static System.DateTime May(this int day, int year) { }
+        public static int Microsecond(this System.DateTime self) { }
+        public static int Microsecond(this System.DateTimeOffset self) { }
+        public static int Nanosecond(this System.DateTime self) { }
+        public static int Nanosecond(this System.DateTimeOffset self) { }
+        public static System.DateTime November(this int day, int year) { }
+        public static System.DateTime October(this int day, int year) { }
+        public static System.DateTime September(this int day, int year) { }
+    }
+    public static class FluentTimeSpanExtensions
+    {
+        public const long TicksPerMicrosecond = 10;
+        public const double TicksPerNanosecond = 0.01D;
+        public static System.TimeSpan And(this System.TimeSpan sourceTime, System.TimeSpan offset) { }
+        public static System.TimeSpan Days(this double days) { }
+        public static System.TimeSpan Days(this int days) { }
+        public static System.TimeSpan Days(this int days, System.TimeSpan offset) { }
+        public static System.TimeSpan Hours(this double hours) { }
+        public static System.TimeSpan Hours(this int hours) { }
+        public static System.TimeSpan Hours(this int hours, System.TimeSpan offset) { }
+        public static int Microseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Microseconds(this int microseconds) { }
+        public static System.TimeSpan Microseconds(this long microseconds) { }
+        public static System.TimeSpan Milliseconds(this double milliseconds) { }
+        public static System.TimeSpan Milliseconds(this int milliseconds) { }
+        public static System.TimeSpan Minutes(this double minutes) { }
+        public static System.TimeSpan Minutes(this int minutes) { }
+        public static System.TimeSpan Minutes(this int minutes, System.TimeSpan offset) { }
+        public static int Nanoseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Nanoseconds(this int nanoseconds) { }
+        public static System.TimeSpan Nanoseconds(this long nanoseconds) { }
+        public static System.TimeSpan Seconds(this double seconds) { }
+        public static System.TimeSpan Seconds(this int seconds) { }
+        public static System.TimeSpan Seconds(this int seconds, System.TimeSpan offset) { }
+        public static System.TimeSpan Ticks(this int ticks) { }
+        public static System.TimeSpan Ticks(this long ticks) { }
+        public static double TotalMicroseconds(this System.TimeSpan self) { }
+        public static double TotalNanoseconds(this System.TimeSpan self) { }
+    }
+}
+namespace FluentAssertions.Formatting
+{
+    public class AggregateExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AggregateExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class AttributeBasedFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AttributeBasedFormatter() { }
+        public System.Reflection.MethodInfo[] Formatters { get; }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DateTimeOffsetValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DateTimeOffsetValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DecimalValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DecimalValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DefaultValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DoubleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public EnumerableValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExpressionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public delegate string FormatChild(string childPath, object value);
+    public static class Formatter
+    {
+        public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
+        public static void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static string ToString(object value, bool useLineBreaks = false) { }
+    }
+    public class FormattingContext
+    {
+        public FormattingContext() { }
+        public int Depth { get; set; }
+        public bool UseLineBreaks { get; set; }
+    }
+    public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public GuidValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public interface IValueFormatter
+    {
+        bool CanHandle(object value);
+        string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
+    }
+    public class Int16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class MultidimensionalArrayFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public MultidimensionalArrayFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class NullValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public NullValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class PropertyInfoFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public PropertyInfoFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SingleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SingleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class StringValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public StringValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TaskFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TaskFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TimeSpanValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TimeSpanValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
+    public class ValueFormatterAttribute : System.Attribute
+    {
+        public ValueFormatterAttribute() { }
+    }
+    public class XAttributeValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XAttributeValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XDocumentValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XDocumentValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XElementValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XElementValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+}
+namespace FluentAssertions.Numeric
+{
+    public class ComparableTypeAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    {
+        public ComparableTypeAssertions(System.IComparable<T> value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
+        where T :  struct
+    {
+        public NullableNumericAssertions(T? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NumericAssertions<T>
+        where T :  struct
+    {
+        public NumericAssertions(object value) { }
+        public System.IComparable Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(params T[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Primitives
+{
+    public class BooleanAssertions
+    {
+        public BooleanAssertions(bool? value) { }
+        public bool? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeAssertions
+    {
+        public DateTimeAssertions(System.DateTime? value) { }
+        public System.DateTime? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.DateTime[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetAssertions
+    {
+        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
+        public System.DateTimeOffset? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetRangeAssertions
+    {
+        protected DateTimeOffsetRangeAssertions(FluentAssertions.Primitives.DateTimeOffsetAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeRangeAssertions
+    {
+        protected DateTimeRangeAssertions(FluentAssertions.Primitives.DateTimeAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
+    }
+    public class GuidAssertions
+    {
+        public GuidAssertions(System.Guid? value) { }
+        public System.Guid? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableBooleanAssertions : FluentAssertions.Primitives.BooleanAssertions
+    {
+        public NullableBooleanAssertions(bool? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions
+    {
+        public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions
+    {
+        public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableGuidAssertions : FluentAssertions.Primitives.GuidAssertions
+    {
+        public NullableGuidAssertions(System.Guid? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions
+    {
+        public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class ObjectAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
+    {
+        public ObjectAssertions(object value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be(object expected, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> HaveFlag(System.Enum expectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe(object unexpected, string because = "", params object[] becauseArgs) { }
+        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotHaveFlag(System.Enum unexpectedFlag, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
+        where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+    {
+        protected ReferenceTypeAssertions() { }
+        protected ReferenceTypeAssertions(TSubject subject) { }
+        protected abstract string Identifier { get; }
+        public TSubject Subject { get; set; }
+        public FluentAssertions.AndConstraint<TAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameAs(TSubject expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<TSubject, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match<T>(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
+            where T : TSubject { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SimpleTimeSpanAssertions
+    {
+        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public System.TimeSpan? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+    }
+    public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>
+    {
+        public StringAssertions(string value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(params string[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+    }
+    public enum TimeSpanCondition
+    {
+        MoreThan = 0,
+        AtLeast = 1,
+        Exactly = 2,
+        Within = 3,
+        LessThan = 4,
+    }
+}
+namespace FluentAssertions.Reflection
+{
+    public class AssemblyAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Reflection.Assembly, FluentAssertions.Reflection.AssemblyAssertions>
+    {
+        public AssemblyAssertions(System.Reflection.Assembly assembly) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Reflection.AssemblyAssertions, System.Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs) { }
+        public void NotReference(System.Reflection.Assembly assembly) { }
+        public void NotReference(System.Reflection.Assembly assembly, string because, params string[] becauseArgs) { }
+        public void Reference(System.Reflection.Assembly assembly) { }
+        public void Reference(System.Reflection.Assembly assembly, string because, params string[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Specialized
+{
+    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action>
+    {
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Action Subject { get; }
+        protected override void InvokeSubject() { }
+    }
+    public class AsyncFunctionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Func<System.Threading.Tasks.Task>>
+    {
+        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Func<System.Threading.Tasks.Task> Subject { get; }
+        protected override void InvokeSubject() { }
+        public System.Threading.Tasks.Task NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public abstract class DelegateAssertions<TDelegate> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Delegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate>>
+        where TDelegate : System.Delegate
+    {
+        protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public new TDelegate Subject { get; }
+        protected abstract void InvokeSubject();
+        public void NotThrow(string because = "", params object[] becauseArgs) { }
+        protected void NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        protected void NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+        public void NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public class ExceptionAssertions<TException> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IEnumerable<TException>, FluentAssertions.Specialized.ExceptionAssertions<TException>>
+        where TException : System.Exception
+    {
+        public ExceptionAssertions(System.Collections.Generic.IEnumerable<TException> exceptions) { }
+        public TException And { get; }
+        protected override string Identifier { get; }
+        public TException Which { get; }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Where(System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, string because = "", params object[] becauseArgs) { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerException<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerExceptionExactly<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TException> WithMessage(string expectedWildcardPattern, string because = "", params object[] becauseArgs) { }
+    }
+    public class ExecutionTime
+    {
+        public ExecutionTime(System.Action action) { }
+        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action) { }
+        protected ExecutionTime(System.Action action, string actionDescription) { }
+        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription) { }
+    }
+    public class ExecutionTimeAssertions
+    {
+        public ExecutionTimeAssertions(FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        public void BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public void BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public void BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public void BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public void BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+    }
+    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
+    {
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Func<T> Subject { get; }
+        protected override void InvokeSubject() { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions
+    {
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+    public interface IExtractExceptions
+    {
+        System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception;
+    }
+    public class MemberExecutionTime<T> : FluentAssertions.Specialized.ExecutionTime
+    {
+        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+    }
+    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions
+    {
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Types
+{
+    public static class AllTypes
+    {
+        public static FluentAssertions.Types.TypeSelector From(System.Reflection.Assembly assembly) { }
+    }
+    public class ConstructorInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.ConstructorInfo, FluentAssertions.Types.ConstructorInfoAssertions>
+    {
+        public ConstructorInfoAssertions(System.Reflection.ConstructorInfo constructorInfo) { }
+        protected override string Identifier { get; }
+    }
+    public abstract class MemberInfoAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MemberInfo
+        where TAssertions : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+    {
+        protected MemberInfoAssertions() { }
+        protected MemberInfoAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+    }
+    public abstract class MethodBaseAssertions<TSubject, TAssertions> : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MethodBase
+        where TAssertions : FluentAssertions.Types.MethodBaseAssertions<TSubject, TAssertions>
+    {
+        protected MethodBaseAssertions() { }
+        protected MethodBaseAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>
+    {
+        public MethodInfoAssertions() { }
+        public MethodInfoAssertions(System.Reflection.MethodInfo methodInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturnVoid(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> ReturnVoid(string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, System.Collections.IEnumerable
+    {
+        public MethodInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public MethodInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.MethodInfoSelector ThatArePublicOrInternal { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturnVoid { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
+        public System.Reflection.MethodInfo[] ToArray() { }
+    }
+    public class MethodInfoSelectorAssertions
+    {
+        public MethodInfoSelectorAssertions(params System.Reflection.MethodInfo[] methods) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> SubjectMethods { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoAssertions : FluentAssertions.Types.MemberInfoAssertions<System.Reflection.PropertyInfo, FluentAssertions.Types.PropertyInfoAssertions>
+    {
+        public PropertyInfoAssertions(System.Reflection.PropertyInfo propertyInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo>, System.Collections.IEnumerable
+    {
+        public PropertyInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public PropertyInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatArePublicOrInternal { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.PropertyInfo> GetEnumerator() { }
+        public FluentAssertions.Types.PropertyInfoSelector NotOfType<TReturn>() { }
+        public FluentAssertions.Types.PropertyInfoSelector OfType<TReturn>() { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public System.Reflection.PropertyInfo[] ToArray() { }
+    }
+    public class PropertyInfoSelectorAssertions
+    {
+        public PropertyInfoSelectorAssertions(params System.Reflection.PropertyInfo[] properties) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> SubjectProperties { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public class TypeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Type, FluentAssertions.Types.TypeAssertions>
+    {
+        public TypeAssertions(System.Type type) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be(System.Type expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be<TExpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<System.Type> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveExplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveExplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveImplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveImplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveIndexer(System.Type indexerType, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty(System.Type propertyType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty<TProperty>(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe(System.Type unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe<TUnexpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<System.Type> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveExplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveExplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveImplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveImplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveIndexer(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveProperty(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+    }
+    public class TypeSelector : System.Collections.Generic.IEnumerable<System.Type>, System.Collections.IEnumerable
+    {
+        public TypeSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public TypeSelector(System.Type type) { }
+        public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
+        public System.Type[] ToArray() { }
+    }
+    public class TypeSelectorAssertions
+    {
+        public TypeSelectorAssertions(params System.Type[] types) { }
+        public System.Collections.Generic.IEnumerable<System.Type> Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+    }
+}
+namespace FluentAssertions.Xml
+{
+    public class XAttributeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XAttribute, FluentAssertions.Xml.XAttributeAssertions>
+    {
+        public XAttributeAssertions(System.Xml.Linq.XAttribute attribute) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> Be(System.Xml.Linq.XAttribute expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> Be(System.Xml.Linq.XAttribute expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> HaveValue(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> HaveValue(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> NotBe(System.Xml.Linq.XAttribute unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> NotBe(System.Xml.Linq.XAttribute unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XDocumentAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XDocument, FluentAssertions.Xml.XDocumentAssertions>
+    {
+        public XDocumentAssertions(System.Xml.Linq.XDocument document) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> Be(System.Xml.Linq.XDocument expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> Be(System.Xml.Linq.XDocument expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> BeEquivalentTo(System.Xml.Linq.XDocument expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> BeEquivalentTo(System.Xml.Linq.XDocument expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBe(System.Xml.Linq.XDocument unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBe(System.Xml.Linq.XDocument unexpected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBeEquivalentTo(System.Xml.Linq.XDocument unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBeEquivalentTo(System.Xml.Linq.XDocument unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XElementAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XElement, FluentAssertions.Xml.XElementAssertions>
+    {
+        public XElementAssertions(System.Xml.Linq.XElement xElement) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> Be(System.Xml.Linq.XElement expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> Be(System.Xml.Linq.XElement expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveValue(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveValue(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBe(System.Xml.Linq.XElement unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBe(System.Xml.Linq.XElement unexpected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBeEquivalentTo(System.Xml.Linq.XElement unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBeEquivalentTo(System.Xml.Linq.XElement unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XmlElementAssertions : FluentAssertions.Xml.XmlNodeAssertions<System.Xml.XmlElement, FluentAssertions.Xml.XmlElementAssertions>
+    {
+        public XmlElementAssertions(System.Xml.XmlElement xmlElement) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttribute(string expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttributeWithNamespace(string expectedName, string expectedNamespace, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttributeWithNamespace(string expectedName, string expectedNamespace, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElement(string expectedName) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElement(string expectedName, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElementWithNamespace(string expectedName, string expectedNamespace) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElementWithNamespace(string expectedName, string expectedNamespace, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveInnerText(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveInnerText(string expected, string because, params object[] becauseArgs) { }
+    }
+    public class XmlNodeAssertions : FluentAssertions.Xml.XmlNodeAssertions<System.Xml.XmlNode, FluentAssertions.Xml.XmlNodeAssertions>
+    {
+        public XmlNodeAssertions(System.Xml.XmlNode xmlNode) { }
+    }
+    public class XmlNodeAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Xml.XmlNode
+        where TAssertions : FluentAssertions.Xml.XmlNodeAssertions<TSubject, TAssertions>
+    {
+        public XmlNodeAssertions(TSubject xmlNode) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Xml.XmlNode expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Xml.XmlNode expected, string because, params object[] reasonArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Xml.XmlNode unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Xml.XmlNode unexpected, string because, params object[] reasonArgs) { }
+    }
+    public class XmlNodeFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XmlNodeFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+}

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -1342,8 +1342,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
         where T :  struct

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -1,0 +1,2157 @@
+﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
+namespace FluentAssertions
+{
+    public class AggregateExceptionExtractor : FluentAssertions.Specialized.IExtractExceptions
+    {
+        public AggregateExceptionExtractor() { }
+        public System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception { }
+    }
+    public class AndConstraint<T>
+    {
+        public AndConstraint(T parentConstraint) { }
+        public T And { get; }
+    }
+    public class AndWhichConstraint<TParentConstraint, TMatchedElement> : FluentAssertions.AndConstraint<TParentConstraint>
+    {
+        public AndWhichConstraint(TParentConstraint parentConstraint, System.Collections.Generic.IEnumerable<TMatchedElement> matchedConstraint) { }
+        public AndWhichConstraint(TParentConstraint parentConstraint, TMatchedElement matchedConstraint) { }
+        public TMatchedElement Subject { get; }
+        public TMatchedElement Which { get; }
+    }
+    public static class AssertionExtensions
+    {
+        public static TTo As<TTo>(this object subject) { }
+        public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task> Awaiting<T>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask> action) { }
+        public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.Task<TResult>> action) { }
+        public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask<TResult>> action) { }
+        public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+        public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
+        public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
+        public static FluentAssertions.Events.IMonitor<T> Monitor<T>(this T eventSource, System.Func<System.DateTime> utcNow = null) { }
+        public static FluentAssertions.Specialized.ExecutionTimeAssertions Should(this FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        public static FluentAssertions.Types.MethodInfoSelectorAssertions Should(this FluentAssertions.Types.MethodInfoSelector methodSelector) { }
+        public static FluentAssertions.Types.PropertyInfoSelectorAssertions Should(this FluentAssertions.Types.PropertyInfoSelector propertyInfoSelector) { }
+        public static FluentAssertions.Types.TypeSelectorAssertions Should(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
+        public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
+        public static FluentAssertions.Collections.NonGenericCollectionAssertions Should(this System.Collections.IEnumerable actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
+        public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
+        public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
+        public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
+        public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
+        public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
+        public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
+        public static FluentAssertions.Types.PropertyInfoAssertions Should(this System.Reflection.PropertyInfo propertyInfo) { }
+        public static FluentAssertions.Primitives.SimpleTimeSpanAssertions Should(this System.TimeSpan actualValue) { }
+        public static FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions Should(this System.TimeSpan? actualValue) { }
+        public static FluentAssertions.Types.TypeAssertions Should(this System.Type subject) { }
+        public static FluentAssertions.Xml.XAttributeAssertions Should(this System.Xml.Linq.XAttribute actualValue) { }
+        public static FluentAssertions.Xml.XDocumentAssertions Should(this System.Xml.Linq.XDocument actualValue) { }
+        public static FluentAssertions.Xml.XElementAssertions Should(this System.Xml.Linq.XElement actualValue) { }
+        public static FluentAssertions.Primitives.BooleanAssertions Should(this bool actualValue) { }
+        public static FluentAssertions.Primitives.NullableBooleanAssertions Should(this bool? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<byte> Should(this byte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<byte> Should(this byte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<decimal> Should(this decimal actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<decimal> Should(this decimal? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<double> Should(this double actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<double> Should(this double? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<float> Should(this float actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<float> Should(this float? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<int> Should(this int actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<int> Should(this int? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<long> Should(this long actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<long> Should(this long? actualValue) { }
+        public static FluentAssertions.Primitives.ObjectAssertions Should(this object actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<sbyte> Should(this sbyte actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<sbyte> Should(this sbyte? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<short> Should(this short actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<short> Should(this short? actualValue) { }
+        public static FluentAssertions.Primitives.StringAssertions Should(this string actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<uint> Should(this uint actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<uint> Should(this uint? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ulong> Should(this ulong actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ulong> Should(this ulong? actualValue) { }
+        public static FluentAssertions.Numeric.NumericAssertions<ushort> Should(this ushort actualValue) { }
+        public static FluentAssertions.Numeric.NullableNumericAssertions<ushort> Should(this ushort? actualValue) { }
+        public static FluentAssertions.Collections.GenericCollectionAssertions<T> Should<T>(this System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public static FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T> Should<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
+        public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
+        public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public static class AssertionOptions
+    {
+        public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
+        public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
+        public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
+    }
+    public static class AtLeast
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class AtMost
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class CallerIdentifier
+    {
+        public static System.Action<string> logger;
+        public static string DetermineCallerIdentity() { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
+    public class CustomAssertionAttribute : System.Attribute
+    {
+        public CustomAssertionAttribute() { }
+    }
+    public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
+    {
+        public EquivalencyStepCollection() { }
+        public void Add<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void AddAfter<TPredecessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Clear() { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IEquivalencyStep> GetEnumerator() { }
+        public void Insert<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void InsertBefore<TSuccessor, TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep, new () { }
+        public void Remove<TStep>()
+            where TStep : FluentAssertions.Equivalency.IEquivalencyStep { }
+        public void Reset() { }
+    }
+    public static class EventRaisingExtensions
+    {
+        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, params System.Linq.Expressions.Expression<>[] predicates) { }
+        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
+        public static FluentAssertions.Events.IEventRecorder WithSender(this FluentAssertions.Events.IEventRecorder eventRecorder, object expectedSender) { }
+    }
+    public static class Exactly
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class FluentActions
+    {
+        public static System.Func<System.Threading.Tasks.Task> Awaiting(System.Func<System.Threading.Tasks.Task> action) { }
+        public static System.Func<System.Threading.Tasks.Task<T>> Awaiting<T>(System.Func<System.Threading.Tasks.Task<T>> func) { }
+        public static System.Action Enumerating(System.Func<System.Collections.IEnumerable> enumerable) { }
+        public static System.Action Enumerating<T>(System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static System.Action Invoking(System.Action action) { }
+        public static System.Func<T> Invoking<T>(System.Func<T> func) { }
+    }
+    public static class LessThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class MoreThan
+    {
+        public static FluentAssertions.OccurrenceConstraint Once() { }
+        public static FluentAssertions.OccurrenceConstraint Thrice() { }
+        public static FluentAssertions.OccurrenceConstraint Times(int expected) { }
+        public static FluentAssertions.OccurrenceConstraint Twice() { }
+    }
+    public static class NumericAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal expectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double expectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> BeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float expectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte nearbyValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort nearbyValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint nearbyValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> BeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong nearbyValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<decimal> parent, decimal? unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<double> parent, double? unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NullableNumericAssertions<float> parent, float? unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<decimal>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<decimal> parent, decimal unexpectedValue, decimal precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<double>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<double> parent, double unexpectedValue, double precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<float>> NotBeApproximately(this FluentAssertions.Numeric.NumericAssertions<float> parent, float unexpectedValue, float precision, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<byte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<byte> parent, byte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<short>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<short> parent, short distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<int>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<int> parent, int distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<long>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<long> parent, long distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<sbyte>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<sbyte> parent, sbyte distantValue, byte delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ushort>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ushort> parent, ushort distantValue, ushort delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<uint>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<uint> parent, uint distantValue, uint delta, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<ulong>> NotBeCloseTo(this FluentAssertions.Numeric.NumericAssertions<ulong> parent, ulong distantValue, ulong delta, string because = "", params object[] becauseArgs) { }
+    }
+    public static class ObjectAssertionsExtensions
+    {
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeXmlSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class OccurrenceConstraint
+    {
+        protected OccurrenceConstraint(int expectedCount) { }
+    }
+    public static class TypeEnumerableExtensions
+    {
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreInNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWith<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreNotDecoratedWithOrInherit<TAttribute>(this System.Collections.Generic.IEnumerable<System.Type> types)
+            where TAttribute : System.Attribute { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatAreUnderNamespace(this System.Collections.Generic.IEnumerable<System.Type> types, string @namespace) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatDeriveFrom<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static System.Collections.Generic.IEnumerable<System.Type> ThatImplement<T>(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+    }
+    public static class TypeExtensions
+    {
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.MethodInfoSelector Methods(this System.Type type) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this FluentAssertions.Types.TypeSelector typeSelector) { }
+        public static FluentAssertions.Types.PropertyInfoSelector Properties(this System.Type type) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Reflection.Assembly assembly) { }
+        public static FluentAssertions.Types.TypeSelector Types(this System.Type type) { }
+    }
+    public static class XmlAssertionExtensions
+    {
+        public static FluentAssertions.Xml.XmlElementAssertions Should(this System.Xml.XmlElement actualValue) { }
+        public static FluentAssertions.Xml.XmlNodeAssertions Should(this System.Xml.XmlNode actualValue) { }
+    }
+}
+namespace FluentAssertions.Collections
+{
+    public abstract class CollectionAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Collections.IEnumerable
+        where TAssertions : FluentAssertions.Collections.CollectionAssertions<TSubject, TAssertions>
+    {
+        protected CollectionAssertions() { }
+        protected CollectionAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeOfType<T>(string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionEndsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actual, System.Collections.Generic.ICollection<TExpected> expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionEndsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actual, TExpected[] expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionStartsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actualItems, System.Collections.Generic.ICollection<TExpected> expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertCollectionStartsWith<TActual, TExpected>(System.Collections.Generic.IEnumerable<TActual> actualItems, TExpected[] expected, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected void AssertSubjectEquality<TActual, TExpected>(System.Collections.IEnumerable expectation, System.Func<TActual, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params object[] expectations) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.IEnumerable expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.IEnumerable expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.IEnumerable>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.IEnumerable>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSubsetOf(System.Collections.IEnumerable expectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params object[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainItemsAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(object element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params object[] elements) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.IEnumerable expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, object> HaveElementAt(int index, object element, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(object successor, object expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(object predecessor, object expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInAscendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAscendingInOrder(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInAscendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAscendingInOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInDescendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDescendingInOrder(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("Use NotBeInDescendingOrder instead")]
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDescendingInOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSubsetOf(System.Collections.IEnumerable unexpectedSuperset, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotIntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(object element, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
+    {
+        public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+            where TKey :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(params TKey[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(params TValue[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(params TKey[] unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(params TValue[] unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+    }
+    public class NonGenericCollectionAssertions : FluentAssertions.Collections.CollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
+    {
+        public NonGenericCollectionAssertions(System.Collections.IEnumerable collection) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
+    {
+        public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params T[] elements) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpectedItemsList, params T[] additionalUnexpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(params System.Action<>[] elementInspectors) { }
+        public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(System.Collections.Generic.IEnumerable<System.Action<T>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+    }
+    public class StringCollectionAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<string, FluentAssertions.Collections.StringCollectionAssertions>
+    {
+        public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(params string[] expectation) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(params string[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+    }
+    public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public WhichValueConstraint(FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> parentConstraint, TValue value) { }
+        public TValue WhichValue { get; }
+    }
+}
+namespace FluentAssertions.Common
+{
+    public enum CSharpAccessModifier
+    {
+        Public = 0,
+        Private = 1,
+        Protected = 2,
+        Internal = 3,
+        ProtectedInternal = 4,
+        InvalidForCSharp = 5,
+        PrivateProtected = 6,
+    }
+    public static class CSharpAccessModifierExtensions { }
+    public class Configuration
+    {
+        public Configuration(FluentAssertions.Common.IConfigurationStore store) { }
+        public string TestFrameworkName { get; set; }
+        public string ValueFormatterAssembly { get; set; }
+        public FluentAssertions.Common.ValueFormatterDetectionMode ValueFormatterDetectionMode { get; set; }
+        public static FluentAssertions.Common.Configuration Current { get; }
+    }
+    public static class DateTimeExtensions
+    {
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime) { }
+        public static System.DateTimeOffset ToDateTimeOffset(this System.DateTime dateTime, System.TimeSpan offset) { }
+    }
+    public interface IClock
+    {
+        void Delay(System.TimeSpan timeToDelay);
+        System.Threading.Tasks.Task DelayAsync(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken);
+        FluentAssertions.Common.ITimer StartTimer();
+        bool Wait(System.Threading.Tasks.Task task, System.TimeSpan timeout);
+    }
+    public interface IConfigurationStore
+    {
+        string GetSetting(string name);
+    }
+    public interface IReflector
+    {
+        System.Collections.Generic.IEnumerable<System.Type> GetAllTypesFromAppDomain(System.Func<System.Reflection.Assembly, bool> predicate);
+    }
+    public interface ITimer
+    {
+        System.TimeSpan Elapsed { get; }
+    }
+    public static class MethodInfoExtensions { }
+    public static class ObjectExtensions
+    {
+        public static bool IsSameOrEqualTo(this object actual, object expected) { }
+    }
+    public static class PropertyInfoExtensions { }
+    public static class Services
+    {
+        public static FluentAssertions.Common.Configuration Configuration { get; }
+        public static FluentAssertions.Common.IConfigurationStore ConfigurationStore { get; set; }
+        public static FluentAssertions.Common.IReflector Reflector { get; set; }
+        public static System.Action<string> ThrowException { get; set; }
+        public static void ResetToDefaults() { }
+    }
+    public static class TypeExtensions
+    {
+        public static System.Reflection.FieldInfo FindField(this System.Type type, string fieldName, System.Type preferredType) { }
+        public static FluentAssertions.Equivalency.SelectedMemberInfo FindMember(this System.Type type, string memberName, System.Type preferredType) { }
+        public static System.Reflection.PropertyInfo FindProperty(this System.Type type, string propertyName, System.Type preferredType) { }
+        public static System.Reflection.ConstructorInfo GetConstructor(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.PropertyInfo GetIndexerByParameterTypes(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Reflection.MethodInfo GetMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> GetNonPrivateFields(this System.Type typeToReflect) { }
+        public static System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetNonPrivateMembers(this System.Type typeToReflect) { }
+        public static System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> GetNonPrivateProperties(this System.Type typeToReflect, System.Collections.Generic.IEnumerable<string> filter = null) { }
+        public static System.Reflection.MethodInfo GetParameterlessMethod(this System.Type type, string methodName) { }
+        public static System.Reflection.PropertyInfo GetPropertyByName(this System.Type type, string propertyName) { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWithOrInherits> instead.")]
+        public static bool HasAttribute<TAttribute>(this System.Reflection.MemberInfo method)
+            where TAttribute : System.Attribute { }
+        public static bool HasExplicitlyImplementedProperty(this System.Type type, System.Type interfaceType, string propertyName) { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWith> instead.")]
+        public static bool HasMatchingAttribute<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        [System.Obsolete("This method is deprecated and will be removed on the next major version. Please u" +
+            "se <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
+        public static bool HasMatchingAttribute<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, bool inherit = false)
+            where TAttribute : System.Attribute { }
+        public static bool HasMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
+        public static bool HasParameterlessMethod(this System.Type type, string methodName) { }
+        public static bool HasValueSemantics(this System.Type type) { }
+        public static bool Implements(this System.Type type, System.Type expectedBaseType) { }
+        public static bool IsCSharpAbstract(this System.Type type) { }
+        public static bool IsCSharpSealed(this System.Type type) { }
+        public static bool IsCSharpStatic(this System.Type type) { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        [System.Obsolete("This overload is deprecated and will be removed on the next major version. Please" +
+            " use <IsDecoratedWithOrInherits> or <IsDecoratedWith> instead.")]
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type, bool inherit = false)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWith<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
+            where TAttribute : System.Attribute { }
+        public static bool IsEquivalentTo(this FluentAssertions.Equivalency.SelectedMemberInfo property, FluentAssertions.Equivalency.SelectedMemberInfo otherProperty) { }
+        public static bool IsIndexer(this System.Reflection.PropertyInfo member) { }
+        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
+        public static bool OverridesEquals(this System.Type type) { }
+    }
+    public enum ValueFormatterDetectionMode
+    {
+        Disabled = 0,
+        Specific = 1,
+        Scan = 2,
+    }
+}
+namespace FluentAssertions.Equivalency
+{
+    public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class ConversionSelector
+    {
+        public ConversionSelector() { }
+        public FluentAssertions.Equivalency.ConversionSelector Clone() { }
+        public void Exclude(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void Include(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void IncludeAll() { }
+        public bool RequiresConversion(FluentAssertions.Equivalency.IMemberInfo info) { }
+        public override string ToString() { }
+    }
+    public enum CyclicReferenceHandling
+    {
+        Ignore = 0,
+        ThrowException = 1,
+    }
+    public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DictionaryEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public virtual bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class EnumEqualityStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumEqualityStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public enum EnumEquivalencyHandling
+    {
+        ByValue = 0,
+        ByName = 1,
+    }
+    public class EnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EnumerableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public enum EqualityStrategy
+    {
+        Equals = 0,
+        Members = 1,
+        ForceEquals = 2,
+        ForceMembers = 3,
+    }
+    public class EquivalencyAssertionOptions : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions>
+    {
+        public EquivalencyAssertionOptions() { }
+    }
+    [System.Obsolete("This class is deprecated and will be removed in version 6.X.")]
+    public static class EquivalencyAssertionOptionsExtentions
+    {
+        public static System.Type GetExpectationType(this FluentAssertions.Equivalency.IEquivalencyAssertionOptions config, FluentAssertions.Equivalency.IMemberInfo context) { }
+    }
+    public class EquivalencyAssertionOptions<TExpectation> : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>>
+    {
+        public EquivalencyAssertionOptions() { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+        public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
+    }
+    public class EquivalencyValidationContext : FluentAssertions.Equivalency.IEquivalencyValidationContext, FluentAssertions.Equivalency.IMemberInfo
+    {
+        public EquivalencyValidationContext() { }
+        public string Because { get; set; }
+        public object[] BecauseArgs { get; set; }
+        public System.Type CompileTimeType { get; set; }
+        public object Expectation { get; set; }
+        public bool IsRoot { get; }
+        public bool RootIsCollection { get; set; }
+        public System.Type RuntimeType { get; }
+        public string SelectedMemberDescription { get; set; }
+        public FluentAssertions.Equivalency.SelectedMemberInfo SelectedMemberInfo { get; set; }
+        public string SelectedMemberPath { get; set; }
+        public object Subject { get; set; }
+        public FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
+        public override string ToString() { }
+        public System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getTraceMessage) { }
+        public void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getTraceMessage) { }
+    }
+    public class EquivalencyValidator : FluentAssertions.Equivalency.IEquivalencyValidator
+    {
+        public EquivalencyValidator(FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public void AssertEquality(FluentAssertions.Equivalency.EquivalencyValidationContext context) { }
+        public void AssertEqualityUsing(FluentAssertions.Equivalency.IEquivalencyValidationContext context) { }
+    }
+    public class GenericDictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericDictionaryEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class GenericEnumerableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public GenericEnumerableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public delegate string GetTraceMessage(string path);
+    public interface IAssertionContext<TSubject>
+    {
+        string Because { get; set; }
+        object[] BecauseArgs { get; set; }
+        TSubject Expectation { get; }
+        TSubject Subject { get; }
+        FluentAssertions.Equivalency.SelectedMemberInfo SubjectProperty { get; }
+    }
+    public interface IAssertionRule
+    {
+        bool AssertEquality(FluentAssertions.Equivalency.IEquivalencyValidationContext context);
+    }
+    public interface IEquivalencyAssertionOptions
+    {
+        bool AllowInfiniteRecursion { get; }
+        FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
+        FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
+        bool IncludeFields { get; }
+        bool IncludeProperties { get; }
+        bool IsRecursive { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberMatchingRule> MatchingRules { get; }
+        FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
+        FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
+        bool UseRuntimeTyping { get; }
+        FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> GetUserEquivalencySteps(FluentAssertions.Equivalency.ConversionSelector conversionSelector);
+    }
+    public interface IEquivalencyStep
+    {
+        bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+        bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IEquivalencyValidationContext : FluentAssertions.Equivalency.IMemberInfo
+    {
+        string Because { get; }
+        object[] BecauseArgs { get; }
+        object Expectation { get; }
+        bool IsRoot { get; }
+        bool RootIsCollection { get; set; }
+        object Subject { get; }
+        FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
+        System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getMessage);
+        void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getMessage);
+    }
+    public interface IEquivalencyValidator
+    {
+        void AssertEqualityUsing(FluentAssertions.Equivalency.IEquivalencyValidationContext context);
+    }
+    public interface IMemberInfo
+    {
+        System.Type CompileTimeType { get; }
+        System.Type RuntimeType { get; }
+        string SelectedMemberDescription { get; }
+        FluentAssertions.Equivalency.SelectedMemberInfo SelectedMemberInfo { get; }
+        string SelectedMemberPath { get; }
+    }
+    public interface IMemberMatchingRule
+    {
+        FluentAssertions.Equivalency.SelectedMemberInfo Match(FluentAssertions.Equivalency.SelectedMemberInfo expectedMember, object subject, string memberPath, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IMemberSelectionRule
+    {
+        bool IncludesMembers { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> SelectMembers(System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> selectedMembers, FluentAssertions.Equivalency.IMemberInfo context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config);
+    }
+    public interface IOrderingRule
+    {
+        FluentAssertions.Equivalency.OrderStrictness Evaluate(FluentAssertions.Equivalency.IMemberInfo memberInfo);
+    }
+    public interface ITraceWriter
+    {
+        System.IDisposable AddBlock(string trace);
+        void AddSingle(string trace);
+        string ToString();
+    }
+    public enum OrderStrictness
+    {
+        Strict = 0,
+        NotStrict = 1,
+        Irrelevant = 2,
+    }
+    public class OrderingRuleCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule>, System.Collections.IEnumerable
+    {
+        public OrderingRuleCollection() { }
+        public OrderingRuleCollection(System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IOrderingRule> orderingRules) { }
+        public void Add(FluentAssertions.Equivalency.IOrderingRule rule) { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Equivalency.IOrderingRule> GetEnumerator() { }
+        public bool IsOrderingStrictFor(FluentAssertions.Equivalency.IMemberInfo memberInfo) { }
+    }
+    public class ReferenceEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ReferenceEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public virtual bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class RunAllUserStepsEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public RunAllUserStepsEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public abstract class SelectedMemberInfo
+    {
+        protected SelectedMemberInfo() { }
+        public abstract System.Type DeclaringType { get; }
+        public abstract System.Type MemberType { get; }
+        public abstract string Name { get; }
+        public abstract object GetValue(object obj, object[] index);
+        public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.FieldInfo fieldInfo) { }
+        public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.PropertyInfo propertyInfo) { }
+    }
+    public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
+        where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
+    {
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        protected readonly FluentAssertions.Equivalency.OrderingRuleCollection orderingRules;
+        protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
+        public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        public FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
+        protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public TSelf AllowingInfiniteRecursion() { }
+        public TSelf ComparingByMembers<T>() { }
+        public TSelf ComparingByValue<T>() { }
+        public TSelf ComparingEnumsByName() { }
+        public TSelf ComparingEnumsByValue() { }
+        public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf ExcludingFields() { }
+        public TSelf ExcludingMissingMembers() { }
+        public TSelf ExcludingNestedObjects() { }
+        public TSelf ExcludingProperties() { }
+        public TSelf IgnoringCyclicReferences() { }
+        public TSelf IncludingAllDeclaredProperties() { }
+        public TSelf IncludingAllRuntimeProperties() { }
+        public TSelf IncludingFields() { }
+        public TSelf IncludingNestedObjects() { }
+        public TSelf IncludingProperties() { }
+        protected void RemoveSelectionRule<T>()
+            where T : FluentAssertions.Equivalency.IMemberSelectionRule { }
+        public TSelf RespectingDeclaredTypes() { }
+        public TSelf RespectingRuntimeTypes() { }
+        public TSelf ThrowingOnMissingMembers() { }
+        public override string ToString() { }
+        public TSelf Using(FluentAssertions.Equivalency.IAssertionRule assertionRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IEquivalencyStep equivalencyStep) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
+        public TSelf WithAutoConversion() { }
+        public TSelf WithAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf WithStrictOrdering() { }
+        public TSelf WithStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public TSelf WithTracing(FluentAssertions.Equivalency.ITraceWriter writer = null) { }
+        public TSelf WithoutAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public void WithoutMatchingRules() { }
+        public void WithoutSelectionRules() { }
+        public TSelf WithoutStrictOrdering() { }
+        public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+        public class Restriction<TMember>
+        {
+            public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
+            public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
+            public TSelf WhenTypeIs<TMemberType>() { }
+        }
+    }
+    public class SimpleEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public SimpleEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class StringBuilderTraceWriter : FluentAssertions.Equivalency.ITraceWriter
+    {
+        public StringBuilderTraceWriter() { }
+        public System.IDisposable AddBlock(string trace) { }
+        public void AddSingle(string trace) { }
+        public override string ToString() { }
+    }
+    public class StringEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StringEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class StructuralEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public StructuralEqualityEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public static class SubjectInfoExtensions
+    {
+        public static bool WhichGetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichGetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+        public static bool WhichSetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
+    }
+    public class TryConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public TryConversionStep(FluentAssertions.Equivalency.ConversionSelector selector) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ValueTypeEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+}
+namespace FluentAssertions.Events
+{
+    public class EventAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<T, FluentAssertions.Events.EventAssertions<T>>
+    {
+        protected EventAssertions(FluentAssertions.Events.IMonitor<T> monitor) { }
+        protected override string Identifier { get; }
+        public void NotRaise(string eventName, string because = "", params object[] becauseArgs) { }
+        public void NotRaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecorder Raise(string eventName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecorder RaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
+    }
+    public class EventMetadata
+    {
+        public EventMetadata(string eventName, System.Type handlerType) { }
+        public string EventName { get; }
+        public System.Type HandlerType { get; }
+    }
+    public class EventRecorder : FluentAssertions.Events.IEventRecorder, System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
+    {
+        public EventRecorder(object eventRaiser, string eventName, System.Func<System.DateTime> utcNow) { }
+        public System.Type EventHandlerType { get; }
+        public string EventName { get; }
+        public object EventObject { get; }
+        public void Attach(System.WeakReference subject, System.Reflection.EventInfo eventInfo) { }
+        public void Dispose() { }
+        public System.Collections.Generic.IEnumerator<FluentAssertions.Events.RecordedEvent> GetEnumerator() { }
+        public void RecordEvent(params object[] parameters) { }
+        public void Reset() { }
+    }
+    public interface IEventRecorder : System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
+    {
+        System.Type EventHandlerType { get; }
+        string EventName { get; }
+        object EventObject { get; }
+        void RecordEvent(params object[] parameters);
+        void Reset();
+    }
+    public interface IMonitor<T> : System.IDisposable
+    {
+        FluentAssertions.Events.EventMetadata[] MonitoredEvents { get; }
+        FluentAssertions.Events.OccurredEvent[] OccurredEvents { get; }
+        T Subject { get; }
+        void Clear();
+        FluentAssertions.Events.IEventRecorder GetEventRecorder(string eventName);
+        FluentAssertions.Events.EventAssertions<T> Should();
+    }
+    public class OccurredEvent
+    {
+        public OccurredEvent() { }
+        public string EventName { get; set; }
+        public object[] Parameters { get; set; }
+        public System.DateTime TimestampUtc { get; set; }
+    }
+    public class RecordedEvent
+    {
+        public RecordedEvent(System.DateTime utcNow, object monitoredObject, params object[] parameters) { }
+        public System.Collections.Generic.IEnumerable<object> Parameters { get; }
+        public System.DateTime TimestampUtc { get; set; }
+    }
+}
+namespace FluentAssertions.Execution
+{
+    public class AssertionFailedException : System.Exception
+    {
+        public AssertionFailedException(string message) { }
+        protected AssertionFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public class AssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public AssertionScope() { }
+        public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
+        public AssertionScope(string context) { }
+        public string Context { get; set; }
+        public bool Succeeded { get; }
+        public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
+        public static FluentAssertions.Execution.AssertionScope Current { get; }
+        public void AddNonReportable(string key, object value) { }
+        public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, string value) { }
+        public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
+        public T Get<T>(string key) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public bool HasFailures() { }
+        public FluentAssertions.Execution.AssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.AssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public class Continuation
+    {
+        public Continuation(FluentAssertions.Execution.AssertionScope sourceScope, bool sourceSucceeded) { }
+        public bool SourceSucceeded { get; }
+        public FluentAssertions.Execution.IAssertionScope Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.Continuation continuation) { }
+    }
+    public class ContinuationOfGiven<TSubject>
+    {
+        public ContinuationOfGiven(FluentAssertions.Execution.GivenSelector<TSubject> parent, bool succeeded) { }
+        public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
+        public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
+    }
+    public class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
+    {
+        public ContinuedAssertionScope(FluentAssertions.Execution.AssertionScope predecessor, bool predecessorSucceeded) { }
+        public bool Succeeded { get; }
+        public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
+        public FluentAssertions.Execution.Continuation ClearExpectation() { }
+        public string[] Discard() { }
+        public void Dispose() { }
+        public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.IAssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
+        public FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier) { }
+        public FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args) { }
+    }
+    public static class Execute
+    {
+        public static FluentAssertions.Execution.AssertionScope Assertion { get; }
+    }
+    public class FailReason
+    {
+        public FailReason(string message, params object[] args) { }
+        public object[] Args { get; }
+        public string Message { get; }
+    }
+    public class GivenSelector<T>
+    {
+        public GivenSelector(System.Func<T> selector, bool predecessorSucceeded, FluentAssertions.Execution.AssertionScope predecessor) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> ClearExpectation() { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<, >[] args) { }
+        public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params object[] args) { }
+        public FluentAssertions.Execution.GivenSelector<T> ForCondition(System.Func<T, bool> predicate) { }
+        public FluentAssertions.Execution.GivenSelector<TOut> Given<TOut>(System.Func<T, TOut> selector) { }
+    }
+    public interface IAssertionScope : System.IDisposable
+    {
+        bool Succeeded { get; }
+        FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
+        FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
+        FluentAssertions.Execution.Continuation ClearExpectation();
+        string[] Discard();
+        FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc);
+        FluentAssertions.Execution.Continuation FailWith(string message, params object[] args);
+        FluentAssertions.Execution.IAssertionScope ForCondition(bool condition);
+        FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector);
+        FluentAssertions.Execution.IAssertionScope WithDefaultIdentifier(string identifier);
+        FluentAssertions.Execution.IAssertionScope WithExpectation(string message, params object[] args);
+    }
+    public interface IAssertionStrategy
+    {
+        System.Collections.Generic.IEnumerable<string> FailureMessages { get; }
+        System.Collections.Generic.IEnumerable<string> DiscardFailures();
+        void HandleFailure(string message);
+        void ThrowIfAny(System.Collections.Generic.IDictionary<string, object> context);
+    }
+    public interface ICloneable2
+    {
+        object Clone();
+    }
+}
+namespace FluentAssertions.Extensions
+{
+    public static class FluentDateTimeExtensions
+    {
+        public static System.DateTime AddMicroseconds(this System.DateTime self, long microseconds) { }
+        public static System.DateTimeOffset AddMicroseconds(this System.DateTimeOffset self, long microseconds) { }
+        public static System.DateTime AddNanoseconds(this System.DateTime self, long nanoseconds) { }
+        public static System.DateTimeOffset AddNanoseconds(this System.DateTimeOffset self, long nanoseconds) { }
+        public static System.DateTime After(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime April(this int day, int year) { }
+        public static System.DateTime AsLocal(this System.DateTime dateTime) { }
+        public static System.DateTime AsUtc(this System.DateTime dateTime) { }
+        public static System.DateTime At(this System.DateTime date, System.TimeSpan time) { }
+        public static System.DateTime At(this System.DateTime date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTimeOffset At(this System.DateTimeOffset date, int hours, int minutes, int seconds = 0, int milliseconds = 0, int microseconds = 0, int nanoseconds = 0) { }
+        public static System.DateTime August(this int day, int year) { }
+        public static System.DateTime Before(this System.TimeSpan timeDifference, System.DateTime sourceDateTime) { }
+        public static System.DateTime December(this int day, int year) { }
+        public static System.DateTime February(this int day, int year) { }
+        public static System.DateTime January(this int day, int year) { }
+        public static System.DateTime July(this int day, int year) { }
+        public static System.DateTime June(this int day, int year) { }
+        public static System.DateTime March(this int day, int year) { }
+        public static System.DateTime May(this int day, int year) { }
+        public static int Microsecond(this System.DateTime self) { }
+        public static int Microsecond(this System.DateTimeOffset self) { }
+        public static int Nanosecond(this System.DateTime self) { }
+        public static int Nanosecond(this System.DateTimeOffset self) { }
+        public static System.DateTime November(this int day, int year) { }
+        public static System.DateTime October(this int day, int year) { }
+        public static System.DateTime September(this int day, int year) { }
+    }
+    public static class FluentTimeSpanExtensions
+    {
+        public const long TicksPerMicrosecond = 10;
+        public const double TicksPerNanosecond = 0.01D;
+        public static System.TimeSpan And(this System.TimeSpan sourceTime, System.TimeSpan offset) { }
+        public static System.TimeSpan Days(this double days) { }
+        public static System.TimeSpan Days(this int days) { }
+        public static System.TimeSpan Days(this int days, System.TimeSpan offset) { }
+        public static System.TimeSpan Hours(this double hours) { }
+        public static System.TimeSpan Hours(this int hours) { }
+        public static System.TimeSpan Hours(this int hours, System.TimeSpan offset) { }
+        public static int Microseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Microseconds(this int microseconds) { }
+        public static System.TimeSpan Microseconds(this long microseconds) { }
+        public static System.TimeSpan Milliseconds(this double milliseconds) { }
+        public static System.TimeSpan Milliseconds(this int milliseconds) { }
+        public static System.TimeSpan Minutes(this double minutes) { }
+        public static System.TimeSpan Minutes(this int minutes) { }
+        public static System.TimeSpan Minutes(this int minutes, System.TimeSpan offset) { }
+        public static int Nanoseconds(this System.TimeSpan self) { }
+        public static System.TimeSpan Nanoseconds(this int nanoseconds) { }
+        public static System.TimeSpan Nanoseconds(this long nanoseconds) { }
+        public static System.TimeSpan Seconds(this double seconds) { }
+        public static System.TimeSpan Seconds(this int seconds) { }
+        public static System.TimeSpan Seconds(this int seconds, System.TimeSpan offset) { }
+        public static System.TimeSpan Ticks(this int ticks) { }
+        public static System.TimeSpan Ticks(this long ticks) { }
+        public static double TotalMicroseconds(this System.TimeSpan self) { }
+        public static double TotalNanoseconds(this System.TimeSpan self) { }
+    }
+}
+namespace FluentAssertions.Formatting
+{
+    public class AggregateExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AggregateExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class AttributeBasedFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public AttributeBasedFormatter() { }
+        public System.Reflection.MethodInfo[] Formatters { get; }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DateTimeOffsetValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DateTimeOffsetValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DecimalValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DecimalValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DefaultValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DoubleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public EnumerableValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExceptionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class ExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public ExpressionValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public delegate string FormatChild(string childPath, object value);
+    public static class Formatter
+    {
+        public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
+        public static void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
+        public static string ToString(object value, bool useLineBreaks = false) { }
+    }
+    public class FormattingContext
+    {
+        public FormattingContext() { }
+        public int Depth { get; set; }
+        public bool UseLineBreaks { get; set; }
+    }
+    public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public GuidValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public interface IValueFormatter
+    {
+        bool CanHandle(object value);
+        string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
+    }
+    public class Int16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class Int64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public Int64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class MultidimensionalArrayFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public MultidimensionalArrayFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class NullValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public NullValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class PropertyInfoFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public PropertyInfoFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SByteValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class SingleValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public SingleValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class StringValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public StringValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TaskFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TaskFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class TimeSpanValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public TimeSpanValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt16ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt32ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class UInt64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public UInt64ValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
+    public class ValueFormatterAttribute : System.Attribute
+    {
+        public ValueFormatterAttribute() { }
+    }
+    public class XAttributeValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XAttributeValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XDocumentValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XDocumentValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class XElementValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XElementValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+}
+namespace FluentAssertions.Numeric
+{
+    public class ComparableTypeAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    {
+        public ComparableTypeAssertions(System.IComparable<T> value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
+        where T :  struct
+    {
+        public NullableNumericAssertions(T? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NumericAssertions<T>
+        where T :  struct
+    {
+        public NumericAssertions(object value) { }
+        public System.IComparable Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(params T[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Primitives
+{
+    public class BooleanAssertions
+    {
+        public BooleanAssertions(bool? value) { }
+        public bool? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeAssertions
+    {
+        public DateTimeAssertions(System.DateTime? value) { }
+        public System.DateTime? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.DateTime[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetAssertions
+    {
+        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
+        public System.DateTimeOffset? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeOffsetRangeAssertions
+    {
+        protected DateTimeOffsetRangeAssertions(FluentAssertions.Primitives.DateTimeOffsetAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+    }
+    public class DateTimeRangeAssertions
+    {
+        protected DateTimeRangeAssertions(FluentAssertions.Primitives.DateTimeAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
+    }
+    public class GuidAssertions
+    {
+        public GuidAssertions(System.Guid? value) { }
+        public System.Guid? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableBooleanAssertions : FluentAssertions.Primitives.BooleanAssertions
+    {
+        public NullableBooleanAssertions(bool? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions
+    {
+        public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions
+    {
+        public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableGuidAssertions : FluentAssertions.Primitives.GuidAssertions
+    {
+        public NullableGuidAssertions(System.Guid? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions
+    {
+        public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class ObjectAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
+    {
+        public ObjectAssertions(object value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be(object expected, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> HaveFlag(System.Enum expectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe(object unexpected, string because = "", params object[] becauseArgs) { }
+        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotHaveFlag(System.Enum unexpectedFlag, string because = "", params object[] becauseArgs) { }
+    }
+    public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
+        where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+    {
+        protected ReferenceTypeAssertions() { }
+        protected ReferenceTypeAssertions(TSubject subject) { }
+        protected abstract string Identifier { get; }
+        public TSubject Subject { get; set; }
+        public FluentAssertions.AndConstraint<TAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, T> BeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameAs(TSubject expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<TSubject, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match<T>(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
+            where T : TSubject { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SimpleTimeSpanAssertions
+    {
+        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public System.TimeSpan? Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+    }
+    public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>
+    {
+        public StringAssertions(string value) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(params string[] validValues) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+    }
+    public enum TimeSpanCondition
+    {
+        MoreThan = 0,
+        AtLeast = 1,
+        Exactly = 2,
+        Within = 3,
+        LessThan = 4,
+    }
+}
+namespace FluentAssertions.Reflection
+{
+    public class AssemblyAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Reflection.Assembly, FluentAssertions.Reflection.AssemblyAssertions>
+    {
+        public AssemblyAssertions(System.Reflection.Assembly assembly) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Reflection.AssemblyAssertions, System.Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs) { }
+        public void NotReference(System.Reflection.Assembly assembly) { }
+        public void NotReference(System.Reflection.Assembly assembly, string because, params string[] becauseArgs) { }
+        public void Reference(System.Reflection.Assembly assembly) { }
+        public void Reference(System.Reflection.Assembly assembly, string because, params string[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Specialized
+{
+    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action>
+    {
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Action Subject { get; }
+        protected override void InvokeSubject() { }
+    }
+    public class AsyncFunctionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Func<System.Threading.Tasks.Task>>
+    {
+        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Func<System.Threading.Tasks.Task> Subject { get; }
+        protected override void InvokeSubject() { }
+        public System.Threading.Tasks.Task NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public abstract class DelegateAssertions<TDelegate> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Delegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate>>
+        where TDelegate : System.Delegate
+    {
+        protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public new TDelegate Subject { get; }
+        protected abstract void InvokeSubject();
+        public void NotThrow(string because = "", params object[] becauseArgs) { }
+        protected void NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        protected void NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+        public void NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+        protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
+            where TException : System.Exception { }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> ThrowExactly<TException>(string because = "", params object[] becauseArgs)
+            where TException : System.Exception { }
+    }
+    public class ExceptionAssertions<TException> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IEnumerable<TException>, FluentAssertions.Specialized.ExceptionAssertions<TException>>
+        where TException : System.Exception
+    {
+        public ExceptionAssertions(System.Collections.Generic.IEnumerable<TException> exceptions) { }
+        public TException And { get; }
+        protected override string Identifier { get; }
+        public TException Which { get; }
+        public FluentAssertions.Specialized.ExceptionAssertions<TException> Where(System.Linq.Expressions.Expression<System.Func<TException, bool>> exceptionExpression, string because = "", params object[] becauseArgs) { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerException<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TInnerException> WithInnerExceptionExactly<TInnerException>(string because = null, params object[] becauseArgs)
+            where TInnerException : System.Exception { }
+        public virtual FluentAssertions.Specialized.ExceptionAssertions<TException> WithMessage(string expectedWildcardPattern, string because = "", params object[] becauseArgs) { }
+    }
+    public class ExecutionTime
+    {
+        public ExecutionTime(System.Action action) { }
+        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action) { }
+        protected ExecutionTime(System.Action action, string actionDescription) { }
+        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription) { }
+    }
+    public class ExecutionTimeAssertions
+    {
+        public ExecutionTimeAssertions(FluentAssertions.Specialized.ExecutionTime executionTime) { }
+        public void BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public void BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public void BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public void BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public void BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+    }
+    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
+    {
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        protected override string Identifier { get; }
+        public System.Func<T> Subject { get; }
+        protected override void InvokeSubject() { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions
+    {
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+    public interface IExtractExceptions
+    {
+        System.Collections.Generic.IEnumerable<T> OfType<T>(System.Exception actualException)
+            where T : System.Exception;
+    }
+    public class MemberExecutionTime<T> : FluentAssertions.Specialized.ExecutionTime
+    {
+        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+    }
+    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions
+    {
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Types
+{
+    public static class AllTypes
+    {
+        public static FluentAssertions.Types.TypeSelector From(System.Reflection.Assembly assembly) { }
+    }
+    public class ConstructorInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.ConstructorInfo, FluentAssertions.Types.ConstructorInfoAssertions>
+    {
+        public ConstructorInfoAssertions(System.Reflection.ConstructorInfo constructorInfo) { }
+        protected override string Identifier { get; }
+    }
+    public abstract class MemberInfoAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MemberInfo
+        where TAssertions : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+    {
+        protected MemberInfoAssertions() { }
+        protected MemberInfoAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+    }
+    public abstract class MethodBaseAssertions<TSubject, TAssertions> : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
+        where TSubject : System.Reflection.MethodBase
+        where TAssertions : FluentAssertions.Types.MethodBaseAssertions<TSubject, TAssertions>
+    {
+        protected MethodBaseAssertions() { }
+        protected MethodBaseAssertions(TSubject subject) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>
+    {
+        public MethodInfoAssertions() { }
+        public MethodInfoAssertions(System.Reflection.MethodInfo methodInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeAsync(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> NotReturnVoid(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return(System.Type returnType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>> ReturnVoid(string because = "", params object[] becauseArgs) { }
+    }
+    public class MethodInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, System.Collections.IEnumerable
+    {
+        public MethodInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public MethodInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.MethodInfoSelector ThatArePublicOrInternal { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturnVoid { get; }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatDoNotReturn<TReturn>() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatReturn<TReturn>() { }
+        public System.Reflection.MethodInfo[] ToArray() { }
+    }
+    public class MethodInfoSelectorAssertions
+    {
+        public MethodInfoSelectorAssertions(params System.Reflection.MethodInfo[] methods) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> SubjectMethods { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoAssertions : FluentAssertions.Types.MemberInfoAssertions<System.Reflection.PropertyInfo, FluentAssertions.Types.PropertyInfoAssertions>
+    {
+        public PropertyInfoAssertions(System.Reflection.PropertyInfo propertyInfo) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeReadable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> BeWritable(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> NotReturn<TReturn>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return(System.Type propertyType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoAssertions> Return<TReturn>(string because = "", params object[] becauseArgs) { }
+    }
+    public class PropertyInfoSelector : System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo>, System.Collections.IEnumerable
+    {
+        public PropertyInfoSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public PropertyInfoSelector(System.Type type) { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatArePublicOrInternal { get; }
+        public System.Collections.Generic.IEnumerator<System.Reflection.PropertyInfo> GetEnumerator() { }
+        public FluentAssertions.Types.PropertyInfoSelector NotOfType<TReturn>() { }
+        public FluentAssertions.Types.PropertyInfoSelector OfType<TReturn>() { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.PropertyInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public System.Reflection.PropertyInfo[] ToArray() { }
+    }
+    public class PropertyInfoSelectorAssertions
+    {
+        public PropertyInfoSelectorAssertions(params System.Reflection.PropertyInfo[] properties) { }
+        protected string Context { get; }
+        public System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> SubjectProperties { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+    }
+    public class TypeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Type, FluentAssertions.Types.TypeAssertions>
+    {
+        public TypeAssertions(System.Type type) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be(System.Type expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Be<TExpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> BeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<System.Type> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> HaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> HaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveExplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveExplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveImplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'HaveImplicitConversionOperator\' and will b" +
+            "e removed in v6.X.")]
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveIndexer(System.Type indexerType, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.MethodInfo> HaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty(System.Type propertyType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.PropertyInfo> HaveProperty<TProperty>(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> Implement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe(System.Type unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBe<TUnexpected>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAbstract(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom(System.Type baseType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeDerivedFrom<TBaseClass>(string because = "", params object[] becauseArgs)
+            where TBaseClass :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeSealed(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotBeStatic(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<System.Type> NotHaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveConstructor(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.TypeAssertions, System.Reflection.ConstructorInfo> NotHaveDefaultConstructor(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod(System.Type interfaceType, string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitMethod<TInterface>(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty(System.Type interfaceType, string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveExplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveExplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveExplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveImplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplictConversionOperator(System.Type sourceType, System.Type targetType, string because = "", params object[] becauseArgs) { }
+        [System.Obsolete("This method is deprecated in favor of \'NotHaveImplicitConversionOperator\' and wil" +
+            "l be removed in v6.X.")]
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveImplictConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveIndexer(System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveMethod(string name, System.Collections.Generic.IEnumerable<System.Type> parameterTypes, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotHaveProperty(string name, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement(System.Type interfaceType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeAssertions> NotImplement<TInterface>(string because = "", params object[] becauseArgs)
+            where TInterface :  class { }
+    }
+    public class TypeSelector : System.Collections.Generic.IEnumerable<System.Type>, System.Collections.IEnumerable
+    {
+        public TypeSelector(System.Collections.Generic.IEnumerable<System.Type> types) { }
+        public TypeSelector(System.Type type) { }
+        public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
+        public System.Type[] ToArray() { }
+    }
+    public class TypeSelectorAssertions
+    {
+        public TypeSelectorAssertions(params System.Type[] types) { }
+        public System.Collections.Generic.IEnumerable<System.Type> Subject { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> BeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWith<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.TypeSelectorAssertions> NotBeDecoratedWithOrInherit<TAttribute>(System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate, string because = "", params object[] becauseArgs)
+            where TAttribute : System.Attribute { }
+    }
+}
+namespace FluentAssertions.Xml
+{
+    public class XAttributeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XAttribute, FluentAssertions.Xml.XAttributeAssertions>
+    {
+        public XAttributeAssertions(System.Xml.Linq.XAttribute attribute) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> Be(System.Xml.Linq.XAttribute expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> Be(System.Xml.Linq.XAttribute expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> HaveValue(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> HaveValue(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> NotBe(System.Xml.Linq.XAttribute unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XAttributeAssertions> NotBe(System.Xml.Linq.XAttribute unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XDocumentAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XDocument, FluentAssertions.Xml.XDocumentAssertions>
+    {
+        public XDocumentAssertions(System.Xml.Linq.XDocument document) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> Be(System.Xml.Linq.XDocument expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> Be(System.Xml.Linq.XDocument expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> BeEquivalentTo(System.Xml.Linq.XDocument expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> BeEquivalentTo(System.Xml.Linq.XDocument expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XDocumentAssertions, System.Xml.Linq.XElement> HaveRoot(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBe(System.Xml.Linq.XDocument unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBe(System.Xml.Linq.XDocument unexpected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBeEquivalentTo(System.Xml.Linq.XDocument unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XDocumentAssertions> NotBeEquivalentTo(System.Xml.Linq.XDocument unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XElementAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Xml.Linq.XElement, FluentAssertions.Xml.XElementAssertions>
+    {
+        public XElementAssertions(System.Xml.Linq.XElement xElement) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> Be(System.Xml.Linq.XElement expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> Be(System.Xml.Linq.XElement expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> BeEquivalentTo(System.Xml.Linq.XElement expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveAttribute(System.Xml.Linq.XName expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(string expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XElementAssertions, System.Xml.Linq.XElement> HaveElement(System.Xml.Linq.XName expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveValue(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> HaveValue(string expected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBe(System.Xml.Linq.XElement unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBe(System.Xml.Linq.XElement unexpected, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBeEquivalentTo(System.Xml.Linq.XElement unexpected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XElementAssertions> NotBeEquivalentTo(System.Xml.Linq.XElement unexpected, string because, params object[] becauseArgs) { }
+    }
+    public class XmlElementAssertions : FluentAssertions.Xml.XmlNodeAssertions<System.Xml.XmlElement, FluentAssertions.Xml.XmlElementAssertions>
+    {
+        public XmlElementAssertions(System.Xml.XmlElement xmlElement) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttribute(string expectedName, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttributeWithNamespace(string expectedName, string expectedNamespace, string expectedValue) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveAttributeWithNamespace(string expectedName, string expectedNamespace, string expectedValue, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElement(string expectedName) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElement(string expectedName, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElementWithNamespace(string expectedName, string expectedNamespace) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Xml.XmlElementAssertions, System.Xml.XmlElement> HaveElementWithNamespace(string expectedName, string expectedNamespace, string because, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveInnerText(string expected) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Xml.XmlElementAssertions> HaveInnerText(string expected, string because, params object[] becauseArgs) { }
+    }
+    public class XmlNodeAssertions : FluentAssertions.Xml.XmlNodeAssertions<System.Xml.XmlNode, FluentAssertions.Xml.XmlNodeAssertions>
+    {
+        public XmlNodeAssertions(System.Xml.XmlNode xmlNode) { }
+    }
+    public class XmlNodeAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.Xml.XmlNode
+        where TAssertions : FluentAssertions.Xml.XmlNodeAssertions<TSubject, TAssertions>
+    {
+        public XmlNodeAssertions(TSubject xmlNode) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Xml.XmlNode expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Xml.XmlNode expected, string because, params object[] reasonArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Xml.XmlNode unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Xml.XmlNode unexpected, string because, params object[] reasonArgs) { }
+    }
+    public class XmlNodeFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XmlNodeFormatter() { }
+        public bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+}


### PR DESCRIPTION
This adds an extra step to the test stage to verify that the public API does not change unnoticed.
The `approved.txt` files contains a snapshot of the current public API for all supported target frameworks.
From now on all public API changes will require updating the `approved.txt` files.

I intentionally added a API breaking change to verify that the CI build breaks as expected.
Will update the PR once the CI-build turns red as expected.

Fixes #1133 