### PR TITLE
Make more assertions chainable

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -517,10 +517,10 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation,
+        public AndConstraint<GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation,
             string because = "", params object[] becauseArgs)
         {
-            AllBeEquivalentTo(expectation, options => options, because, becauseArgs);
+            return AllBeEquivalentTo(expectation, options => options, because, becauseArgs);
         }
 
         /// <summary>
@@ -547,7 +547,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation,
+        public AndConstraint<GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation,
             Func<EquivalencyAssertionOptions<TExpectation>, EquivalencyAssertionOptions<TExpectation>> config,
             string because = "",
             params object[] becauseArgs)
@@ -565,7 +565,7 @@ namespace FluentAssertions.Collections
             Func<EquivalencyAssertionOptions<TExpectation>, EquivalencyAssertionOptions<TExpectation>> forceStringOrderingConfig =
                 x => config(x).WithStrictOrderingFor(s => string.IsNullOrEmpty(s.SelectedMemberPath));
 
-            BeEquivalentTo(repeatedExpectation, forceStringOrderingConfig, because, becauseArgs);
+            return BeEquivalentTo(repeatedExpectation, forceStringOrderingConfig, because, becauseArgs);
         }
 
         private static IEnumerable<TExpectation> RepeatAsManyAs<TExpectation>(TExpectation value, IEnumerable<T> enumerable)

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -512,10 +512,10 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation,
+        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation,
             string because = "", params object[] becauseArgs)
         {
-            BeEquivalentTo(expectation, options => options, because, becauseArgs);
+            return BeEquivalentTo(expectation, options => options, because, becauseArgs);
         }
 
         /// <summary>
@@ -542,7 +542,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation,
+        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation,
             Func<EquivalencyAssertionOptions<TExpectation>, EquivalencyAssertionOptions<TExpectation>> config, string because = "",
             params object[] becauseArgs)
         {
@@ -563,6 +563,8 @@ namespace FluentAssertions.Collections
 
             var equivalencyValidator = new EquivalencyValidator(options);
             equivalencyValidator.AssertEquality(context);
+
+            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
         }
 
         #region ContainKey

--- a/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
@@ -60,10 +60,10 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "",
+        public AndConstraint<ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "",
             params object[] becauseArgs)
         {
-            BeEquivalentTo(expectation, config => config, because, becauseArgs);
+            return BeEquivalentTo(expectation, config => config, because, becauseArgs);
         }
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation,
+        public AndConstraint<ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation,
             Func<EquivalencyAssertionOptions<TExpectation>, EquivalencyAssertionOptions<TExpectation>> config, string because = "",
             params object[] becauseArgs)
         {
@@ -108,6 +108,8 @@ namespace FluentAssertions.Numeric
 
             var equivalencyValidator = new EquivalencyValidator(options);
             equivalencyValidator.AssertEquality(context);
+
+            return new AndConstraint<ComparableTypeAssertions<T>>(this);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Primitives/ObjectAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ObjectAssertions.cs
@@ -75,10 +75,10 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "",
+        public AndConstraint<ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "",
             params object[] becauseArgs)
         {
-            BeEquivalentTo(expectation, config => config, because, becauseArgs);
+            return BeEquivalentTo(expectation, config => config, because, becauseArgs);
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation,
+        public AndConstraint<ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation,
             Func<EquivalencyAssertionOptions<TExpectation>, EquivalencyAssertionOptions<TExpectation>> config, string because = "",
             params object[] becauseArgs)
         {
@@ -123,6 +123,8 @@ namespace FluentAssertions.Primitives
 
             var equivalencyValidator = new EquivalencyValidator(options);
             equivalencyValidator.AssertEquality(context);
+
+            return new AndConstraint<ObjectAssertions>(this);
         }
 
         /// <summary>
