### PR TITLE
Remove overloads of `[Not]BeCloseTo` that has a default precision

### DIFF
--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -71,33 +71,6 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTime"/>  is within the specified number of milliseconds (default = 20 ms)
-        /// from the specified <paramref name="nearbyTime"/> value.
-        /// </summary>
-        /// <remarks>
-        /// Use this assertion when, for example the database truncates datetimes to nearest 20ms. If you want to assert to the exact datetime,
-        /// use <see cref="Be(DateTime, string, object[])"/>.
-        /// </remarks>
-        /// <param name="nearbyTime">
-        /// The expected time to compare the actual value with.
-        /// </param>
-        /// <param name="precision">
-        /// The maximum amount of milliseconds which the two values may differ.
-        /// </param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="because" />.
-        /// </param>
-        public AndConstraint<DateTimeAssertions> BeCloseTo(DateTime nearbyTime, int precision = 20, string because = "",
-            params object[] becauseArgs)
-        {
-            return BeCloseTo(nearbyTime, TimeSpan.FromMilliseconds(precision), because, becauseArgs);
-        }
-
-        /// <summary>
         /// Asserts that the current <see cref="DateTime"/>  is within the specified time
         /// from the specified <paramref name="nearbyTime"/> value.
         /// </summary>
@@ -135,33 +108,6 @@ namespace FluentAssertions.Primitives
                     nearbyTime, Subject ?? default(DateTime?));
 
             return new AndConstraint<DateTimeAssertions>(this);
-        }
-
-        /// <summary>
-        /// Asserts that the current <see cref="DateTime"/>  is not within the specified number of milliseconds (default = 20 ms)
-        /// from the specified <paramref name="distantTime"/> value.
-        /// </summary>
-        /// <remarks>
-        /// Use this assertion when, for example the database truncates datetimes to nearest 20ms. If you want to assert to the exact datetime,
-        /// use <see cref="NotBe(DateTime, string, object[])"/>.
-        /// </remarks>
-        /// <param name="distantTime">
-        /// The time to compare the actual value with.
-        /// </param>
-        /// <param name="precision">
-        /// The maximum amount of milliseconds which the two values must differ.
-        /// </param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="because" />.
-        /// </param>
-        public AndConstraint<DateTimeAssertions> NotBeCloseTo(DateTime distantTime, int precision = 20, string because = "",
-            params object[] becauseArgs)
-        {
-            return NotBeCloseTo(distantTime, TimeSpan.FromMilliseconds(precision), because, becauseArgs);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -72,34 +72,6 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTimeOffset"/> is within the specified number of milliseconds (default = 20 ms)
-        /// from the specified <paramref name="nearbyTime"/> value.
-        /// </summary>
-        /// <remarks>
-        /// Use this assertion when, for example the database truncates datetimes to nearest 20ms. If you want to assert to the exact datetime,
-        /// use <see cref="Be(DateTimeOffset, string, object[])"/>.
-        /// </remarks>
-        /// <param name="nearbyTime">
-        /// The expected time to compare the actual value with.
-        /// </param>
-        /// <param name="precision">
-        /// The maximum amount of milliseconds which the two values may differ.
-        /// </param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="because" />.
-        /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> BeCloseTo(DateTimeOffset nearbyTime, int precision = 20,
-            string because = "",
-            params object[] becauseArgs)
-        {
-            return BeCloseTo(nearbyTime, TimeSpan.FromMilliseconds(precision), because, becauseArgs);
-        }
-
-        /// <summary>
         /// Asserts that the current <see cref="DateTimeOffset"/> is within the specified time
         /// from the specified <paramref name="nearbyTime"/> value.
         /// </summary>
@@ -138,33 +110,6 @@ namespace FluentAssertions.Primitives
                     nearbyTime, Subject ?? default(DateTimeOffset?));
 
             return new AndConstraint<DateTimeOffsetAssertions>(this);
