### PR TITLE
Use Ordinal[IgnoreCase] string comparison

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -121,3 +121,16 @@ csharp_space_between_method_declaration_name_and_open_parenthesis = false
 csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
 csharp_space_between_square_brackets = false
+
+# FxCop Analyzers
+dotnet_diagnostic.CA1030.severity = none
+dotnet_diagnostic.CA1034.severity = none
+dotnet_diagnostic.CA1062.severity = none
+dotnet_diagnostic.CA1304.severity = error
+dotnet_diagnostic.CA1305.severity = none
+dotnet_diagnostic.CA1307.severity = error
+dotnet_diagnostic.CA1308.severity = error
+dotnet_diagnostic.CA1309.severity = error
+
+# Banned API Analyzers
+dotnet_diagnostic.RS0030.severity = error

--- a/Src/FluentAssertions/BannedSymbols.txt
+++ b/Src/FluentAssertions/BannedSymbols.txt
@@ -1,0 +1,5 @@
+﻿F:System.StringComparison.CurrentCulture;Use Ordinal instead
+F:System.StringComparison.CurrentCultureIgnoreCase;Use OrdinalIgnoreCase instead
+F:System.StringComparison.InvariantCulture;Use Ordinal instead
+F:System.StringComparison.InvariantCultureIgnoreCase;Use OrdinalIgnoreCase instead
+P:System.Globalization.CultureInfo.CurrentCulture;Use InvariantCulture instead

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
 using FluentAssertions.Common;
@@ -65,7 +66,7 @@ namespace FluentAssertions
         private static bool IsDotNet(StackFrame frame)
         {
             var frameNamespace = frame.GetMethod().DeclaringType.Namespace;
-            var comparisonType = StringComparison.InvariantCultureIgnoreCase;
+            var comparisonType = StringComparison.OrdinalIgnoreCase;
 
             return frameNamespace?.StartsWith("system.", comparisonType) == true ||
                 frameNamespace?.Equals("system", comparisonType) == true;
@@ -84,7 +85,7 @@ namespace FluentAssertions
 
                 logger(statement);
 
-                int indexOfShould = statement.IndexOf("Should", StringComparison.InvariantCulture);
+                int indexOfShould = statement.IndexOf("Should", StringComparison.Ordinal);
                 if (indexOfShould != -1)
                 {
                     string candidate = statement.Substring(0, indexOfShould - 1);
@@ -146,7 +147,8 @@ namespace FluentAssertions
 
         private static bool IsNumeric(string candidate)
         {
-            return double.TryParse(candidate, out _);
+            const NumberStyles DefaultStyle = NumberStyles.Float | NumberStyles.AllowThousands;
+            return double.TryParse(candidate, DefaultStyle, CultureInfo.InvariantCulture, out _);
         }
 
         private static bool IsBooleanLiteral(string candidate)

--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -149,7 +149,7 @@ namespace FluentAssertions.Common
             string[] reversedSegments = segments.AsEnumerable().Reverse().ToArray();
             string segmentPath = string.Join(".", reversedSegments);
 
-            return new MemberPath(declaringType, segmentPath.Replace(".[", "["));
+            return new MemberPath(declaringType, segmentPath.Replace(".[", "[", StringComparison.Ordinal));
         }
     }
 }

--- a/Src/FluentAssertions/Common/FullFrameworkReflector.cs
+++ b/Src/FluentAssertions/Common/FullFrameworkReflector.cs
@@ -19,14 +19,14 @@ namespace FluentAssertions.Common
 
         private bool IsRelevant(Assembly ass)
         {
-            string assemblyName = ass.GetName().Name.ToLower();
+            string assemblyName = ass.GetName().Name;
 
-            return !assemblyName.StartsWith("microsoft.") &&
-                   !assemblyName.StartsWith("xunit") &&
-                   !assemblyName.StartsWith("jetbrains.") &&
-                   !assemblyName.StartsWith("system") &&
-                   !assemblyName.StartsWith("mscorlib") &&
-                   !assemblyName.StartsWith("newtonsoft");
+            return !assemblyName.StartsWith("microsoft.", StringComparison.OrdinalIgnoreCase) &&
+                   !assemblyName.StartsWith("xunit", StringComparison.OrdinalIgnoreCase) &&
+                   !assemblyName.StartsWith("jetbrains.", StringComparison.OrdinalIgnoreCase) &&
+                   !assemblyName.StartsWith("system", StringComparison.OrdinalIgnoreCase) &&
+                   !assemblyName.StartsWith("mscorlib", StringComparison.OrdinalIgnoreCase) &&
+                   !assemblyName.StartsWith("newtonsoft", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool IsDynamic(Assembly assembly)

--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -31,20 +31,20 @@ namespace FluentAssertions.Common
             int length = Math.Min(value.Length - index, 3);
             string formattedString = Formatter.ToString(value.Substring(index, length));
 
-            return $"{formattedString} (index {index})".Replace("{", "{{").Replace("}", "}}");
+            return $"{formattedString} (index {index})".EscapePlaceholders();
         }
 
         /// <summary>
         /// Replaces all characters that might conflict with formatting placeholders with their escaped counterparts.
         /// </summary>
         public static string EscapePlaceholders(this string value) =>
-            value.Replace("{", "{{").Replace("}", "}}");
+            value.Replace("{", "{{", StringComparison.Ordinal).Replace("}", "}}", StringComparison.Ordinal);
 
         /// <summary>
         /// Replaces all characters that might conflict with formatting placeholders with their escaped counterparts.
         /// </summary>
         internal static string UnescapePlaceholders(this string value) =>
-            value.Replace("{{", "{").Replace("}}", "}");
+            value.Replace("{{", "{", StringComparison.Ordinal).Replace("}}", "}", StringComparison.Ordinal);
 
         /// <summary>
         /// Joins a string with one or more other strings using a specified separator.
@@ -78,7 +78,7 @@ namespace FluentAssertions.Common
             }
 
             char[] charArray = @this.ToCharArray();
