### PR TITLE
Add PropertyInfoSelectorAssertions.NotBeWritable

### DIFF
--- a/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
@@ -110,7 +110,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the selected properties does not have a setter.
+        /// Asserts that the selected properties do not have a setter.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion

--- a/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
@@ -109,9 +109,41 @@ namespace FluentAssertions.Types
             return new AndConstraint<PropertyInfoSelectorAssertions>(this);
         }
 
+        /// <summary>
+        /// Asserts that the selected properties does not have a setter.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="because" />.
+        /// </param>
+        public AndConstraint<PropertyInfoSelectorAssertions> NotBeWritable(string because = "", params object[] becauseArgs)
+        {
+            PropertyInfo[] writableProperties = GetAllWritablePropertiesFromSelection();
+
+            string failureMessage =
+                "Expected selected properties to not have a setter{reason}, but the following properties do:" +
+                Environment.NewLine +
+                GetDescriptionsFor(writableProperties);
+
+            Execute.Assertion
+                .ForCondition(!writableProperties.Any())
+                .BecauseOf(because, becauseArgs)
+                .FailWith(failureMessage);
+
+            return new AndConstraint<PropertyInfoSelectorAssertions>(this);
+        }
+
         private PropertyInfo[] GetAllReadOnlyPropertiesFromSelection()
         {
             return SubjectProperties.Where(property => !property.CanWrite).ToArray();
+        }
+
+        private PropertyInfo[] GetAllWritablePropertiesFromSelection()
+        {
+            return SubjectProperties.Where(property => property.CanWrite).ToArray();
         }
 
         private PropertyInfo[] GetAllNonVirtualPropertiesFromSelection()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -1874,6 +1874,7 @@ namespace FluentAssertions.Types
         public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : System.Attribute { }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
     }
     public class TypeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Type, FluentAssertions.Types.TypeAssertions>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -1874,6 +1874,7 @@ namespace FluentAssertions.Types
         public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : System.Attribute { }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
     }
     public class TypeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Type, FluentAssertions.Types.TypeAssertions>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -1874,6 +1874,7 @@ namespace FluentAssertions.Types
         public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : System.Attribute { }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
     }
     public class TypeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Type, FluentAssertions.Types.TypeAssertions>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1830,6 +1830,7 @@ namespace FluentAssertions.Types
         public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : System.Attribute { }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
     }
     public class TypeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Type, FluentAssertions.Types.TypeAssertions>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -1874,6 +1874,7 @@ namespace FluentAssertions.Types
         public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
             where TAttribute : System.Attribute { }
         public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeVirtual(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Types.PropertyInfoSelectorAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
     }
     public class TypeAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Type, FluentAssertions.Types.TypeAssertions>
     {

--- a/Tests/Shared.Specs/Types/PropertyInfoSelectorAssertionSpecs.cs
+++ b/Tests/Shared.Specs/Types/PropertyInfoSelectorAssertionSpecs.cs
@@ -239,6 +239,38 @@ namespace FluentAssertions.Specs
             // Assert
             action.Should().NotThrow();
         }
+
+        [Fact]
+        public void When_a_writable_property_is_expected_to_be_read_only_it_should_throw_with_descriptive_message()
+        {
+            // Arrange
+            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithWritableProperties));
+
+            // Act
+            Action action = () => propertyInfoSelector.Should().NotBeWritable("because we want to test the error {0}", "message");
+
+            // Assert
+            action
+                .Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected selected properties to not have a setter because we want to test the error message, " +
+                    "but the following properties do:*" +
+                    "String FluentAssertions.Specs.ClassWithWritableProperties.ReadWriteProperty*" +
+                    "String FluentAssertions.Specs.ClassWithWritableProperties.ReadWriteProperty2");
+        }
+
+        [Fact]
+        public void When_read_only_properties_are_expected_to_not_be_writable_it_should_not_throw()
+        {
+            // Arrange
+            var propertyInfoSelector = new PropertyInfoSelector(typeof(ClassWithOnlyReadOnlyProperties));
+
+            // Act
+            Action action = () => propertyInfoSelector.Should().NotBeWritable();
+
+            // Assert
+            action.Should().NotThrow();
+        }
     }
 
     #region Internal classes used in unit tests
@@ -273,9 +305,22 @@ namespace FluentAssertions.Specs
         public string ReadWriteProperty { get { return ""; } set { } }
     }
 
+    internal class ClassWithWritableProperties
+    {
+        public string ReadOnlyProperty { get { return ""; } }
+        public string ReadWriteProperty { get { return ""; } set { } }
+        public string ReadWriteProperty2 { get { return ""; } set { } }
+    }
+
     internal class ClassWithOnlyWritableProperties
     {
         public string ReadWriteProperty { set { } }
+    }
+
+    internal class ClassWithOnlyReadOnlyProperties
+    {
+        public string ReadOnlyProperty { get { return ""; } }
+        public string ReadOnlyProperty2 { get { return ""; } }
     }
 
     internal class ClassWithAllPropertiesDecoratedWithDummyAttribute

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -14,6 +14,7 @@ sidebar:
 * Added `WithOffset` extension method on `DateTime` for easier creation of `DateTimeOffset` objects.
 * Added `collectionOfStrings.Should().NotContainMatch()` to assert that the collection does not contain a string that matches a wildcard pattern 
 * The `Using`/`When` option on `BeEquivalentTo` will now use the conversion rules when trying to match the predicate.
+* Added `NotBeWritable` to `PropertyInfoSelectorAssertions` to be able to assert that properties are not writable.
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` (#1223)


### PR DESCRIPTION
Add assertion method NotBeWritable to PropertyInfoSelectorAssertions.

Closes #1256

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/master/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com).
