### PR TITLE
Changed so contributing file correctly states pull requests should be targeted at develop instead of master

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 No open-source project is going to be successful without contributions. After we decided to move to Github, the involvement of the .NET community has increased significantly. However, contributing to this project involves a few steps that will seriously increase the chance we will accept it.
 
-* The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
+* The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `develop` branch.
 * The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](https://csharpcodingguidelines.com/)/.
 * The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
 * If the contribution affects the documentation, please update [**the documentation**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which is published on the [website](https://fluentassertions.com/documentation/).


### PR DESCRIPTION
Currently the contributing markdown file states pull requests should be targeted at `master`, this should be `develop`.