@@ -142,12 +144,12 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void NotBeEquivalentTo<TExpectation>(
+        public AndConstraint<ObjectAssertions> NotBeEquivalentTo<TExpectation>(
             TExpectation unexpected,
             string because = "",
             params object[] becauseArgs)
         {
-            NotBeEquivalentTo(unexpected, config => config, because, becauseArgs);
+            return NotBeEquivalentTo(unexpected, config => config, because, becauseArgs);
         }
 
         /// <summary>
@@ -172,7 +174,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void NotBeEquivalentTo<TExpectation>(
+        public AndConstraint<ObjectAssertions> NotBeEquivalentTo<TExpectation>(
             TExpectation unexpected,
             Func<EquivalencyAssertionOptions<TExpectation>, EquivalencyAssertionOptions<TExpectation>> config,
             string because = "",
@@ -191,6 +193,8 @@ namespace FluentAssertions.Primitives
                 .ForCondition(hasMismatches)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:object} not to be equivalent to {0}, but they are.", unexpected);
+
+            return new AndConstraint<ObjectAssertions>(this);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
@@ -32,7 +32,7 @@ namespace FluentAssertions.Reflection
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void NotReference(Assembly assembly, string because = "", params string[] becauseArgs)
+        public AndConstraint<AssemblyAssertions> NotReference(Assembly assembly, string because = "", params string[] becauseArgs)
         {
             var subjectName = Subject.GetName().Name;
             var assemblyName = assembly.GetName().Name;
@@ -43,6 +43,8 @@ namespace FluentAssertions.Reflection
                    .BecauseOf(because, becauseArgs)
                    .ForCondition(!references.Contains(assemblyName))
                    .FailWith("Expected assembly {0} not to reference assembly {1}{reason}.", subjectName, assemblyName);
+
+            return new AndConstraint<AssemblyAssertions>(this);
         }
 
         /// <summary>
@@ -56,7 +58,7 @@ namespace FluentAssertions.Reflection
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void Reference(Assembly assembly, string because = "", params string[] becauseArgs)
+        public AndConstraint<AssemblyAssertions> Reference(Assembly assembly, string because = "", params string[] becauseArgs)
         {
             var subjectName = Subject.GetName().Name;
             var assemblyName = assembly.GetName().Name;
@@ -67,6 +69,8 @@ namespace FluentAssertions.Reflection
                    .BecauseOf(because, becauseArgs)
                    .ForCondition(references.Contains(assemblyName))
                    .FailWith("Expected assembly {0} to reference assembly {1}{reason}, but it does not.", subjectName, assemblyName);
+
+            return new AndConstraint<AssemblyAssertions>(this);
         }
 #endif
 

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -69,7 +69,7 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+        public AndConstraint<DelegateAssertions<TDelegate>> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : Exception
         {
             Execute.Assertion
@@ -79,7 +79,7 @@ namespace FluentAssertions.Specialized
 
             FailIfSubjectIsAsyncVoid();
             Exception exception = InvokeSubjectWithInterception();
-            NotThrow<TException>(exception, because, becauseArgs);
+            return NotThrow<TException>(exception, because, becauseArgs);
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public void NotThrow(string because = "", params object[] becauseArgs)
+        public AndConstraint<DelegateAssertions<TDelegate>> NotThrow(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject is object)
@@ -101,7 +101,7 @@ namespace FluentAssertions.Specialized
 
             FailIfSubjectIsAsyncVoid();
             Exception exception = InvokeSubjectWithInterception();
-            NotThrow(exception, because, becauseArgs);
+            return NotThrow(exception, because, becauseArgs);
         }
 
         /// <summary>
@@ -167,7 +167,7 @@ namespace FluentAssertions.Specialized
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
         /// <exception cref="ArgumentOutOfRangeException">Throws if waitTime or pollInterval are negative.</exception>
-        public void NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
+        public AndConstraint<DelegateAssertions<TDelegate>> NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject is object)
@@ -194,7 +194,7 @@ namespace FluentAssertions.Specialized
                 exception = InvokeSubjectWithInterception();
                 if (exception is null)
                 {
-                    return;
+                    break;
                 }
 
                 Clock.Delay(pollInterval);
@@ -203,7 +203,10 @@ namespace FluentAssertions.Specialized
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(exception is null)
                 .FailWith("Did not expect any exceptions after {0}{reason}, but found {1}.", waitTime, exception);
+
+            return new AndConstraint<DelegateAssertions<TDelegate>>(this);
         }
 
         protected ExceptionAssertions<TException> Throw<TException>(Exception exception, string because, object[] becauseArgs)
@@ -228,21 +231,25 @@ namespace FluentAssertions.Specialized
             return new ExceptionAssertions<TException>(expectedExceptions);
         }
 
