### PR TITLE
Make properties with `private set` truly `readonly`

### DIFF
--- a/Src/FluentAssertions/AssertionOptions.cs
+++ b/Src/FluentAssertions/AssertionOptions.cs
@@ -43,6 +43,6 @@ namespace FluentAssertions
         /// Represents a mutable collection of steps that are executed while asserting a (collection of) object(s)
         /// is structurally equivalent to another (collection of) object(s).
         /// </summary>
-        public static EquivalencyStepCollection EquivalencySteps { get; private set; }
+        public static EquivalencyStepCollection EquivalencySteps { get; }
     }
 }

--- a/Src/FluentAssertions/Collections/WhichValueConstraint.cs
+++ b/Src/FluentAssertions/Collections/WhichValueConstraint.cs
@@ -11,6 +11,6 @@ namespace FluentAssertions.Collections
         /// <summary>
         /// Gets the value of the object referred to by the key.
         /// </summary>
-        public TValue WhichValue { get; private set; }
+        public TValue WhichValue { get; }
     }
 }

--- a/Src/FluentAssertions/Equivalency/AssertionContext.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionContext.cs
@@ -12,11 +12,11 @@ namespace FluentAssertions.Equivalency
             BecauseArgs = becauseArgs;
         }
 
-        public SelectedMemberInfo SubjectProperty { get; private set; }
+        public SelectedMemberInfo SubjectProperty { get; }
 
-        public TSubject Subject { get; private set; }
+        public TSubject Subject { get; }
 
-        public TSubject Expectation { get; private set; }
+        public TSubject Expectation { get; }
 
         public string Because { get; set; }
 

--- a/Src/FluentAssertions/Equivalency/CollectionMemberMemberInfo.cs
+++ b/Src/FluentAssertions/Equivalency/CollectionMemberMemberInfo.cs
@@ -18,14 +18,14 @@ namespace FluentAssertions.Equivalency
             return propertyPath.Substring(propertyPath.IndexOf('.') + 1);
         }
 
-        public SelectedMemberInfo SelectedMemberInfo { get; private set; }
+        public SelectedMemberInfo SelectedMemberInfo { get; }
 
-        public string SelectedMemberPath { get; private set; }
+        public string SelectedMemberPath { get; }
 
-        public string SelectedMemberDescription { get; private set; }
+        public string SelectedMemberDescription { get; }
 
-        public Type CompileTimeType { get; private set; }
+        public Type CompileTimeType { get; }
 
-        public Type RuntimeType { get; private set; }
+        public Type RuntimeType { get; }
     }
 }

--- a/Src/FluentAssertions/Equivalency/Selection/NestedSelectionContext.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/NestedSelectionContext.cs
@@ -17,21 +17,21 @@ namespace FluentAssertions.Equivalency.Selection
             SelectedMemberInfo = selectedMemberInfo;
         }
 
-        public SelectedMemberInfo SelectedMemberInfo { get; private set; }
+        public SelectedMemberInfo SelectedMemberInfo { get; }
 
-        public string SelectedMemberPath { get; private set; }
+        public string SelectedMemberPath { get; }
 
-        public string SelectedMemberDescription { get; private set; }
+        public string SelectedMemberDescription { get; }
 
         /// <summary>
         /// Gets the compile-time type of the current object. If the current object is not the root object, then it returns the
         /// same <see cref="System.Type"/> as the <see cref="IMemberInfo.RuntimeType"/> property does.
         /// </summary>
-        public Type CompileTimeType { get; private set; }
+        public Type CompileTimeType { get; }
 
         /// <summary>
         /// Gets the run-time type of the current object.
         /// </summary>
-        public Type RuntimeType { get; private set; }
+        public Type RuntimeType { get; }
     }
 }

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -28,7 +28,7 @@ namespace FluentAssertions.Numeric
             }
         }
 
-        public IComparable Subject { get; private set; }
+        public IComparable Subject { get; }
 
         /// <summary>
         /// Asserts that the integral number value is exactly the same as the <paramref name="expected"/> value.

--- a/Src/FluentAssertions/OccurrenceConstraint.cs
+++ b/Src/FluentAssertions/OccurrenceConstraint.cs
@@ -14,7 +14,7 @@ namespace FluentAssertions
             ExpectedCount = expectedCount;
         }
 
-        internal int ExpectedCount { get; private set; }
+        internal int ExpectedCount { get; }
 
         internal abstract string Mode { get; }
 

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -17,7 +17,7 @@ namespace FluentAssertions.Primitives
         /// <summary>
         /// Gets the object which value is being asserted.
         /// </summary>
-        public bool? Subject { get; private set; }
+        public bool? Subject { get; }
 
         /// <summary>
         /// Asserts that the value is <c>false</c>.

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -24,7 +24,7 @@ namespace FluentAssertions.Primitives
         /// <summary>
         /// Gets the object which value is being asserted.
         /// </summary>
-        public DateTime? Subject { get; private set; }
+        public DateTime? Subject { get; }
 
         /// <summary>
         /// Asserts that the current <see cref="DateTime"/> is exactly equal to the <paramref name="expected"/> value.

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -24,7 +24,7 @@ namespace FluentAssertions.Primitives
         /// <summary>
         /// Gets the object which value is being asserted.
         /// </summary>
-        public DateTimeOffset? Subject { get; private set; }
+        public DateTimeOffset? Subject { get; }
 
         /// <summary>
         /// Asserts that the current <see cref="DateTimeOffset"/> is exactly equal to the <paramref name="expected"/> value.

--- a/Src/FluentAssertions/Primitives/GuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/GuidAssertions.cs
@@ -18,7 +18,7 @@ namespace FluentAssertions.Primitives
         /// <summary>
         /// Gets the object which value is being asserted.
         /// </summary>
-        public Guid? Subject { get; private set; }
+        public Guid? Subject { get; }
 
         #region BeEmpty / NotBeEmpty
 

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -18,11 +18,7 @@ namespace FluentAssertions.Primitives
         /// <summary>
         /// Gets the object which value is being asserted.
         /// </summary>
-        public TimeSpan? Subject
-        {
-            get;
-            private set;
-        }
+        public TimeSpan? Subject { get; }
 
         /// <summary>
         /// Asserts that the time difference of the current <see cref="TimeSpan"/> is greater than zero.

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -27,7 +27,7 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Gets the object which value is being asserted.
         /// </summary>
-        public IEnumerable<MethodInfo> SubjectMethods { get; private set; }
+        public IEnumerable<MethodInfo> SubjectMethods { get; }
 
         /// <summary>
         /// Asserts that the selected methods are virtual.

--- a/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
@@ -17,7 +17,7 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Gets the object which value is being asserted.
         /// </summary>
-        public IEnumerable<PropertyInfo> SubjectProperties { get; private set; }
+        public IEnumerable<PropertyInfo> SubjectProperties { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PropertyInfoSelectorAssertions"/> class, for a number of <see cref="PropertyInfo"/> objects.

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -26,7 +26,7 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Gets the object which value is being asserted.
         /// </summary>
-        public IEnumerable<Type> Subject { get; private set; }
+        public IEnumerable<Type> Subject { get; }
 
         /// <summary>
         /// Asserts that the current <see cref="Type"/> is decorated with the specified <typeparamref name="TAttribute"/>.


### PR DESCRIPTION
Probably just a leftover from pre C# 6, where readonly auto properties where introduced.