-            charArray[0] = char.ToUpper(charArray[0]);
+            charArray[0] = char.ToUpperInvariant(charArray[0]);
             return new string(charArray);
         }
 
@@ -95,7 +95,9 @@ namespace FluentAssertions.Common
 
         public static string RemoveNewLines(this string @this)
         {
-            return @this.Replace("\n", "").Replace("\r", "").Replace("\\r\\n", "");
+            return @this.Replace("\n", "", StringComparison.Ordinal)
+                        .Replace("\r", "", StringComparison.Ordinal)
+                        .Replace("\\r\\n", "", StringComparison.Ordinal);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -496,7 +496,7 @@ namespace FluentAssertions.Common
 
         private static bool IsAnonymousType(this Type type)
         {
-            bool nameContainsAnonymousType = type.FullName.Contains("AnonymousType");
+            bool nameContainsAnonymousType = type.FullName.Contains("AnonymousType", StringComparison.Ordinal);
 
             if (!nameContainsAnonymousType)
             {

--- a/Src/FluentAssertions/Equivalency/CollectionMemberMemberInfo.cs
+++ b/Src/FluentAssertions/Equivalency/CollectionMemberMemberInfo.cs
@@ -15,7 +15,7 @@ namespace FluentAssertions.Equivalency
 
         internal static string GetAdjustedPropertyPath(string propertyPath)
         {
-            return propertyPath.Substring(propertyPath.IndexOf('.') + 1);
+            return propertyPath.Substring(propertyPath.IndexOf('.', StringComparison.Ordinal) + 1);
         }
 
         public SelectedMemberInfo SelectedMemberInfo { get; }

--- a/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
+++ b/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
@@ -108,7 +108,7 @@ namespace FluentAssertions.Equivalency
 
         private static decimal? ExtractDecimal(object o)
         {
-            return o != null ? Convert.ToDecimal(o) : (decimal?)null;
+            return o != null ? Convert.ToDecimal(o, CultureInfo.InvariantCulture) : (decimal?)null;
         }
     }
 }

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
@@ -48,8 +48,8 @@ namespace FluentAssertions.Equivalency
             {
                 // SMELL: That prefix should be obtained from some kind of constant
                 return (SelectedMemberDescription.Length == 0) ||
-                       (RootIsCollection && SelectedMemberDescription.StartsWith("item[") &&
-                        !SelectedMemberDescription.Contains("."));
+                       (RootIsCollection && SelectedMemberDescription.StartsWith("item[", StringComparison.Ordinal) &&
+                        !SelectedMemberDescription.Contains(".", StringComparison.Ordinal));
             }
         }
 

--- a/Src/FluentAssertions/Equivalency/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/ObjectReference.cs
@@ -39,7 +39,8 @@ namespace FluentAssertions.Equivalency
         }
 
         private string[] GetPathElements() => pathElements
-            ?? (pathElements = path.ToUpperInvariant().Replace("][", "].[").Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries));
+            ?? (pathElements = path.ToUpperInvariant().Replace("][", "].[", StringComparison.Ordinal)
+                    .Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries));
 
         private bool IsParentOf(ObjectReference other)
         {

--- a/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
+++ b/Src/FluentAssertions/Equivalency/Ordering/PathBasedOrderingRule.cs
@@ -27,7 +27,7 @@ namespace FluentAssertions.Equivalency.Ordering
                 currentPropertyPath = RemoveInitialIndexQualifier(currentPropertyPath);
             }
 
-            if (currentPropertyPath.Equals(path, StringComparison.CurrentCultureIgnoreCase))
+            if (currentPropertyPath.Equals(path, StringComparison.OrdinalIgnoreCase))
             {
                 return OrderStrictness.Strict;
             }
@@ -39,7 +39,7 @@ namespace FluentAssertions.Equivalency.Ordering
 
         private static bool ContainsIndexingQualifiers(string path)
         {
-            return path.Contains("[") && path.Contains("]");
+            return path.Contains("[", StringComparison.Ordinal) && path.Contains("]", StringComparison.Ordinal);
         }
 
         private string RemoveInitialIndexQualifier(string sourcePath)

--- a/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/SelectMemberByPathSelectionRule.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
@@ -30,7 +31,7 @@ namespace FluentAssertions.Equivalency.Selection
 
         private static bool ContainsIndexingQualifiers(string path)
         {
-            return path.Contains("[") && path.Contains("]");
+            return path.Contains("[", StringComparison.Ordinal) && path.Contains("]", StringComparison.Ordinal);
         }
 
         private string RemoveInitialIndexQualifier(string propertyPath)

--- a/Src/FluentAssertions/Equivalency/TryConversionStep.cs
+++ b/Src/FluentAssertions/Equivalency/TryConversionStep.cs
@@ -64,7 +64,7 @@ namespace FluentAssertions.Equivalency
             conversionResult = null;
             try
             {
-                conversionResult = Convert.ChangeType(subject, expectationType, CultureInfo.CurrentCulture);
+                conversionResult = Convert.ChangeType(subject, expectationType, CultureInfo.InvariantCulture);
                 return true;
             }
             catch (FormatException)

--- a/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
+++ b/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
@@ -29,7 +29,7 @@ namespace FluentAssertions.Execution
 
                 assembly = AppDomain.CurrentDomain
                     .GetAssemblies()
-                    .FirstOrDefault(a => a.FullName.StartsWith(prefix, StringComparison.CurrentCultureIgnoreCase));
+                    .FirstOrDefault(a => a.FullName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
 
                 return (assembly != null);
             }

