### PR TITLE
Renamed [Start|End]WithEquivalent to [Start|End]WithEquivalentOf

### DIFF
--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -399,7 +399,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> StartWithEquivalent(string expected, string because = "",
+        public AndConstraint<StringAssertions> StartWithEquivalentOf(string expected, string because = "",
             params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare string start equivalence with <null>.");
@@ -533,7 +533,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> EndWithEquivalent(string expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<StringAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare string end equivalence with <null>.");
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -1590,7 +1590,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
@@ -1614,7 +1614,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
     }
     public enum TimeSpanCondition
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -1590,7 +1590,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
@@ -1614,7 +1614,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
     }
     public enum TimeSpanCondition
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -1590,7 +1590,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
@@ -1614,7 +1614,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
     }
     public enum TimeSpanCondition
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1546,7 +1546,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
@@ -1570,7 +1570,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
     }
     public enum TimeSpanCondition
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -1590,7 +1590,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
@@ -1614,7 +1614,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalent(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
     }
     public enum TimeSpanCondition
     {

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
@@ -1032,14 +1032,14 @@ namespace FluentAssertions.Specs
             string expectedPrefix = "Ab";
 
             // Act / Assert
-            actual.Should().StartWithEquivalent(expectedPrefix);
+            actual.Should().StartWithEquivalentOf(expectedPrefix);
         }
 
         [Fact]
         public void When_start_of_string_does_not_meet_equivalent_it_should_throw()
         {
             // Act
-            Action act = () => "ABC".Should().StartWithEquivalent("bc", "because it should start");
+            Action act = () => "ABC".Should().StartWithEquivalentOf("bc", "because it should start");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1051,7 +1051,7 @@ namespace FluentAssertions.Specs
         public void When_start_of_string_does_not_meet_equivalent_and_one_of_them_is_long_it_should_display_both_strings_on_separate_line()
         {
             // Act
-            Action act = () => "ABCDEFGHI".Should().StartWithEquivalent("abcddfghi", "it should {0}", "start");
+            Action act = () => "ABCDEFGHI".Should().StartWithEquivalentOf("abcddfghi", "it should {0}", "start");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1064,7 +1064,7 @@ namespace FluentAssertions.Specs
         public void When_start_of_string_is_compared_with_equivalent_of_null_it_should_throw()
         {
             // Act
-            Action act = () => "ABC".Should().StartWithEquivalent(null);
+            Action act = () => "ABC".Should().StartWithEquivalentOf(null);
 
             // Assert
             act.Should().Throw<ArgumentNullException>().WithMessage(
@@ -1075,7 +1075,7 @@ namespace FluentAssertions.Specs
         public void When_start_of_string_is_compared_with_equivalent_of_empty_string_it_should_throw()
         {
             // Act
-            Action act = () => "ABC".Should().StartWithEquivalent("");
+            Action act = () => "ABC".Should().StartWithEquivalentOf("");
 
             // Assert
             act.Should().Throw<ArgumentException>().WithMessage(
@@ -1087,7 +1087,7 @@ namespace FluentAssertions.Specs
         public void When_start_of_string_is_compared_with_equivalent_of_string_that_is_longer_it_should_throw()
         {
             // Act
-            Action act = () => "ABC".Should().StartWithEquivalent("abcdef");
+            Action act = () => "ABC".Should().StartWithEquivalentOf("abcdef");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1101,7 +1101,7 @@ namespace FluentAssertions.Specs
         {
             // Act
             string someString = null;
-            Action act = () => someString.Should().StartWithEquivalent("AbC");
+            Action act = () => someString.Should().StartWithEquivalentOf("AbC");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -1197,7 +1197,7 @@ namespace FluentAssertions.Specs
             string expectedSuffix = "bC";
 
             // Act / Assert
-            actual.Should().EndWithEquivalent(expectedSuffix);
+            actual.Should().EndWithEquivalentOf(expectedSuffix);
         }
 
         [Fact]
@@ -1208,14 +1208,14 @@ namespace FluentAssertions.Specs
             string expectedSuffix = "AbC";
 
             // Act / Assert
-            actual.Should().EndWithEquivalent(expectedSuffix);
+            actual.Should().EndWithEquivalentOf(expectedSuffix);
         }
 
         [Fact]
         public void When_end_of_string_does_not_meet_equivalent_it_should_throw()
         {
             // Act
-            Action act = () => "ABC".Should().EndWithEquivalent("ab", "because it should end");
+            Action act = () => "ABC".Should().EndWithEquivalentOf("ab", "because it should end");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1226,7 +1226,7 @@ namespace FluentAssertions.Specs
         public void When_end_of_string_is_compared_with_equivalent_of_null_it_should_throw()
         {
             // Act
-            Action act = () => "ABC".Should().EndWithEquivalent(null);
+            Action act = () => "ABC".Should().EndWithEquivalentOf(null);
 
             // Assert
             act.Should().Throw<ArgumentNullException>().WithMessage(
@@ -1237,7 +1237,7 @@ namespace FluentAssertions.Specs
         public void When_end_of_string_is_compared_with_equivalent_of_empty_string_it_should_throw()
         {
             // Act
-            Action act = () => "ABC".Should().EndWithEquivalent("");
+            Action act = () => "ABC".Should().EndWithEquivalentOf("");
 
             // Assert
             act.Should().Throw<ArgumentException>().WithMessage(
@@ -1248,7 +1248,7 @@ namespace FluentAssertions.Specs
         public void When_string_ending_is_compared_with_equivalent_of_string_that_is_longer_it_should_throw()
         {
             // Act
-            Action act = () => "ABC".Should().EndWithEquivalent("00abc");
+            Action act = () => "ABC".Should().EndWithEquivalentOf("00abc");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1262,7 +1262,7 @@ namespace FluentAssertions.Specs
         {
             // Act
             string someString = null;
-            Action act = () => someString.Should().EndWithEquivalent("abC");
+            Action act = () => someString.Should().EndWithEquivalentOf("abC");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(

--- a/Tests/FluentAssertions.Specs/Primitives/StringComparisonSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringComparisonSpecs.cs
@@ -87,7 +87,7 @@ namespace FluentAssertions.Specs.Primitives
         public void When_comparing_strings_for_having_equivalent_prefix_it_should_ignore_culture(string subject, string expected)
         {
             // Act
-            Action act = () => subject.Should().StartWithEquivalent(expected);
+            Action act = () => subject.Should().StartWithEquivalentOf(expected);
 
             // Assert
             act.Should().NotThrow<XunitException>();
@@ -131,7 +131,7 @@ namespace FluentAssertions.Specs.Primitives
         public void When_comparing_strings_for_having_equivalent_suffix_it_should_ignore_culture(string subject, string expected)
         {
             // Act
-            Action act = () => subject.Should().EndWithEquivalent(expected);
+            Action act = () => subject.Should().EndWithEquivalentOf(expected);
 
             // Assert
             act.Should().NotThrow<XunitException>();

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -46,6 +46,7 @@ sidebar:
   * Use the overloads that take a `TimeSpan precision` instead.
 * Aligned strings to be compared using `Ordinal[Ignorecase]` - [#1283](https://github.com/fluentassertions/fluentassertions/pull/1283).
 * Changed `AutoConversion` to convert using `CultureInfo.InvariantCulture` instead of `CultureInfo.CurrentCulture` - [#1283](https://github.com/fluentassertions/fluentassertions/pull/1283).
+* Renamed `StartWithEquivalent` and `EndWithEquivalent` to `StartWithEquivalentOf` and `EndWithEquivalentOf` to make the API for Equivalent methods consistent - [#1292](https://github.com/fluentassertions/fluentassertions/pull/1292).
 
 ## 5.10.3
 **Fixes**

--- a/docs/_pages/strings.md
+++ b/docs/_pages/strings.md
@@ -55,12 +55,12 @@ theString.Should().NotContainEquivalentOf("HeRe ThE CaSiNg Is IgNoReD As WeLl");
 
 theString.Should().StartWith("This");
 theString.Should().NotStartWith("This");
-theString.Should().StartWithEquivalent("this");
+theString.Should().StartWithEquivalentOf("this");
 theString.Should().NotStartWithEquivalentOf("this");
 
 theString.Should().EndWith("a String");
 theString.Should().NotEndWith("a String");
-theString.Should().EndWithEquivalent("a string");
+theString.Should().EndWithEquivalentOf("a string");
 theString.Should().NotEndWithEquivalentOf("a string");
 ```
 


### PR DESCRIPTION
Renamed `StartWithEquivalent` and `EndWithEquivalent` to `StartWithEquivalentOf` and `EndWithEquivalentOf` to make the API for Equivalent methods consistent

Closes #1286 

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/master/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com).
