### PR TITLE
Fix spelling on homepage 

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -22,7 +22,7 @@ intro:
      [Follow <i class="fab fa-twitter"></i> @jnyrup](https://twitter.com/jnyrup){: .btn .btn--twitter}
      [<i class="fab fa-paypal"></i> Tip Us](https://paypal.me/fluentassertions){: .btn .btn--paypal}
      [<i class="fa fa-coffee"></i> Buy us a coffee](https://ko-fi.com/dennisdoomen){: .btn .btn--paypal}
-     [<i class="fab fa-patreon"></i> Sponser Us](https://www.patreon.com/bePatron?u=9250052&redirect_uri=http%3A%2F%2Ffluentassertions.com%2F&utm_medium=widget){: .btn .btn--patreon}
+     [<i class="fab fa-patreon"></i> Sponsor Us](https://www.patreon.com/bePatron?u=9250052&redirect_uri=http%3A%2F%2Ffluentassertions.com%2F&utm_medium=widget){: .btn .btn--patreon}
      [<i class="fas fa-money-check"></i> Wire Us](mailto:dennis.doomen@avivasolutions.nl?subject=Support%20Fluent%20Assertions){: .btn .btn--rabobank}
      <br/>
      A very extensive set of extension methods that allow you to more naturally specify the expected outcome of a TDD or


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/master/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com).
