### PR TITLE
Reduce usage of IsSameOrEqualTo

### DIFF
--- a/Src/FluentAssertions/Common/MethodInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/MethodInfoExtensions.cs
@@ -18,7 +18,7 @@ namespace FluentAssertions.Common
 
         internal static bool IsAsync(this MethodInfo methodInfo)
         {
-            return methodInfo.GetMatchingAttributes<Attribute>(a => a.GetType().FullName.Equals("System.Runtime.CompilerServices.AsyncStateMachineAttribute")).Any();
+            return methodInfo.GetMatchingAttributes<Attribute>(a => a.GetType().FullName == "System.Runtime.CompilerServices.AsyncStateMachineAttribute").Any();
         }
 
         internal static IEnumerable<TAttribute> GetMatchingAttributes<TAttribute>(this MemberInfo memberInfo, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -547,7 +547,7 @@ namespace FluentAssertions.Common
             }
             else
             {
-                return type.IsSameOrEqualTo(definition) || type.IsDerivedFromOpenGeneric(definition);
+                return type == definition || type.IsDerivedFromOpenGeneric(definition);
             }
         }
 
@@ -556,7 +556,7 @@ namespace FluentAssertions.Common
             // check subject against definition
             TypeInfo subjectInfo = type.GetTypeInfo();
             if (subjectInfo.IsInterface && subjectInfo.IsGenericType &&
-                subjectInfo.GetGenericTypeDefinition().IsSameOrEqualTo(definition))
+                subjectInfo.GetGenericTypeDefinition() == definition)
             {
                 return true;
             }
@@ -566,12 +566,12 @@ namespace FluentAssertions.Common
                 .Select(i => i.GetTypeInfo())
                 .Where(i => i.IsGenericType)
                 .Select(i => i.GetGenericTypeDefinition())
