### PR TITLE
Add BooleanAssertions.NotBe

### DIFF
--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -79,5 +79,26 @@ namespace FluentAssertions.Primitives
 
             return new AndConstraint<BooleanAssertions>(this);
         }
+
+        /// <summary>
+        /// Asserts that the value is not equal to the specified <paramref name="unexpected"/> value.
+        /// </summary>
+        /// <param name="unexpected">The unexpected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndConstraint<BooleanAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(!Subject.HasValue || (Subject.Value != unexpected))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:boolean} not to be {0}{reason}, but found {1}.", unexpected, Subject);
+
+            return new AndConstraint<BooleanAssertions>(this);
+        }
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -1367,6 +1367,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -1367,6 +1367,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -1367,6 +1367,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1323,6 +1323,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -1367,6 +1367,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class DateTimeAssertions
     {

--- a/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -109,5 +109,39 @@ namespace FluentAssertions.Specs
             action.Should().Throw<XunitException>()
                 .WithMessage("*Expected*boolean*True*because we want to test the failure message, but found False.*");
         }
+
+        [Fact]
+        public void Should_succeed_when_asserting_boolean_value_not_to_be_equal_to_the_same_value()
+        {
+            // Act
+            Action action = () =>
+                true.Should().NotBe(false);
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_boolean_value_not_to_be_equal_to_a_different_value()
+        {
+            // Act
+            Action action = () =>
+                true.Should().NotBe(true);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Should_fail_with_descriptive_message_when_asserting_boolean_value_not_to_be_equal_to_a_different_value()
+        {
+            // Act
+            Action action = () =>
+                true.Should().NotBe(true, "because we want to test the failure {0}", "message");
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("*Expected*boolean*True*because we want to test the failure message, but found True.*");
+        }
     }
 }

--- a/docs/_pages/booleans.md
+++ b/docs/_pages/booleans.md
@@ -14,6 +14,7 @@ theBoolean.Should().BeFalse("it's set to false");
 theBoolean = true;
 theBoolean.Should().BeTrue();
 theBoolean.Should().Be(otherBoolean);
+theBoolean.Should().NotBe(false);
 ```
 
 Obviously the above assertions also work for nullable booleans, but if you really want to be make sure a boolean is either `true` or `false` and not `null`, you can use these methods.

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -17,6 +17,7 @@ sidebar:
 * Added `NotBeWritable` to `PropertyInfoSelectorAssertions` to be able to assert that properties are not writable - [#1269](https://github.com/fluentassertions/fluentassertions/pull/1269).
 * Added extension to assert `TaskCompletionSource<T>` - [#1267](https://github.com/fluentassertions/fluentassertions/pull/1267).
 * Added the ability to pass an `IEqualityComparer<T>` through `BeEquivalentTo(x => x.Using<MyComparer>())` - [#1284](https://github.com/fluentassertions/fluentassertions/pull/1284).
+* Added `NotBe` to `BooleanAssertions` to be able to assert that a boolean is not the expected value - [#1290](https://github.com/fluentassertions/fluentassertions/pull/1290).
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).


### PR DESCRIPTION
Add assertion method NotBe to BooleanAssertions.

Closes #1285


## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/master/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com).
