### PR TITLE
Overriding DefaultValueFormatter and EnumerableValueFormatter

### DIFF
--- a/Src/FluentAssertions/Formatting/EnumerableValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/EnumerableValueFormatter.cs
@@ -8,13 +8,19 @@ namespace FluentAssertions.Formatting
     public class EnumerableValueFormatter : IValueFormatter
     {
         /// <summary>
+        /// The number of items to include when formatting this object.
+        /// </summary>
+        /// <remarks>The default value is 32.</remarks>
+        protected virtual int MaxItems { get; } = 32;
+
+        /// <summary>
         /// Indicates whether the current <see cref="IValueFormatter"/> can handle the specified <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value for which to create a <see cref="System.String"/>.</param>
         /// <returns>
         /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
         /// </returns>
-        public bool CanHandle(object value)
+        public virtual bool CanHandle(object value)
         {
             return value is IEnumerable;
         }
@@ -28,11 +34,10 @@ namespace FluentAssertions.Formatting
             {
                 string postfix = "";
 
-                const int maxItems = 32;
-                if (enumerable.Count > maxItems)
+                if (enumerable.Count > MaxItems)
                 {
-                    postfix = $", …{enumerable.Count - maxItems} more…";
-                    enumerable = enumerable.Take(maxItems).ToArray();
+                    postfix = $", …{enumerable.Count - MaxItems} more…";
+                    enumerable = enumerable.Take(MaxItems).ToArray();
                 }
 
                 return "{" + string.Join(", ", enumerable.Select((item, index) => formatChild(index.ToString(), item))) + postfix + "}";

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -1144,8 +1144,11 @@ namespace FluentAssertions.Formatting
     public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DefaultValueFormatter() { }
-        public bool CanHandle(object value) { }
+        protected virtual int SpacesPerIndentionLevel { get; }
+        public virtual bool CanHandle(object value) { }
         public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        protected virtual System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetMembers(System.Type type) { }
+        protected virtual string TypeDisplayName(System.Type type) { }
     }
     public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
@@ -1156,7 +1159,8 @@ namespace FluentAssertions.Formatting
     public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumerableValueFormatter() { }
-        public bool CanHandle(object value) { }
+        protected virtual int MaxItems { get; }
+        public virtual bool CanHandle(object value) { }
         public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -1144,8 +1144,11 @@ namespace FluentAssertions.Formatting
     public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DefaultValueFormatter() { }
-        public bool CanHandle(object value) { }
+        protected virtual int SpacesPerIndentionLevel { get; }
+        public virtual bool CanHandle(object value) { }
         public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        protected virtual System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetMembers(System.Type type) { }
+        protected virtual string TypeDisplayName(System.Type type) { }
     }
     public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
@@ -1156,7 +1159,8 @@ namespace FluentAssertions.Formatting
     public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumerableValueFormatter() { }
-        public bool CanHandle(object value) { }
+        protected virtual int MaxItems { get; }
+        public virtual bool CanHandle(object value) { }
         public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -1144,8 +1144,11 @@ namespace FluentAssertions.Formatting
     public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DefaultValueFormatter() { }
-        public bool CanHandle(object value) { }
+        protected virtual int SpacesPerIndentionLevel { get; }
+        public virtual bool CanHandle(object value) { }
         public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        protected virtual System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetMembers(System.Type type) { }
+        protected virtual string TypeDisplayName(System.Type type) { }
     }
     public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
@@ -1156,7 +1159,8 @@ namespace FluentAssertions.Formatting
     public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumerableValueFormatter() { }
-        public bool CanHandle(object value) { }
+        protected virtual int MaxItems { get; }
+        public virtual bool CanHandle(object value) { }
         public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1100,8 +1100,11 @@ namespace FluentAssertions.Formatting
     public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DefaultValueFormatter() { }
-        public bool CanHandle(object value) { }
+        protected virtual int SpacesPerIndentionLevel { get; }
+        public virtual bool CanHandle(object value) { }
         public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        protected virtual System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetMembers(System.Type type) { }
+        protected virtual string TypeDisplayName(System.Type type) { }
     }
     public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
@@ -1112,7 +1115,8 @@ namespace FluentAssertions.Formatting
     public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumerableValueFormatter() { }
-        public bool CanHandle(object value) { }
+        protected virtual int MaxItems { get; }
+        public virtual bool CanHandle(object value) { }
         public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -1144,8 +1144,11 @@ namespace FluentAssertions.Formatting
     public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DefaultValueFormatter() { }
-        public bool CanHandle(object value) { }
+        protected virtual int SpacesPerIndentionLevel { get; }
+        public virtual bool CanHandle(object value) { }
         public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        protected virtual System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetMembers(System.Type type) { }
+        protected virtual string TypeDisplayName(System.Type type) { }
     }
     public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
@@ -1156,7 +1159,8 @@ namespace FluentAssertions.Formatting
     public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumerableValueFormatter() { }
-        public bool CanHandle(object value) { }
+        protected virtual int MaxItems { get; }
+        public virtual bool CanHandle(object value) { }
         public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter

--- a/docs/_pages/extensibility.md
+++ b/docs/_pages/extensibility.md
@@ -129,6 +129,40 @@ public class DirectoryInfoValueFormatter : IValueFormatter
 }
 ```
 
+Say you want to customize the formatting of your `CustomClass` type to:
+* Increase the indentation from the default 3 to 8,
+* Exclude all `string` members and
+* Exclude the namespace of the type.
+
+An easy way to achieve this is by extending the `DefaultValueFormatter`.
+
+```csharp
+class CustomClassFormatter : DefaultValueFormatter
+{
+    protected override int SpacesPerIndentionLevel => 8;
+
+    public override bool CanHandle(object value) => value is CustomClass;
+
+    protected override IEnumerable<SelectedMemberInfo> GetMembers(Type type) =>
+        base.GetMembers(type).Where(e => e.MemberType != typeof(string));
+
+    protected override string TypeDisplayName(Type type) => type.Name;
+}
+```
+
+Per default the first 32 items are included when formatting an enumerable.
+That might be too many or too few depending on your data.
+To create a formatter that only prints out the first 5 items, when formatting an `IEnumerable<CustomClass>` you can extend the `EnumerableValueFormatter`.
+
+```c#
+class EnumerableCustomClassFormatter : EnumerableValueFormatter
+{
+    protected override int MaxItems => 5;
+
+    public override bool CanHandle(object value) => value is IEnumerable<CustomClass>;
+}
+```
+
 ## To be or not to be a value type ##
 
 The structural equivalency API provided by `Should().BeEquivalentTo` and is arguably the most powerful, but also the most complicated part of Fluent Assertions. And to make things worse, you can extend and adapt the default behavior quite extensively. 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -18,6 +18,7 @@ sidebar:
 * Added extension to assert `TaskCompletionSource<T>` - [#1267](https://github.com/fluentassertions/fluentassertions/pull/1267).
 * Added the ability to pass an `IEqualityComparer<T>` through `BeEquivalentTo(x => x.Using<MyComparer>())` - [#1284](https://github.com/fluentassertions/fluentassertions/pull/1284).
 * Added `NotBe` to `BooleanAssertions` to be able to assert that a boolean is not the expected value - [#1290](https://github.com/fluentassertions/fluentassertions/pull/1290).
+* Make `DefaultValueFormatter` and `EnumerableValueFormatter` suitable for inheritance - [#1295](https://github.com/fluentassertions/fluentassertions/pull/1295).
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).


### PR DESCRIPTION
This PR makes  `DefaultValueFormatter` and `EnumerableValueFormatter` more suitable for extending for making it easier to create custom formatters.