### PR TITLE
Using/When in BeEquivalentTo will respect the conversion rules. 

### DIFF
--- a/AcceptApiChanges.ps1
+++ b/AcceptApiChanges.ps1
@@ -2,18 +2,17 @@
 ## If your change does change the API on purpose and you double-checked correctness of the changes you can use this script to change the "approved" state of the API
 ## Make sure that you run the approval tests before running this script, because the tests generate *.received.txt files.
 
-
-## Go to the directory where "approved" API is saved as .txt files
-Push-Location -Path .\Tests\Approval.Tests\ApprovedApi\FluentAssertions
+$ApprovalFiles = ".\Tests\Approval.Tests\ApprovedApi\FluentAssertions\";
 
 ## Remove current "approved" API 
-Remove-Item *.approved.txt*
+Remove-Item "$ApprovalFiles\*.approved.txt"
 
 ## Copy new API from .received.txt files to .approved.txt files
 ## Note that .received.txt files are ignored in git and are not part of the repository
-Get-ChildItem -Filter "*received.txt" | ForEach-Object {
+Get-ChildItem -Path $ApprovalFiles -Filter "*received.txt" | ForEach-Object {
 	$NewName = $_.FullName -replace 'received.txt', 'approved.txt'
 	Copy-Item $_.FullName $NewName
 }
 
-Pop-Location
+Remove-Item "$ApprovalFiles\*.received.txt"
+

--- a/Src/FluentAssertions/Equivalency/CollectionMemberAssertionOptionsDecorator.cs
+++ b/Src/FluentAssertions/Equivalency/CollectionMemberAssertionOptionsDecorator.cs
@@ -39,9 +39,9 @@ namespace FluentAssertions.Equivalency
 
         public ConversionSelector ConversionSelector => inner.ConversionSelector;
 
-        public IEnumerable<IEquivalencyStep> GetUserEquivalencySteps(ConversionSelector conversionSelector)
+        public IEnumerable<IEquivalencyStep> UserEquivalencySteps
         {
-            return inner.GetUserEquivalencySteps(conversionSelector).Select(step => new CollectionMemberAssertionRuleDecorator(step)).ToArray();
+            get { return inner.UserEquivalencySteps.Select(step => new CollectionMemberAssertionRuleDecorator(step)).ToArray(); }
         }
 
         public bool IsRecursive => inner.IsRecursive;

--- a/Src/FluentAssertions/Equivalency/ConversionSelector.cs
+++ b/Src/FluentAssertions/Equivalency/ConversionSelector.cs
@@ -8,7 +8,7 @@ using FluentAssertions.Common;
 namespace FluentAssertions.Equivalency
 {
     /// <summary>
-    /// Collects the members that need to be converted by the <see cref="TryConversionStep"/>.
+    /// Collects the members that need to be converted by the <see cref="AutoConversionStep"/>.
     /// </summary>
     public class ConversionSelector
     {

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidationContextExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidationContextExtensions.cs
@@ -71,19 +71,18 @@ namespace FluentAssertions.Equivalency
             };
         }
 
-        internal static IEquivalencyValidationContext CreateWithDifferentSubject(this IEquivalencyValidationContext context,
-            object convertedSubject, Type expectationType)
+        internal static IEquivalencyValidationContext Clone(this IEquivalencyValidationContext context)
         {
             return new EquivalencyValidationContext
             {
-                CompileTimeType = expectationType,
+                CompileTimeType = context.CompileTimeType,
                 Expectation = context.Expectation,
                 SelectedMemberDescription = context.SelectedMemberDescription,
                 SelectedMemberInfo = context.SelectedMemberInfo,
                 SelectedMemberPath = context.SelectedMemberPath,
                 Because = context.Because,
                 BecauseArgs = context.BecauseArgs,
-                Subject = convertedSubject,
+                Subject = context.Subject,
                 Tracer = context.Tracer
             };
         }

--- a/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
@@ -53,7 +53,7 @@ namespace FluentAssertions.Equivalency
         /// <summary>
         /// Gets an ordered collection of Equivalency steps how a subject is compared with the expectation.
         /// </summary>
-        IEnumerable<IEquivalencyStep> GetUserEquivalencySteps(ConversionSelector conversionSelector);
+        IEnumerable<IEquivalencyStep> UserEquivalencySteps { get; }
 
         /// <summary>
         /// Gets a value indicating whether the runtime type of the expectation should be used rather than the declared type.

--- a/Src/FluentAssertions/Equivalency/IEquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyValidationContext.cs
@@ -31,7 +31,7 @@ namespace FluentAssertions.Equivalency
         /// <summary>
         /// Gets the value of the <see cref="ISelectionContext.PropertyInfo"/>
         /// </summary>
-        object Subject { get; }
+        object Subject { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating that the root of the graph is a collection so all type-specific options apply on

--- a/Src/FluentAssertions/Equivalency/RunAllUserStepsEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/RunAllUserStepsEquivalencyStep.cs
@@ -10,13 +10,13 @@ namespace FluentAssertions.Equivalency
     {
         public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
         {
-            return config.GetUserEquivalencySteps(config.ConversionSelector).Any(s => s.CanHandle(context, config));
+            return config.UserEquivalencySteps.Any(s => s.CanHandle(context, config));
         }
 
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent,
             IEquivalencyAssertionOptions config)
         {
-            foreach (IEquivalencyStep step in config.GetUserEquivalencySteps(config.ConversionSelector))
+            foreach (IEquivalencyStep step in config.UserEquivalencySteps)
             {
                 if (step.CanHandle(context, config) && step.Handle(context, parent, config))
                 {

--- a/Src/FluentAssertions/Equivalency/TryConversionStep.cs
+++ b/Src/FluentAssertions/Equivalency/TryConversionStep.cs
@@ -10,21 +10,14 @@ namespace FluentAssertions.Equivalency
     /// <remarks>
     /// Whether or not the conversion is attempted depends on the <see cref="ConversionSelector"/>.
     /// </remarks>
-    public class TryConversionStep : IEquivalencyStep
+    public class AutoConversionStep : IEquivalencyStep
     {
-        private readonly ConversionSelector selector;
-
-        public TryConversionStep(ConversionSelector selector)
-        {
-            this.selector = selector;
-        }
-
         /// <summary>
         /// Gets a value indicating whether this step can handle the current subject and/or expectation.
         /// </summary>
         public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
         {
-            return selector.RequiresConversion(context);
+            return config.ConversionSelector.RequiresConversion(context);
         }
 
         /// <summary>
@@ -37,8 +30,7 @@ namespace FluentAssertions.Equivalency
         /// <remarks>
         /// May throw when preconditions are not met or if it detects mismatching data.
         /// </remarks>
-        public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator structuralEqualityValidator,
-            IEquivalencyAssertionOptions config)
+        public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
         {
             if ((context.Expectation is null) || (context.Subject is null))
             {
@@ -57,13 +49,12 @@ namespace FluentAssertions.Equivalency
             {
                 context.TraceSingle(path => $"Converted subject {context.Subject} at {path} to {expectationType}");
 
-                IEquivalencyValidationContext newContext = context.CreateWithDifferentSubject(convertedSubject, expectationType);
-
-                structuralEqualityValidator.AssertEqualityUsing(newContext);
-                return true;
+                context.Subject = convertedSubject;
             }
-
-            context.TraceSingle(path => $"Subject {context.Subject} at {path} could not be converted to {expectationType}");
+            else
+            {
+                context.TraceSingle(path => $"Subject {context.Subject} at {path} could not be converted to {expectationType}");
+            }
 
             return false;
         }
@@ -88,7 +79,7 @@ namespace FluentAssertions.Equivalency
 
         public override string ToString()
         {
-            return selector.ToString();
+            return "";
         }
     }
 }

--- a/Src/FluentAssertions/EquivalencyStepCollection.cs
+++ b/Src/FluentAssertions/EquivalencyStepCollection.cs
@@ -113,6 +113,7 @@ namespace FluentAssertions
             return new List<IEquivalencyStep>(12)
             {
                 new RunAllUserStepsEquivalencyStep(),
+                new AutoConversionStep(),
                 new ReferenceEqualityEquivalencyStep(),
                 new GenericDictionaryEquivalencyStep(),
                 new DictionaryEquivalencyStep(),

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -560,7 +560,14 @@ namespace FluentAssertions.Equivalency
 {
     public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
     {
-        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public AssertionRuleEquivalencyStep(FluentAssertions.Equivalency.ConversionSelector conversionSelector, System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class AutoConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public AutoConversionStep() { }
         public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public override string ToString() { }
@@ -683,8 +690,8 @@ namespace FluentAssertions.Equivalency
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
         FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
         bool UseRuntimeTyping { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> UserEquivalencySteps { get; }
         FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
-        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> GetUserEquivalencySteps(FluentAssertions.Equivalency.ConversionSelector conversionSelector);
     }
     public interface IEquivalencyStep
     {
@@ -698,7 +705,7 @@ namespace FluentAssertions.Equivalency
         object Expectation { get; }
         bool IsRoot { get; }
         bool RootIsCollection { get; set; }
-        object Subject { get; }
+        object Subject { get; set; }
         FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
         System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getMessage);
         void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getMessage);
@@ -795,8 +802,6 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingFields() { }
         public TSelf IncludingNestedObjects() { }
         public TSelf IncludingProperties() { }
-        protected void RemoveSelectionRule<T>()
-            where T : FluentAssertions.Equivalency.IMemberSelectionRule { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }
         public TSelf ThrowingOnMissingMembers() { }
@@ -817,7 +822,7 @@ namespace FluentAssertions.Equivalency
         public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public class Restriction<TMember>
         {
-            public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
+            public Restriction(TSelf options, FluentAssertions.Equivalency.ConversionSelector conversionSelector, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
             public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
             public TSelf WhenTypeIs<TMemberType>() { }
         }
@@ -853,13 +858,6 @@ namespace FluentAssertions.Equivalency
         public static bool WhichGetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public static bool WhichSetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public static bool WhichSetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
-    }
-    public class TryConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
-    {
-        public TryConversionStep(FluentAssertions.Equivalency.ConversionSelector selector) { }
-        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
-        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
-        public override string ToString() { }
     }
     public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -560,7 +560,7 @@ namespace FluentAssertions.Equivalency
 {
     public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
     {
-        public AssertionRuleEquivalencyStep(FluentAssertions.Equivalency.ConversionSelector conversionSelector, System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> assertion) { }
         public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public override string ToString() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -560,7 +560,14 @@ namespace FluentAssertions.Equivalency
 {
     public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
     {
-        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public AssertionRuleEquivalencyStep(FluentAssertions.Equivalency.ConversionSelector conversionSelector, System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class AutoConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public AutoConversionStep() { }
         public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public override string ToString() { }
@@ -683,8 +690,8 @@ namespace FluentAssertions.Equivalency
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
         FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
         bool UseRuntimeTyping { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> UserEquivalencySteps { get; }
         FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
-        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> GetUserEquivalencySteps(FluentAssertions.Equivalency.ConversionSelector conversionSelector);
     }
     public interface IEquivalencyStep
     {
@@ -698,7 +705,7 @@ namespace FluentAssertions.Equivalency
         object Expectation { get; }
         bool IsRoot { get; }
         bool RootIsCollection { get; set; }
-        object Subject { get; }
+        object Subject { get; set; }
         FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
         System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getMessage);
         void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getMessage);
@@ -795,8 +802,6 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingFields() { }
         public TSelf IncludingNestedObjects() { }
         public TSelf IncludingProperties() { }
-        protected void RemoveSelectionRule<T>()
-            where T : FluentAssertions.Equivalency.IMemberSelectionRule { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }
         public TSelf ThrowingOnMissingMembers() { }
@@ -817,7 +822,7 @@ namespace FluentAssertions.Equivalency
         public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public class Restriction<TMember>
         {
-            public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
+            public Restriction(TSelf options, FluentAssertions.Equivalency.ConversionSelector conversionSelector, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
             public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
             public TSelf WhenTypeIs<TMemberType>() { }
         }
@@ -853,13 +858,6 @@ namespace FluentAssertions.Equivalency
         public static bool WhichGetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public static bool WhichSetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public static bool WhichSetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
-    }
-    public class TryConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
-    {
-        public TryConversionStep(FluentAssertions.Equivalency.ConversionSelector selector) { }
-        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
-        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
-        public override string ToString() { }
     }
     public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -560,7 +560,7 @@ namespace FluentAssertions.Equivalency
 {
     public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
     {
-        public AssertionRuleEquivalencyStep(FluentAssertions.Equivalency.ConversionSelector conversionSelector, System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> assertion) { }
         public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public override string ToString() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -560,7 +560,14 @@ namespace FluentAssertions.Equivalency
 {
     public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
     {
-        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public AssertionRuleEquivalencyStep(FluentAssertions.Equivalency.ConversionSelector conversionSelector, System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class AutoConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public AutoConversionStep() { }
         public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public override string ToString() { }
@@ -683,8 +690,8 @@ namespace FluentAssertions.Equivalency
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
         FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
         bool UseRuntimeTyping { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> UserEquivalencySteps { get; }
         FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
-        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> GetUserEquivalencySteps(FluentAssertions.Equivalency.ConversionSelector conversionSelector);
     }
     public interface IEquivalencyStep
     {
@@ -698,7 +705,7 @@ namespace FluentAssertions.Equivalency
         object Expectation { get; }
         bool IsRoot { get; }
         bool RootIsCollection { get; set; }
-        object Subject { get; }
+        object Subject { get; set; }
         FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
         System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getMessage);
         void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getMessage);
@@ -795,8 +802,6 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingFields() { }
         public TSelf IncludingNestedObjects() { }
         public TSelf IncludingProperties() { }
-        protected void RemoveSelectionRule<T>()
-            where T : FluentAssertions.Equivalency.IMemberSelectionRule { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }
         public TSelf ThrowingOnMissingMembers() { }
@@ -817,7 +822,7 @@ namespace FluentAssertions.Equivalency
         public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public class Restriction<TMember>
         {
-            public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
+            public Restriction(TSelf options, FluentAssertions.Equivalency.ConversionSelector conversionSelector, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
             public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
             public TSelf WhenTypeIs<TMemberType>() { }
         }
@@ -853,13 +858,6 @@ namespace FluentAssertions.Equivalency
         public static bool WhichGetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public static bool WhichSetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public static bool WhichSetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
-    }
-    public class TryConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
-    {
-        public TryConversionStep(FluentAssertions.Equivalency.ConversionSelector selector) { }
-        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
-        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
-        public override string ToString() { }
     }
     public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -560,7 +560,7 @@ namespace FluentAssertions.Equivalency
 {
     public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
     {
-        public AssertionRuleEquivalencyStep(FluentAssertions.Equivalency.ConversionSelector conversionSelector, System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> assertion) { }
         public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public override string ToString() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -559,7 +559,7 @@ namespace FluentAssertions.Equivalency
 {
     public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
     {
-        public AssertionRuleEquivalencyStep(FluentAssertions.Equivalency.ConversionSelector conversionSelector, System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> assertion) { }
         public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public override string ToString() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -559,7 +559,14 @@ namespace FluentAssertions.Equivalency
 {
     public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
     {
-        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public AssertionRuleEquivalencyStep(FluentAssertions.Equivalency.ConversionSelector conversionSelector, System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class AutoConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public AutoConversionStep() { }
         public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public override string ToString() { }
@@ -682,8 +689,8 @@ namespace FluentAssertions.Equivalency
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
         FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
         bool UseRuntimeTyping { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> UserEquivalencySteps { get; }
         FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
-        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> GetUserEquivalencySteps(FluentAssertions.Equivalency.ConversionSelector conversionSelector);
     }
     public interface IEquivalencyStep
     {
@@ -697,7 +704,7 @@ namespace FluentAssertions.Equivalency
         object Expectation { get; }
         bool IsRoot { get; }
         bool RootIsCollection { get; set; }
-        object Subject { get; }
+        object Subject { get; set; }
         FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
         System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getMessage);
         void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getMessage);
@@ -794,8 +801,6 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingFields() { }
         public TSelf IncludingNestedObjects() { }
         public TSelf IncludingProperties() { }
-        protected void RemoveSelectionRule<T>()
-            where T : FluentAssertions.Equivalency.IMemberSelectionRule { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }
         public TSelf ThrowingOnMissingMembers() { }
@@ -816,7 +821,7 @@ namespace FluentAssertions.Equivalency
         public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public class Restriction<TMember>
         {
-            public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
+            public Restriction(TSelf options, FluentAssertions.Equivalency.ConversionSelector conversionSelector, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
             public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
             public TSelf WhenTypeIs<TMemberType>() { }
         }
@@ -852,13 +857,6 @@ namespace FluentAssertions.Equivalency
         public static bool WhichGetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public static bool WhichSetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public static bool WhichSetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
-    }
-    public class TryConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
-    {
-        public TryConversionStep(FluentAssertions.Equivalency.ConversionSelector selector) { }
-        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
-        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
-        public override string ToString() { }
     }
     public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -560,7 +560,14 @@ namespace FluentAssertions.Equivalency
 {
     public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
     {
-        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public AssertionRuleEquivalencyStep(FluentAssertions.Equivalency.ConversionSelector conversionSelector, System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
+    public class AutoConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public AutoConversionStep() { }
         public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public override string ToString() { }
@@ -683,8 +690,8 @@ namespace FluentAssertions.Equivalency
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberSelectionRule> SelectionRules { get; }
         FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
         bool UseRuntimeTyping { get; }
+        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> UserEquivalencySteps { get; }
         FluentAssertions.Equivalency.EqualityStrategy GetEqualityStrategy(System.Type type);
-        System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep> GetUserEquivalencySteps(FluentAssertions.Equivalency.ConversionSelector conversionSelector);
     }
     public interface IEquivalencyStep
     {
@@ -698,7 +705,7 @@ namespace FluentAssertions.Equivalency
         object Expectation { get; }
         bool IsRoot { get; }
         bool RootIsCollection { get; set; }
-        object Subject { get; }
+        object Subject { get; set; }
         FluentAssertions.Equivalency.ITraceWriter Tracer { get; set; }
         System.IDisposable TraceBlock(FluentAssertions.Equivalency.GetTraceMessage getMessage);
         void TraceSingle(FluentAssertions.Equivalency.GetTraceMessage getMessage);
@@ -795,8 +802,6 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingFields() { }
         public TSelf IncludingNestedObjects() { }
         public TSelf IncludingProperties() { }
-        protected void RemoveSelectionRule<T>()
-            where T : FluentAssertions.Equivalency.IMemberSelectionRule { }
         public TSelf RespectingDeclaredTypes() { }
         public TSelf RespectingRuntimeTypes() { }
         public TSelf ThrowingOnMissingMembers() { }
@@ -817,7 +822,7 @@ namespace FluentAssertions.Equivalency
         public TSelf WithoutStrictOrderingFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public class Restriction<TMember>
         {
-            public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
+            public Restriction(TSelf options, FluentAssertions.Equivalency.ConversionSelector conversionSelector, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
             public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
             public TSelf WhenTypeIs<TMemberType>() { }
         }
@@ -853,13 +858,6 @@ namespace FluentAssertions.Equivalency
         public static bool WhichGetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public static bool WhichSetterDoesNotHave(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
         public static bool WhichSetterHas(this FluentAssertions.Equivalency.IMemberInfo memberInfo, FluentAssertions.Common.CSharpAccessModifier accessModifier) { }
-    }
-    public class TryConversionStep : FluentAssertions.Equivalency.IEquivalencyStep
-    {
-        public TryConversionStep(FluentAssertions.Equivalency.ConversionSelector selector) { }
-        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
-        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator structuralEqualityValidator, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
-        public override string ToString() { }
     }
     public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -560,7 +560,7 @@ namespace FluentAssertions.Equivalency
 {
     public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
     {
-        public AssertionRuleEquivalencyStep(FluentAssertions.Equivalency.ConversionSelector conversionSelector, System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> action) { }
+        public AssertionRuleEquivalencyStep(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate, System.Action<FluentAssertions.Equivalency.IAssertionContext<TSubject>> assertion) { }
         public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public override string ToString() { }

--- a/Tests/Shared.Specs/Equivalency/BasicEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/Equivalency/BasicEquivalencySpecs.cs
@@ -2581,7 +2581,7 @@ namespace FluentAssertions.Specs
                 // but in that case it was done on purpose, so that we have at least single
                 // test confirming that whole mechanism of gathering description from
                 // equivalency steps works.
-                .Should().MatchRegex(@"^Expected member Level\.Text to be ""Level2"", but ""Level1"" differs near ""1"" \(index 5\)\.[\r\n]+With configuration:[\r\n]+\- Use declared types and members[\r\n]+\- Compare enums by value[\r\n]+\- Match member by name \(or throw\)[\r\n]+\- Without automatic conversion\.[\r\n]+\- Be strict about the order of items in byte arrays[\r\n]+$");
+                .Should().MatchRegex(@"^Expected member Level\.Text to be ""Level2"", but ""Level1"" differs near ""1"" \(index 5\)\.[\r\n]+With configuration:[\r\n]+\- Use declared types and members[\r\n]+\- Compare enums by value[\r\n]+\- Match member by name \(or throw\)[\r\n]+\- Be strict about the order of items in byte arrays[\r\n]+\- Without automatic conversion\.[\r\n]+$");
         }
 
         [Fact]

--- a/Tests/Shared.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
@@ -554,6 +554,28 @@ namespace FluentAssertions.Specs
             act.Should().NotThrow();
         }
 
+        [Fact]
+        public void When_a_predicate_matches_after_auto_conversion_it_should_execute_the_assertion()
+        {
+            //Arrange
+            var expectation = new
+            {
+                ThisIsMyDateTime = DateTime.Now
+            };
+
+            var actual = new
+            {
+                ThisIsMyDateTime = expectation.ThisIsMyDateTime.ToString()
+            };
+
+            //Asserts
+            actual.Should().BeEquivalentTo(expectation,
+                options => options
+                    .WithAutoConversion()
+                    .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1000))
+                    .WhenTypeIs<DateTime>());
+        }
+
         #endregion
 
         #region Equivalency Steps

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,6 +13,7 @@ sidebar:
 * Added official support for .NET Core 3.0
 * Added `WithOffset` extension method on `DateTime` for easier creation of `DateTimeOffset` objects.
 * Added `collectionOfStrings.Should().NotContainMatch()` to assert that the collection does not contain a string that matches a wildcard pattern 
+* The `Using`/`When` option on `BeEquivalentTo` will now use the conversion rules when trying to match the predicate.
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` (#1223)


### PR DESCRIPTION
This implements the functionality as suggested by @jnyrup in #876. 

* If both subject and expectation are `DateTime`s, use the `Using`
* If `WithAutoConversion` is enabled, try to convert subject into the type of expectation
* If, after conversion, both the converted subject and the expectation are `DateTime`s, use the `Using`

Also fixes the API approval script. 