### PR TITLE
Added NotContainMatch method for string collections and unit tests to cover it

### DIFF
--- a/FluentAssertions.sln
+++ b/FluentAssertions.sln
@@ -48,12 +48,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetCore30.Specs", "Tests\Ne
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Approval.Tests", "Tests\Approval.Tests\Approval.Tests.csproj", "{F5115158-A038-4D14-A04E-46E7863E40B9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetCore21.Specs", "Tests\NetCore21.Specs\NetCore21.Specs.csproj", "{0CF100F2-CE71-41F4-9523-62AD78BD6961}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetCore21.Specs", "Tests\NetCore21.Specs\NetCore21.Specs.csproj", "{0CF100F2-CE71-41F4-9523-62AD78BD6961}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Tests\Shared.Specs\Shared.Specs.projitems*{0c23c12c-899f-4ad1-b737-b967a9910c08}*SharedItemsImports = 13
-		Tests\Shared.Specs\Shared.Specs.projitems*{442c9b50-6f91-4cba-8d4e-b470e5cc3d5f}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/FluentAssertions.sln
+++ b/FluentAssertions.sln
@@ -18,7 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Specs", "Specs", "{963262D0
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Shared.Specs", "Tests\Shared.Specs\Shared.Specs.shproj", "{0C23C12C-899F-4AD1-B737-B967A9910C08}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyA", "Tests\AssemblyA\AssemblyA.csproj", "{7144BD9D-2A5F-45B6-AC5B-E35578D03350}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyA", "Tests\AssemblyA\AssemblyA.csproj", "{7144BD9D-2A5F-45B6-AC5B-E35578D03350}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyB", "Tests\AssemblyB\AssemblyB.csproj", "{D9CCCAF6-FF9E-4688-9D96-645E27616AC4}"
 EndProject

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -256,7 +256,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <see cref="because" />.
         /// </param>
-        public AndWhichConstraint<StringCollectionAssertions, string> NotContainMatch(string wildcardPattern, string because = "",
+        public AndConstraint<StringCollectionAssertions> NotContainMatch(string wildcardPattern, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -267,7 +267,7 @@ namespace FluentAssertions.Collections
                 .ForCondition(NotContainsMatch(wildcardPattern))
                 .FailWith("Did not expect {context:collection} {0} to contain a match of {1}{reason}.", Subject, wildcardPattern);
 
-            return new AndWhichConstraint<StringCollectionAssertions, string>(this, AllThatDoNotMatch(wildcardPattern));
+            return new AndConstraint<StringCollectionAssertions>(this);
         }
 
         private bool NotContainsMatch(string wildcardPattern)
@@ -280,18 +280,6 @@ namespace FluentAssertions.Collections
                     return !scope.Discard().Any();
                 });
             }
-        }
-
-        private IEnumerable<string> AllThatDoNotMatch(string wildcardPattern)
-        {
-            return Subject.Where(item =>
-            {
-                using (var scope = new AssertionScope())
-                {
-                    item.Should().NotMatch(wildcardPattern);
-                    return !scope.Discard().Any();
-                }
-            });
         }
 
         

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -242,5 +242,58 @@ namespace FluentAssertions.Collections
                 }
             });
         }
+
+        /// <summary>
+        /// Asserts that the collection does not contain any string that matches a wildcard pattern.
+        /// </summary>
+        /// <param name="wildcardPattern">
+        /// The wildcard pattern with which the subject is matched, where * and ? have special meanings.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndWhichConstraint<StringCollectionAssertions, string> NotContainMatch(string wildcardPattern, string because = "",
+            params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is object)
+                .FailWith("Expected {context:collection} to not contain a match of {0}{reason}, but found <null>.", wildcardPattern)
+                .Then
+                .ForCondition(NotContainsMatch(wildcardPattern))
+                .FailWith("Expected {context:collection} {0} to not contain a match of {1}{reason}.", Subject, wildcardPattern);
+
+            return new AndWhichConstraint<StringCollectionAssertions, string>(this, AllThatDontMatch(wildcardPattern));
+        }
+
+        private bool NotContainsMatch(string wildcardPattern)
+        {
+            using (var scope = new AssertionScope())
+            {
+                return Subject.All(item =>
+                {
+                    item.Should().NotMatch(wildcardPattern);
+                    return !scope.Discard().Any();
+                });
+            }
+        }
+
+        private IEnumerable<string> AllThatDontMatch(string wildcardPattern)
+        {
+            return Subject.Where(item =>
+            {
+                using (var scope = new AssertionScope())
+                {
+                    item.Should().NotMatch(wildcardPattern);
+                    return !scope.Discard().Any();
+                }
+            });
+        }
+
+        
     }
 }

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -262,12 +262,12 @@ namespace FluentAssertions.Collections
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is object)
-                .FailWith("Expected {context:collection} to not contain a match of {0}{reason}, but found <null>.", wildcardPattern)
+                .FailWith("Did not expect {context:collection} to contain a match of {0}{reason}, but found <null>.", wildcardPattern)
                 .Then
                 .ForCondition(NotContainsMatch(wildcardPattern))
-                .FailWith("Expected {context:collection} {0} to not contain a match of {1}{reason}.", Subject, wildcardPattern);
+                .FailWith("Did not expect {context:collection} {0} to contain a match of {1}{reason}.", Subject, wildcardPattern);
 
-            return new AndWhichConstraint<StringCollectionAssertions, string>(this, AllThatDontMatch(wildcardPattern));
+            return new AndWhichConstraint<StringCollectionAssertions, string>(this, AllThatDoNotMatch(wildcardPattern));
         }
 
         private bool NotContainsMatch(string wildcardPattern)