-        }
-
-        /// <summary>
-        /// Asserts that the current <see cref="DateTimeOffset"/> is not within the specified number of milliseconds (default = 20 ms)
-        /// from the specified <paramref name="distantTime"/> value.
-        /// </summary>
-        /// <remarks>
-        /// Use this assertion when, for example the database truncates datetimes to nearest 20ms. If you want to assert to the exact datetime,
-        /// use <see cref="NotBe(DateTimeOffset, string, object[])"/>.
-        /// </remarks>
-        /// <param name="distantTime">
-        /// The time to compare the actual value with.
-        /// </param>
-        /// <param name="precision">
-        /// The maximum amount of milliseconds which the two values must differ.
-        /// </param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="because" />.
-        /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> NotBeCloseTo(DateTimeOffset distantTime, int precision = 20, string because = "",
-            params object[] becauseArgs)
-        {
-            return NotBeCloseTo(distantTime, TimeSpan.FromMilliseconds(precision), because, becauseArgs);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -236,33 +236,6 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="TimeSpan"/> is within the specified number of milliseconds (default = 20 ms)
-        /// from the specified <paramref name="nearbyTime"/> value.
-        /// </summary>
-        /// <remarks>
-        /// Use this assertion when, for example the database truncates datetimes to nearest 20ms. If you want to assert to the exact datetime,
-        /// use <see cref="Be"/>.
-        /// </remarks>
-        /// <param name="nearbyTime">
-        /// The expected time to compare the actual value with.
-        /// </param>
-        /// <param name="precision">
-        /// The maximum amount of milliseconds which the two values may differ.
-        /// </param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="because" />.
-        /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> BeCloseTo(TimeSpan nearbyTime, int precision = 20, string because = "",
-            params object[] becauseArgs)
-        {
-            return BeCloseTo(nearbyTime, TimeSpan.FromMilliseconds(precision), because, becauseArgs);
-        }
-
-        /// <summary>
         /// Asserts that the current <see cref="TimeSpan"/> is within the specified time
         /// from the specified <paramref name="nearbyTime"/> value.
         /// </summary>
@@ -297,33 +270,6 @@ namespace FluentAssertions.Primitives
                     nearbyTime, Subject ?? default(TimeSpan?));
 
             return new AndConstraint<SimpleTimeSpanAssertions>(this);
-        }
-
-        /// <summary>
-        /// Asserts that the current <see cref="TimeSpan"/> is not within the specified number of milliseconds (default = 20 ms)
-        /// from the specified <paramref name="distantTime"/> value.
-        /// </summary>
-        /// <remarks>
-        /// Use this assertion when, for example the database truncates datetimes to nearest 20ms. If you want to assert to the exact datetime,
-        /// use <see cref="NotBe"/>.
-        /// </remarks>
-        /// <param name="distantTime">
-        /// The time to compare the actual value with.
-        /// </param>
-        /// <param name="precision">
-        /// The maximum amount of milliseconds which the two values may differ.
-        /// </param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <see cref="because" />.
-        /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> NotBeCloseTo(TimeSpan distantTime, int precision = 20, string because = "",
-            params object[] becauseArgs)
-        {
-            return NotBeCloseTo(distantTime, TimeSpan.FromMilliseconds(precision), because, becauseArgs);
         }
 
         /// <summary>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -1366,7 +1366,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
@@ -1389,7 +1388,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
@@ -1409,7 +1407,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
@@ -1432,7 +1429,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
@@ -1554,7 +1550,6 @@ namespace FluentAssertions.Primitives
         public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
         public System.TimeSpan? Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
@@ -1563,7 +1558,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
     }
     public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -1366,7 +1366,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
@@ -1389,7 +1388,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
@@ -1409,7 +1407,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
@@ -1432,7 +1429,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
@@ -1554,7 +1550,6 @@ namespace FluentAssertions.Primitives
         public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
         public System.TimeSpan? Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
@@ -1563,7 +1558,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
     }
     public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -1366,7 +1366,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
@@ -1389,7 +1388,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
@@ -1409,7 +1407,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
@@ -1432,7 +1429,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
@@ -1554,7 +1550,6 @@ namespace FluentAssertions.Primitives
         public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
         public System.TimeSpan? Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
@@ -1563,7 +1558,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
     }
     public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1322,7 +1322,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
@@ -1345,7 +1344,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
@@ -1365,7 +1363,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
@@ -1388,7 +1385,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
@@ -1510,7 +1506,6 @@ namespace FluentAssertions.Primitives
         public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
         public System.TimeSpan? Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
@@ -1519,7 +1514,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
     }
     public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -1366,7 +1366,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
@@ -1389,7 +1388,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
@@ -1409,7 +1407,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
@@ -1432,7 +1429,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
@@ -1554,7 +1550,6 @@ namespace FluentAssertions.Primitives
         public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
         public System.TimeSpan? Subject { get; }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
@@ -1563,7 +1558,6 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, int precision = 20, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
     }
     public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>

