### PR TITLE
Support chaining `NotThrowAfter` and `NotThrowAsync`

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -71,7 +71,7 @@ namespace FluentAssertions
 
         /// <summary>
         /// Invokes the specified action on a subject so that you can chain it
-        /// with any of the assertions from <see cref="AsyncFunctionAssertions"/>
+        /// with any of the assertions from <see cref="NonGenericAsyncFunctionAssertions"/>
         /// </summary>
         [Pure]
         public static Func<Task> Awaiting<T>(this T subject, Func<T, ValueTask> action)
@@ -81,7 +81,7 @@ namespace FluentAssertions
 
         /// <summary>
         /// Invokes the specified action on a subject so that you can chain it
-        /// with any of the assertions from <see cref="AsyncFunctionAssertions"/>
+        /// with any of the assertions from <see cref="GenericAsyncFunctionAssertions{TResult}"/>
         /// </summary>
         [Pure]
         public static Func<Task<TResult>> Awaiting<T, TResult>(this T subject, Func<T, ValueTask<TResult>> action)

--- a/Src/FluentAssertions/Specialized/ActionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ActionAssertions.cs
@@ -8,7 +8,7 @@ namespace FluentAssertions.Specialized
     /// Contains a number of methods to assert that an <see cref="Action"/> yields the expected result.
     /// </summary>
     [DebuggerNonUserCode]
