### PR TITLE
Constrain generic type on NumericAssertions

### DIFF
--- a/Src/FluentAssertions/Numeric/NullableNumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableNumericAssertions.cs
@@ -8,12 +8,14 @@ namespace FluentAssertions.Numeric
 {
     [DebuggerNonUserCode]
     public class NullableNumericAssertions<T> : NumericAssertions<T>
-        where T : struct
+        where T : struct, IComparable<T>
     {
         public NullableNumericAssertions(T? value)
             : base(value)
         {
         }
+
+        public new T? Subject => SubjectInternal;
 
         /// <summary>
         /// Asserts that a nullable numeric value is not <c>null</c>.
@@ -28,7 +30,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!(Subject is null))
+                .ForCondition(Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value{reason}.");
 
@@ -63,7 +65,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject is null)
+                .ForCondition(!Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect a value{reason}, but found {0}.", Subject);
 
@@ -105,7 +107,7 @@ namespace FluentAssertions.Numeric
             Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
 
             Execute.Assertion
-                .ForCondition(predicate.Compile()((T?)Subject))
+                .ForCondition(predicate.Compile()(Subject))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected value to match {0}{reason}, but found {1}.", predicate.Body, Subject);
 

--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -9,7 +9,6 @@ namespace FluentAssertions
     /// </summary>
     public static class NumericAssertionsExtensions
     {
-
         #region BeCloseTo
         /// <summary>
         /// Asserts an integral value is close to another value within a specified value.
@@ -32,7 +31,7 @@ namespace FluentAssertions
             sbyte nearbyValue, byte delta, string because = "",
             params object[] becauseArgs)
         {
-            sbyte actualValue = (sbyte)parent.Subject;
+            sbyte actualValue = parent.Subject;
             sbyte minValue = (sbyte)(nearbyValue - delta);
             if (minValue > nearbyValue)
             {
@@ -71,7 +70,7 @@ namespace FluentAssertions
             byte nearbyValue, byte delta, string because = "",
             params object[] becauseArgs)
         {
-            byte actualValue = (byte)parent.Subject;
+            byte actualValue = parent.Subject;
             byte minValue = (byte)(nearbyValue - delta);
             if (minValue > nearbyValue)
             {
@@ -110,7 +109,7 @@ namespace FluentAssertions
             short nearbyValue, ushort delta, string because = "",
             params object[] becauseArgs)
         {
-            short actualValue = (short)parent.Subject;
+            short actualValue = parent.Subject;
             short minValue = (short)(nearbyValue - delta);
             if (minValue > nearbyValue)
             {
@@ -149,7 +148,7 @@ namespace FluentAssertions
             ushort nearbyValue, ushort delta, string because = "",
             params object[] becauseArgs)
         {
-            ushort actualValue = (ushort)parent.Subject;
+            ushort actualValue = parent.Subject;
             ushort minValue = (ushort)(nearbyValue - delta);
             if (minValue > nearbyValue)
             {
@@ -188,7 +187,7 @@ namespace FluentAssertions
             int nearbyValue, uint delta, string because = "",
             params object[] becauseArgs)
         {
-            int actualValue = (int)parent.Subject;
+            int actualValue = parent.Subject;
             int minValue = (int)(nearbyValue - delta);
             if (minValue > nearbyValue)
             {
@@ -227,7 +226,7 @@ namespace FluentAssertions
             uint nearbyValue, uint delta, string because = "",
             params object[] becauseArgs)
         {
-            uint actualValue = (uint)parent.Subject;
+            uint actualValue = parent.Subject;
             uint minValue = nearbyValue - delta;
             if (minValue > nearbyValue)
             {
@@ -266,7 +265,7 @@ namespace FluentAssertions
             long nearbyValue, ulong delta, string because = "",
             params object[] becauseArgs)
         {
-            long actualValue = (long)parent.Subject;
+            long actualValue = parent.Subject;
             long minValue = GetMinValue(nearbyValue, delta);
             long maxValue = GetMaxValue(nearbyValue, delta);
 
@@ -296,7 +295,7 @@ namespace FluentAssertions
             ulong nearbyValue, ulong delta, string because = "",
             params object[] becauseArgs)
         {
-            ulong actualValue = (ulong)parent.Subject;
+            ulong actualValue = parent.Subject;
             ulong minValue = nearbyValue - delta;
             if (minValue > nearbyValue)
             {
@@ -350,7 +349,7 @@ namespace FluentAssertions
             sbyte distantValue, byte delta, string because = "",
             params object[] becauseArgs)
         {
-            sbyte actualValue = (sbyte)parent.Subject;
+            sbyte actualValue = parent.Subject;
             sbyte minValue = (sbyte)(distantValue - delta);
             if (minValue > distantValue)
             {
@@ -389,7 +388,7 @@ namespace FluentAssertions
             byte distantValue, byte delta, string because = "",
             params object[] becauseArgs)
         {
-            byte actualValue = (byte)parent.Subject;
+            byte actualValue = parent.Subject;
             byte minValue = (byte)(distantValue - delta);
             if (minValue > distantValue)
             {
@@ -428,7 +427,7 @@ namespace FluentAssertions
             short distantValue, ushort delta, string because = "",
             params object[] becauseArgs)
         {
-            short actualValue = (short)parent.Subject;
+            short actualValue = parent.Subject;
             short minValue = (short)(distantValue - delta);
             if (minValue > distantValue)
             {
@@ -467,7 +466,7 @@ namespace FluentAssertions
             ushort distantValue, ushort delta, string because = "",
             params object[] becauseArgs)
         {
-            ushort actualValue = (ushort)parent.Subject;
+            ushort actualValue = parent.Subject;
             ushort minValue = (ushort)(distantValue - delta);
             if (minValue > distantValue)
             {
@@ -506,7 +505,7 @@ namespace FluentAssertions
             int distantValue, uint delta, string because = "",
             params object[] becauseArgs)
         {
-            int actualValue = (int)parent.Subject;
+            int actualValue = parent.Subject;
             int minValue = (int)(distantValue - delta);
             if (minValue > distantValue)
             {
@@ -545,7 +544,7 @@ namespace FluentAssertions
             uint distantValue, uint delta, string because = "",
             params object[] becauseArgs)
         {
-            uint actualValue = (uint)parent.Subject;
+            uint actualValue = parent.Subject;
             uint minValue = distantValue - delta;
             if (minValue > distantValue)
             {
@@ -584,7 +583,7 @@ namespace FluentAssertions
             long distantValue, ulong delta, string because = "",
             params object[] becauseArgs)
         {
-            long actualValue = (long)parent.Subject;
+            long actualValue = parent.Subject;
             long minValue = GetMinValue(distantValue, delta);
             long maxValue = GetMaxValue(distantValue, delta);
 
@@ -614,7 +613,7 @@ namespace FluentAssertions
             ulong distantValue, ulong delta, string because = "",
             params object[] becauseArgs)
         {
-            ulong actualValue = (ulong)parent.Subject;
+            ulong actualValue = parent.Subject;
             ulong minValue = distantValue - delta;
             if (minValue > distantValue)
             {
@@ -742,7 +741,7 @@ namespace FluentAssertions
             float expectedValue, float precision, string because = "",
             params object[] becauseArgs)
         {
-            float actualDifference = Math.Abs(expectedValue - (float)parent.Subject);
+            float actualDifference = Math.Abs(expectedValue - parent.Subject);
 
             FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference, because, becauseArgs);
 
@@ -843,7 +842,7 @@ namespace FluentAssertions
             double expectedValue, double precision, string because = "",
             params object[] becauseArgs)
         {
-            double actualDifference = Math.Abs(expectedValue - (double)parent.Subject);
+            double actualDifference = Math.Abs(expectedValue - parent.Subject);
 
             FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference, because, becauseArgs);
 
@@ -944,7 +943,7 @@ namespace FluentAssertions
             decimal expectedValue, decimal precision, string because = "",
             params object[] becauseArgs)
         {
-            decimal actualDifference = Math.Abs(expectedValue - (decimal)parent.Subject);
+            decimal actualDifference = Math.Abs(expectedValue - parent.Subject);
 
             FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference, because, becauseArgs);
 
@@ -954,7 +953,7 @@ namespace FluentAssertions
         private static void FailIfDifferenceOutsidePrecision<T>(
             bool differenceWithinPrecision,
             NumericAssertions<T> parent, T expectedValue, T precision, T actualDifference,
-            string because, object[] becauseArgs) where T : struct
+            string because, object[] becauseArgs) where T : struct, IComparable<T>
         {
             Execute.Assertion
                 .ForCondition(differenceWithinPrecision)
@@ -1059,7 +1058,7 @@ namespace FluentAssertions
             float unexpectedValue, float precision, string because = "",
             params object[] becauseArgs)
         {
-            float actualDifference = Math.Abs(unexpectedValue - (float)parent.Subject);
+            float actualDifference = Math.Abs(unexpectedValue - parent.Subject);
 
             FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference, because, becauseArgs);
 
@@ -1158,7 +1157,7 @@ namespace FluentAssertions
             double unexpectedValue, double precision, string because = "",
             params object[] becauseArgs)
         {
-            double actualDifference = Math.Abs(unexpectedValue - (double)parent.Subject);
+            double actualDifference = Math.Abs(unexpectedValue - parent.Subject);
 
             FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference, because, becauseArgs);
 
@@ -1257,7 +1256,7 @@ namespace FluentAssertions
             decimal unexpectedValue, decimal precision, string because = "",
             params object[] becauseArgs)
         {
-            decimal actualDifference = Math.Abs(unexpectedValue - (decimal)parent.Subject);
+            decimal actualDifference = Math.Abs(unexpectedValue - parent.Subject);
 
             FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference, because, becauseArgs);
 
@@ -1267,7 +1266,7 @@ namespace FluentAssertions
         private static void FailIfDifferenceWithinPrecision<T>(
             NumericAssertions<T> parent, bool differenceOutsidePrecision,
             T unexpectedValue, T precision, T actualDifference,
-            string because, object[] becauseArgs) where T : struct
+            string because, object[] becauseArgs) where T : struct, IComparable<T>
         {
             Execute.Assertion
                 .ForCondition(differenceOutsidePrecision)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -1313,9 +1313,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
-        where T :  struct
+        where T :  struct, System.IComparable<T>
     {
         public NullableNumericAssertions(T? value) { }
+        public T? Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
@@ -1323,10 +1324,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
     public class NumericAssertions<T>
-        where T :  struct
+        where T :  struct, System.IComparable<T>
     {
-        public NumericAssertions(object value) { }
-        public System.IComparable Subject { get; }
+        public NumericAssertions(T value) { }
+        public T Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -1313,9 +1313,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
-        where T :  struct
+        where T :  struct, System.IComparable<T>
     {
         public NullableNumericAssertions(T? value) { }
+        public T? Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
@@ -1323,10 +1324,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
     public class NumericAssertions<T>
-        where T :  struct
+        where T :  struct, System.IComparable<T>
     {
-        public NumericAssertions(object value) { }
-        public System.IComparable Subject { get; }
+        public NumericAssertions(T value) { }
+        public T Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -1313,9 +1313,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
-        where T :  struct
+        where T :  struct, System.IComparable<T>
     {
         public NullableNumericAssertions(T? value) { }
+        public T? Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
@@ -1323,10 +1324,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
     public class NumericAssertions<T>
-        where T :  struct
+        where T :  struct, System.IComparable<T>
     {
-        public NumericAssertions(object value) { }
-        public System.IComparable Subject { get; }
+        public NumericAssertions(T value) { }
+        public T Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1269,9 +1269,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
-        where T :  struct
+        where T :  struct, System.IComparable<T>
     {
         public NullableNumericAssertions(T? value) { }
+        public T? Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
@@ -1279,10 +1280,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
     public class NumericAssertions<T>
-        where T :  struct
+        where T :  struct, System.IComparable<T>
     {
-        public NumericAssertions(object value) { }
-        public System.IComparable Subject { get; }
+        public NumericAssertions(T value) { }
+        public T Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -1313,9 +1313,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
-        where T :  struct
+        where T :  struct, System.IComparable<T>
     {
         public NullableNumericAssertions(T? value) { }
+        public T? Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
@@ -1323,10 +1324,10 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
     public class NumericAssertions<T>
-        where T :  struct
+        where T :  struct, System.IComparable<T>
     {
-        public NumericAssertions(object value) { }
-        public System.IComparable Subject { get; }
+        public NumericAssertions(T value) { }
+        public T Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }


### PR DESCRIPTION
Further constraining of `T` to `IComparable<T>` gets us:
* No more runtime type check in constructor
* Avoid (un)boxing of primitives
* Type preserving `Subject`, i.e. `T`/`T?` instead of `IComparable<T>`