--- a/Tests/Shared.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
+++ b/Tests/Shared.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
@@ -345,7 +345,7 @@ namespace FluentAssertions.Specs
 
             // Act
             Action act = () => subject.Should().BeEquivalentTo(expectation, options => options
-                .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1000))
+                .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1.Seconds()))
                 .When(info => info.SelectedMemberPath.EndsWith("Date")));
 
             // Assert
@@ -377,7 +377,7 @@ namespace FluentAssertions.Specs
             // Act
             Action act = () => subject.Should().BeEquivalentTo(expectation, options =>
                 options
-                    .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1000))
+                    .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1.Seconds()))
                     .WhenTypeIs<DateTime>());
 
             // Assert
@@ -502,7 +502,7 @@ namespace FluentAssertions.Specs
 
             public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
             {
-                ((DateTime)context.Subject).Should().BeCloseTo((DateTime)context.Expectation, 1000 * 60);
+                ((DateTime)context.Subject).Should().BeCloseTo((DateTime)context.Expectation, 1.Minutes());
                 return true;
             }
         }
@@ -572,7 +572,7 @@ namespace FluentAssertions.Specs
             actual.Should().BeEquivalentTo(expectation,
                 options => options
                     .WithAutoConversion()
-                    .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1000))
+                    .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1.Seconds()))
                     .WhenTypeIs<DateTime>());
         }
 

