### PR TITLE
[WIP] Reduce usage of IsSameOrEqualTo

### DIFF
--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -434,7 +434,7 @@ namespace FluentAssertions.Collections
             foreach (var key in expected.Keys)
             {
                 Execute.Assertion
-                    .ForCondition(Subject[key].IsSameOrEqualTo(expected[key]))
+                    .ForCondition(EqualityComparer<TValue>.Default.Equals(Subject[key], expected[key]))
                     .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but {1} differs at key {2}.",
                     expected, Subject, key);
@@ -480,7 +480,7 @@ namespace FluentAssertions.Collections
 
             bool foundDifference = missingKeys.Any()
                 || additionalKeys.Any()
-                    || (Subject.Keys.Any(key => !Subject[key].IsSameOrEqualTo(unexpected[key])));
+                    || (Subject.Keys.Any(key => !EqualityComparer<TValue>.Default.Equals(Subject[key], unexpected[key])));
 
             if (!foundDifference)
             {
@@ -1037,7 +1037,7 @@ namespace FluentAssertions.Collections
                 }
             }
 
-            KeyValuePair<TKey, TValue>[] keyValuePairsNotSameOrEqualInSubject = expectedKeyValuePairs.Where(keyValuePair => !Subject[keyValuePair.Key].IsSameOrEqualTo(keyValuePair.Value)).ToArray();
+            KeyValuePair<TKey, TValue>[] keyValuePairsNotSameOrEqualInSubject = expectedKeyValuePairs.Where(keyValuePair => !EqualityComparer<TValue>.Default.Equals(Subject[keyValuePair.Key], keyValuePair.Value)).ToArray();
 
             if (keyValuePairsNotSameOrEqualInSubject.Any())
             {
@@ -1110,7 +1110,7 @@ namespace FluentAssertions.Collections
             if (Subject.TryGetValue(key, out TValue actual))
             {
                 Execute.Assertion
-                    .ForCondition(actual.IsSameOrEqualTo(value))
+                    .ForCondition(EqualityComparer<TValue>.Default.Equals(actual, value))
                     .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} to contain value {0} at key {1}{reason}, but found {2}.", value, key, actual);
             }
@@ -1178,7 +1178,7 @@ namespace FluentAssertions.Collections
             if (keyValuePairsFound.Any())
             {
                 KeyValuePair<TKey, TValue>[] keyValuePairsSameOrEqualInSubject = keyValuePairsFound
-                    .Where(keyValuePair => Subject[keyValuePair.Key].IsSameOrEqualTo(keyValuePair.Value)).ToArray();
+                    .Where(keyValuePair => EqualityComparer<TValue>.Default.Equals(Subject[keyValuePair.Key], keyValuePair.Value)).ToArray();
 
                 if (keyValuePairsSameOrEqualInSubject.Any())
                 {
@@ -1250,7 +1250,7 @@ namespace FluentAssertions.Collections
             if (Subject.TryGetValue(key, out TValue actual))
             {
                 Execute.Assertion
-                    .ForCondition(!actual.IsSameOrEqualTo(value))
+                    .ForCondition(!EqualityComparer<TValue>.Default.Equals(actual, value))
                     .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but found it anyhow.", value, key);
             }

--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -244,21 +244,9 @@ namespace FluentAssertions.Collections
         /// <param name="elements">A params array with the expected elements.</param>
         public AndConstraint<TAssertions> Equal(params T[] elements)
         {
-            Func<T, T, bool> comparer = GetComparer();
-
-            AssertSubjectEquality(elements, comparer, string.Empty);
+            AssertSubjectEquality(elements, (T x, T y) => EqualityComparer<T>.Default.Equals(x, y), string.Empty);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-
-        private static Func<T, T, bool> GetComparer()
-        {
-            if (typeof(T).GetTypeInfo().IsValueType)
-            {
-                return (T s, T e) => s.Equals(e);
-            }
-
-            return (T s, T e) => Equals(s, e);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -22,7 +22,7 @@ namespace FluentAssertions.Collections
         /// <param name="expected">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
         public new AndConstraint<StringCollectionAssertions> Equal(params string[] expected)
         {
-            return base.Equal(expected.AsEnumerable());
+            return Equal(expected, (a, b) => a == b);
         }
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace FluentAssertions.Collections
         /// <param name="expected">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
         public AndConstraint<StringCollectionAssertions> Equal(IEnumerable<string> expected)
         {
-            return base.Equal(expected);
+            return Equal(expected, (a, b) => a == b);
         }
 
         /// <summary>
@@ -281,7 +281,5 @@ namespace FluentAssertions.Collections
                 });
             }
         }
-
-        
     }
 }

