### PR TITLE
Fix for issue 1270. BeApproximately now respects positive and negative infinity

### DIFF
--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -741,9 +741,20 @@ namespace FluentAssertions
             float expectedValue, float precision, string because = "",
             params object[] becauseArgs)
         {
-            float actualDifference = Math.Abs(expectedValue - parent.Subject);
+            if (float.IsPositiveInfinity(expectedValue))
+            {
+                FailIfDifferenceOutsidePrecision(float.IsPositiveInfinity(parent.Subject), parent, expectedValue, precision, float.NaN, because, becauseArgs);
+            }
+            else if (float.IsNegativeInfinity(expectedValue))
+            {
+                FailIfDifferenceOutsidePrecision(float.IsNegativeInfinity(parent.Subject), parent, expectedValue, precision, float.NaN, because, becauseArgs);
+            }
+            else
+            {
+                float actualDifference = Math.Abs(expectedValue - parent.Subject);
 
-            FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference, because, becauseArgs);
+                FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference, because, becauseArgs);
+            }
 
             return new AndConstraint<NumericAssertions<float>>(parent);
         }
@@ -842,9 +853,20 @@ namespace FluentAssertions
             double expectedValue, double precision, string because = "",
             params object[] becauseArgs)
         {
-            double actualDifference = Math.Abs(expectedValue - parent.Subject);
+            if (double.IsPositiveInfinity(expectedValue))
+            {
+                FailIfDifferenceOutsidePrecision(double.IsPositiveInfinity(parent.Subject), parent, expectedValue, precision, double.NaN, because, becauseArgs);
+            }
+            else if (double.IsNegativeInfinity(expectedValue))
+            {
+                FailIfDifferenceOutsidePrecision(double.IsNegativeInfinity(parent.Subject), parent, expectedValue, precision, double.NaN, because, becauseArgs);
+            }
+            else
+            {
+                double actualDifference = Math.Abs(expectedValue - parent.Subject);
 
-            FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference, because, becauseArgs);
+                FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference, because, becauseArgs);
+            }
 
             return new AndConstraint<NumericAssertions<double>>(parent);
         }
@@ -1058,9 +1080,20 @@ namespace FluentAssertions
             float unexpectedValue, float precision, string because = "",
             params object[] becauseArgs)
         {
-            float actualDifference = Math.Abs(unexpectedValue - parent.Subject);
+            if (float.IsPositiveInfinity(unexpectedValue))
+            {
+                FailIfDifferenceWithinPrecision(parent, !float.IsPositiveInfinity(parent.Subject), unexpectedValue, precision, float.NaN, because, becauseArgs);
+            }
+            else if (float.IsNegativeInfinity(unexpectedValue))
+            {
+                FailIfDifferenceWithinPrecision(parent, !float.IsNegativeInfinity(parent.Subject), unexpectedValue, precision, float.NaN, because, becauseArgs);
+            }
+            else
+            {
+                float actualDifference = Math.Abs(unexpectedValue - parent.Subject);
 
-            FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference, because, becauseArgs);
+                FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference, because, becauseArgs);
+            }
 
             return new AndConstraint<NumericAssertions<float>>(parent);
         }
@@ -1157,10 +1190,20 @@ namespace FluentAssertions
             double unexpectedValue, double precision, string because = "",
             params object[] becauseArgs)
         {
-            double actualDifference = Math.Abs(unexpectedValue - parent.Subject);
+            if (double.IsPositiveInfinity(unexpectedValue))
+            {
+                FailIfDifferenceWithinPrecision(parent, !double.IsPositiveInfinity(parent.Subject), unexpectedValue, precision, double.NaN, because, becauseArgs);
+            }
+            else if (double.IsNegativeInfinity(unexpectedValue))
+            {
+                FailIfDifferenceWithinPrecision(parent, !double.IsNegativeInfinity(parent.Subject), unexpectedValue, precision, double.NaN, because, becauseArgs);
+            }
+            else
+            {
+                double actualDifference = Math.Abs(unexpectedValue - parent.Subject);
 
-            FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference, because, becauseArgs);
-
+                FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference, because, becauseArgs);
+            }
             return new AndConstraint<NumericAssertions<double>>(parent);
         }
 