--- a/Tests/Shared.Specs/Primitives/DateTimeAssertionSpecs.cs
+++ b/Tests/Shared.Specs/Primitives/DateTimeAssertionSpecs.cs
@@ -426,7 +426,7 @@ namespace FluentAssertions.Specs
             DateTime nearbyTime = DateTime.SpecifyKind(new DateTime(2016, 06, 04).At(12, 15, 31), DateTimeKind.Utc);
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -440,7 +440,7 @@ namespace FluentAssertions.Specs
             DateTime nearbyTime = DateTime.SpecifyKind(new DateTime(2016, 06, 04).At(12, 15, 31), DateTimeKind.Utc);
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -455,7 +455,7 @@ namespace FluentAssertions.Specs
             DateTime nearbyTime = new DateTime(2016, 06, 04).At(12, 15, 31);
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -469,7 +469,7 @@ namespace FluentAssertions.Specs
             DateTime nearbyTime = new DateTime(2016, 06, 04).At(12, 15, 31);
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -499,7 +499,7 @@ namespace FluentAssertions.Specs
             DateTime nearbyTime = 13.March(2012).At(12, 15, 31);
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -531,7 +531,7 @@ namespace FluentAssertions.Specs
             DateTime nearbyTime = 13.March(2012).At(12, 15, 31);
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -545,7 +545,7 @@ namespace FluentAssertions.Specs
             DateTime nearbyTime = 13.March(2012).At(12, 15, 31);
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -561,7 +561,7 @@ namespace FluentAssertions.Specs
             DateTime nearbyTime = 13.March(2012).At(12, 15, 31);
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -575,7 +575,7 @@ namespace FluentAssertions.Specs
             DateTime nearbyTime = new DateTime(2016, 06, 04).At(12, 15, 31);
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime, 35);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 35.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -589,7 +589,7 @@ namespace FluentAssertions.Specs
             DateTime nearbyTime = new DateTime(2016, 06, 04).At(12, 15, 31);
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 35);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 35.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -604,7 +604,7 @@ namespace FluentAssertions.Specs
             DateTime nearbyTime = new DateTime(2016, 06, 04).At(12, 15, 31);
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime, 35);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 35.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -619,7 +619,7 @@ namespace FluentAssertions.Specs
             DateTime nearbyTime = new DateTime(2016, 06, 04).At(12, 15, 31);
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 35);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 35.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -634,7 +634,7 @@ namespace FluentAssertions.Specs
             DateTime nearbyTime = DateTime.MinValue;
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime, 100);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 100.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -648,7 +648,7 @@ namespace FluentAssertions.Specs
             DateTime nearbyTime = DateTime.MinValue;
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 100);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 100.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -663,7 +663,7 @@ namespace FluentAssertions.Specs
             DateTime nearbyTime = DateTime.MaxValue;
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime, 100);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 100.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -677,7 +677,7 @@ namespace FluentAssertions.Specs
             DateTime nearbyTime = DateTime.MaxValue;
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 100);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 100.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/Shared.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/Shared.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
@@ -427,7 +427,7 @@ namespace FluentAssertions.Specs
             DateTimeOffset nearbyTime = new DateTimeOffset(2016, 06, 04, 12, 15, 31, 0, TimeSpan.Zero);
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -441,7 +441,7 @@ namespace FluentAssertions.Specs
             DateTimeOffset nearbyTime = new DateTimeOffset(2016, 06, 04, 12, 15, 31, 0, TimeSpan.Zero);
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -471,7 +471,7 @@ namespace FluentAssertions.Specs
             DateTimeOffset nearbyTime = new DateTimeOffset(2016, 06, 04, 12, 15, 31, 0, TimeSpan.Zero);
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -485,7 +485,7 @@ namespace FluentAssertions.Specs
             DateTimeOffset nearbyTime = new DateTimeOffset(2016, 06, 04, 12, 15, 31, 0, TimeSpan.Zero);
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -500,7 +500,7 @@ namespace FluentAssertions.Specs
             DateTimeOffset nearbyTime = 13.March(2012).At(12, 15, 31).ToDateTimeOffset(1.Hours());
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -516,7 +516,7 @@ namespace FluentAssertions.Specs
             DateTimeOffset nearbyTime = 13.March(2012).At(12, 15, 31).ToDateTimeOffset(1.Hours());
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -530,7 +530,7 @@ namespace FluentAssertions.Specs
             DateTimeOffset nearbyTime = 13.March(2012).At(12, 15, 31).ToDateTimeOffset(1.Hours());
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -562,7 +562,7 @@ namespace FluentAssertions.Specs
             DateTimeOffset nearbyTime = 13.March(2012).At(12, 15, 31).ToDateTimeOffset(1.Hours());
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -576,7 +576,7 @@ namespace FluentAssertions.Specs
             DateTimeOffset nearbyTime = 13.March(2012).At(12, 15, 31).ToDateTimeOffset(1.Hours());
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime, 35);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 35.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -590,7 +590,7 @@ namespace FluentAssertions.Specs
             DateTimeOffset nearbyTime = 13.March(2012).At(12, 15, 31).ToDateTimeOffset(1.Hours());
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 35);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 35.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -605,7 +605,7 @@ namespace FluentAssertions.Specs
             DateTimeOffset nearbyTime = 13.March(2012).At(12, 15, 31).ToDateTimeOffset(5.Hours());
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime, 35);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 35.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -620,7 +620,7 @@ namespace FluentAssertions.Specs
             DateTimeOffset nearbyTime = 13.March(2012).At(12, 15, 31).ToDateTimeOffset(5.Hours());
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 35);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 35.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -635,7 +635,7 @@ namespace FluentAssertions.Specs
             DateTimeOffset nearbyTime = DateTimeOffset.MinValue;
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime, 100);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 100.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -649,7 +649,7 @@ namespace FluentAssertions.Specs
             DateTimeOffset nearbyTime = DateTimeOffset.MinValue;
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 100);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 100.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -664,7 +664,7 @@ namespace FluentAssertions.Specs
             DateTimeOffset nearbyTime = DateTimeOffset.MaxValue;
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime, 100);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 100.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -678,7 +678,7 @@ namespace FluentAssertions.Specs
             DateTimeOffset nearbyTime = DateTimeOffset.MaxValue;
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 100);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 100.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/Shared.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
+++ b/Tests/Shared.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
@@ -407,7 +407,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected nullTimeSpan to be less than 1s because we want to test the failure message, but found <null>.");
-            
+
         }
 
         [Fact]
@@ -511,7 +511,7 @@ namespace FluentAssertions.Specs
             var nearbyTime = new TimeSpan(1, 12, 15, 31, 000);
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -525,7 +525,7 @@ namespace FluentAssertions.Specs
             var nearbyTime = new TimeSpan(1, 12, 15, 31, 000);
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -539,7 +539,7 @@ namespace FluentAssertions.Specs
             var nearbyTime = new TimeSpan(1, 12, 15, 31, 000);
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime, 20, "we want to test the error message");
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds(), "we want to test the error message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -555,7 +555,7 @@ namespace FluentAssertions.Specs
             var nearbyTime = new TimeSpan(1, 12, 15, 31, 000);
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime, 20, "we want to test the error message");
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 20.Milliseconds(), "we want to test the error message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -571,7 +571,7 @@ namespace FluentAssertions.Specs
             var nearbyTime = new TimeSpan(1, 12, 15, 31, 000);
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime, 35);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 35.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -585,7 +585,7 @@ namespace FluentAssertions.Specs
             var nearbyTime = new TimeSpan(1, 12, 15, 31, 000);
 
             // Act