-        protected void NotThrow(Exception exception, string because, object[] becauseArgs)
+        protected AndConstraint<DelegateAssertions<TDelegate>> NotThrow(Exception exception, string because, object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(exception is null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect any exception{reason}, but found {0}.", exception);
+
+            return new AndConstraint<DelegateAssertions<TDelegate>>(this);
         }
 
-        protected void NotThrow<TException>(Exception exception, string because, object[] becauseArgs) where TException : Exception
+        protected AndConstraint<DelegateAssertions<TDelegate>> NotThrow<TException>(Exception exception, string because, object[] becauseArgs) where TException : Exception
         {
             IEnumerable<TException> exceptions = extractor.OfType<TException>(exception);
             Execute.Assertion
                 .ForCondition(!exceptions.Any())
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {0}{reason}, but found {1}.", typeof(TException), exception);
+
+            return new AndConstraint<DelegateAssertions<TDelegate>>(this);
         }
 
         protected abstract void InvokeSubject();

--- a/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
@@ -68,7 +68,7 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public void BeLessOrEqualTo(TimeSpan maxDuration, string because = "", params object[] becauseArgs)
+        public AndConstraint<ExecutionTimeAssertions> BeLessOrEqualTo(TimeSpan maxDuration, string because = "", params object[] becauseArgs)
         {
             bool Condition(TimeSpan duration) => duration.CompareTo(maxDuration) <= 0;
             (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: false, rate: maxDuration);
@@ -81,6 +81,8 @@ namespace FluentAssertions.Specialized
                           (isRunning ? "more than " : "exactly ") + "{1}.",
                     maxDuration,
                     elapsed);
+
+            return new AndConstraint<ExecutionTimeAssertions>(this);
         }
 
         /// <summary>
@@ -96,7 +98,7 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public void BeLessThan(TimeSpan maxDuration, string because = "", params object[] becauseArgs)
+        public AndConstraint<ExecutionTimeAssertions> BeLessThan(TimeSpan maxDuration, string because = "", params object[] becauseArgs)
         {
             bool Condition(TimeSpan duration) => duration.CompareTo(maxDuration) < 0;
             (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: false, rate: maxDuration);
@@ -109,6 +111,8 @@ namespace FluentAssertions.Specialized
                           (isRunning ? "more than " : "exactly ") + "{1}.",
                     maxDuration,
                     elapsed);
+
+            return new AndConstraint<ExecutionTimeAssertions>(this);
         }
 
         /// <summary>
@@ -124,7 +128,7 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public void BeGreaterOrEqualTo(TimeSpan minDuration, string because = "", params object[] becauseArgs)
+        public AndConstraint<ExecutionTimeAssertions> BeGreaterOrEqualTo(TimeSpan minDuration, string because = "", params object[] becauseArgs)
         {
             bool Condition(TimeSpan duration) => duration.CompareTo(minDuration) >= 0;
             (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: true, rate: minDuration);
@@ -137,6 +141,8 @@ namespace FluentAssertions.Specialized
                           (isRunning ? "more than " : "exactly ") + "{1}.",
                     minDuration,
                     elapsed);
+
+            return new AndConstraint<ExecutionTimeAssertions>(this);
         }
 
         /// <summary>
@@ -152,7 +158,7 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public void BeGreaterThan(TimeSpan minDuration, string because = "", params object[] becauseArgs)
+        public AndConstraint<ExecutionTimeAssertions> BeGreaterThan(TimeSpan minDuration, string because = "", params object[] becauseArgs)
         {
             bool Condition(TimeSpan duration) => duration.CompareTo(minDuration) > 0;
             (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: true, rate: minDuration);
@@ -165,6 +171,8 @@ namespace FluentAssertions.Specialized
                           (isRunning ? "more than " : "exactly ") + "{1}.",
                     minDuration,
                     elapsed);
+
+            return new AndConstraint<ExecutionTimeAssertions>(this);
         }
 
         /// <summary>
@@ -184,7 +192,7 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public void BeCloseTo(TimeSpan expectedDuration, TimeSpan precision, string because = "", params object[] becauseArgs)
+        public AndConstraint<ExecutionTimeAssertions> BeCloseTo(TimeSpan expectedDuration, TimeSpan precision, string because = "", params object[] becauseArgs)
         {
             TimeSpan minimumValue = expectedDuration - precision;
             TimeSpan maximumValue = expectedDuration + precision;
@@ -205,6 +213,8 @@ namespace FluentAssertions.Specialized
                     precision,
                     expectedDuration,
                     elapsed);