--- a/Src/FluentAssertions/Common/MethodInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/MethodInfoExtensions.cs
@@ -18,7 +18,7 @@ namespace FluentAssertions.Common
 
         internal static bool IsAsync(this MethodInfo methodInfo)
         {
-            return methodInfo.GetMatchingAttributes<Attribute>(a => a.GetType().FullName.Equals("System.Runtime.CompilerServices.AsyncStateMachineAttribute")).Any();
+            return methodInfo.GetMatchingAttributes<Attribute>(a => a.GetType().FullName == "System.Runtime.CompilerServices.AsyncStateMachineAttribute").Any();
         }
 
         internal static IEnumerable<TAttribute> GetMatchingAttributes<TAttribute>(this MemberInfo memberInfo, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -547,7 +547,7 @@ namespace FluentAssertions.Common
             }
             else
             {
-                return type.IsSameOrEqualTo(definition) || type.IsDerivedFromOpenGeneric(definition);
+                return type == definition || type.IsDerivedFromOpenGeneric(definition);
             }
         }
 
@@ -556,7 +556,7 @@ namespace FluentAssertions.Common
             // check subject against definition
             TypeInfo subjectInfo = type.GetTypeInfo();
             if (subjectInfo.IsInterface && subjectInfo.IsGenericType &&
-                subjectInfo.GetGenericTypeDefinition().IsSameOrEqualTo(definition))
+                subjectInfo.GetGenericTypeDefinition() == definition)
             {
                 return true;
             }
@@ -566,12 +566,12 @@ namespace FluentAssertions.Common
                 .Select(i => i.GetTypeInfo())
                 .Where(i => i.IsGenericType)
                 .Select(i => i.GetGenericTypeDefinition())
