### PR TITLE
Allows using an IEqualityComparer<T> with BeEquivalentTo

### DIFF
--- a/Src/FluentAssertions/Equivalency/EqualityComparerEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/EqualityComparerEquivalencyStep.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Equivalency
+{
+    public class EqualityComparerEquivalencyStep<T> : IEquivalencyStep
+    {
+        private readonly IEqualityComparer<T> comparer;
+
+        public EqualityComparerEquivalencyStep(IEqualityComparer<T> comparer)
+        {
+            this.comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
+        }
+
+        public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
+        {
+            return config.GetExpectationType(context) == typeof(T);
+        }
+
+        public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
+        {
+            Execute.Assertion
+                .BecauseOf(context.Because, context.BecauseArgs)
+                .ForCondition(context.Subject is T)
+                .FailWith("Expected {context:object} to be of type {0}{because}, but found {1}", typeof(T), context.Subject)
+                .Then
+                .ForCondition(comparer.Equals((T)context.Subject, (T)context.Expectation))
+                .FailWith("Expected {context:object} to be equal to {1} according to {0}{because}, but {2} was not.",
+                    comparer.ToString(), context.Expectation, context.Subject);
+
+            return true;
+        }
+
+        public override string ToString()
+        {
+            return $"Use {comparer} for objects of type {typeof(T)}";
+        }
+    }
+}

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -423,6 +423,27 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
+        /// Ensures the equivalency comparison will create and use an instance of <typeparamref name="TEqualityComparer"/>
+        /// that implements <see cref="IEqualityComparer{T}"/>, any time
+        /// when a property is of type <typeparamref name="T"/>.
+        /// </summary>
+        public TSelf Using<T, TEqualityComparer>() where TEqualityComparer : IEqualityComparer<T>, new()
+        {
+            return Using(new TEqualityComparer());
+        }
+
+        /// <summary>
+        /// Ensures the equivalency comparison will use the specified implementation of <see cref="IEqualityComparer{T}"/>
+        /// any time when a property is of type <typeparamref name="T"/>.
+        /// </summary>
+        public TSelf Using<T>(IEqualityComparer<T> comparer)
+        {
+            userEquivalencySteps.Insert(0, new EqualityComparerEquivalencyStep<T>(comparer));
+
+            return (TSelf)this;
+        }
+
+        /// <summary>
         /// Causes all collections to be compared in the order in which the items appear in the expectation.
         /// </summary>
         public TSelf WithStrictOrdering()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -611,6 +611,13 @@ namespace FluentAssertions.Equivalency
         public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
     }
+    public class EqualityComparerEquivalencyStep<T> : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EqualityComparerEquivalencyStep(System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
     public enum EqualityStrategy
     {
         Equals = 0,
@@ -811,6 +818,9 @@ namespace FluentAssertions.Equivalency
         public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
+        public TSelf Using<T>(System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public TSelf Using<T, TEqualityComparer>()
+            where TEqualityComparer : System.Collections.Generic.IEqualityComparer<T>, new () { }
         public TSelf WithAutoConversion() { }
         public TSelf WithAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf WithStrictOrdering() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -611,6 +611,13 @@ namespace FluentAssertions.Equivalency
         public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
     }
+    public class EqualityComparerEquivalencyStep<T> : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EqualityComparerEquivalencyStep(System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
     public enum EqualityStrategy
     {
         Equals = 0,
@@ -811,6 +818,9 @@ namespace FluentAssertions.Equivalency
         public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
+        public TSelf Using<T>(System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public TSelf Using<T, TEqualityComparer>()
+            where TEqualityComparer : System.Collections.Generic.IEqualityComparer<T>, new () { }
         public TSelf WithAutoConversion() { }
         public TSelf WithAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf WithStrictOrdering() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -611,6 +611,13 @@ namespace FluentAssertions.Equivalency
         public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
     }
+    public class EqualityComparerEquivalencyStep<T> : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EqualityComparerEquivalencyStep(System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
     public enum EqualityStrategy
     {
         Equals = 0,
@@ -811,6 +818,9 @@ namespace FluentAssertions.Equivalency
         public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
+        public TSelf Using<T>(System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public TSelf Using<T, TEqualityComparer>()
+            where TEqualityComparer : System.Collections.Generic.IEqualityComparer<T>, new () { }
         public TSelf WithAutoConversion() { }
         public TSelf WithAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf WithStrictOrdering() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -610,6 +610,13 @@ namespace FluentAssertions.Equivalency
         public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
     }
+    public class EqualityComparerEquivalencyStep<T> : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EqualityComparerEquivalencyStep(System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
     public enum EqualityStrategy
     {
         Equals = 0,
@@ -810,6 +817,9 @@ namespace FluentAssertions.Equivalency
         public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
+        public TSelf Using<T>(System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public TSelf Using<T, TEqualityComparer>()
+            where TEqualityComparer : System.Collections.Generic.IEqualityComparer<T>, new () { }
         public TSelf WithAutoConversion() { }
         public TSelf WithAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf WithStrictOrdering() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -611,6 +611,13 @@ namespace FluentAssertions.Equivalency
         public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
     }
+    public class EqualityComparerEquivalencyStep<T> : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public EqualityComparerEquivalencyStep(System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public override string ToString() { }
+    }
     public enum EqualityStrategy
     {
         Equals = 0,
@@ -811,6 +818,9 @@ namespace FluentAssertions.Equivalency
         public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
+        public TSelf Using<T>(System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public TSelf Using<T, TEqualityComparer>()
+            where TEqualityComparer : System.Collections.Generic.IEqualityComparer<T>, new () { }
         public TSelf WithAutoConversion() { }
         public TSelf WithAutoConversionFor(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf WithStrictOrdering() { }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -16,6 +16,7 @@ sidebar:
 * The `Using`/`When` option on `BeEquivalentTo` will now use the conversion rules when trying to match the predicate - [#1257](https://github.com/fluentassertions/fluentassertions/pull/1257).
 * Added `NotBeWritable` to `PropertyInfoSelectorAssertions` to be able to assert that properties are not writable - [#1269](https://github.com/fluentassertions/fluentassertions/pull/1269).
 * Added extension to assert `TaskCompletionSource<T>` - [#1267](https://github.com/fluentassertions/fluentassertions/pull/1267).
+* Added the ability to pass an `IEqualityComparer<T>` through `BeEquivalentTo(x => x.Using<MyComparer>())` - [#1284](https://github.com/fluentassertions/fluentassertions/pull/1284).
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).


### PR DESCRIPTION
Adds overloads to the `Using` method of `BeEquivalentTo` options parameter to allows using an implementation of `IEqualityComparer<T>` as an alternative to `IEquivalencyStep`.

Resolves #1236 