-                .Any(d => d.IsSameOrEqualTo(definition));
+                .Contains(definition);
         }
 
         internal static bool IsDerivedFromOpenGeneric(this Type type, Type definition)
         {
-            if (type.IsSameOrEqualTo(definition))
+            if (type == definition)
             {
                 // do not consider a type to be derived from itself
                 return false;
@@ -581,7 +581,7 @@ namespace FluentAssertions.Common
             for (TypeInfo baseType = type.GetTypeInfo(); baseType != null;
                     baseType = baseType.BaseType?.GetTypeInfo())
             {
-                if (baseType.IsGenericType && baseType.GetGenericTypeDefinition().IsSameOrEqualTo(definition))
+                if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == definition)
                 {
                     return true;
                 }

--- a/Src/FluentAssertions/Equivalency/AssertionResultSet.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionResultSet.cs
@@ -39,7 +39,7 @@ namespace FluentAssertions.Equivalency
 
             KeyValuePair<object, string[]> bestMatch = bestResultSets.FirstOrDefault(r => r.Key.Equals(key));
 
-            if (bestMatch.Equals(default(KeyValuePair<object, string[]>)))
+            if ((bestMatch.Key, bestMatch.Value) == default)
             {
                 return bestResultSets[0].Value;
             }

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -53,7 +53,7 @@ namespace FluentAssertions.Formatting
         {
             string str = value.ToString();
 
-            return str is null || str.Equals(value.GetType().ToString());
+            return str is null || str == value.GetType().ToString();
         }
 
         private static string GetTypeAndPublicPropertyValues(object obj, FormattingContext context, FormatChild formatChild)

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -73,7 +73,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && Subject.Value.Equals(expected))
+                .ForCondition(Subject.HasValue && Subject.Value == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:boolean} to be {0}{reason}, but found {1}.", expected, Subject);
 

--- a/Src/FluentAssertions/Primitives/GuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/GuidAssertions.cs
@@ -97,7 +97,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<GuidAssertions> Be(Guid expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.Equals(expected))
+                .ForCondition(Subject.HasValue && Subject.Value == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:Guid} to be {0}{reason}, but found {1}.", expected, Subject);
 
@@ -118,7 +118,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<GuidAssertions> NotBe(Guid unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.Equals(unexpected))
+                .ForCondition(!Subject.HasValue || Subject.Value != unexpected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:Guid} to be {0}{reason}.", Subject);
 

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -53,7 +53,7 @@ namespace FluentAssertions.Types
         public AndConstraint<TypeAssertions> Be(Type expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.IsSameOrEqualTo(expected))
+                .ForCondition(Subject == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(GetFailureMessageIfTypesAreDifferent(Subject, expected));
 

--- a/Src/FluentAssertions/Xml/XAttributeAssertions.cs
+++ b/Src/FluentAssertions/Xml/XAttributeAssertions.cs
@@ -32,7 +32,7 @@ namespace FluentAssertions.Xml
         public AndConstraint<XAttributeAssertions> Be(XAttribute expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.Name.Equals(expected.Name) && Subject.Value.Equals(expected.Value))
+                .ForCondition(Subject.Name == expected.Name && Subject.Value == expected.Value)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected XML attribute to be {0}{reason}, but found {1}.", expected, Subject);
 
@@ -54,7 +54,7 @@ namespace FluentAssertions.Xml
         public AndConstraint<XAttributeAssertions> NotBe(XAttribute unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.Name.Equals(unexpected.Name) || !Subject.Value.Equals(unexpected.Value))
+                .ForCondition(!(Subject.Name == unexpected.Name && Subject.Value == unexpected.Value))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect XML attribute to be {0}{reason}.", unexpected);
 

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -38,7 +38,7 @@ namespace FluentAssertions.Xml
         public AndConstraint<XDocumentAssertions> Be(XDocument expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.IsSameOrEqualTo(expected))
+                .ForCondition(Equals(Subject, expected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected XML document to be {0}{reason}, but found {1}.", expected, Subject);
 
@@ -61,10 +61,7 @@ namespace FluentAssertions.Xml
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(!(Subject is null))
-                .FailWith("Did not expect XML document to be {0}, but found <null>.", unexpected)
-                .Then
-                .ForCondition(!Subject.Equals(unexpected))
+                .ForCondition(!Equals(Subject, unexpected))
                 .FailWith("Did not expect XML document to be {0}{reason}.", unexpected);
 
             return new AndConstraint<XDocumentAssertions>(this);

--- a/Tests/Shared.Specs/Xml/XDocumentAssertionSpecs.cs
+++ b/Tests/Shared.Specs/Xml/XDocumentAssertionSpecs.cs
@@ -57,6 +57,21 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_a_null_xml_document_is_equal_to_a_null_xml_document_it_should_succeed()
+        {
+            // Arrange
+            XDocument document = null;
+            XDocument otherXDocument = null;
+
+            // Act
+            Action act = () =>
+                document.Should().Be(otherXDocument);
+
+            // Assert
+            act.Should().NotThrow<XunitException>();
+        }
+
+        [Fact]
         public void When_asserting_a_xml_document_is_equal_to_a_different_xml_document_it_should_fail_with_descriptive_message()
         {
             // Arrange
@@ -105,7 +120,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_asserting_a_null_xml_document_is_not_equal_to_some_xml_document_it_should_fail()
+        public void When_asserting_a_null_xml_document_is_not_equal_to_some_xml_document_it_should_succeed()
         {
             // Arrange
             XDocument document = null;
@@ -116,8 +131,23 @@ namespace FluentAssertions.Specs
                 document.Should().NotBe(someXDocument);
 
             // Assert
+            act.Should().NotThrow<XunitException>();
+        }
+
+        [Fact]
+        public void When_asserting_a_null_xml_document_is_not_equal_to_a_null_xml_document_it_should_fail()
+        {
+            // Arrange
+            XDocument document = null;
+            XDocument someXDocument = null;
+
+            // Act
+            Action act = () =>
+                document.Should().NotBe(someXDocument);
+
+            // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*not expect XML document to be*, but found <null>*");
+                .WithMessage("Did not expect XML document to be <null>.");
         }
 
         [Fact]


### PR DESCRIPTION
`IsSameOrEqualTo` is necessary when comparing boxed numerics, e.g. that `1` is equal to `1L`.
`Type` and `XDocument` are not numerics, so this check is pure overhead and can be replaced with either `==` or `Equals`.

`KeyValuePair.Equals` uses `ValueType.Equals(object)` and causes boxing.
This is avoided by converting the `KeyValuePair` into a 2-tuple and compare it against the default 2-tuple.

This is split out from #1258 