### PR TITLE
Fix XPath index calculation for XML comparison

### DIFF
--- a/Src/FluentAssertions/Xml/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/Node.cs
@@ -54,14 +54,19 @@ namespace FluentAssertions.Xml.Equivalency
 
         public Node Parent { get; }
 
-        public Node Push(string name)
+        public Node Push(string localName)
         {
-            Node node = children.Find(e => e.name == name)
-                        ?? AddChildNode(name);
+            Node node = children.Find(e => e.name == localName)
+                        ?? AddChildNode(localName);
 
             node.count++;
 
             return node;
+        }
+
+        public void Pop()
+        {
+            children.Clear();
         }
 
         private Node AddChildNode(string name)

--- a/Src/FluentAssertions/Xml/Equivalency/XmlReaderValidator.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/XmlReaderValidator.cs
@@ -86,6 +86,7 @@ namespace FluentAssertions.Xml.Equivalency
                         // No need to verify end element, if it doesn't match
                         // the start element it isn't valid XML, so the parser
                         // would handle that.
+                        currentNode.Pop();
                         currentNode = currentNode.Parent;
                         break;
 

--- a/Tests/Shared.Specs/Xml/XDocumentAssertionSpecs.cs
+++ b/Tests/Shared.Specs/Xml/XDocumentAssertionSpecs.cs
@@ -573,15 +573,15 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             XDocument actual = XDocument.Parse(
-                "<root><xml1><xml2 /><xml2 a=\"x\" /></xml1><xml1><xml2 /><xml2 a=\"x\" /></xml1></root>");
+                "<root><xml1 /><xml1><xml2 /><xml2 a=\"x\" /></xml1><xml1><xml2 /><xml2 a=\"x\" /></xml1></root>");
             XDocument expected = XDocument.Parse(
-                "<root><xml1><xml2 /><xml2 a=\"x\" /></xml1><xml1><xml2 /><xml2 a=\"y\" /></xml1></root>");
+                "<root><xml1 /><xml1><xml2 /><xml2 a=\"x\" /></xml1><xml1><xml2 /><xml2 a=\"y\" /></xml1></root>");
 
             // Act
             Action act = () => actual.Should().BeEquivalentTo(expected);
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*\"/root/xml1[2]/xml2[2]\"*");
+            act.Should().Throw<XunitException>().WithMessage("*\"/root/xml1[3]/xml2[2]\"*");
         }
 
         #endregion

--- a/Tests/Shared.Specs/Xml/XDocumentAssertionSpecs.cs
+++ b/Tests/Shared.Specs/Xml/XDocumentAssertionSpecs.cs
@@ -568,6 +568,22 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>().WithMessage("*\"/xml/xml[3]/xml[2]\"*");
         }
 
+        [Fact]
+        public void When_asserting_equivalence_of_document_with_repeating_element_names_with_different_parents_but_differs_it_should_fail_with_index_xpath_to_difference()
+        {
+            // Arrange
+            XDocument actual = XDocument.Parse(
+                "<root><xml1><xml2 /><xml2 a=\"x\" /></xml1><xml1><xml2 /><xml2 a=\"x\" /></xml1></root>");
+            XDocument expected = XDocument.Parse(
+                "<root><xml1><xml2 /><xml2 a=\"x\" /></xml1><xml1><xml2 /><xml2 a=\"y\" /></xml1></root>");
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("*\"/root/xml1[2]/xml2[2]\"*");
+        }
+
         #endregion
 
         #region BeNull / NotBeNull


### PR DESCRIPTION
Last year I provided rework of the assertion failure message when comparing XML by introducing XPath index.
Now I found that the current implementation can generate invalid XPath. The index could should apply to the parent.

## Input
Compare
```xml
<root>
  <xml1 />
  <xml1><xml2 /><xml2 a=\"x\" /></xml1>
  <xml1>
    <xml2 />
    <xml2 a=\"x\" />
  </xml1>
</root>
```

with
```xml
<root>
  <xml1 />
  <xml1><xml2 /><xml2 a=\"x\" /></xml1>
  <xml1>
    <xml2 />
    <xml2 a=\"y\" /> <!-- note the different attribute -->
  </xml1>
</root>
```

## Expected behavior
Expected attribute "a" at "/root/xml1[3]/xml2[**2**]" to have value "y", but found "x".

## Actual behavior
Expected attribute "a" at "/root/xml1[3]/xml2[**4**]" to have value "y", but found "x".