### PR TITLE
Prevent constructing Assertions without a `Subject`

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -18,10 +18,6 @@ namespace FluentAssertions.Collections
         where TSubject : IEnumerable
         where TAssertions : CollectionAssertions<TSubject, TAssertions>
     {
-        protected CollectionAssertions() : this(default)
-        {
-        }
-
         protected CollectionAssertions(TSubject subject) : base(subject)
         {
         }

--- a/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
@@ -19,7 +19,6 @@ namespace FluentAssertions.Numeric
         {
         }
 
-
         /// <summary>
         /// Asserts that an object equals another object using its <see cref="object.Equals(object)" /> implementation.<br/>
         /// Verification whether <see cref="IComparable{T}.CompareTo(T)"/> returns 0 is not done here, you should use

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -15,10 +15,6 @@ namespace FluentAssertions.Primitives
     public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
         where TAssertions : ReferenceTypeAssertions<TSubject, TAssertions>
     {
-        protected ReferenceTypeAssertions()
-        {
-        }
-
         protected ReferenceTypeAssertions(TSubject subject)
         {
             Subject = subject;
@@ -27,7 +23,7 @@ namespace FluentAssertions.Primitives
         /// <summary>
         /// Gets the object which value is being asserted.
         /// </summary>
-        public TSubject Subject { get; protected set; }
+        public TSubject Subject { get; }
 
         /// <summary>
         /// Asserts that the current object has not been initialized yet.

--- a/Src/FluentAssertions/Types/MemberInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MemberInfoAssertions.cs
@@ -18,10 +18,6 @@ namespace FluentAssertions.Types
         where TSubject : MemberInfo
         where TAssertions : MemberInfoAssertions<TSubject, TAssertions>
     {
-        protected MemberInfoAssertions() : this(null)
-        {
-        }
-
         protected MemberInfoAssertions(TSubject subject) : base(subject)
         {
         }

--- a/Src/FluentAssertions/Types/MethodBaseAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodBaseAssertions.cs
@@ -16,10 +16,6 @@ namespace FluentAssertions.Types
         where TSubject : MethodBase
         where TAssertions : MethodBaseAssertions<TSubject, TAssertions>
     {
-        protected MethodBaseAssertions() : this(default)
-        {
-        }
-
         protected MethodBaseAssertions(TSubject subject) : base(subject)
         {
         }

--- a/Src/FluentAssertions/Types/MethodInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoAssertions.cs
@@ -12,10 +12,6 @@ namespace FluentAssertions.Types
     [DebuggerNonUserCode]
     public class MethodInfoAssertions : MethodBaseAssertions<MethodInfo, MethodInfoAssertions>
     {
-        public MethodInfoAssertions() : this(default)
-        {
-        }
-
         public MethodInfoAssertions(MethodInfo methodInfo) : base(methodInfo)
         {
         }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net45.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net45.approved.txt
@@ -258,7 +258,6 @@ namespace FluentAssertions.Collections
         where TSubject : System.Collections.IEnumerable
         where TAssertions : FluentAssertions.Collections.CollectionAssertions<TSubject, TAssertions>
     {
-        protected CollectionAssertions() { }
         protected CollectionAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
@@ -1532,10 +1531,9 @@ namespace FluentAssertions.Primitives
     public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
         where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
     {
-        protected ReferenceTypeAssertions() { }
         protected ReferenceTypeAssertions(TSubject subject) { }
         protected abstract string Identifier { get; }
-        public TSubject Subject { get; set; }
+        public TSubject Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
@@ -1760,7 +1758,6 @@ namespace FluentAssertions.Types
         where TSubject : System.Reflection.MemberInfo
         where TAssertions : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
     {
-        protected MemberInfoAssertions() { }
         protected MemberInfoAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
@@ -1776,7 +1773,6 @@ namespace FluentAssertions.Types
         where TSubject : System.Reflection.MethodBase
         where TAssertions : FluentAssertions.Types.MethodBaseAssertions<TSubject, TAssertions>
     {
-        protected MethodBaseAssertions() { }
         protected MethodBaseAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
@@ -1784,7 +1780,6 @@ namespace FluentAssertions.Types
     }
     public class MethodInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>
     {
-        public MethodInfoAssertions() { }
         public MethodInfoAssertions(System.Reflection.MethodInfo methodInfo) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -258,7 +258,6 @@ namespace FluentAssertions.Collections
         where TSubject : System.Collections.IEnumerable
         where TAssertions : FluentAssertions.Collections.CollectionAssertions<TSubject, TAssertions>
     {
-        protected CollectionAssertions() { }
         protected CollectionAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
@@ -1532,10 +1531,9 @@ namespace FluentAssertions.Primitives
     public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
         where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
     {
-        protected ReferenceTypeAssertions() { }
         protected ReferenceTypeAssertions(TSubject subject) { }
         protected abstract string Identifier { get; }
-        public TSubject Subject { get; set; }
+        public TSubject Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
@@ -1760,7 +1758,6 @@ namespace FluentAssertions.Types
         where TSubject : System.Reflection.MemberInfo
         where TAssertions : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
     {
-        protected MemberInfoAssertions() { }
         protected MemberInfoAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
@@ -1776,7 +1773,6 @@ namespace FluentAssertions.Types
         where TSubject : System.Reflection.MethodBase
         where TAssertions : FluentAssertions.Types.MethodBaseAssertions<TSubject, TAssertions>
     {
-        protected MethodBaseAssertions() { }
         protected MethodBaseAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
@@ -1784,7 +1780,6 @@ namespace FluentAssertions.Types
     }
     public class MethodInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>
     {
-        public MethodInfoAssertions() { }
         public MethodInfoAssertions(System.Reflection.MethodInfo methodInfo) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.0.approved.txt
@@ -259,7 +259,6 @@ namespace FluentAssertions.Collections
         where TSubject : System.Collections.IEnumerable
         where TAssertions : FluentAssertions.Collections.CollectionAssertions<TSubject, TAssertions>
     {
-        protected CollectionAssertions() { }
         protected CollectionAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
@@ -1533,10 +1532,9 @@ namespace FluentAssertions.Primitives
     public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
         where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
     {
-        protected ReferenceTypeAssertions() { }
         protected ReferenceTypeAssertions(TSubject subject) { }
         protected abstract string Identifier { get; }
-        public TSubject Subject { get; set; }
+        public TSubject Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
@@ -1761,7 +1759,6 @@ namespace FluentAssertions.Types
         where TSubject : System.Reflection.MemberInfo
         where TAssertions : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
     {
-        protected MemberInfoAssertions() { }
         protected MemberInfoAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
@@ -1777,7 +1774,6 @@ namespace FluentAssertions.Types
         where TSubject : System.Reflection.MethodBase
         where TAssertions : FluentAssertions.Types.MethodBaseAssertions<TSubject, TAssertions>
     {
-        protected MethodBaseAssertions() { }
         protected MethodBaseAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
@@ -1785,7 +1781,6 @@ namespace FluentAssertions.Types
     }
     public class MethodInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>
     {
-        public MethodInfoAssertions() { }
         public MethodInfoAssertions(System.Reflection.MethodInfo methodInfo) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -260,7 +260,6 @@ namespace FluentAssertions.Collections
         where TSubject : System.Collections.IEnumerable
         where TAssertions : FluentAssertions.Collections.CollectionAssertions<TSubject, TAssertions>
     {
-        protected CollectionAssertions() { }
         protected CollectionAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
@@ -1534,10 +1533,9 @@ namespace FluentAssertions.Primitives
     public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
         where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
     {
-        protected ReferenceTypeAssertions() { }
         protected ReferenceTypeAssertions(TSubject subject) { }
         protected abstract string Identifier { get; }
-        public TSubject Subject { get; set; }
+        public TSubject Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
@@ -1762,7 +1760,6 @@ namespace FluentAssertions.Types
         where TSubject : System.Reflection.MemberInfo
         where TAssertions : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
     {
-        protected MemberInfoAssertions() { }
         protected MemberInfoAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
@@ -1778,7 +1775,6 @@ namespace FluentAssertions.Types
         where TSubject : System.Reflection.MethodBase
         where TAssertions : FluentAssertions.Types.MethodBaseAssertions<TSubject, TAssertions>
     {
-        protected MethodBaseAssertions() { }
         protected MethodBaseAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
@@ -1786,7 +1782,6 @@ namespace FluentAssertions.Types
     }
     public class MethodInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>
     {
-        public MethodInfoAssertions() { }
         public MethodInfoAssertions(System.Reflection.MethodInfo methodInfo) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard1.3.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard1.3.approved.txt
@@ -244,7 +244,6 @@ namespace FluentAssertions.Collections
         where TSubject : System.Collections.IEnumerable
         where TAssertions : FluentAssertions.Collections.CollectionAssertions<TSubject, TAssertions>
     {
-        protected CollectionAssertions() { }
         protected CollectionAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
@@ -1474,10 +1473,9 @@ namespace FluentAssertions.Primitives
     public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
         where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
     {
-        protected ReferenceTypeAssertions() { }
         protected ReferenceTypeAssertions(TSubject subject) { }
         protected abstract string Identifier { get; }
-        public TSubject Subject { get; set; }
+        public TSubject Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
@@ -1700,7 +1698,6 @@ namespace FluentAssertions.Types
         where TSubject : System.Reflection.MemberInfo
         where TAssertions : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
     {
-        protected MemberInfoAssertions() { }
         protected MemberInfoAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
@@ -1716,7 +1713,6 @@ namespace FluentAssertions.Types
         where TSubject : System.Reflection.MethodBase
         where TAssertions : FluentAssertions.Types.MethodBaseAssertions<TSubject, TAssertions>
     {
-        protected MethodBaseAssertions() { }
         protected MethodBaseAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
@@ -1724,7 +1720,6 @@ namespace FluentAssertions.Types
     }
     public class MethodInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>
     {
-        public MethodInfoAssertions() { }
         public MethodInfoAssertions(System.Reflection.MethodInfo methodInfo) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard1.6.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard1.6.approved.txt
@@ -244,7 +244,6 @@ namespace FluentAssertions.Collections
         where TSubject : System.Collections.IEnumerable
         where TAssertions : FluentAssertions.Collections.CollectionAssertions<TSubject, TAssertions>
     {
-        protected CollectionAssertions() { }
         protected CollectionAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
@@ -1474,10 +1473,9 @@ namespace FluentAssertions.Primitives
     public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
         where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
     {
-        protected ReferenceTypeAssertions() { }
         protected ReferenceTypeAssertions(TSubject subject) { }
         protected abstract string Identifier { get; }
-        public TSubject Subject { get; set; }
+        public TSubject Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
@@ -1700,7 +1698,6 @@ namespace FluentAssertions.Types
         where TSubject : System.Reflection.MemberInfo
         where TAssertions : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
     {
-        protected MemberInfoAssertions() { }
         protected MemberInfoAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
@@ -1716,7 +1713,6 @@ namespace FluentAssertions.Types
         where TSubject : System.Reflection.MethodBase
         where TAssertions : FluentAssertions.Types.MethodBaseAssertions<TSubject, TAssertions>
     {
-        protected MethodBaseAssertions() { }
         protected MethodBaseAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
@@ -1724,7 +1720,6 @@ namespace FluentAssertions.Types
     }
     public class MethodInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>
     {
-        public MethodInfoAssertions() { }
         public MethodInfoAssertions(System.Reflection.MethodInfo methodInfo) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -257,7 +257,6 @@ namespace FluentAssertions.Collections
         where TSubject : System.Collections.IEnumerable
         where TAssertions : FluentAssertions.Collections.CollectionAssertions<TSubject, TAssertions>
     {
-        protected CollectionAssertions() { }
         protected CollectionAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
@@ -1488,10 +1487,9 @@ namespace FluentAssertions.Primitives
     public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
         where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
     {
-        protected ReferenceTypeAssertions() { }
         protected ReferenceTypeAssertions(TSubject subject) { }
         protected abstract string Identifier { get; }
-        public TSubject Subject { get; set; }
+        public TSubject Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
@@ -1716,7 +1714,6 @@ namespace FluentAssertions.Types
         where TSubject : System.Reflection.MemberInfo
         where TAssertions : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
     {
-        protected MemberInfoAssertions() { }
         protected MemberInfoAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
@@ -1732,7 +1729,6 @@ namespace FluentAssertions.Types
         where TSubject : System.Reflection.MethodBase
         where TAssertions : FluentAssertions.Types.MethodBaseAssertions<TSubject, TAssertions>
     {
-        protected MethodBaseAssertions() { }
         protected MethodBaseAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
@@ -1740,7 +1736,6 @@ namespace FluentAssertions.Types
     }
     public class MethodInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>
     {
-        public MethodInfoAssertions() { }
         public MethodInfoAssertions(System.Reflection.MethodInfo methodInfo) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -260,7 +260,6 @@ namespace FluentAssertions.Collections
         where TSubject : System.Collections.IEnumerable
         where TAssertions : FluentAssertions.Collections.CollectionAssertions<TSubject, TAssertions>
     {
-        protected CollectionAssertions() { }
         protected CollectionAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> AllBeAssignableTo(System.Type expectedType, string because = "", params object[] becauseArgs) { }
@@ -1534,10 +1533,9 @@ namespace FluentAssertions.Primitives
     public abstract class ReferenceTypeAssertions<TSubject, TAssertions>
         where TAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
     {
-        protected ReferenceTypeAssertions() { }
         protected ReferenceTypeAssertions(TSubject subject) { }
         protected abstract string Identifier { get; }
-        public TSubject Subject { get; set; }
+        public TSubject Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeAssignableTo(System.Type type, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
@@ -1762,7 +1760,6 @@ namespace FluentAssertions.Types
         where TSubject : System.Reflection.MemberInfo
         where TAssertions : FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>
     {
-        protected MemberInfoAssertions() { }
         protected MemberInfoAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Types.MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
@@ -1778,7 +1775,6 @@ namespace FluentAssertions.Types
         where TSubject : System.Reflection.MethodBase
         where TAssertions : FluentAssertions.Types.MethodBaseAssertions<TSubject, TAssertions>
     {
-        protected MethodBaseAssertions() { }
         protected MethodBaseAssertions(TSubject subject) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<TAssertions> HaveAccessModifier(FluentAssertions.Common.CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs) { }
@@ -1786,7 +1782,6 @@ namespace FluentAssertions.Types
     }
     public class MethodInfoAssertions : FluentAssertions.Types.MethodBaseAssertions<System.Reflection.MethodInfo, FluentAssertions.Types.MethodInfoAssertions>
     {
-        public MethodInfoAssertions() { }
         public MethodInfoAssertions(System.Reflection.MethodInfo methodInfo) { }
         protected override string Identifier { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs) { }

--- a/Tests/Shared.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/Shared.Specs/Collections/CollectionAssertionSpecs.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using FluentAssertions.Collections;
 using Xunit;
 using Xunit.Sdk;
 
@@ -11,16 +10,6 @@ namespace FluentAssertions.Specs
 {
     public class CollectionAssertionSpecs
     {
-        [Fact]
-        public void Should_have_parameterless_constructor()
-        {
-            // Arrange
-            Type type = typeof(CollectionAssertions<,>);
-
-            // Act / Assert
-            type.Should().HaveDefaultConstructor();
-        }
-
         #region Be Null
 
         [Fact]

--- a/Tests/Shared.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/Shared.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using FluentAssertions.Extensions;
-using FluentAssertions.Primitives;
 using Xunit;
 using Xunit.Sdk;
 
@@ -8,16 +7,6 @@ namespace FluentAssertions.Specs
 {
     public class ReferenceTypeAssertionsSpecs
     {
-        [Fact]
-        public void Should_have_parameterless_constructor()
-        {
-            // Arrange
-            Type type = typeof(ReferenceTypeAssertions<,>);
-
-            // Act / Assert
-            type.Should().HaveDefaultConstructor();
-        }
-
         [Fact]
         public void When_the_same_objects_are_expected_to_be_the_same_it_should_not_fail()
         {

--- a/Tests/Shared.Specs/Types/MethodBaseAssertionSpecs.cs
+++ b/Tests/Shared.Specs/Types/MethodBaseAssertionSpecs.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Reflection;
 using FluentAssertions.Common;
-using FluentAssertions.Types;
 using Xunit;
 using Xunit.Sdk;
 
@@ -9,16 +8,6 @@ namespace FluentAssertions.Specs
 {
     public class MethodBaseAssertionSpecs
     {
-        [Fact]
-        public void Should_have_parameterless_constructor()
-        {
-            // Arrange
-            Type type = typeof(MethodBaseAssertions<,>);
-
-            // Act / Assert
-            type.Should().HaveDefaultConstructor();
-        }
-
         #region Return
 
         [Fact]

--- a/Tests/Shared.Specs/Types/MethodInfoAssertionSpecs.cs
+++ b/Tests/Shared.Specs/Types/MethodInfoAssertionSpecs.cs
@@ -4,7 +4,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using FluentAssertions.Common;
-using FluentAssertions.Types;
 using Xunit;
 using Xunit.Sdk;
 
@@ -12,16 +11,6 @@ namespace FluentAssertions.Specs
 {
     public class MethodInfoAssertionSpecs
     {
-        [Fact]
-        public void Should_have_parameterless_constructor()
-        {
-            // Arrange
-            Type type = typeof(MethodInfoAssertions);
-
-            // Act / Assert
-            type.Should().HaveDefaultConstructor();
-        }
-
         #region BeVirtual
 
         [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -21,6 +21,10 @@ sidebar:
 * Removed `HasAttribute`, `HasMatchingAttribute` and `IsDecoratedWith(Type, bool)` `Type` extensions - [#1221](https://github.com/fluentassertions/fluentassertions/pull/1221).
   * Use `IsDecoratedWith`/`IsDecoratedWithOrInherits` instead.
 * Made `EquivalencyAssertionOptionsExtentions` `internal` (and fixed a typo in the type name) - [#1221](https://github.com/fluentassertions/fluentassertions/pull/1221).
+* Removed parameterless constructors from: `CollectionAssertions`, `ReferenceTypeAssertions`, `MemberInfoAssertions`, `MethodBaseAssertions` and `MethodInfoAssertions` - [#1229](https://github.com/fluentassertions/fluentassertions/pull/1229).
+  * Use the constructors taking a `subject` instead.
+* Changed `ReferenceTypeAssertions.Subject` to be `readonly` - [#1229](https://github.com/fluentassertions/fluentassertions/pull/1229).
+  * Set the `Subject` through the constructor instead.
 
 ## 5.10.0
 


### PR DESCRIPTION
In https://github.com/fluentassertions/fluentassertions/pull/1067#pullrequestreview-244314223 we kept the parameterless constructors to avoid breaking changes.
Now is the time of breaking changes.