--- a/Tests/Shared.Specs/Numeric/NumericAssertionSpecs.cs
+++ b/Tests/Shared.Specs/Numeric/NumericAssertionSpecs.cs
@@ -1154,6 +1154,58 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_approximating_positive_infinity_float_towards_positive_infinity_it_should_not_throw()
+        {
+            // Arrange
+            float value = float.PositiveInfinity;
+
+            // Act
+            Action act = () => value.Should().BeApproximately(float.PositiveInfinity, 0.1F);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_approximating_negative_infinity_float_towards_negative_infinity_it_should_not_throw()
+        {
+            // Arrange
+            float value = float.NegativeInfinity;
+
+            // Act
+            Action act = () => value.Should().BeApproximately(float.NegativeInfinity, 0.1F);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_float_is_not_approximating_positive_infinity_it_should_throw()
+        {
+            // Arrange
+            float value = float.PositiveInfinity;
+
+            // Act
+            Action act = () => value.Should().BeApproximately(float.MaxValue, 0.1F);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_float_is_not_approximating_negative_infinity_it_should_throw()
+        {
+            // Arrange
+            float value = float.NegativeInfinity;
+
+            // Act
+            Action act = () => value.Should().BeApproximately(float.MinValue, 0.1F);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
         public void When_a_nullable_float_has_no_value_it_should_throw()
         {
             // Arrange
@@ -1205,6 +1257,58 @@ namespace FluentAssertions.Specs
 
             // Act
             Action act = () => value.Should().NotBeApproximately(3.14F, 0.1F);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_not_approximating_a_float_towards_positive_infinity_and_should_not_approximate_it_should_not_throw()
+        {
+            // Arrange
+            float value = float.PositiveInfinity;
+
+            // Act
+            Action act = () => value.Should().NotBeApproximately(float.MaxValue, 0.1F);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_not_approximating_a_float_towards_negative_infinity_and_should_not_approximate_it_should_not_throw()
+        {
+            // Arrange
+            float value = float.NegativeInfinity;
+
+            // Act
+            Action act = () => value.Should().NotBeApproximately(float.MinValue, 0.1F);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_approximating_positive_infinity_float_towards_positive_infinity_and_should_not_approximate_it_should_throw()
+        {
+            // Arrange
+            float value = float.PositiveInfinity;
+
+            // Act
+            Action act = () => value.Should().NotBeApproximately(float.PositiveInfinity, 0.1F);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_not_approximating_negative_infinity_float_towards_negative_infinity_and_should_not_approximate_it_should_throw()
+        {
+            // Arrange
+            float value = float.NegativeInfinity;
+
+            // Act
+            Action act = () => value.Should().NotBeApproximately(float.NegativeInfinity, 0.1F);
 
             // Assert
             act.Should().Throw<XunitException>();
@@ -1338,6 +1442,59 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>();
         }
 
+        [Fact]
+        public void When_approximating_positive_infinity_double_towards_positive_infinity_it_should_not_throw()
+        {
+            // Arrange
+            double value = double.PositiveInfinity;
+
+            // Act
+            Action act = () => value.Should().BeApproximately(double.PositiveInfinity, 0.1);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_approximating_negative_infinity_double_towards_negative_infinity_it_should_not_throw()
+        {
+            // Arrange
+            double value = double.NegativeInfinity;
+
+            // Act
+            Action act = () => value.Should().BeApproximately(double.NegativeInfinity, 0.1);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_double_is_not_approximating_positive_infinity_it_should_throw()
+        {
+            // Arrange
+            double value = double.PositiveInfinity;
+
+            // Act
+            Action act = () => value.Should().BeApproximately(double.MaxValue, 0.1);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_double_is_not_approximating_negative_infinity_it_should_throw()
+        {
+            // Arrange
+            double value = double.NegativeInfinity;
+
+            // Act
+            Action act = () => value.Should().BeApproximately(double.MinValue, 0.1);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+
         [InlineData(9D)]
         [InlineData(11D)]
         [Theory]
@@ -1399,6 +1556,58 @@ namespace FluentAssertions.Specs
 
             // Act
             Action act = () => value.Should().NotBeApproximately(3.14, 0.1);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_not_approximating_a_double_towards_positive_infinity_and_should_not_approximate_it_should_not_throw()
+        {
+            // Arrange
+            double value = double.PositiveInfinity;
+
+            // Act
+            Action act = () => value.Should().NotBeApproximately(double.MaxValue, 0.1);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_not_approximating_a_double_towards_negative_infinity_and_should_not_approximate_it_should_not_throw()
+        {
+            // Arrange
+            double value = double.NegativeInfinity;
+
+            // Act
+            Action act = () => value.Should().NotBeApproximately(double.MinValue, 0.1);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_approximating_positive_infinity_double_towards_positive_infinity_and_should_not_approximate_it_should_throw()
+        {
+            // Arrange
+            double value = double.PositiveInfinity;
+
+            // Act
+            Action act = () => value.Should().NotBeApproximately(double.PositiveInfinity, 0.1);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_not_approximating_negative_infinity_double_towards_negative_infinity_and_should_not_approximate_it_should_throw()
+        {
+            // Arrange
+            double value = double.NegativeInfinity;
+
+            // Act
+            Action act = () => value.Should().NotBeApproximately(double.NegativeInfinity, 0.1);
 
             // Assert
             act.Should().Throw<XunitException>();


### PR DESCRIPTION
This pull request fixes issue #1270. NumericAssertionsExtensions.BeApproximately() was not respecting PositiveInfinity and NegativeInfinity for double and float assertions. I added the corresponding tests failing and fixed them.

Although, NumericAssertionsExtensions.NotBeApproximately() was working as expected, I also added the checks for infinity. I added tests for all four methods with positve and negative assertion.