-    public class ActionAssertions : DelegateAssertions<Action>
+    public class ActionAssertions : DelegateAssertions<Action, ActionAssertions>
     {
         public ActionAssertions(Action subject, IExtractExceptions extractor) : this(subject, extractor, new Clock())
         {
@@ -16,13 +16,7 @@ namespace FluentAssertions.Specialized
 
         public ActionAssertions(Action subject, IExtractExceptions extractor, IClock clock) : base(subject, extractor, clock)
         {
-            Subject = subject;
         }
-
-        /// <summary>
-        /// Gets the <see cref="Action"/> that is being asserted.
-        /// </summary>
-        public new Action Subject { get; }
 
         protected override void InvokeSubject()
         {

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
@@ -12,7 +11,9 @@ using FluentAssertions.Primitives;
 namespace FluentAssertions.Specialized
 {
     [DebuggerNonUserCode]
-    public abstract class DelegateAssertions<TDelegate> : ReferenceTypeAssertions<Delegate, DelegateAssertions<TDelegate>> where TDelegate : Delegate
+    public abstract class DelegateAssertions<TDelegate, TAssertions> : ReferenceTypeAssertions<TDelegate, DelegateAssertions<TDelegate, TAssertions>>
+        where TDelegate : Delegate
+        where TAssertions : DelegateAssertions<TDelegate, TAssertions>
     {
         private readonly IExtractExceptions extractor;
 
@@ -24,13 +25,7 @@ namespace FluentAssertions.Specialized
         {
             this.extractor = extractor ?? throw new ArgumentNullException(nameof(extractor));
             Clock = clock ?? throw new ArgumentNullException(nameof(clock));
-            Subject = @delegate;
         }
-
-        /// <summary>
-        /// Gets the <typeparamref name="TDelegate"/> that is being asserted.
-        /// </summary>
-        public new TDelegate Subject { get; }
 
         private protected IClock Clock { get; }
 
@@ -69,7 +64,7 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DelegateAssertions<TDelegate>> NotThrow<TException>(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : Exception
         {
             Execute.Assertion
@@ -92,7 +87,7 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DelegateAssertions<TDelegate>> NotThrow(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotThrow(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject is object)
@@ -167,7 +162,7 @@ namespace FluentAssertions.Specialized
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
         /// <exception cref="ArgumentOutOfRangeException">Throws if waitTime or pollInterval are negative.</exception>
-        public AndConstraint<DelegateAssertions<TDelegate>> NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject is object)
@@ -206,7 +201,7 @@ namespace FluentAssertions.Specialized
                 .ForCondition(exception is null)
                 .FailWith("Did not expect any exceptions after {0}{reason}, but found {1}.", waitTime, exception);
 
-            return new AndConstraint<DelegateAssertions<TDelegate>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         protected ExceptionAssertions<TException> Throw<TException>(Exception exception, string because, object[] becauseArgs)
@@ -231,17 +226,17 @@ namespace FluentAssertions.Specialized
             return new ExceptionAssertions<TException>(expectedExceptions);
         }
 
-        protected AndConstraint<DelegateAssertions<TDelegate>> NotThrow(Exception exception, string because, object[] becauseArgs)
+        protected AndConstraint<TAssertions> NotThrow(Exception exception, string because, object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(exception is null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect any exception{reason}, but found {0}.", exception);
 
-            return new AndConstraint<DelegateAssertions<TDelegate>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
-        protected AndConstraint<DelegateAssertions<TDelegate>> NotThrow<TException>(Exception exception, string because, object[] becauseArgs) where TException : Exception
+        protected AndConstraint<TAssertions> NotThrow<TException>(Exception exception, string because, object[] becauseArgs) where TException : Exception
         {
             IEnumerable<TException> exceptions = extractor.OfType<TException>(exception);
             Execute.Assertion
@@ -249,7 +244,7 @@ namespace FluentAssertions.Specialized
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {0}{reason}, but found {1}.", typeof(TException), exception);
 
-            return new AndConstraint<DelegateAssertions<TDelegate>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         protected abstract void InvokeSubject();

--- a/Src/FluentAssertions/Specialized/FunctionAssertionHelpers.cs
+++ b/Src/FluentAssertions/Specialized/FunctionAssertionHelpers.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using FluentAssertions.Common;
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Specialized
+{
+    internal class FunctionAssertionHelpers
+    {
+        internal static T NotThrow<T>(Func<T> subject, string because, object[] becauseArgs)
+        {
+            try
+            {
+                return subject();
+            }
+            catch (Exception exception)
+            {
+                Execute.Assertion
+                .ForCondition(exception is null)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Did not expect any exception{reason}, but found {0}.", exception);
+
+                return default;
+            }
+        }
+
+        internal static TResult NotThrowAfter<TResult>(Func<TResult> subject, IClock clock, TimeSpan waitTime, TimeSpan pollInterval, string because, object[] becauseArgs)
+        {
+            if (waitTime < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(waitTime), $"The value of {nameof(waitTime)} must be non-negative.");
+            }
+
+            if (pollInterval < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(pollInterval), $"The value of {nameof(pollInterval)} must be non-negative.");
+            }
+
+            TimeSpan? invocationEndTime = null;
+            Exception exception = null;
+            ITimer timer = clock.StartTimer();
+
+            while (invocationEndTime is null || invocationEndTime < waitTime)
+            {
+                try
+                {
+                    return subject();
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                }
+
+                clock.Delay(pollInterval);
+                invocationEndTime = timer.Elapsed;
+            }
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Did not expect any exceptions after {0}{reason}, but found {1}.", waitTime, exception);
+
+            return default;
+        }
+    }
+}

--- a/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
@@ -6,18 +6,19 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Specialized
 {
-    public class GenericAsyncFunctionAssertions<TResult> : AsyncFunctionAssertions
+    public class GenericAsyncFunctionAssertions<TResult> : AsyncFunctionAssertions<Task<TResult>, GenericAsyncFunctionAssertions<TResult>>
     {
-        private readonly Func<Task<TResult>> subject;
-
         public GenericAsyncFunctionAssertions(Func<Task<TResult>> subject, IExtractExceptions extractor) : this(subject, extractor, new Clock())
         {
         }
 
-        public GenericAsyncFunctionAssertions(Func<Task<TResult>> subject, IExtractExceptions extractor, IClock clock) : base(
-            subject, extractor, clock)
+        public GenericAsyncFunctionAssertions(Func<Task<TResult>> subject, IExtractExceptions extractor, IClock clock) : base(subject, extractor, clock)
         {
-            this.subject = subject;
+        }
+
+        private new TResult InvokeSubject()
+        {
+            return Subject.ExecuteInDefaultSynchronizationContext().GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -31,15 +32,15 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult> CompleteWithin(
+        public new AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult> CompleteWithin(
             TimeSpan timeSpan, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(subject is object)
+                .ForCondition(Subject is object)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context} to complete within {0}{reason}, but found <null>.", timeSpan);
 
-            Task<TResult> task = subject.ExecuteInDefaultSynchronizationContext();
+            Task<TResult> task = Subject.ExecuteInDefaultSynchronizationContext();
             bool completed = Clock.Wait(task, timeSpan);
 
             Execute.Assertion
@@ -61,17 +62,17 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public async Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(
+        public new async Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(
             TimeSpan timeSpan, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(subject is object)
+                .ForCondition(Subject is object)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context} to complete within {0}{reason}, but found <null>.", timeSpan);
 
             using (var timeoutCancellationTokenSource = new CancellationTokenSource())
             {
-                Task<TResult> task = subject.ExecuteInDefaultSynchronizationContext();
+                Task<TResult> task = Subject.ExecuteInDefaultSynchronizationContext();
 
                 Task completedTask =
                     await Task.WhenAny(task, Clock.DelayAsync(timeSpan, timeoutCancellationTokenSource.Token));
@@ -88,6 +89,164 @@ namespace FluentAssertions.Specialized
                     .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
 
                 return new AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>(this, task.Result);
+            }
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Task{T}"/> does not throw any exception.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public new AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult> NotThrow(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+               .ForCondition(Subject is object)
+               .BecauseOf(because, becauseArgs)
+               .FailWith("Expected {context} not to throw{reason}, but found <null>.");
+
+            TResult result = FunctionAssertionHelpers.NotThrow(InvokeSubject, because, becauseArgs);
+            return new AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>(this, result);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Task{T}"/> stops throwing any exception
+        /// after a specified amount of time.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Task{T}"/> is invoked. If it raises an exception,
+        /// the invocation is repeated until it either stops raising any exceptions
+        /// or the specified wait time is exceeded.
+        /// </remarks>
+        /// <param name="waitTime">
+        /// The time after which the <see cref="Task{T}"/> should have stopped throwing any exception.
+        /// </param>
+        /// <param name="pollInterval">
+        /// The time between subsequent invocations of the <see cref="Task{T}"/>.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">Throws if waitTime or pollInterval are negative.</exception>
+        public new AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult> NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(Subject is object)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context} not to throw any exceptions after {0}{reason}, but found <null>.", waitTime);
+
+            TResult result = FunctionAssertionHelpers.NotThrowAfter(InvokeSubject, Clock, waitTime, pollInterval, because, becauseArgs);
+            return new AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>(this, result);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Task{T}"/> does not throw any exception.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public new async Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAsync(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(Subject is object)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context} not to throw{reason}, but found <null>.");
+
+            try
+            {
+                TResult result = await Subject.ExecuteInDefaultSynchronizationContext();
+                return new AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>(this, result);
+            }
+            catch (Exception exception)
+            {
+                NotThrow(exception, because, becauseArgs);
+                return new AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>(this, default(TResult));
+            }
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Task{T}"/> stops throwing any exception
+        /// after a specified amount of time.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Task{T}"/> is invoked. If it raises an exception,
+        /// the invocation is repeated until it either stops raising any exceptions
+        /// or the specified wait time is exceeded.
+        /// </remarks>
+        /// <param name="waitTime">
+        /// The time after which the <see cref="Task{T}"/> should have stopped throwing any exception.
+        /// </param>
+        /// <param name="pollInterval">
+        /// The time between subsequent invocations of the <see cref="Task{T}"/>.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">Throws if waitTime or pollInterval are negative.</exception>
+        public new Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfterAsync(TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
+        {
+            if (waitTime < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(waitTime), $"The value of {nameof(waitTime)} must be non-negative.");
+            }
+
+            if (pollInterval < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(pollInterval),
+                    $"The value of {nameof(pollInterval)} must be non-negative.");
+            }
+
+            Execute.Assertion
+                .ForCondition(Subject is object)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context} not to throw any exceptions after {0}{reason}, but found <null>.", waitTime);
+
+            Func<Task<TResult>> wrappedSubject = Subject.ExecuteInDefaultSynchronizationContext;
+
+            return assertionTask();
+
+            async Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> assertionTask()
+            {
+                TimeSpan? invocationEndTime = null;
+                Exception exception = null;
+                ITimer timer = Clock.StartTimer();
+
+                while (invocationEndTime is null || invocationEndTime < waitTime)
+                {
+                    try
+                    {
+                        TResult result = await wrappedSubject();
+                        return new AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>(this, result);
+                    }
+                    catch (Exception ex)
+                    {
+                        exception = ex;
+                        await Clock.DelayAsync(pollInterval, CancellationToken.None);
+                        invocationEndTime = timer.Elapsed;
+                    }
+                }
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Did not expect any exceptions after {0}{reason}, but found {1}.", waitTime, exception);
+
+                return new AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>(this, default(TResult));
             }
         }
     }

--- a/Src/FluentAssertions/Specialized/NonGenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/NonGenericAsyncFunctionAssertions.cs
@@ -1,92 +1,17 @@
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions.Common;
-using FluentAssertions.Execution;
 
 namespace FluentAssertions.Specialized
 {
-    public class NonGenericAsyncFunctionAssertions : AsyncFunctionAssertions
+    public class NonGenericAsyncFunctionAssertions : AsyncFunctionAssertions<Task, NonGenericAsyncFunctionAssertions>
     {
-        public NonGenericAsyncFunctionAssertions(Func<Task> subject, IExtractExceptions extractor) : this(subject,
-            extractor, new Clock())
+        public NonGenericAsyncFunctionAssertions(Func<Task> subject, IExtractExceptions extractor) : this(subject, extractor, new Clock())
         {
         }
 
-        public NonGenericAsyncFunctionAssertions(Func<Task> subject, IExtractExceptions extractor, IClock clock) : base(subject,
-            extractor, clock)
+        public NonGenericAsyncFunctionAssertions(Func<Task> subject, IExtractExceptions extractor, IClock clock) : base(subject, extractor, clock)
         {
-        }
-
-        /// <summary>
-        /// Asserts that the current <see cref="Task{T}"/> will complete within specified time.
-        /// </summary>
-        /// <param name="timeSpan">The allowed time span for the operation.</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-        /// </param>
-        public AndConstraint<AsyncFunctionAssertions> CompleteWithin(
-            TimeSpan timeSpan, string because = "", params object[] becauseArgs)
-        {
-            Execute.Assertion
-                .ForCondition(Subject is object)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:task} to complete within {0}{reason}, but found <null>.", timeSpan);
-
-            Task task = Subject.ExecuteInDefaultSynchronizationContext();
-            bool completed = Clock.Wait(task, timeSpan);
-
-            Execute.Assertion
-                .ForCondition(completed)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
-
-            return new AndConstraint<AsyncFunctionAssertions>(this);
-        }
-
-        /// <summary>
-        /// Asserts that the current <see cref="Task{T}"/> will complete within the specified time.
-        /// </summary>
-        /// <param name="timeSpan">The allowed time span for the operation.</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-        /// </param>
-        public async Task<AndConstraint<AsyncFunctionAssertions>> CompleteWithinAsync(
-            TimeSpan timeSpan, string because = "", params object[] becauseArgs)
-        {
-            Execute.Assertion
-                .ForCondition(Subject is object)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:task} to complete within {0}{reason}, but found <null>.", timeSpan);
-
-            using (var timeoutCancellationTokenSource = new CancellationTokenSource())
-            {
-                Task task = Subject.ExecuteInDefaultSynchronizationContext();
-
-                Task completedTask =
-                    await Task.WhenAny(task, Clock.DelayAsync(timeSpan, timeoutCancellationTokenSource.Token));
-
-                if (completedTask == task)
-                {
-                    timeoutCancellationTokenSource.Cancel();
-                    await completedTask;
-                }
-
-                Execute.Assertion
-                    .ForCondition(completedTask == task)
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
-
-                return new AndConstraint<AsyncFunctionAssertions>(this);
-            }
         }
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -1754,43 +1754,45 @@ namespace FluentAssertions.Reflection
 }
 namespace FluentAssertions.Specialized
 {
-    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action>
+    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action, FluentAssertions.Specialized.ActionAssertions>
     {
         public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Action Subject { get; }
         protected override void InvokeSubject() { }
     }
-    public class AsyncFunctionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Func<System.Threading.Tasks.Task>>
+    public class AsyncFunctionAssertions<TTask, TAssertions> : FluentAssertions.Specialized.DelegateAssertions<System.Func<TTask>, TAssertions>
+        where TTask : System.Threading.Tasks.Task
+        where TAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<TTask, TAssertions>
     {
-        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
-        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Func<System.Threading.Tasks.Task> Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         protected override void InvokeSubject() { }
-        public System.Threading.Tasks.Task NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task NotThrowAsync(string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
-    public abstract class DelegateAssertions<TDelegate> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Delegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate>>
+    public abstract class DelegateAssertions<TDelegate, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TDelegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate, TAssertions>>
         where TDelegate : System.Delegate
+        where TAssertions : FluentAssertions.Specialized.DelegateAssertions<TDelegate, TAssertions>
     {
         protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
-        public new TDelegate Subject { get; }
         protected abstract void InvokeSubject();
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(string because = "", params object[] becauseArgs) { }
-        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(string because = "", params object[] becauseArgs)
+        public FluentAssertions.AndConstraint<TAssertions> NotThrow(string because = "", params object[] becauseArgs) { }
+        protected FluentAssertions.AndConstraint<TAssertions> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+        protected FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
             where TException : System.Exception { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
@@ -1828,22 +1830,25 @@ namespace FluentAssertions.Specialized
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
-    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
+    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>, FluentAssertions.Specialized.FunctionAssertions<T>>
     {
         public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Func<T> Subject { get; }
         protected override void InvokeSubject() { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions
+    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions<System.Threading.Tasks.Task<TResult>, FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>>
     {
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
     }
     public interface IExtractExceptions
     {
@@ -1854,12 +1859,10 @@ namespace FluentAssertions.Specialized
     {
         public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
     }
-    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions
+    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<System.Threading.Tasks.Task, FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>
     {
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
     public class TaskCompletionSourceAssertions<T>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -1754,43 +1754,45 @@ namespace FluentAssertions.Reflection
 }
 namespace FluentAssertions.Specialized
 {
-    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action>
+    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action, FluentAssertions.Specialized.ActionAssertions>
     {
         public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Action Subject { get; }
         protected override void InvokeSubject() { }
     }
-    public class AsyncFunctionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Func<System.Threading.Tasks.Task>>
+    public class AsyncFunctionAssertions<TTask, TAssertions> : FluentAssertions.Specialized.DelegateAssertions<System.Func<TTask>, TAssertions>
+        where TTask : System.Threading.Tasks.Task
+        where TAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<TTask, TAssertions>
     {
-        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
-        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Func<System.Threading.Tasks.Task> Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         protected override void InvokeSubject() { }
-        public System.Threading.Tasks.Task NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task NotThrowAsync(string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
-    public abstract class DelegateAssertions<TDelegate> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Delegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate>>
+    public abstract class DelegateAssertions<TDelegate, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TDelegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate, TAssertions>>
         where TDelegate : System.Delegate
+        where TAssertions : FluentAssertions.Specialized.DelegateAssertions<TDelegate, TAssertions>
     {
         protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
-        public new TDelegate Subject { get; }
         protected abstract void InvokeSubject();
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(string because = "", params object[] becauseArgs) { }
-        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(string because = "", params object[] becauseArgs)
+        public FluentAssertions.AndConstraint<TAssertions> NotThrow(string because = "", params object[] becauseArgs) { }
+        protected FluentAssertions.AndConstraint<TAssertions> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+        protected FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
             where TException : System.Exception { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
@@ -1828,22 +1830,25 @@ namespace FluentAssertions.Specialized
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
-    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
+    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>, FluentAssertions.Specialized.FunctionAssertions<T>>
     {
         public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Func<T> Subject { get; }
         protected override void InvokeSubject() { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions
+    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions<System.Threading.Tasks.Task<TResult>, FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>>
     {
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
     }
     public interface IExtractExceptions
     {
@@ -1854,12 +1859,10 @@ namespace FluentAssertions.Specialized
     {
         public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
     }
-    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions
+    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<System.Threading.Tasks.Task, FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>
     {
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
     public class TaskCompletionSourceAssertions<T>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -1754,43 +1754,45 @@ namespace FluentAssertions.Reflection
 }
 namespace FluentAssertions.Specialized
 {
-    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action>
+    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action, FluentAssertions.Specialized.ActionAssertions>
     {
         public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Action Subject { get; }
         protected override void InvokeSubject() { }
     }
-    public class AsyncFunctionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Func<System.Threading.Tasks.Task>>
+    public class AsyncFunctionAssertions<TTask, TAssertions> : FluentAssertions.Specialized.DelegateAssertions<System.Func<TTask>, TAssertions>
+        where TTask : System.Threading.Tasks.Task
+        where TAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<TTask, TAssertions>
     {
-        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
-        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Func<System.Threading.Tasks.Task> Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         protected override void InvokeSubject() { }
-        public System.Threading.Tasks.Task NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task NotThrowAsync(string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
-    public abstract class DelegateAssertions<TDelegate> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Delegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate>>
+    public abstract class DelegateAssertions<TDelegate, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TDelegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate, TAssertions>>
         where TDelegate : System.Delegate
+        where TAssertions : FluentAssertions.Specialized.DelegateAssertions<TDelegate, TAssertions>
     {
         protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
-        public new TDelegate Subject { get; }
         protected abstract void InvokeSubject();
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(string because = "", params object[] becauseArgs) { }
-        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(string because = "", params object[] becauseArgs)
+        public FluentAssertions.AndConstraint<TAssertions> NotThrow(string because = "", params object[] becauseArgs) { }
+        protected FluentAssertions.AndConstraint<TAssertions> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+        protected FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
             where TException : System.Exception { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
@@ -1828,22 +1830,25 @@ namespace FluentAssertions.Specialized
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
-    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
+    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>, FluentAssertions.Specialized.FunctionAssertions<T>>
     {
         public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Func<T> Subject { get; }
         protected override void InvokeSubject() { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions
+    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions<System.Threading.Tasks.Task<TResult>, FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>>
     {
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
     }
     public interface IExtractExceptions
     {
@@ -1854,12 +1859,10 @@ namespace FluentAssertions.Specialized
     {
         public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
     }
-    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions
+    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<System.Threading.Tasks.Task, FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>
     {
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
     public class TaskCompletionSourceAssertions<T>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1710,43 +1710,45 @@ namespace FluentAssertions.Reflection
 }
 namespace FluentAssertions.Specialized
 {
-    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action>
+    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action, FluentAssertions.Specialized.ActionAssertions>
     {
         public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Action Subject { get; }
         protected override void InvokeSubject() { }
     }
-    public class AsyncFunctionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Func<System.Threading.Tasks.Task>>
+    public class AsyncFunctionAssertions<TTask, TAssertions> : FluentAssertions.Specialized.DelegateAssertions<System.Func<TTask>, TAssertions>
+        where TTask : System.Threading.Tasks.Task
+        where TAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<TTask, TAssertions>
     {
-        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
-        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Func<System.Threading.Tasks.Task> Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         protected override void InvokeSubject() { }
-        public System.Threading.Tasks.Task NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task NotThrowAsync(string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
-    public abstract class DelegateAssertions<TDelegate> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Delegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate>>
+    public abstract class DelegateAssertions<TDelegate, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TDelegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate, TAssertions>>
         where TDelegate : System.Delegate
+        where TAssertions : FluentAssertions.Specialized.DelegateAssertions<TDelegate, TAssertions>
     {
         protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
-        public new TDelegate Subject { get; }
         protected abstract void InvokeSubject();
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(string because = "", params object[] becauseArgs) { }
-        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(string because = "", params object[] becauseArgs)
+        public FluentAssertions.AndConstraint<TAssertions> NotThrow(string because = "", params object[] becauseArgs) { }
+        protected FluentAssertions.AndConstraint<TAssertions> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+        protected FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
             where TException : System.Exception { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
@@ -1784,22 +1786,25 @@ namespace FluentAssertions.Specialized
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
-    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
+    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>, FluentAssertions.Specialized.FunctionAssertions<T>>
     {
         public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Func<T> Subject { get; }
         protected override void InvokeSubject() { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions
+    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions<System.Threading.Tasks.Task<TResult>, FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>>
     {
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
     }
     public interface IExtractExceptions
     {
@@ -1810,12 +1815,10 @@ namespace FluentAssertions.Specialized
     {
         public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
     }
-    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions
+    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<System.Threading.Tasks.Task, FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>
     {
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
     public class TaskCompletionSourceAssertions<T>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -1754,43 +1754,45 @@ namespace FluentAssertions.Reflection
 }
 namespace FluentAssertions.Specialized
 {
-    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action>
+    public class ActionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Action, FluentAssertions.Specialized.ActionAssertions>
     {
         public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public ActionAssertions(System.Action subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Action Subject { get; }
         protected override void InvokeSubject() { }
     }
-    public class AsyncFunctionAssertions : FluentAssertions.Specialized.DelegateAssertions<System.Func<System.Threading.Tasks.Task>>
+    public class AsyncFunctionAssertions<TTask, TAssertions> : FluentAssertions.Specialized.DelegateAssertions<System.Func<TTask>, TAssertions>
+        where TTask : System.Threading.Tasks.Task
+        where TAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<TTask, TAssertions>
     {
-        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
-        public AsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
+        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
+        public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Func<System.Threading.Tasks.Task> Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         protected override void InvokeSubject() { }
-        public System.Threading.Tasks.Task NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task NotThrowAsync(string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
-    public abstract class DelegateAssertions<TDelegate> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Delegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate>>
+    public abstract class DelegateAssertions<TDelegate, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TDelegate, FluentAssertions.Specialized.DelegateAssertions<TDelegate, TAssertions>>
         where TDelegate : System.Delegate
+        where TAssertions : FluentAssertions.Specialized.DelegateAssertions<TDelegate, TAssertions>
     {
         protected DelegateAssertions(TDelegate @delegate, FluentAssertions.Specialized.IExtractExceptions extractor) { }
-        public new TDelegate Subject { get; }
         protected abstract void InvokeSubject();
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(string because = "", params object[] becauseArgs) { }
-        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(string because = "", params object[] becauseArgs)
+        public FluentAssertions.AndConstraint<TAssertions> NotThrow(string because = "", params object[] becauseArgs) { }
+        protected FluentAssertions.AndConstraint<TAssertions> NotThrow(System.Exception exception, string because, object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        protected FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
+        protected FluentAssertions.AndConstraint<TAssertions> NotThrow<TException>(System.Exception exception, string because, object[] becauseArgs)
             where TException : System.Exception { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.DelegateAssertions<TDelegate>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         protected FluentAssertions.Specialized.ExceptionAssertions<TException> Throw<TException>(System.Exception exception, string because, object[] becauseArgs)
@@ -1828,22 +1830,25 @@ namespace FluentAssertions.Specialized
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
-    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>>
+    public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>, FluentAssertions.Specialized.FunctionAssertions<T>>
     {
         public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public FunctionAssertions(System.Func<T> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Func<T> Subject { get; }
         protected override void InvokeSubject() { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.FunctionAssertions<T>, T> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions
+    public class GenericAsyncFunctionAssertions<TResult> : FluentAssertions.Specialized.AsyncFunctionAssertions<System.Threading.Tasks.Task<TResult>, FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>>
     {
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> NotThrow(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
     }
     public interface IExtractExceptions
     {
@@ -1854,12 +1859,10 @@ namespace FluentAssertions.Specialized
     {
         public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
     }
-    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions
+    public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<System.Threading.Tasks.Task, FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>
     {
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public NonGenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<FluentAssertions.Specialized.AsyncFunctionAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
     public class TaskCompletionSourceAssertions<T>
     {

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -1127,7 +1127,7 @@ namespace FluentAssertions.Specs
                     throw new ArgumentException("An exception was forced");
                 }
 
-                await Task.Delay(0);
+                await Task.Yield();
             };
 
             // Act
@@ -1156,7 +1156,7 @@ namespace FluentAssertions.Specs
                 {
                     throw new ArgumentException("An exception was forced");
                 }
-                await Task.Delay(0);
+                await Task.Yield();
             };
 
             // Act
@@ -1258,7 +1258,7 @@ namespace FluentAssertions.Specs
                     throw new ArgumentException("An exception was forced");
                 }
 
-                await Task.Delay(0);
+                await Task.Yield();
             };
 
             // Act
@@ -1288,7 +1288,7 @@ namespace FluentAssertions.Specs
                     throw new ArgumentException("An exception was forced");
                 }
 
-                await Task.Delay(0);
+                await Task.Yield();
             };
 
             // Act

--- a/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
@@ -438,7 +438,7 @@ namespace FluentAssertions.Specs
 
         #region NotThrowAfter
         [Fact]
-        public void When_subject_it_null_it_should_throw()
+        public void When_subject_is_null_it_should_throw()
         {
             // Arrange
             var waitTime = 0.Milliseconds();
@@ -562,11 +562,11 @@ namespace FluentAssertions.Specs
             };
 
             // Act
-            AndWhichConstraint<FunctionAssertions<int>, int> act =
-                throwShorterThanWaitTime.Should(clock).NotThrowAfter(waitTime, pollInterval);
+            Action act = () => throwShorterThanWaitTime.Should(clock).NotThrowAfter(waitTime, pollInterval)
+                    .Which.Should().Be(42);
 
             // Assert
-            act.Subject.Should().Be(42);
+            act.Should().NotThrow();
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -22,7 +22,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_subject_it_null_when_expecting_to_complete_it_should_throw()
+        public void When_subject_is_null_when_expecting_to_complete_it_should_throw()
         {
             // Arrange
             var timer = new FakeClock();
@@ -70,7 +70,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_subject_it_null_when_expecting_to_complete_async_it_should_throw()
+        public void When_subject_is_null_when_expecting_to_complete_async_it_should_throw()
         {
             // Arrange
             var timer = new FakeClock();

--- a/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
@@ -8,8 +9,9 @@ namespace FluentAssertions.Specs
 {
     public class TaskOfTAssertionSpecs
     {
+        #region CompleteWithin
         [Fact]
-        public void When_subject_it_null_when_expecting_to_complete_it_should_throw()
+        public void When_subject_is_null_when_expecting_to_complete_it_should_throw()
         {
             // Arrange
             var timer = new FakeClock();
@@ -68,9 +70,11 @@ namespace FluentAssertions.Specs
             // Assert
             action.Should().Throw<XunitException>();
         }
+        #endregion
 
+        #region CompleteWithinAsync
         [Fact]
-        public void When_subject_it_null_when_expecting_to_complete_async_it_should_throw()
+        public void When_subject_is_null_when_expecting_to_complete_async_it_should_throw()
         {
             // Arrange
             var timer = new FakeClock();
@@ -129,5 +133,406 @@ namespace FluentAssertions.Specs
             // Assert
             action.Should().Throw<XunitException>();
         }
+        #endregion
+
+        #region NotThrow
+        [Fact]
+        public void When_subject_is_null_when_not_expecting_an_exception_it_should_throw()
+        {
+            // Arrange
+            Func<Task<int>> action = null;
+
+            // Act
+            Action testAction = () => action.Should().NotThrow("because we want to test the failure {0}", "message");
+
+            // Assert
+            testAction.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*found <null>*");
+        }
+
+        [Fact]
+        public void When_method_throws_an_empty_AggregateException_it_should_fail()
+        {
+            // Arrange
+            Func<Task<int>> act = () => throw new AggregateException();
+
+            // Act
+            Action act2 = () => act.Should().NotThrow("because we want to test the failure {0}", "message");
+
+            // Assert
+            act2.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
+        }
+
+        [Fact]
+        public void When_task_does_not_throw_when_not_expecting_an_exception_it_should_succeed()
+        {
+            // Arrange
+            Func<Task<int>> action = () => Task.FromResult(42);
+
+            // Act
+            Action testAction = () => action.Should().NotThrow()
+                .Which.Should().Be(42);
+
+            // Assert
+            testAction.Should().NotThrow();
+        }
+        #endregion
+
+        #region NotThrowAsync
+        [Fact]
+        public void When_subject_is_null_when_expecting_to_not_throw_async_it_should_throw()
+        {
+            // Arrange
+            Func<Task<int>> action = null;
+
+            // Act
+            Func<Task> testAction = () => action.Should().NotThrowAsync(
+                "because we want to test the failure {0}", "message");
+
+            // Assert
+            testAction.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*found <null>*");
+        }
+
+        [Fact]
+        public void When_task_does_not_throw_async_it_should_succeed()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<int>();
+
+            // Act
+            Func<Task> action = async () =>
+            {
+                Func<Task<int>> func = () => taskFactory.Task;
+
+                (await func.Should(timer).NotThrowAsync())
+                    .Which.Should().Be(42);
+            };
+
+            taskFactory.SetResult(42);
+            timer.Complete();
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_task_throws_async_it_should_fail()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<int>();
+
+            // Act
+            Func<Task> action = () =>
+            {
+                Func<Task<int>> func = () => throw new AggregateException();
+
+                return func.Should(timer).NotThrowAsync();
+            };
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+        #endregion
+
+        #region NotThrowAfter
+        [Fact]
+        public void When_subject_is_null_it_should_throw()
+        {
+            // Arrange
+            var waitTime = 0.Milliseconds();
+            var pollInterval = 0.Milliseconds();
+            Func<Task<int>> action = null;
+
+            // Act
+            Action testAction = () => action.Should().NotThrowAfter(
+                waitTime, pollInterval, "because we want to test the failure {0}", "message");
+
+            // Assert
+            testAction.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*found <null>*");
+        }
+
+        [Fact]
+        public void When_wait_time_is_negative_it_should_throw()
+        {
+            // Arrange
+            var waitTime = -1.Milliseconds();
+            var pollInterval = 10.Milliseconds();
+            Func<Task<int>> someFunc = () => Task.FromResult(42);
+
+            // Act
+            Action action = () =>
+                someFunc.Should().NotThrowAfter(waitTime, pollInterval);
+
+            // Assert
+            action.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of waitTime must be non-negative*");
+        }
+
+        [Fact]
+        public void When_poll_interval_is_negative_it_should_throw()
+        {
+            // Arrange
+            var waitTime = 10.Milliseconds();
+            var pollInterval = -1.Milliseconds();
+            Func<Task<int>> someAction = () => Task.FromResult(42);
+
+            // Act
+            Action action = () =>
+                someAction.Should().NotThrowAfter(waitTime, pollInterval);
+
+            // Assert
+            action.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of pollInterval must be non-negative*");
+        }
+
+        [Fact]
+        public void When_no_exception_should_be_thrown_after_wait_time_but_it_was_it_should_throw()
+        {
+            // Arrange
+            var clock = new FakeClock();
+            var timer = clock.StartTimer();
+            var waitTime = 100.Milliseconds();
+            var pollInterval = 10.Milliseconds();
+
+            Func<Task<int>> throwLongerThanWaitTime = () =>
+            {
+                if (timer.Elapsed <= waitTime.Multiply(1.5))
+                {
+                    throw new ArgumentException("An exception was forced");
+                }
+
+                return Task.FromResult(42);
+            };
+
+            // Act
+            Action action = () =>
+                throwLongerThanWaitTime.Should(clock).NotThrowAfter(waitTime, pollInterval, "we passed valid arguments");
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                         .WithMessage("Did not expect any exceptions after 0.100s because we passed valid arguments*");
+        }
+
+        [Fact]
+        public void When_no_exception_should_be_thrown_after_wait_time_and_none_was_it_should_not_throw()
+        {
+            // Arrange
+            var clock = new FakeClock();
+            var timer = clock.StartTimer();
+            var waitTime = 100.Milliseconds();
+            var pollInterval = 10.Milliseconds();
+
+            Func<Task<int>> throwShorterThanWaitTime = () =>
+            {
+                if (timer.Elapsed <= waitTime.Divide(2))
+                {
+                    throw new ArgumentException("An exception was forced");
+                }
+
+                return Task.FromResult(42);
+            };
+
+            // Act
+            Action act = () => throwShorterThanWaitTime.Should(clock).NotThrowAfter(waitTime, pollInterval);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_no_exception_should_be_thrown_after_wait_time_the_func_result_should_be_returned()
+        {
+            // Arrange
+            var clock = new FakeClock();
+            var timer = clock.StartTimer();
+            var waitTime = 100.Milliseconds();
+            var pollInterval = 10.Milliseconds();
+
+            Func<Task<int>> throwShorterThanWaitTime = () =>
+            {
+                if (timer.Elapsed <= waitTime.Divide(2))
+                {
+                    throw new ArgumentException("An exception was forced");
+                }
+
+                return Task.FromResult(42);
+            };
+
+            // Act
+            Action act = () => throwShorterThanWaitTime.Should(clock).NotThrowAfter(waitTime, pollInterval)
+                .Which.Should().Be(42);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_an_assertion_fails_on_NotThrowAfter_succeeding_message_should_be_included()
+        {
+            // Arrange
+            var waitTime = TimeSpan.Zero;
+            var pollInterval = TimeSpan.Zero;
+            Func<Task<int>> throwingFunction = () => throw new Exception();
+
+            // Act
+            Action act = () =>
+            {
+                using (new AssertionScope())
+                {
+                    throwingFunction.Should().NotThrowAfter(waitTime, pollInterval)
+                        .And.BeNull();
+                }
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "*Did not expect any exceptions after*" +
+                    "*to be <null>*"
+                );
+        }
+        #endregion
+
+        #region NotThrowAfterAsync
+        [Fact]
+        public void When_subject_is_null_and_expecting_to_not_throw_async_it_should_throw()
+        {
+            // Arrange
+            var waitTime = 0.Milliseconds();
+            var pollInterval = 0.Milliseconds();
+            Func<Task<int>> action = null;
+
+            // Act
+            Func<Task> testAction = () => action.Should().NotThrowAfterAsync(
+                waitTime, pollInterval, "because we want to test the failure {0}", "message");
+
+            // Assert
+            testAction.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*found <null>*");
+        }
+
+        [Fact]
+        public void When_wait_time_is_negative_and_expecting_to_not_throw_async_it_should_throw()
+        {
+            // Arrange
+            var waitTime = -1.Milliseconds();
+            var pollInterval = 10.Milliseconds();
+
+            var asyncObject = new AsyncClass();
+            Func<Task<int>> someFunc = () => asyncObject.ReturnTaskInt();
+
+            // Act
+            Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of waitTime must be non-negative*");
+        }
+
+        [Fact]
+        public void When_poll_interval_is_negative_and_expecting_to_not_throw_async_it_should_throw()
+        {
+            // Arrange
+            var waitTime = 10.Milliseconds();
+            var pollInterval = -1.Milliseconds();
+
+            var asyncObject = new AsyncClass();
+            Func<Task<int>> someFunc = () => asyncObject.ReturnTaskInt();
+
+            // Act
+            Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of pollInterval must be non-negative*");
+        }
+
+        [Fact]
+        public void When_no_exception_should_be_thrown_async_for_null_after_wait_time_it_should_throw()
+        {
+            // Arrange
+            var waitTime = 2.Seconds();
+            var pollInterval = 10.Milliseconds();
+
+            Func<Task<int>> func = null;
+
+            // Act
+            Func<Task> action = () => func.Should()
+                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("*but found <null>*");
+        }
+
+        [Fact]
+        public void When_no_exception_should_be_thrown_async_after_wait_time_but_it_was_it_should_throw()
+        {
+            // Arrange
+            var waitTime = 2.Seconds();
+            var pollInterval = 10.Milliseconds();
+
+            var clock = new FakeClock();
+            var timer = clock.StartTimer();
+            clock.CompleteAfter(waitTime);
+
+            Func<Task<int>> throwLongerThanWaitTime = async () =>
+            {
+                if (timer.Elapsed <= waitTime.Multiply(1.5))
+                {
+                    throw new ArgumentException("An exception was forced");
+                }
+
+                await Task.Yield();
+                return 42;
+            };
+
+            // Act
+            Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
+                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
+        }
+
+        [Fact]
+        public void When_no_exception_should_be_thrown_async_after_wait_time_and_none_was_it_should_not_throw()
+        {
+            // Arrange
+            var waitTime = 6.Seconds();
+            var pollInterval = 10.Milliseconds();
+
+            var clock = new FakeClock();
+            var timer = clock.StartTimer();
+            clock.Delay(waitTime);
+
+            Func<Task<int>> throwShorterThanWaitTime = async () =>
+            {
+                if (timer.Elapsed <= waitTime.Divide(12))
+                {
+                    throw new ArgumentException("An exception was forced");
+                }
+
+                await Task.Yield();
+                return 42;
+            };
+
+            // Act
+            Func<Task> act = async () =>
+            {
+                (await throwShorterThanWaitTime.Should(clock).NotThrowAfterAsync(waitTime, pollInterval))
+                    .Which.Should().Be(42);
+            };
+
+            // Assert
+            act.Should().NotThrow();
+        }
+        #endregion
     }
 }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -20,6 +20,7 @@ sidebar:
 * Added `NotBe` to `BooleanAssertions` to be able to assert that a boolean is not the expected value - [#1290](https://github.com/fluentassertions/fluentassertions/pull/1290).
 * Make `DefaultValueFormatter` and `EnumerableValueFormatter` suitable for inheritance - [#1295](https://github.com/fluentassertions/fluentassertions/pull/1295).
 * Added support for dictionary assertions on `IReadOnlyDictionary<TKey, TValue>` - [#1298](https://github.com/fluentassertions/fluentassertions/pull/1298).
+* `GenericAsyncFunctionAssertions` now has `AndWhichConstraint` overloads for `NotThrow[Async]` and `NotThrowAfter[Async]` - [#1289](https://github.com/fluentassertions/fluentassertions/pull/1289).
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).


### PR DESCRIPTION
This PR enables you to continue asserting on the result of `Func<Task<int>>` when it does not throw.

```c#
Func<Task<int>> func = () => Task.FromResult(42);

func.Should().NotThrow()
    .Which.Should().Be(42);

(await func.Should().NotThrowAsync())
    .Which.Should().Be(42);

func.Should().NotThrowAfter(10.Seconds(), 1.Seconds())
    .Which.Should().Be(42)

(await func.Should().NotThrowAfterAsync(10.Seconds(), 1.Seconds()))
    .Which.Should().Be(42);
```

The implementations and tests are mostly copied from the non-generic or sync versions.
To avoid the redefinitions of `Subject` in each class two changes in generics:
* `DelegateAssertions` and `AsyncFunctionAssertions` are now generic in `TAssertions`.
* `AsyncFunctionAssertions` is also generic in `TTask : Task` to support
  both `Task` and `Task<T>` equally.

This fixes #990