-            Action act = () => time.Should().BeCloseTo(nearbyTime, 35);
+            Action act = () => time.Should().BeCloseTo(nearbyTime, 35.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -620,7 +620,7 @@ namespace FluentAssertions.Specs
             var nearbyTime = new TimeSpan(1, 12, 15, 31, 000);
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("Expected time to not be within 0.020s from 1d, 12h, 15m and 31s, but found 1d, 12h, 15m and 30.980s.");
@@ -634,7 +634,7 @@ namespace FluentAssertions.Specs
             var nearbyTime = new TimeSpan(1, 12, 15, 31, 000);
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("Expected time to not be within 0.020s from 1d, 12h, 15m and 31s, but found 1d, 12h, 15m and 31.020s.");
@@ -662,7 +662,7 @@ namespace FluentAssertions.Specs
             var nearbyTime = new TimeSpan(1, 12, 15, 31, 000);
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -676,7 +676,7 @@ namespace FluentAssertions.Specs
             var nearbyTime = new TimeSpan(1, 12, 15, 31, 000);
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 20.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
@@ -690,7 +690,7 @@ namespace FluentAssertions.Specs
             var nearbyTime = new TimeSpan(1, 12, 15, 31, 000);
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 35);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 35.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("Expected time to not be within 0.035s from 1d, 12h, 15m and 31s, but found 1d, 12h, 15m and 31.035s.");
@@ -704,7 +704,7 @@ namespace FluentAssertions.Specs
             TimeSpan nearbyTime = TimeSpan.FromHours(1);
 
             // Act
-            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 35);
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, 35.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/docs/_pages/datetimespans.md
+++ b/docs/_pages/datetimespans.md
@@ -72,11 +72,9 @@ theDatetime.Should().BeAtLeast(2.Days()).Before(deliveryDate);       // Equivale
 theDatetime.Should().BeExactly(24.Hours()).Before(appointment);      // Equivalent to ==
 ```
 
-To assert that a date/time is (not) within a specified number of milliseconds from another date/time value you can use this method.
+To assert that a date/time is (not) within a specified time span from another date/time value you can use this method.
 
 ```csharp
-theDatetime.Should().BeCloseTo(1.March(2010).At(22, 15), 2000); // 2000 milliseconds
-theDatetime.Should().BeCloseTo(1.March(2010).At(22, 15));       // default is 20 milliseconds
 theDatetime.Should().BeCloseTo(1.March(2010).At(22, 15), 2.Seconds());
 
 theDatetime.Should().NotBeCloseTo(2.March(2010), 1.Hours());

--- a/docs/_pages/objectgraphs.md
+++ b/docs/_pages/objectgraphs.md
@@ -160,7 +160,7 @@ In addition to influencing the members that are including in the comparison, you
 
 ```csharp
 orderDto.Should().BeEquivalentTo(order, options => options
-    .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1000))
+    .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1.Seconds()))
     .When(info => info.SelectedMemberPath.EndsWith("Date")));
 ```
 
@@ -168,7 +168,7 @@ If you want to do this for all members of a certain type, you can shorten the ab
 
 ```csharp
 orderDto.Should().BeEquivalentTo(order, options => options 
-    .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1000))
+    .Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, 1.Seconds()))
     .WhenTypeIs<DateTime>());
 ```
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -38,6 +38,8 @@ sidebar:
 * Changed `TypeAssertions.HaveAccessModifier` return type from `AndConstraint<Type> ` to `AndConstraint<TypeAssertions>` - [#1159](https://github.com/fluentassertions/fluentassertions/pull/1159).
 * Changed `TypeAssertions.NotHaveAccessModifier` return type from `AndConstraint<Type> ` to `AndConstraint<TypeAssertions>` - [#1159](https://github.com/fluentassertions/fluentassertions/pull/1159).
 * The new extension on `TaskCompletionSource<T>` overlays the previously used assertions based on `ObjectAssertions`.
+* Removed `[Not]BeCloseTo` for `DateTime[Offset]` and `TimeSpan` that took an `int precision` - [#1278](https://github.com/fluentassertions/fluentassertions/pull/1278).
+  * Use the overloads that take a `TimeSpan precision` instead.
 
 ## 5.10.3
 **Fixes**


### PR DESCRIPTION
Whether two time instances are "close" is context dependent and therefore Fluent Assertions should not try to guess a precision.