--- a/Src/FluentAssertions/Execution/MessageBuilder.cs
+++ b/Src/FluentAssertions/Execution/MessageBuilder.cs
@@ -80,7 +80,7 @@ namespace FluentAssertions.Execution
             {
                 string key = match.Groups["key"].Value;
                 string contextualTags = contextData.AsStringOrDefault(key);
-                string contextualTagsSubstituted = contextualTags?.Replace("{", "{{").Replace("}", "}}");
+                string contextualTagsSubstituted = contextualTags?.EscapePlaceholders();
 
                 return contextualTagsSubstituted ?? match.Groups["default"].Value;
             });
@@ -99,7 +99,7 @@ namespace FluentAssertions.Execution
             if (!string.IsNullOrEmpty(reason))
             {
                 reason = EnsurePrefix("because", reason);
-                reason = reason.Replace("{", "{{").Replace("}", "}}");
+                reason = reason.EscapePlaceholders();
 
                 return StartsWithBlank(reason) ? reason : " " + reason;
             }
@@ -113,7 +113,7 @@ namespace FluentAssertions.Execution
             string leadingBlanks = ExtractLeadingBlanksFrom(text);
             string textWithoutLeadingBlanks = text.Substring(leadingBlanks.Length);
 
-            return !textWithoutLeadingBlanks.StartsWith(prefix, StringComparison.CurrentCultureIgnoreCase)
+            return !textWithoutLeadingBlanks.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
                 ? leadingBlanks + prefix + " " + textWithoutLeadingBlanks
                 : text;
         }

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -33,6 +33,12 @@
     <OutputPath>..\..\Artifacts\Release</OutputPath>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="BannedSymbols.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="BannedSymbols.txt" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="..\JetBrainsAnnotations.cs" Link="JetBrainsAnnotations.cs" />
     <None Include="..\FluentAssertions.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
@@ -52,5 +58,15 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
@@ -91,7 +91,7 @@ namespace FluentAssertions.Formatting
 
             return ((mode == ValueFormatterDetectionMode.Scan) || (
                 (mode == ValueFormatterDetectionMode.Specific) &&
-                assembly.FullName.Split(',')[0].Equals(configuration.ValueFormatterAssembly, StringComparison.CurrentCultureIgnoreCase)));
+                assembly.FullName.Split(',')[0].Equals(configuration.ValueFormatterAssembly, StringComparison.OrdinalIgnoreCase)));
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/ByteValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ByteValueFormatter.cs
@@ -1,4 +1,6 @@
-﻿namespace FluentAssertions.Formatting
+﻿using System.Globalization;
+
+namespace FluentAssertions.Formatting
 {
     public class ByteValueFormatter : IValueFormatter
     {
@@ -17,7 +19,7 @@
         /// <inheritdoc />
         public string Format(object value, FormattingContext context, FormatChild formatChild)
         {
-            return "0x" + ((byte)value).ToString("X2");
+            return "0x" + ((byte)value).ToString("X2", CultureInfo.InvariantCulture);
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/DoubleValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DoubleValueFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System;
 
 namespace FluentAssertions.Formatting
 {
@@ -38,7 +39,7 @@ namespace FluentAssertions.Formatting
 
             string formattedValue = doubleValue.ToString("R", CultureInfo.InvariantCulture);
 
-            return (formattedValue.IndexOf('.') == -1) && (formattedValue.IndexOf('E') == -1)
+            return (formattedValue.IndexOf('.', StringComparison.Ordinal) == -1) && (formattedValue.IndexOf('E', StringComparison.Ordinal) == -1)
                 ? formattedValue + ".0"
                 : formattedValue;
         }

--- a/Src/FluentAssertions/Formatting/ExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ExpressionValueFormatter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq.Expressions;
+﻿using System;
+using System.Linq.Expressions;
 
 namespace FluentAssertions.Formatting
 {
@@ -19,7 +20,7 @@ namespace FluentAssertions.Formatting
         /// <inheritdoc />
         public string Format(object value, FormattingContext context, FormatChild formatChild)
         {
-            return value.ToString().Replace(" = ", " == ");
+            return value.ToString().Replace(" = ", " == ", StringComparison.Ordinal);
         }
     }
 }

--- a/Src/FluentAssertions/Primitives/NegatedStringStartValidator.cs
+++ b/Src/FluentAssertions/Primitives/NegatedStringStartValidator.cs
@@ -26,8 +26,7 @@ namespace FluentAssertions.Primitives
         {
             get
             {
-                return (stringComparison == StringComparison.CurrentCultureIgnoreCase) ||
-                    (stringComparison == StringComparison.OrdinalIgnoreCase);
+                return stringComparison == StringComparison.OrdinalIgnoreCase;
             }
         }
 

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -35,7 +35,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<StringAssertions> Be(string expected, string because = "", params object[] becauseArgs)
         {
-            var stringEqualityValidator = new StringEqualityValidator(Subject, expected, StringComparison.CurrentCulture, because, becauseArgs);
+            var stringEqualityValidator = new StringEqualityValidator(Subject, expected, StringComparison.Ordinal, because, becauseArgs);
             stringEqualityValidator.Validate();
 
             return new AndConstraint<StringAssertions>(this);
@@ -93,7 +93,7 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             var expectation = new StringEqualityValidator(
-                Subject, expected, StringComparison.CurrentCultureIgnoreCase, because, becauseArgs);
+                Subject, expected, StringComparison.OrdinalIgnoreCase, because, becauseArgs);
 
             expectation.Validate();
 
@@ -354,7 +354,7 @@ namespace FluentAssertions.Primitives
                 throw new ArgumentException("Cannot compare start of string with empty string.", nameof(expected));
             }
 
-            var stringStartValidator = new StringStartValidator(Subject, expected, StringComparison.CurrentCulture, because, becauseArgs);
+            var stringStartValidator = new StringStartValidator(Subject, expected, StringComparison.Ordinal, because, becauseArgs);
             stringStartValidator.Validate();
 
             return new AndConstraint<StringAssertions>(this);
@@ -381,7 +381,7 @@ namespace FluentAssertions.Primitives
                 throw new ArgumentException("Cannot compare start of string with empty string.", nameof(unexpected));
             }
 