+
+            return new AndConstraint<ExecutionTimeAssertions>(this);
         }
     }
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net45.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net45.approved.txt
@@ -323,8 +323,8 @@ namespace FluentAssertions.Collections
     public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
     {
         public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
@@ -346,8 +346,8 @@ namespace FluentAssertions.Collections
         public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
@@ -1333,8 +1333,8 @@ namespace FluentAssertions.Numeric
         public ComparableTypeAssertions(System.IComparable<T> value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
@@ -1550,12 +1550,12 @@ namespace FluentAssertions.Primitives
         public ObjectAssertions(object value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be(object expected, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> HaveFlag(System.Enum expectedFlag, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe(object unexpected, string because = "", params object[] becauseArgs) { }
-        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
-        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotHaveFlag(System.Enum unexpectedFlag, string because = "", params object[] becauseArgs) { }
     }
     public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
@@ -1660,8 +1660,8 @@ namespace FluentAssertions.Reflection
         public AssemblyAssertions(System.Reflection.Assembly assembly) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Reflection.AssemblyAssertions, System.Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs) { }
-        public void NotReference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
-        public void Reference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Reflection.AssemblyAssertions> NotReference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Reflection.AssemblyAssertions> Reference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Specialized
@@ -1696,13 +1696,13 @@ namespace FluentAssertions.Specialized
         protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public new TDelegate Subject { get; }
         protected abstract void InvokeSubject();
-        public void NotThrow(string because = "", params object[] becauseArgs) { }
-        protected void NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
-        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(string because = "", params object[] becauseArgs) { }
+        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        protected void NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
             where TException : System.Exception { }
-        public void NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
@@ -1734,11 +1734,11 @@ namespace FluentAssertions.Specialized
     public class ExecutionTimeAssertions
     {
         public ExecutionTimeAssertions(FluentAssertions.Specialized.ExecutionTime executionTime) { }
-        public void BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public void BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
-        public void BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
-        public void BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
-        public void BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
     public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -323,8 +323,8 @@ namespace FluentAssertions.Collections
     public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
     {
         public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
@@ -346,8 +346,8 @@ namespace FluentAssertions.Collections
         public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
@@ -1333,8 +1333,8 @@ namespace FluentAssertions.Numeric
         public ComparableTypeAssertions(System.IComparable<T> value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
@@ -1550,12 +1550,12 @@ namespace FluentAssertions.Primitives
         public ObjectAssertions(object value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be(object expected, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> HaveFlag(System.Enum expectedFlag, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe(object unexpected, string because = "", params object[] becauseArgs) { }
-        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
-        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotHaveFlag(System.Enum unexpectedFlag, string because = "", params object[] becauseArgs) { }
     }
     public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
@@ -1660,8 +1660,8 @@ namespace FluentAssertions.Reflection
         public AssemblyAssertions(System.Reflection.Assembly assembly) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Reflection.AssemblyAssertions, System.Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs) { }
-        public void NotReference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
-        public void Reference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Reflection.AssemblyAssertions> NotReference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Reflection.AssemblyAssertions> Reference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Specialized
@@ -1696,13 +1696,13 @@ namespace FluentAssertions.Specialized
         protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public new TDelegate Subject { get; }
         protected abstract void InvokeSubject();
-        public void NotThrow(string because = "", params object[] becauseArgs) { }
-        protected void NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
-        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(string because = "", params object[] becauseArgs) { }
+        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        protected void NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
             where TException : System.Exception { }
-        public void NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
@@ -1734,11 +1734,11 @@ namespace FluentAssertions.Specialized
     public class ExecutionTimeAssertions
     {
         public ExecutionTimeAssertions(FluentAssertions.Specialized.ExecutionTime executionTime) { }
-        public void BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public void BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
-        public void BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
-        public void BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
-        public void BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
     public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.0.approved.txt
@@ -324,8 +324,8 @@ namespace FluentAssertions.Collections
     public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
     {
         public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
@@ -347,8 +347,8 @@ namespace FluentAssertions.Collections
         public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
@@ -1334,8 +1334,8 @@ namespace FluentAssertions.Numeric
         public ComparableTypeAssertions(System.IComparable<T> value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
@@ -1551,12 +1551,12 @@ namespace FluentAssertions.Primitives
         public ObjectAssertions(object value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be(object expected, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> HaveFlag(System.Enum expectedFlag, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe(object unexpected, string because = "", params object[] becauseArgs) { }
-        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
-        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotHaveFlag(System.Enum unexpectedFlag, string because = "", params object[] becauseArgs) { }
     }
     public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
@@ -1661,8 +1661,8 @@ namespace FluentAssertions.Reflection
         public AssemblyAssertions(System.Reflection.Assembly assembly) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Reflection.AssemblyAssertions, System.Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs) { }
-        public void NotReference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
-        public void Reference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Reflection.AssemblyAssertions> NotReference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Reflection.AssemblyAssertions> Reference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Specialized
@@ -1697,13 +1697,13 @@ namespace FluentAssertions.Specialized
         protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public new TDelegate Subject { get; }
         protected abstract void InvokeSubject();
-        public void NotThrow(string because = "", params object[] becauseArgs) { }
-        protected void NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
-        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(string because = "", params object[] becauseArgs) { }
+        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        protected void NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
             where TException : System.Exception { }
-        public void NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
@@ -1735,11 +1735,11 @@ namespace FluentAssertions.Specialized
     public class ExecutionTimeAssertions
     {
         public ExecutionTimeAssertions(FluentAssertions.Specialized.ExecutionTime executionTime) { }
-        public void BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public void BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
-        public void BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
-        public void BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
-        public void BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
     public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -325,8 +325,8 @@ namespace FluentAssertions.Collections
     public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
     {
         public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
@@ -348,8 +348,8 @@ namespace FluentAssertions.Collections
         public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
@@ -1335,8 +1335,8 @@ namespace FluentAssertions.Numeric
         public ComparableTypeAssertions(System.IComparable<T> value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
@@ -1552,12 +1552,12 @@ namespace FluentAssertions.Primitives
         public ObjectAssertions(object value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be(object expected, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> HaveFlag(System.Enum expectedFlag, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe(object unexpected, string because = "", params object[] becauseArgs) { }
-        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
-        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotHaveFlag(System.Enum unexpectedFlag, string because = "", params object[] becauseArgs) { }
     }
     public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
@@ -1662,8 +1662,8 @@ namespace FluentAssertions.Reflection
         public AssemblyAssertions(System.Reflection.Assembly assembly) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Reflection.AssemblyAssertions, System.Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs) { }
-        public void NotReference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
-        public void Reference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Reflection.AssemblyAssertions> NotReference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Reflection.AssemblyAssertions> Reference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Specialized
@@ -1698,13 +1698,13 @@ namespace FluentAssertions.Specialized
         protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public new TDelegate Subject { get; }
         protected abstract void InvokeSubject();
-        public void NotThrow(string because = "", params object[] becauseArgs) { }
-        protected void NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
-        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(string because = "", params object[] becauseArgs) { }
+        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        protected void NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
             where TException : System.Exception { }
-        public void NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
@@ -1736,11 +1736,11 @@ namespace FluentAssertions.Specialized
     public class ExecutionTimeAssertions
     {
         public ExecutionTimeAssertions(FluentAssertions.Specialized.ExecutionTime executionTime) { }
-        public void BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public void BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
-        public void BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
-        public void BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
-        public void BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
     public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard1.3.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard1.3.approved.txt
@@ -309,8 +309,8 @@ namespace FluentAssertions.Collections
     public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
     {
         public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
@@ -332,8 +332,8 @@ namespace FluentAssertions.Collections
         public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
@@ -1275,8 +1275,8 @@ namespace FluentAssertions.Numeric
         public ComparableTypeAssertions(System.IComparable<T> value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
@@ -1492,12 +1492,12 @@ namespace FluentAssertions.Primitives
         public ObjectAssertions(object value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be(object expected, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> HaveFlag(System.Enum expectedFlag, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe(object unexpected, string because = "", params object[] becauseArgs) { }
-        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
-        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotHaveFlag(System.Enum unexpectedFlag, string because = "", params object[] becauseArgs) { }
     }
     public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
@@ -1636,13 +1636,13 @@ namespace FluentAssertions.Specialized
         protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public new TDelegate Subject { get; }
         protected abstract void InvokeSubject();
-        public void NotThrow(string because = "", params object[] becauseArgs) { }
-        protected void NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
-        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(string because = "", params object[] becauseArgs) { }
+        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        protected void NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
             where TException : System.Exception { }
-        public void NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
@@ -1674,11 +1674,11 @@ namespace FluentAssertions.Specialized
     public class ExecutionTimeAssertions
     {
         public ExecutionTimeAssertions(FluentAssertions.Specialized.ExecutionTime executionTime) { }
-        public void BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public void BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
-        public void BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
-        public void BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
-        public void BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
     public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard1.6.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard1.6.approved.txt
@@ -309,8 +309,8 @@ namespace FluentAssertions.Collections
     public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
     {
         public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
@@ -332,8 +332,8 @@ namespace FluentAssertions.Collections
         public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
@@ -1275,8 +1275,8 @@ namespace FluentAssertions.Numeric
         public ComparableTypeAssertions(System.IComparable<T> value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
@@ -1492,12 +1492,12 @@ namespace FluentAssertions.Primitives
         public ObjectAssertions(object value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be(object expected, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> HaveFlag(System.Enum expectedFlag, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe(object unexpected, string because = "", params object[] becauseArgs) { }
-        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
-        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotHaveFlag(System.Enum unexpectedFlag, string because = "", params object[] becauseArgs) { }
     }
     public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
@@ -1636,13 +1636,13 @@ namespace FluentAssertions.Specialized
         protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public new TDelegate Subject { get; }
         protected abstract void InvokeSubject();
-        public void NotThrow(string because = "", params object[] becauseArgs) { }
-        protected void NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
-        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(string because = "", params object[] becauseArgs) { }
+        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        protected void NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
             where TException : System.Exception { }
-        public void NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
@@ -1674,11 +1674,11 @@ namespace FluentAssertions.Specialized
     public class ExecutionTimeAssertions
     {
         public ExecutionTimeAssertions(FluentAssertions.Specialized.ExecutionTime executionTime) { }
-        public void BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public void BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
-        public void BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
-        public void BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
-        public void BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
     public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -322,8 +322,8 @@ namespace FluentAssertions.Collections
     public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
     {
         public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
@@ -345,8 +345,8 @@ namespace FluentAssertions.Collections
         public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
@@ -1289,8 +1289,8 @@ namespace FluentAssertions.Numeric
         public ComparableTypeAssertions(System.IComparable<T> value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
@@ -1506,12 +1506,12 @@ namespace FluentAssertions.Primitives
         public ObjectAssertions(object value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be(object expected, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> HaveFlag(System.Enum expectedFlag, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe(object unexpected, string because = "", params object[] becauseArgs) { }
-        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
-        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotHaveFlag(System.Enum unexpectedFlag, string because = "", params object[] becauseArgs) { }
     }
     public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
@@ -1616,8 +1616,8 @@ namespace FluentAssertions.Reflection
         public AssemblyAssertions(System.Reflection.Assembly assembly) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Reflection.AssemblyAssertions, System.Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs) { }
-        public void NotReference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
-        public void Reference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Reflection.AssemblyAssertions> NotReference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Reflection.AssemblyAssertions> Reference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Specialized
@@ -1652,13 +1652,13 @@ namespace FluentAssertions.Specialized
         protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public new TDelegate Subject { get; }
         protected abstract void InvokeSubject();
-        public void NotThrow(string because = "", params object[] becauseArgs) { }
-        protected void NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
-        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(string because = "", params object[] becauseArgs) { }
+        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        protected void NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
             where TException : System.Exception { }
-        public void NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
@@ -1690,11 +1690,11 @@ namespace FluentAssertions.Specialized
     public class ExecutionTimeAssertions
     {
         public ExecutionTimeAssertions(FluentAssertions.Specialized.ExecutionTime executionTime) { }
-        public void BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public void BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
-        public void BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
-        public void BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
-        public void BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
     public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -325,8 +325,8 @@ namespace FluentAssertions.Collections
     public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
     {
         public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
@@ -348,8 +348,8 @@ namespace FluentAssertions.Collections
         public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
@@ -1335,8 +1335,8 @@ namespace FluentAssertions.Numeric
         public ComparableTypeAssertions(System.IComparable<T> value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
@@ -1552,12 +1552,12 @@ namespace FluentAssertions.Primitives
         public ObjectAssertions(object value) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> Be(object expected, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public void BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> HaveFlag(System.Enum expectedFlag, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBe(object unexpected, string because = "", params object[] becauseArgs) { }
-        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
-        public void NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotBeEquivalentTo<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> NotHaveFlag(System.Enum unexpectedFlag, string because = "", params object[] becauseArgs) { }
     }
     public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
@@ -1662,8 +1662,8 @@ namespace FluentAssertions.Reflection
         public AssemblyAssertions(System.Reflection.Assembly assembly) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Reflection.AssemblyAssertions, System.Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs) { }
-        public void NotReference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
-        public void Reference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Reflection.AssemblyAssertions> NotReference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Reflection.AssemblyAssertions> Reference(System.Reflection.Assembly assembly, string because = "", params string[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Specialized
@@ -1698,13 +1698,13 @@ namespace FluentAssertions.Specialized
         protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public new TDelegate Subject { get; }
         protected abstract void InvokeSubject();
-        public void NotThrow(string because = "", params object[] becauseArgs) { }
-        protected void NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
-        public void NotThrow<TException>(string because = "", params object[] becauseArgs)
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(string because = "", params object[] becauseArgs) { }
+        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        protected void NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
             where TException : System.Exception { }
-        public void NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
@@ -1736,11 +1736,11 @@ namespace FluentAssertions.Specialized
     public class ExecutionTimeAssertions
     {
         public ExecutionTimeAssertions(FluentAssertions.Specialized.ExecutionTime executionTime) { }
-        public void BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public void BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
-        public void BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
-        public void BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
-        public void BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
     public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
     {

--- a/Tests/Shared.Specs/AssemblyAssertionSpecs.cs
+++ b/Tests/Shared.Specs/AssemblyAssertionSpecs.cs
@@ -26,6 +26,21 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_an_assembly_is_not_referenced_it_should_allow_chaining()
+        {
+            // Arrange
+            var assemblyA = FindAssembly.Containing<ClassA>();
+            var assemblyB = FindAssembly.Containing<ClassB>();
+
+            // Act
+            Action act = () => assemblyB.Should().NotReference(assemblyA)
+                .And.NotBeNull();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
         public void When_an_assembly_is_referenced_and_should_not_reference_is_asserted_it_should_fail()
         {
             // Arrange
@@ -48,6 +63,21 @@ namespace FluentAssertions.Specs
 
             // Act
             Action act = () => assemblyA.Should().Reference(assemblyB);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_an_assembly_is_referenced_it_should_allow_chaining()
+        {
+            // Arrange
+            var assemblyA = FindAssembly.Containing<ClassA>();
+            var assemblyB = FindAssembly.Containing<ClassB>();
+
+            // Act
+            Action act = () => assemblyA.Should().Reference(assemblyB)
+                .And.NotBeNull();
 
             // Assert
             act.Should().NotThrow();

--- a/Tests/Shared.Specs/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/AsyncFunctionExceptionAssertionSpecs.cs
@@ -488,6 +488,22 @@ namespace FluentAssertions.Specs
             action.Should().NotThrow();
         }
 
+        [Fact]
+        public void When_async_method_does_not_throw_exception_it_should_allow_chaining()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+
+            // Act
+            Action action = () => asyncObject
+                .Awaiting(x => x.SucceedAsync())
+                .Should().NotThrow()
+                    .And.NotBeNull();
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
 #if NETCOREAPP2_1 || NETCOREAPP3_0
         [Fact]
         public void When_async_method_does_not_throw_exception_through_ValueTask_and_that_was_expected_it_should_succeed()
@@ -718,6 +734,22 @@ namespace FluentAssertions.Specs
             Action action = () => asyncObject
                 .Awaiting(x => asyncObject.SucceedAsync())
                 .Should().NotThrow<InvalidOperationException>();
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_async_method_succeeds_it_should_allow_chaining()
+        {
+            // Arrange
+            var asyncObject = new AsyncClass();
+
+            // Act
+            Action action = () => asyncObject
+                .Awaiting(x => asyncObject.SucceedAsync())
+                .Should().NotThrow<InvalidOperationException>()
+                    .And.NotBeNull();
 
             // Assert
             action.Should().NotThrow();
@@ -1081,6 +1113,25 @@ namespace FluentAssertions.Specs
 
             // Act
             Action act = () => someFunc.Should(clock).NotThrowAfter(waitTime, pollInterval);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_async_func_does_not_throw_it_should_allow_chaining()
+        {
+            // Arrange
+            var waitTime = 0.Milliseconds();
+            var pollInterval = 0.Milliseconds();
+
+            var clock = new FakeClock();
+            var asyncObject = new AsyncClass();
+            Func<Task> someFunc = () => asyncObject.SucceedAsync();
+
+            // Act
+            Action act = () => someFunc.Should(clock).NotThrowAfter(waitTime, pollInterval)
+                .And.NotBeNull();
 
             // Assert
             act.Should().NotThrow();

--- a/Tests/Shared.Specs/BasicEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/BasicEquivalencySpecs.cs
@@ -107,6 +107,62 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_subject_and_expectation_are_compared_for_equivalence_it_should_allow_chaining()
+        {
+            // Arrange
+            SomeDto subject = null;
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo<object>(null)
+                .And.BeNull();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_subject_and_expectation_are_compared_for_equivalence_with_config_it_should_allow_chaining()
+        {
+            // Arrange
+            SomeDto subject = null;
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo<object>(null, opt => opt)
+                .And.BeNull();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_subject_and_expectation_are_compared_for_non_equivalence_it_should_allow_chaining()
+        {
+            // Arrange
+            SomeDto subject = null;
+
+            // Act
+            Action act = () => subject.Should().NotBeEquivalentTo<object>(new { })
+                .And.BeNull();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_subject_and_expectation_are_compared_for_non_equivalence_with_config_it_should_allow_chaining()
+        {
+            // Arrange
+            SomeDto subject = null;
+
+            // Act
+            Action act = () => subject.Should().NotBeEquivalentTo<object>(new { }, opt => opt)
+                .And.BeNull();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
         public void When_asserting_equivalence_on_a_value_type_from_system_it_should_not_do_a_structural_comparision()
         {
             // Arrange

--- a/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/CollectionEquivalencySpecs.cs
@@ -868,6 +868,30 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_all_subject_items_are_equivalent_to_expectation_object_it_should_allow_chaining()
+        {
+            // Arrange
+            var subject = new List<SomeDto>
+            {
+                new SomeDto { Name = "someDto", Age = 1 },
+                new SomeDto { Name = "someDto", Age = 1 },
+                new SomeDto { Name = "someDto", Age = 1 }
+            };
+
+            // Act
+            Action action = () => subject.Should().AllBeEquivalentTo(new
+            {
+                Name = "someDto",
+                Age = 1,
+                Birthdate = new DateTime()
+            })
+            .And.HaveCount(3);
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
         public void When_some_subject_items_are_not_equivalent_to_expectation_object_it_should_throw()
         {
             // Arrange
@@ -1565,6 +1589,47 @@ namespace FluentAssertions.Specs
             // Assert
             action.Should().ThrowExactly<ArgumentNullException>()
                 .Which.ParamName.Should().Be("config");
+        }
+
+        [Fact]
+        public void When_all_subject_items_are_equivalent_to_expectation_object_with_a_config_it_should_succeed()
+        {
+            // Arrange
+            var subject = new List<char> { 'g', 'g' };
+
+            // Act
+            Action action = () => subject.Should().AllBeEquivalentTo('g', opt => opt);
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_not_all_subject_items_are_equivalent_to_expectation_object_with_a_config_it_should_fail()
+        {
+            // Arrange
+            var subject = new List<char> { 'g', 'a' };
+
+            // Act
+            Action action = () => subject.Should().AllBeEquivalentTo('g', opt => opt, "we want to test the failure {0}", "message");
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("*we want to test the failure message*");
+        }
+
+        [Fact]
+        public void When_all_subject_items_are_equivalent_to_expectation_object_with_a_config_it_should_allow_chaining()
+        {
+            // Arrange
+            var subject = new List<char> { 'g', 'g' };
+
+            // Act
+            Action action = () => subject.Should().AllBeEquivalentTo('g', opt => opt)
+                .And.HaveCount(2);
+
+            // Assert
+            action.Should().NotThrow();
         }
 
         [Fact]

--- a/Tests/Shared.Specs/ComparableSpecs.cs
+++ b/Tests/Shared.Specs/ComparableSpecs.cs
@@ -118,6 +118,30 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_two_instances_are_compared_it_should_allow_chaining()
+        {
+            // Arrange
+            var subject = new ComparableCustomer(42);
+            var expected = new CustomerDTO(42);
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expected)
+                .And.NotBeNull();
+        }
+
+        [Fact]
+        public void When_two_instances_are_compared_with_config_it_should_allow_chaining()
+        {
+            // Arrange
+            var subject = new ComparableCustomer(42);
+            var expected = new CustomerDTO(42);
+
+            // Act / Assert
+            subject.Should().BeEquivalentTo(expected, opt => opt)
+                .And.NotBeNull();
+        }
+
+        [Fact]
         public void When_two_instances_are_equivalent_due_to_exclusion_it_should_succeed()
         {
             // Arrange

--- a/Tests/Shared.Specs/DictionaryEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/DictionaryEquivalencySpecs.cs
@@ -390,6 +390,36 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_a_dictionary_is_compared_to_a_dictionary_it_should_allow_chaining()
+        {
+            // Arrange
+            Dictionary<int, int> subject = new Dictionary<int, int> { [42] = 1337 };
+            Dictionary<int, int> expectation = new Dictionary<int, int> { [42] = 1337 };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation)
+                .And.ContainKey(42);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_a_dictionary_is_compared_to_a_dictionary_with_a_config_it_should_allow_chaining()
+        {
+            // Arrange
+            Dictionary<int, int> subject = new Dictionary<int, int> { [42] = 1337 };
+            Dictionary<int, int> expectation = new Dictionary<int, int> { [42] = 1337 };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation, opt => opt)
+                .And.ContainKey(42);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
         public void
             When_a_dictionary_property_is_detected_it_should_ignore_the_order_of_the_pairs
             ()


### PR DESCRIPTION
Change return type from `void` to `AndConstraint` to make the assertions chainable.
I deliberately didn't add tests for `ExecutionTimeAssertions` as time hasn't been abstracted away from it yet.