@@ -282,7 +282,7 @@ namespace FluentAssertions.Collections
             }
         }
 
-        private IEnumerable<string> AllThatDontMatch(string wildcardPattern)
+        private IEnumerable<string> AllThatDoNotMatch(string wildcardPattern)
         {
             return Subject.Where(item =>
             {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -430,7 +430,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
     public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -430,6 +430,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
     public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -430,7 +430,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
     public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -430,6 +430,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
     public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -430,7 +430,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
     public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -430,6 +430,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
     public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -429,7 +429,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
     public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -429,6 +429,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
     public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -430,7 +430,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
     public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -430,6 +430,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
     public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
     {

--- a/Tests/Shared.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/Shared.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -1702,7 +1702,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection {\"build succeded\", \"test failed\"} to not contain a match of \"* failed\" because it shouldn't.");
+                .WithMessage("Did not expect collection {\"build succeded\", \"test failed\"} to contain a match of \"* failed\" because it shouldn't.");
         }
 
         [Fact]
@@ -1716,7 +1716,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection {\"build failed\", \"test failed\"} to not contain a match of \"* failed\" because it shouldn't.");
+                .WithMessage("Did not expect collection {\"build failed\", \"test failed\"} to contain a match of \"* failed\" because it shouldn't.");
         }
 
         [Fact]
@@ -1744,7 +1744,26 @@ namespace FluentAssertions.Specs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection to not contain a match of <null>, but found <null>.");
+                .WithMessage("Did not expect collection to contain a match of <null>, but found <null>.");
+        }
+
+        [Fact]
+        public void When_collection_contains_multiple_matches_for_not_match_which_should_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = new string[] { "build succeded", "test failed", "pack failed" };
+
+            // Act
+            Action action = () =>
+            {
+                string item = collection.Should().NotContainMatch("* failed").Which;
+            };
+
+            // Assert
+            action.Should().Throw<XunitException>()
+               .WithMessage("Did not expect string item = collection {\"build succeded\", \"test failed\", \"pack failed\"} to contain a match of \"* failed\".");
+
+
         }
 
 

--- a/Tests/Shared.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/Shared.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -1663,6 +1663,93 @@ namespace FluentAssertions.Specs
 
         #endregion
 
+        #region NotContainMatch
+
+        [Fact]
+        public void When_collection_doesnt_contain_a_match_it_should_not_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = new string[] { "build succeded", "test" };
+
+            // Act
+            Action action = () => collection.Should().NotContainMatch("* failed");
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_collection_doesnt_contain_multiple_matches_it_should_not_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = new string[] { "build succeded", "test", "pack" };
+
+            // Act
+            Action action = () => collection.Should().NotContainMatch("* failed");
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_collection_contains_a_match_it_should_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = new string[] { "build succeded", "test failed" };
+
+            // Act
+            Action action = () => collection.Should().NotContainMatch("* failed", "because {0}", "it shouldn't");
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected collection {\"build succeded\", \"test failed\"} to not contain a match of \"* failed\" because it shouldn't.");
+        }
+
+        [Fact]
+        public void When_collection_contains_multiple_matches_it_should_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = new string[] { "build failed", "test failed" };
+
+            // Act
+            Action action = () => collection.Should().NotContainMatch("* failed", "because {0}", "it shouldn't");
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected collection {\"build failed\", \"test failed\"} to not contain a match of \"* failed\" because it shouldn't.");
+        }
+
+        [Fact]
+        public void When_collection_contains_a_match_with_different_casing_it_should_not_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = new string[] { "build succeded", "test failed" };
+
+            // Act
+            Action action = () => collection.Should().NotContainMatch("* Failed");
+
+            // Assert
+            action.Should().NotThrow<XunitException>();
+        }
+
+
+        [Fact]
+        public void When_asserting_null_collection_for_not_match_it_should_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = null;
+
+            // Act
+            Action action = () => collection.Should().NotContainMatch(null);
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected collection to not contain a match of <null>, but found <null>.");
+        }
+
+
+        #endregion
+
         #region SatisfyRespectively
 
         [Fact]

--- a/Tests/Shared.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/Shared.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -1747,25 +1747,6 @@ namespace FluentAssertions.Specs
                 .WithMessage("Did not expect collection to contain a match of <null>, but found <null>.");
         }
 
-        [Fact]
-        public void When_collection_contains_multiple_matches_for_not_match_which_should_throw()
-        {
-            // Arrange
-            IEnumerable<string> collection = new string[] { "build succeded", "test failed", "pack failed" };
-
-            // Act
-            Action action = () =>
-            {
-                string item = collection.Should().NotContainMatch("* failed").Which;
-            };
-
-            // Assert
-            action.Should().Throw<XunitException>()
-               .WithMessage("Did not expect string item = collection {\"build succeded\", \"test failed\", \"pack failed\"} to contain a match of \"* failed\".");
-
-
-        }
-
 
         #endregion
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,7 +11,8 @@ sidebar:
 
 **What's New**
 * Added official support for .NET Core 3.0
-* Add `WithOffset` extension method on `DateTime` for easier creation of `DateTimeOffset` objects.
+* Added `WithOffset` extension method on `DateTime` for easier creation of `DateTimeOffset` objects.
+* Added `collectionOfStrings.Should().NotContainMatch()` to assert that the collection does not contain a string that matches a wildcard pattern 
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` (#1223)


### PR DESCRIPTION
Added NotContainMatch for string collections which does the opposite of ContainMatch. I recently had a need for NotContainMatch so decided to add it.