-            var negatedStringStartValidator = new NegatedStringStartValidator(Subject, unexpected, StringComparison.CurrentCulture, because, becauseArgs);
+            var negatedStringStartValidator = new NegatedStringStartValidator(Subject, unexpected, StringComparison.Ordinal, because, becauseArgs);
             negatedStringStartValidator.Validate();
 
             return new AndConstraint<StringAssertions>(this);
@@ -409,7 +409,7 @@ namespace FluentAssertions.Primitives
                 throw new ArgumentException("Cannot compare string start equivalence with empty string.", nameof(expected));
             }
 
-            var stringStartValidator = new StringStartValidator(Subject, expected, StringComparison.CurrentCultureIgnoreCase, because, becauseArgs);
+            var stringStartValidator = new StringStartValidator(Subject, expected, StringComparison.OrdinalIgnoreCase, because, becauseArgs);
             stringStartValidator.Validate();
 
             return new AndConstraint<StringAssertions>(this);
@@ -436,7 +436,7 @@ namespace FluentAssertions.Primitives
                 throw new ArgumentException("Cannot compare start of string with empty string.", nameof(unexpected));
             }
 
-            var negatedStringStartValidator = new NegatedStringStartValidator(Subject, unexpected, StringComparison.CurrentCultureIgnoreCase, because, becauseArgs);
+            var negatedStringStartValidator = new NegatedStringStartValidator(Subject, unexpected, StringComparison.OrdinalIgnoreCase, because, becauseArgs);
             negatedStringStartValidator.Validate();
 
             return new AndConstraint<StringAssertions>(this);
@@ -478,7 +478,7 @@ namespace FluentAssertions.Primitives
             }
 
             Execute.Assertion
-                .ForCondition(Subject.EndsWith(expected))
+                .ForCondition(Subject.EndsWith(expected, StringComparison.Ordinal))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} {0} to end with {1}{reason}.", Subject, expected);
 
@@ -514,7 +514,7 @@ namespace FluentAssertions.Primitives
             }
 
             Execute.Assertion
-                .ForCondition(!Subject.EndsWith(unexpected))
+                .ForCondition(!Subject.EndsWith(unexpected, StringComparison.Ordinal))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} {0} not to end with {1}{reason}.", Subject, unexpected);
 
@@ -557,7 +557,7 @@ namespace FluentAssertions.Primitives
             }
 
             Execute.Assertion
-                .ForCondition(Subject.EndsWith(expected, StringComparison.CurrentCultureIgnoreCase))
+                .ForCondition(Subject.EndsWith(expected, StringComparison.OrdinalIgnoreCase))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} that ends with equivalent of {0}{reason}, but found {1}.", expected, Subject);
 
@@ -593,7 +593,7 @@ namespace FluentAssertions.Primitives
             }
 
             Execute.Assertion
-                .ForCondition(!Subject.EndsWith(unexpected, StringComparison.CurrentCultureIgnoreCase))
+                .ForCondition(!Subject.EndsWith(unexpected, StringComparison.OrdinalIgnoreCase))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} that does not end with equivalent of {0}{reason}, but found {1}.", unexpected, Subject);
 
@@ -692,7 +692,7 @@ namespace FluentAssertions.Primitives
             }
 
             Execute.Assertion
-                .ForCondition(Contains(Subject, expected, StringComparison.CurrentCultureIgnoreCase))
+                .ForCondition(Contains(Subject, expected, StringComparison.OrdinalIgnoreCase))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} {0} to contain the equivalent of {1}{reason}.", Subject, expected);
 
@@ -940,7 +940,7 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Contains(Subject, unexpected, StringComparison.CurrentCultureIgnoreCase))
+                .ForCondition(!Contains(Subject, unexpected, StringComparison.OrdinalIgnoreCase))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:string} to contain equivalent of {0}{reason} but found {1}.", unexpected, Subject);
 

--- a/Src/FluentAssertions/Primitives/StringEqualityValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityValidator.cs
@@ -95,8 +95,7 @@ namespace FluentAssertions.Primitives
         {
             get
             {
-                return (comparisonMode == StringComparison.CurrentCultureIgnoreCase) ||
-                    (comparisonMode == StringComparison.OrdinalIgnoreCase);
+                return comparisonMode == StringComparison.OrdinalIgnoreCase;
             }
         }
     }

--- a/Src/FluentAssertions/Primitives/StringStartValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringStartValidator.cs
@@ -27,8 +27,7 @@ namespace FluentAssertions.Primitives
         {
             get
             {
-                return (stringComparison == StringComparison.CurrentCultureIgnoreCase) ||
-                    (stringComparison == StringComparison.OrdinalIgnoreCase);
+                return stringComparison == StringComparison.OrdinalIgnoreCase;
             }
         }
 

--- a/Src/FluentAssertions/Primitives/StringValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringValidator.cs
@@ -60,7 +60,7 @@ namespace FluentAssertions.Primitives
 
         private static bool IsLongOrMultiline(string value)
         {
-            return (value.Length > HumanReadableLength) || value.Contains(Environment.NewLine);
+            return (value.Length > HumanReadableLength) || value.Contains(Environment.NewLine, StringComparison.Ordinal);
         }
 
         protected virtual bool ValidateAgainstSuperfluousWhitespace()