-                .Any(d => d.IsSameOrEqualTo(definition));
+                .Contains(definition);
         }
 
         internal static bool IsDerivedFromOpenGeneric(this Type type, Type definition)
         {
-            if (type.IsSameOrEqualTo(definition))
+            if (type == definition)
             {
                 // do not consider a type to be derived from itself
                 return false;
@@ -581,7 +581,7 @@ namespace FluentAssertions.Common
             for (TypeInfo baseType = type.GetTypeInfo(); baseType != null;
                     baseType = baseType.BaseType?.GetTypeInfo())
             {
-                if (baseType.IsGenericType && baseType.GetGenericTypeDefinition().IsSameOrEqualTo(definition))
+                if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == definition)
                 {
                     return true;
                 }

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -53,7 +53,7 @@ namespace FluentAssertions.Formatting
         {
             string str = value.ToString();
 
-            return str is null || str.Equals(value.GetType().ToString());
+            return str is null || str == value.GetType().ToString();
         }
 
         private static string GetTypeAndPublicPropertyValues(object obj, FormattingContext context, FormatChild formatChild)

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -73,7 +73,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && Subject.Value.Equals(expected))
+                .ForCondition(Subject.HasValue && Subject.Value == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:boolean} to be {0}{reason}, but found {1}.", expected, Subject);
 

--- a/Src/FluentAssertions/Primitives/GuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/GuidAssertions.cs
@@ -97,7 +97,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<GuidAssertions> Be(Guid expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.Equals(expected))
+                .ForCondition(Subject.HasValue && Subject.Value == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:Guid} to be {0}{reason}, but found {1}.", expected, Subject);
 
@@ -118,7 +118,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<GuidAssertions> NotBe(Guid unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.Equals(unexpected))
+                .ForCondition(!Subject.HasValue || Subject != unexpected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:Guid} to be {0}{reason}.", Subject);
 

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -92,7 +92,7 @@ namespace FluentAssertions.Primitives
                 .ForCondition(Subject.HasValue)
                 .FailWith("but found <null>.")
                 .Then
-                .ForCondition(Subject.Value.CompareTo(expected) == 0)
+                .ForCondition(Subject.Value == expected)
                 .FailWith("but found {0}.", Subject.Value)
                 .Then
                 .ClearExpectation();
@@ -115,7 +115,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<SimpleTimeSpanAssertions> NotBe(TimeSpan unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.HasValue || Subject.Value.CompareTo(unexpected) != 0)
+                .ForCondition(!Subject.HasValue || Subject.Value != unexpected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {0}{reason}.", unexpected);
 

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -53,7 +53,7 @@ namespace FluentAssertions.Types
         public AndConstraint<TypeAssertions> Be(Type expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.IsSameOrEqualTo(expected))
+                .ForCondition(Subject == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(GetFailureMessageIfTypesAreDifferent(Subject, expected));
 

--- a/Src/FluentAssertions/Xml/XAttributeAssertions.cs
+++ b/Src/FluentAssertions/Xml/XAttributeAssertions.cs
@@ -54,7 +54,7 @@ namespace FluentAssertions.Xml
         public AndConstraint<XAttributeAssertions> NotBe(XAttribute unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.Name.Equals(unexpected.Name) || !Subject.Value.Equals(unexpected.Value))
+                .ForCondition(!Subject.Name.Equals(unexpected.Name) || Subject.Value != unexpected.Value)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect XML attribute to be {0}{reason}.", unexpected);
 

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -38,15 +38,9 @@ namespace FluentAssertions.Xml
         public AndConstraint<XDocumentAssertions> Be(XDocument expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .ForCondition(Equals(Subject, expected))
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected XML document to be {0}{reason}, ", expected)
-                .ForCondition(!(Subject is null))
-                .FailWith("but found <null>.")
-                .Then
-                .ForCondition(Subject.Equals(expected))
-                .FailWith("but found {0}.", Subject)
-                .Then
-                .ClearExpectation();
+                .FailWith("Expected XML document to be {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<XDocumentAssertions>(this);
         }
@@ -66,11 +60,8 @@ namespace FluentAssertions.Xml
         public AndConstraint<XDocumentAssertions> NotBe(XDocument unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
+                .ForCondition(!Equals(Subject, unexpected))
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(!(Subject is null))
-                .FailWith("Did not expect XML document to be {0}, but found <null>.", unexpected)
-                .Then
-                .ForCondition(!Subject.Equals(unexpected))
                 .FailWith("Did not expect XML document to be {0}{reason}.", unexpected);
 
             return new AndConstraint<XDocumentAssertions>(this);

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -38,9 +38,15 @@ namespace FluentAssertions.Xml
         public AndConstraint<XDocumentAssertions> Be(XDocument expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.IsSameOrEqualTo(expected))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected XML document to be {0}{reason}, but found {1}.", expected, Subject);
+                .WithExpectation("Expected XML document to be {0}{reason}, ", expected)
+                .ForCondition(!(Subject is null))
+                .FailWith("but found <null>.")
+                .Then
+                .ForCondition(Subject.Equals(expected))
+                .FailWith("but found {0}.", Subject)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<XDocumentAssertions>(this);
         }

--- a/Tests/Shared.Specs/Xml/XDocumentAssertionSpecs.cs
+++ b/Tests/Shared.Specs/Xml/XDocumentAssertionSpecs.cs
@@ -57,6 +57,21 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_a_a_null_xml_document_is_equal_to_a_null_xml_document_it_should_succeed()
+        {
+            // Arrange
+            XDocument document = null;
+            XDocument otherXDocument = null;
+
+            // Act
+            Action act = () =>
+                document.Should().Be(otherXDocument);
+
+            // Assert
+            act.Should().NotThrow<XunitException>();
+        }
+
+        [Fact]
         public void When_asserting_a_xml_document_is_equal_to_a_different_xml_document_it_should_fail_with_descriptive_message()
         {
             // Arrange
@@ -105,7 +120,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_asserting_a_null_xml_document_is_not_equal_to_some_xml_document_it_should_fail()
+        public void When_asserting_a_null_xml_document_is_not_equal_to_some_xml_document_it_should_succeed()
         {
             // Arrange
             XDocument document = null;
@@ -116,8 +131,23 @@ namespace FluentAssertions.Specs
                 document.Should().NotBe(someXDocument);
 
             // Assert
+            act.Should().NotThrow<XunitException>();
+        }
+
+        [Fact]
+        public void When_asserting_a_null_xml_document_is_not_equal_to_a_null_xml_document_it_should_fail()
+        {
+            // Arrange
+            XDocument document = null;
+            XDocument someXDocument = null;
+
+            // Act
+            Action act = () =>
+                document.Should().NotBe(someXDocument);
+
+            // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*not expect XML document to be*, but found <null>*");
+                .WithMessage("Did not expect XML document to be <null>.");
         }
 
         [Fact]


### PR DESCRIPTION
One of the original benefits of `IsSameOrEqualTo` seems to have been that it could handle `null` values but it also handles comparing boxed numerics.
In many cases the extra functionality of `IsSameOrEqualTo` is purely overhead,

The better alternatives than using `IsSameOrEqualTo`:
* Potentially null `object`s can use [`Equals(a, b)`](https://referencesource.microsoft.com/#mscorlib/system/object.cs,68).
* Generic objects can use [`EqualityComparer<T>.Default.Equals(a, b)`](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.equalitycomparer-1.default?view=netframework-4.8).
* `Type` can be compared using `==`

For primitives `a.Equals(b)` and `a.CompareTo(b) == b` (for `TimeSpan`) are replaced with infix operators such as `==` and `!=`.

`(Not)Be` for `XDocument` is fixed to handle comparing two `null`s as expected.