--- a/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringWildcardMatchingValidator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -39,7 +40,11 @@ namespace FluentAssertions.Primitives
 
         private static string ConvertWildcardToRegEx(string wildcardExpression)
         {
-            return "^" + Regex.Escape(wildcardExpression).Replace("\\*", ".*").Replace("\\?", ".") + "$";
+            return "^"
+                + Regex.Escape(wildcardExpression)
+                 .Replace("\\*", ".*", StringComparison.Ordinal)
+                 .Replace("\\?", ".", StringComparison.Ordinal)
+                + "$";
         }
 
         private string CleanNewLines(string input)

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -219,9 +219,7 @@ namespace FluentAssertions.Specialized
                     foreach (string failure in results.SelectClosestMatchFor())
                     {
                         string replacedCurlyBraces =
-                            failure
-                                .Replace("{", "{{")
-                                .Replace("}", "}}");
+                            failure.EscapePlaceholders();
                         AssertionScope.Current.FailWith(replacedCurlyBraces);
                     }
                 }

--- a/Src/FluentAssertions/SystemExtensions.cs
+++ b/Src/FluentAssertions/SystemExtensions.cs
@@ -1,0 +1,19 @@
+﻿#if NET47 || NETSTANDARD2_0
+namespace System
+{
+    internal static class SystemExtensions
+    {
+        // https://docs.microsoft.com/en-us/dotnet/api/system.string.indexof?view=netframework-4.8#System_String_IndexOf_System_Char_
+        public static int IndexOf(this string str, char c, StringComparison _) =>
+            str.IndexOf(c);
+
+        // https://docs.microsoft.com/en-us/dotnet/api/system.string.replace?view=netframework-4.8#System_String_Replace_System_String_System_String_
+        public static string Replace(this string str, string oldValue, string newValue, StringComparison _) =>
+            str.Replace(oldValue, newValue);
+
+        // https://docs.microsoft.com/en-us/dotnet/api/system.string.indexof?view=netframework-4.8#System_String_IndexOf_System_String_System_StringComparison_
+        public static bool Contains(this string str, string value, StringComparison comparison) =>
+            str.IndexOf(value, comparison) != -1;
+    }
+}
+#endif

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -1233,7 +1233,7 @@ namespace FluentAssertions.Specs
 
             // Act
             Action action = () => actual.Should().Equal(expected,
-                (a, e) => string.Equals(a, e.Value, StringComparison.CurrentCultureIgnoreCase));
+                (a, e) => string.Equals(a, e.Value, StringComparison.OrdinalIgnoreCase));
 
             // Assert
             action.Should().NotThrow();
@@ -1254,7 +1254,7 @@ namespace FluentAssertions.Specs
 
             // Act
             Action action = () => actual.Should().Equal(expected,
-                (a, e) => string.Equals(a, e.Value, StringComparison.CurrentCultureIgnoreCase));
+                (a, e) => string.Equals(a, e.Value, StringComparison.OrdinalIgnoreCase));
 
             // Assert
             action

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -256,7 +256,7 @@ namespace FluentAssertions.Specs
 
             // Act
             Action action = () => actual.Should().Equal(expected,
-                (a, e) => string.Equals(a, e, StringComparison.CurrentCultureIgnoreCase));
+                (a, e) => string.Equals(a, e, StringComparison.OrdinalIgnoreCase));
 
             // Assert
             action.Should().NotThrow();
@@ -315,7 +315,7 @@ namespace FluentAssertions.Specs
 
             // Act
             Action action = () => actual.Should().Equal(expected,
-                (a, e) => string.Equals(a, e, StringComparison.CurrentCultureIgnoreCase));
+                (a, e) => string.Equals(a, e, StringComparison.OrdinalIgnoreCase));
 
             // Assert
             action

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedFactAttribute.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedFactAttribute.cs
@@ -1,0 +1,11 @@
+﻿using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.CultureAwareTesting
+{
+    [XunitTestCaseDiscoverer("FluentAssertions.Specs.CultureAwareTesting.CulturedFactAttributeDiscoverer", "FluentAssertions.Specs")]
+    public sealed class CulturedFactAttribute : FactAttribute
+    {
+        public CulturedFactAttribute(params string[] cultures) { }
+    }
+}

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedFactAttributeDiscoverer.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedFactAttributeDiscoverer.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.CultureAwareTesting
+{
+    public class CulturedFactAttributeDiscoverer : IXunitTestCaseDiscoverer
+    {
+        private readonly IMessageSink diagnosticMessageSink;
+
+        public CulturedFactAttributeDiscoverer(IMessageSink diagnosticMessageSink)
+        {
+            this.diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        {
+            var ctorArgs = factAttribute.GetConstructorArguments().ToArray();
+            var cultures = Reflector.ConvertArguments(ctorArgs, new[] { typeof(string[]) }).Cast<string[]>().Single();
+
+            if (cultures == null || cultures.Length == 0)
+                cultures = new[] { "en-US", "fr-FR" };
+
+            TestMethodDisplay methodDisplay = discoveryOptions.MethodDisplayOrDefault();
+            TestMethodDisplayOptions methodDisplayOptions = discoveryOptions.MethodDisplayOptionsOrDefault();
+
+            return cultures.Select(culture => new CulturedXunitTestCase(diagnosticMessageSink, methodDisplay, methodDisplayOptions, testMethod, culture)).ToList();
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedTheoryAttribute.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedTheoryAttribute.cs
@@ -1,0 +1,11 @@
+﻿using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.CultureAwareTesting
+{
+    [XunitTestCaseDiscoverer("FluentAssertions.Specs.CultureAwareTesting.CulturedTheoryAttributeDiscoverer", "FluentAssertions.Specs")]
+    public sealed class CulturedTheoryAttribute : TheoryAttribute
+    {
+        public CulturedTheoryAttribute(params string[] cultures) { }
+    }
+}

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedTheoryAttributeDiscoverer.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedTheoryAttributeDiscoverer.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.CultureAwareTesting
+{
+    public class CulturedTheoryAttributeDiscoverer : TheoryDiscoverer
+    {
+        public CulturedTheoryAttributeDiscoverer(IMessageSink diagnosticMessageSink)
+            : base(diagnosticMessageSink) { }
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
+        {
+            var cultures = GetCultures(theoryAttribute);
+            return cultures.Select(culture => new CulturedXunitTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, culture, dataRow)).ToList();
+        }
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
+        {
+            var cultures = GetCultures(theoryAttribute);
+            return cultures.Select(culture => new CulturedXunitTheoryTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, culture)).ToList();
+        }
+
+        private static string[] GetCultures(IAttributeInfo culturedTheoryAttribute)
+        {
+            var ctorArgs = culturedTheoryAttribute.GetConstructorArguments().ToArray();
+            var cultures = Reflector.ConvertArguments(ctorArgs, new[] { typeof(string[]) }).Cast<string[]>().Single();
+
+            if (cultures == null || cultures.Length == 0)
+                cultures = new[] { "en-US", "fr-FR" };
+
+            return cultures;
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedXunitTestCase.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedXunitTestCase.cs
@@ -1,0 +1,92 @@
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.CultureAwareTesting
+{
+    public class CulturedXunitTestCase : XunitTestCase
+    {
+        private string culture;
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public CulturedXunitTestCase() { }
+
+        public CulturedXunitTestCase(IMessageSink diagnosticMessageSink,
+                                     TestMethodDisplay defaultMethodDisplay,
+                                     TestMethodDisplayOptions defaultMethodDisplayOptions,
+                                     ITestMethod testMethod,
+                                     string culture,
+                                     object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
+        {
+            Initialize(culture);
+        }
+
+        private void Initialize(string culture)
+        {
+            this.culture = culture;
+
+            Traits.Add("Culture", culture);
+
+            DisplayName += $"[{culture}]";
+        }
+
+        protected override string GetUniqueID()
+            => $"{base.GetUniqueID()}[{culture}]";
+
+        public override void Deserialize(IXunitSerializationInfo data)
+        {
+            base.Deserialize(data);
+
+            Initialize(data.GetValue<string>("Culture"));
+        }
+
+        public override void Serialize(IXunitSerializationInfo data)
+        {
+            base.Serialize(data);
+
+            data.AddValue("Culture", culture);
+        }
+
+        public override async Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
+                                                        IMessageBus messageBus,
+                                                        object[] constructorArguments,
+                                                        ExceptionAggregator aggregator,
+                                                        CancellationTokenSource cancellationTokenSource)
+        {
+            CultureInfo originalCulture = CurrentCulture;
+            CultureInfo originalUICulture = CurrentUICulture;
+
+            try
+            {
+                var cultureInfo = new CultureInfo(culture);
+                CurrentCulture = cultureInfo;
+                CurrentUICulture = cultureInfo;
+
+                return await base.RunAsync(diagnosticMessageSink, messageBus, constructorArguments, aggregator, cancellationTokenSource);
+            }
+            finally
+            {
+                CurrentCulture = originalCulture;
+                CurrentUICulture = originalUICulture;
+            }
+        }
+
+        private static CultureInfo CurrentCulture
+        {
+            get => CultureInfo.CurrentCulture;
+            set => CultureInfo.CurrentCulture = value;
+        }
+
+        private static CultureInfo CurrentUICulture
+        {
+            get => CultureInfo.CurrentUICulture;
+            set => CultureInfo.CurrentUICulture = value;
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedXunitTheoryTestCase.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedXunitTheoryTestCase.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.CultureAwareTesting
+{
+    public class CulturedXunitTheoryTestCase : XunitTheoryTestCase
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public CulturedXunitTheoryTestCase() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CulturedXunitTheoryTestCase"/> class.
+        /// </summary>
+        /// <param name="diagnosticMessageSink">The message sink used to send diagnostic messages</param>
+        /// <param name="defaultMethodDisplay">Default method display to use (when not customized).</param>
+        /// <param name="defaultMethodDisplayOptions">Default method display options to use (when not customized).</param>
+        /// <param name="testMethod">The method under test.</param>
+        public CulturedXunitTheoryTestCase(IMessageSink diagnosticMessageSink,
+                                           TestMethodDisplay defaultMethodDisplay,
+                                           TestMethodDisplayOptions defaultMethodDisplayOptions,
+                                           ITestMethod testMethod,
+                                           string culture)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod)
+        {
+            Initialize(culture);
+        }
+
+        public string Culture { get; private set; }
+
+        public override void Deserialize(IXunitSerializationInfo data)
+        {
+            base.Deserialize(data);
+
+            Initialize(data.GetValue<string>("Culture"));
+        }
+
+        protected override string GetUniqueID()
+            => $"{base.GetUniqueID()}[{Culture}]";
+
+        private void Initialize(string culture)
+        {
+            Culture = culture;
+
+            Traits.Add("Culture", culture);
+
+            DisplayName += $"[{culture}]";
+        }
+
+        public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
+                                                  IMessageBus messageBus,
+                                                  object[] constructorArguments,
+                                                  ExceptionAggregator aggregator,
+                                                  CancellationTokenSource cancellationTokenSource)
+            => new CulturedXunitTheoryTestCaseRunner(this, DisplayName, SkipReason, constructorArguments, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource).RunAsync();
+
+        public override void Serialize(IXunitSerializationInfo data)
+        {
+            base.Serialize(data);
+
+            data.AddValue("Culture", Culture);
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedXunitTheoryTestCaseRunner.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedXunitTheoryTestCaseRunner.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.CultureAwareTesting
+{
+    public class CulturedXunitTheoryTestCaseRunner : XunitTheoryTestCaseRunner
+    {
+        private readonly string culture;
+        private CultureInfo originalCulture;
+        private CultureInfo originalUICulture;
+
+        public CulturedXunitTheoryTestCaseRunner(CulturedXunitTheoryTestCase culturedXunitTheoryTestCase,
+                                                 string displayName,
+                                                 string skipReason,
+                                                 object[] constructorArguments,
+                                                 IMessageSink diagnosticMessageSink,
+                                                 IMessageBus messageBus,
+                                                 ExceptionAggregator aggregator,
+                                                 CancellationTokenSource cancellationTokenSource)
+            : base(culturedXunitTheoryTestCase, displayName, skipReason, constructorArguments, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource)
+        {
+            culture = culturedXunitTheoryTestCase.Culture;
+        }
+
+        protected override Task AfterTestCaseStartingAsync()
+        {
+            try
+            {
+                originalCulture = CurrentCulture;
+                originalUICulture = CurrentUICulture;
+
+                var cultureInfo = new CultureInfo(culture);
+                CurrentCulture = cultureInfo;
+                CurrentUICulture = cultureInfo;
+            }
+            catch (Exception ex)
+            {
+                Aggregator.Add(ex);
+                return Task.FromResult(0);
+            }
+
+            return base.AfterTestCaseStartingAsync();
+        }
+
+        protected override Task BeforeTestCaseFinishedAsync()
+        {
+            if (originalUICulture != null)
+                CurrentUICulture = originalUICulture;
+            if (originalCulture != null)
+                CurrentCulture = originalCulture;
+
+            return base.BeforeTestCaseFinishedAsync();
+        }
+
+        private static CultureInfo CurrentCulture
+        {
+            get => CultureInfo.CurrentCulture;
+            set => CultureInfo.CurrentCulture = value;
+        }
+
+        private static CultureInfo CurrentUICulture
+        {
+            get => CultureInfo.CurrentUICulture;
+            set => CultureInfo.CurrentUICulture = value;
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/DictionaryExtensions.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/DictionaryExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace FluentAssertions.Specs.CultureAwareTesting
+{
+    internal static class DictionaryExtensions
+    {
+        public static void Add<TKey, TValue>(this IDictionary<TKey, List<TValue>> dictionary, TKey key, TValue value) =>
+            dictionary.GetOrAdd(key).Add(value);
+
+        public static TValue GetOrAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
+            where TValue : new() =>
+            dictionary.GetOrAdd(key, () => new TValue());
+
+        public static TValue GetOrAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, Func<TValue> newValue)
+        {
+            if (!dictionary.TryGetValue(key, out TValue result))
+            {
+                result = newValue();
+                dictionary[key] = result;
+            }
+
+            return result;
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Equivalency;
@@ -565,7 +566,7 @@ namespace FluentAssertions.Specs
 
             var actual = new
             {
-                ThisIsMyDateTime = expectation.ThisIsMyDateTime.ToString()
+                ThisIsMyDateTime = expectation.ThisIsMyDateTime.ToString(CultureInfo.InvariantCulture)
             };
 
             //Asserts

--- a/Tests/FluentAssertions.Specs/Primitives/StringComparisonSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringComparisonSpecs.cs
@@ -1,0 +1,283 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions.Specs.CultureAwareTesting;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Primitives
+{
+    // Due to CulturedTheory changing CultureInfo
+    [CollectionDefinition(nameof(StringComparisonSpecs), DisableParallelization = true)]
+    public class StringComparisonDefinition { }
+
+    [Collection(nameof(StringComparisonSpecs))]
+    public class StringComparisonSpecs
+    {
+        [CulturedTheory("tr-TR")]
+        [MemberData(nameof(EquivalencyData))]
+        public void When_comparing_the_Turkish_letter_i_it_should_differ_by_dottedness(string subject, string expected)
+        {
+            // Act
+            bool ordinal = string.Equals(subject, expected, StringComparison.OrdinalIgnoreCase);
+            bool currentCulture = string.Equals(subject, expected, StringComparison.CurrentCultureIgnoreCase);
+
+            // Assert
+            ordinal.Should().Be(!currentCulture, "Turkish distinguishes between a dotted and a non-dotted 'i'");
+        }
+
+        [CulturedTheory("zh-CN")]
+        [MemberData(nameof(EqualityData))]
+        public void When_comparing_Mandarin_diacritics_they_should_be_the_same(string subject, string expected)
+        {
+            // Act
+            bool ordinal = string.Equals(subject, expected, StringComparison.Ordinal);
+            bool currentCulture = string.Equals(subject, expected, StringComparison.CurrentCulture);
+
+            // Assert
+            ordinal.Should().Be(!currentCulture,
+                "Mandarin does not distinguish between the vertical order of macron and umlaut diacritics");
+        }
+
+        [CulturedTheory("tr-TR")]
+        [MemberData(nameof(EquivalencyData))]
+        public void When_comparing_strings_for_equivalency_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expected);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [CulturedTheory("zh-CN")]
+        [MemberData(nameof(EqualityData))]
+        public void When_comparing_strings_for_equality_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().Be(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [CulturedTheory("zh-CN")]
+        [MemberData(nameof(EqualityData))]
+        public void When_comparing_strings_for_having_prefix_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().StartWith(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [CulturedTheory("zh-CN")]
+        [MemberData(nameof(EqualityData))]
+        public void When_comparing_strings_for_not_having_prefix_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().NotStartWith(expected);
+
+            // Assert
+            act.Should().NotThrow<XunitException>();
+        }
+
+        [CulturedTheory("tr-TR")]
+        [MemberData(nameof(EquivalencyData))]
+        public void When_comparing_strings_for_having_equivalent_prefix_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().StartWithEquivalent(expected);
+
+            // Assert
+            act.Should().NotThrow<XunitException>();
+        }
+
+        [CulturedTheory("tr-TR")]
+        [MemberData(nameof(EquivalencyData))]
+        public void When_comparing_strings_for_not_having_equivalent_prefix_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().NotStartWithEquivalentOf(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [CulturedTheory("zh-CN")]
+        [MemberData(nameof(EqualityData))]
+        public void When_comparing_strings_for_having_suffix_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().EndWith(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [CulturedTheory("zh-CN")]
+        [MemberData(nameof(EqualityData))]
+        public void When_comparing_strings_for_not_having_suffix_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().NotEndWith(expected);
+
+            // Assert
+            act.Should().NotThrow<XunitException>();
+        }
+
+        [CulturedTheory("tr-TR")]
+        [MemberData(nameof(EquivalencyData))]
+        public void When_comparing_strings_for_having_equivalent_suffix_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().EndWithEquivalent(expected);
+
+            // Assert
+            act.Should().NotThrow<XunitException>();
+        }
+
+        [CulturedTheory("tr-TR")]
+        [MemberData(nameof(EquivalencyData))]
+        public void When_comparing_strings_for_not_having_equivalent_suffix_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().NotEndWithEquivalentOf(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [CulturedTheory("tr-TR")]
+        [MemberData(nameof(EquivalencyData))]
+        public void When_comparing_strings_for_containing_equivalent_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().ContainEquivalentOf(expected);
+
+            // Assert
+            act.Should().NotThrow<XunitException>();
+        }
+
+        [CulturedTheory("tr-TR")]
+        [MemberData(nameof(EquivalencyData))]
+        public void When_comparing_strings_for_not_containing_equivalent_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().NotContainEquivalentOf(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [CulturedTheory("zh-CN")]
+        [MemberData(nameof(EqualityData))]
+        public void When_comparing_strings_for_containing_equal_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().Contain(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [CulturedTheory("zh-CN")]
+        [MemberData(nameof(EqualityData))]
+        public void When_comparing_strings_for_containing_all_equals_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().ContainAll(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [CulturedTheory("zh-CN")]
+        [MemberData(nameof(EqualityData))]
+        public void When_comparing_strings_for_containing_any_equals_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().ContainAny(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [CulturedTheory("zh-CN")]
+        [MemberData(nameof(EqualityData))]
+        public void When_comparing_strings_for_containing_one_equal_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().Contain(expected, Exactly.Once());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [CulturedTheory("tr-TR")]
+        [MemberData(nameof(EquivalencyData))]
+        public void When_comparing_strings_for_containing_one_equivalent_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().ContainEquivalentOf(expected, Exactly.Once());
+
+            // Assert
+            act.Should().NotThrow<XunitException>();
+        }
+
+        [CulturedTheory("zh-CN")]
+        [MemberData(nameof(EqualityData))]
+        public void When_comparing_strings_for_not_containing_equal_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().NotContain(expected);
+
+            // Assert
+            act.Should().NotThrow<XunitException>();
+        }
+
+        [CulturedTheory("zh-CN")]
+        [MemberData(nameof(EqualityData))]
+        public void When_comparing_strings_for_not_containing_all_equals_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().NotContainAll(expected);
+
+            // Assert
+            act.Should().NotThrow<XunitException>();
+        }
+
+        [CulturedTheory("zh-CN")]
+        [MemberData(nameof(EqualityData))]
+        public void When_comparing_strings_for_not_containing_any_equals_it_should_ignore_culture(string subject, string expected)
+        {
+            // Act
+            Action act = () => subject.Should().NotContainAny(expected);
+
+            // Assert
+            act.Should().NotThrow<XunitException>();
+        }
+
+        public static IEnumerable<object[]> EquivalencyData
+        {
+            get
+            {
+                const string LowerCaseI = "i";
+                const string UpperCaseI = "I";
+
+                return new List<object[]> { new object[] { LowerCaseI, UpperCaseI } };
+            }
+        }
+
+        public static IEnumerable<object[]> EqualityData
+        {
+            get
+            {
+                const string MacronAboveUmlat = "ǖ";
+                const string UmlautAboveMacron = "ṻ";
+
+                return new List<object[]> { new object[] { MacronAboveUmlat, UmlautAboveMacron } };
+            }
+        }
+    }
+}

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -43,6 +43,8 @@ sidebar:
 * The new extension on `TaskCompletionSource<T>` overlays the previously used assertions based on `ObjectAssertions`.
 * Removed `[Not]BeCloseTo` for `DateTime[Offset]` and `TimeSpan` that took an `int precision` - [#1278](https://github.com/fluentassertions/fluentassertions/pull/1278).
   * Use the overloads that take a `TimeSpan precision` instead.
+* Aligned strings to be compared using `Ordinal[Ignorecase]` - [#1283](https://github.com/fluentassertions/fluentassertions/pull/1283).
+* Changed `AutoConversion` to convert using `CultureInfo.InvariantCulture` instead of `CultureInfo.CurrentCulture` - [#1283](https://github.com/fluentassertions/fluentassertions/pull/1283).
 
 ## 5.10.3
 **Fixes**


### PR DESCRIPTION
Unit tests should behave the same no matter the culture of the machine being run on.

* [Microsoft.CodeAnalysis.FxCopAnalyzers](https://github.com/dotnet/roslyn-analyzers#microsoftcodeanalysisfxcopanalyzers)
  * Helps find usages of methods where a `StringComparison` is not specified.
* [Microsoft.CodeAnalysis.BannedApiAnalyzers](https://github.com/dotnet/roslyn-analyzers#microsoftcodeanalysisbannedapianalyzers)
  * Used in conjuction with `BannedSymbols.txt` to prohibit usage of culture aware `StringComparison` and `CultureInfo`.

As netcoreapp2.1/netcoreapp3.0/netstandard2.1 has more string overloads than net47/netstandard2.0 I added some dummy overloads in `SystemExtensions` to satisfy the analyzers.

One large difference in behavior is that `TryConversionStep` now uses `CultureInfo.Invariant` instead of `CultureInfo.CurrentCulture`.

This fixes #1096
This closes #1184 (Thanks @kimsey0 for pushing this change forward)