### PR TITLE
Make types generic in `TAssertions`

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -13,9 +13,32 @@ namespace FluentAssertions.Collections
 {
     [DebuggerNonUserCode]
     public class GenericCollectionAssertions<T> :
-        SelfReferencingCollectionAssertions<T, GenericCollectionAssertions<T>>
+        GenericCollectionAssertions<IEnumerable<T>, T, GenericCollectionAssertions<T>>
     {
         public GenericCollectionAssertions(IEnumerable<T> actualValue)
+            : base(actualValue)
+        {
+        }
+    }
+
+    [DebuggerNonUserCode]
+    public class GenericCollectionAssertions<TCollection, T> :
+        GenericCollectionAssertions<TCollection, T, GenericCollectionAssertions<TCollection, T>>
+        where TCollection : IEnumerable<T>
+    {
+        public GenericCollectionAssertions(TCollection actualValue)
+            : base(actualValue)
+        {
+        }
+    }
+
+    [DebuggerNonUserCode]
+    public class GenericCollectionAssertions<TCollection, T, TAssertions> :
+        SelfReferencingCollectionAssertions<TCollection, T, TAssertions>
+        where TCollection : IEnumerable<T>
+        where TAssertions : GenericCollectionAssertions<TCollection, T, TAssertions>
+    {
+        public GenericCollectionAssertions(TCollection actualValue)
             : base(actualValue)
         {
         }
@@ -31,7 +54,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericCollectionAssertions<T>> NotContainNulls<TKey>(Expression<Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotContainNulls<TKey>(Expression<Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
             where TKey : class
         {
             Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
@@ -58,7 +81,7 @@ namespace FluentAssertions.Collections
                         values);
             }
 
-            return new AndConstraint<GenericCollectionAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -72,7 +95,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericCollectionAssertions<T>> OnlyHaveUniqueItems<TKey>(Expression<Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> OnlyHaveUniqueItems<TKey>(Expression<Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
 
@@ -110,7 +133,7 @@ namespace FluentAssertions.Collections
                 }
             }
 
-            return new AndConstraint<GenericCollectionAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -130,7 +153,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
-        public AndConstraint<GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(
+        public AndConstraint<TAssertions> BeInAscendingOrder<TSelector>(
             Expression<Func<T, TSelector>> propertyExpression, string because = "", params object[] args)
         {
             return BeInAscendingOrder(propertyExpression, Comparer<TSelector>.Default, because, args);
@@ -153,7 +176,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
-        public AndConstraint<GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(
+        public AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(
             Expression<Func<T, TSelector>> propertyExpression, string because = "", params object[] args)
         {
             return NotBeInAscendingOrder(propertyExpression, Comparer<TSelector>.Default, because, args);
@@ -176,7 +199,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
-        public AndConstraint<GenericCollectionAssertions<T>> BeInAscendingOrder(
+        public AndConstraint<TAssertions> BeInAscendingOrder(
             IComparer<T> comparer, string because = "", params object[] args)
         {
             return BeInAscendingOrder(item => item, comparer, because, args);
@@ -199,7 +222,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
-        public AndConstraint<GenericCollectionAssertions<T>> NotBeInAscendingOrder(
+        public AndConstraint<TAssertions> NotBeInAscendingOrder(
             IComparer<T> comparer, string because = "", params object[] args)
         {
             return NotBeInAscendingOrder(item => item, comparer, because, args);
@@ -225,7 +248,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
-        public AndConstraint<GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(
+        public AndConstraint<TAssertions> BeInAscendingOrder<TSelector>(
             Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] args)
         {
             return BeOrderedBy(propertyExpression, comparer, SortOrder.Ascending, because, args);
@@ -251,7 +274,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
-        public AndConstraint<GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(
+        public AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(
             Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] args)
         {
             return NotBeOrderedBy(propertyExpression, comparer, SortOrder.Ascending, because, args);
@@ -274,7 +297,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
-        public AndConstraint<GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(
+        public AndConstraint<TAssertions> BeInDescendingOrder<TSelector>(
             Expression<Func<T, TSelector>> propertyExpression, string because = "", params object[] args)
         {
             return BeInDescendingOrder(propertyExpression, Comparer<TSelector>.Default, because, args);
@@ -297,7 +320,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
-        public AndConstraint<GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(
+        public AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(
             Expression<Func<T, TSelector>> propertyExpression, string because = "", params object[] args)
         {
             return NotBeInDescendingOrder(propertyExpression, Comparer<TSelector>.Default, because, args);
@@ -320,7 +343,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
-        public AndConstraint<GenericCollectionAssertions<T>> BeInDescendingOrder(
+        public AndConstraint<TAssertions> BeInDescendingOrder(
             IComparer<T> comparer, string because = "", params object[] args)
         {
             return BeInDescendingOrder(item => item, comparer, because, args);
@@ -343,7 +366,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
-        public AndConstraint<GenericCollectionAssertions<T>> NotBeInDescendingOrder(
+        public AndConstraint<TAssertions> NotBeInDescendingOrder(
             IComparer<T> comparer, string because = "", params object[] args)
         {
             return NotBeInDescendingOrder(item => item, comparer, because, args);
@@ -369,7 +392,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
-        public AndConstraint<GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(
+        public AndConstraint<TAssertions> BeInDescendingOrder<TSelector>(
             Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] args)
         {
             return BeOrderedBy(propertyExpression, comparer, SortOrder.Descending, because, args);
@@ -395,13 +418,13 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
-        public AndConstraint<GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(
+        public AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(
             Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] args)
         {
             return NotBeOrderedBy(propertyExpression, comparer, SortOrder.Descending, because, args);
         }
 
-        private AndConstraint<GenericCollectionAssertions<T>> BeOrderedBy<TSelector>(
+        private AndConstraint<TAssertions> BeOrderedBy<TSelector>(
             Expression<Func<T, TSelector>> propertyExpression,
             IComparer<TSelector> comparer,
             SortOrder direction,
@@ -429,10 +452,10 @@ namespace FluentAssertions.Collections
                         Subject, orderString, expectation);
             }
 
-            return new AndConstraint<GenericCollectionAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
-        private AndConstraint<GenericCollectionAssertions<T>> NotBeOrderedBy<TSelector>(
+        private AndConstraint<TAssertions> NotBeOrderedBy<TSelector>(
             Expression<Func<T, TSelector>> propertyExpression,
             IComparer<TSelector> comparer,
             SortOrder direction,
@@ -460,7 +483,7 @@ namespace FluentAssertions.Collections
                         Subject, orderString, expectation);
             }
 
-            return new AndConstraint<GenericCollectionAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         private bool IsValidProperty<TSelector>(Expression<Func<T, TSelector>> propertyExpression, string because, object[] args)
@@ -517,7 +540,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation,
+        public AndConstraint<TAssertions> AllBeEquivalentTo<TExpectation>(TExpectation expectation,
             string because = "", params object[] becauseArgs)
         {
             return AllBeEquivalentTo(expectation, options => options, because, becauseArgs);
@@ -547,7 +570,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation,
+        public AndConstraint<TAssertions> AllBeEquivalentTo<TExpectation>(TExpectation expectation,
             Func<EquivalencyAssertionOptions<TExpectation>, EquivalencyAssertionOptions<TExpectation>> config,
             string because = "",
             params object[] becauseArgs)

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -16,7 +16,20 @@ namespace FluentAssertions.Collections
     /// </summary>
     [DebuggerNonUserCode]
     public class GenericDictionaryAssertions<TKey, TValue> :
-        ReferenceTypeAssertions<IDictionary<TKey, TValue>, GenericDictionaryAssertions<TKey, TValue>>
+        GenericDictionaryAssertions<TKey, TValue, GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public GenericDictionaryAssertions(IDictionary<TKey, TValue> dictionary) : base(dictionary)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that an <see cref="IDictionary{TKey,TValue}"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class GenericDictionaryAssertions<TKey, TValue, TAssertions> :
+        ReferenceTypeAssertions<IDictionary<TKey, TValue>, TAssertions>
+        where TAssertions : GenericDictionaryAssertions<TKey, TValue, TAssertions>
     {
         public GenericDictionaryAssertions(IDictionary<TKey, TValue> dictionary) : base(dictionary)
         {
@@ -35,7 +48,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> HaveCount(int expected,
+        public AndConstraint<TAssertions> HaveCount(int expected,
             string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
@@ -52,7 +65,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:dictionary} {0} to have {1} item(s){reason}, but found {2}.", Subject, expected, actualCount);
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -66,7 +79,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
             {
@@ -82,7 +95,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:dictionary} {0} to not have {1} item(s){reason}, but found {2}.", Subject, unexpected, actualCount);
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -96,7 +109,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
             {
@@ -112,7 +125,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:dictionary} {0} to contain more than {1} item(s){reason}, but found {2}.", Subject, expected, actualCount);
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -126,7 +139,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
             {
@@ -142,7 +155,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:dictionary} {0} to contain at least {1} item(s){reason}, but found {2}.", Subject, expected, actualCount);
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -156,7 +169,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
             {
@@ -172,7 +185,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:dictionary} {0} to contain fewer than {1} item(s){reason}, but found {2}.", Subject, expected, actualCount);
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -186,7 +199,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
             {
@@ -202,7 +215,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:dictionary} {0} to contain at most {1} item(s){reason}, but found {2}.", Subject, expected, actualCount);
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -216,7 +229,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> HaveCount(Expression<Func<int, bool>> countPredicate,
+        public AndConstraint<TAssertions> HaveCount(Expression<Func<int, bool>> countPredicate,
             string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(countPredicate, nameof(countPredicate), "Cannot compare dictionary count against a <null> predicate.");
@@ -240,7 +253,7 @@ namespace FluentAssertions.Collections
                         Subject, countPredicate.Body, actualCount);
             }
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -254,7 +267,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> HaveSameCount(IEnumerable otherCollection, string because = "",
+        public AndConstraint<TAssertions> HaveSameCount(IEnumerable otherCollection, string because = "",
             params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot compare dictionary count against a <null> collection.");
@@ -276,7 +289,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:dictionary} to have {0} item(s){reason}, but count is {1}.", expectedCount, actualCount);
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -290,7 +303,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotHaveSameCount(IEnumerable otherCollection, string because = "",
+        public AndConstraint<TAssertions> NotHaveSameCount(IEnumerable otherCollection, string because = "",
             params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot compare dictionary count against a <null> collection.");
@@ -321,7 +334,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:dictionary} to not have {0} item(s){reason}, but count is {1}.", expectedCount, actualCount);
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         #endregion
@@ -338,7 +351,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
             {
@@ -352,7 +365,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:dictionary} to not have any items{reason}, but found {0}.", Subject.Count);
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -365,7 +378,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotBeEmpty(string because = "",
+        public AndConstraint<TAssertions> NotBeEmpty(string because = "",
             params object[] becauseArgs)
         {
             if (Subject is null)
@@ -380,7 +393,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected one or more items{reason}, but found none.");
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         #endregion
@@ -400,7 +413,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> Equal(IDictionary<TKey, TValue> expected,
+        public AndConstraint<TAssertions> Equal(IDictionary<TKey, TValue> expected,
             string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
@@ -440,7 +453,7 @@ namespace FluentAssertions.Collections
                     expected, Subject, key);
             }
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -456,7 +469,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotEqual(IDictionary<TKey, TValue> unexpected,
+        public AndConstraint<TAssertions> NotEqual(IDictionary<TKey, TValue> unexpected,
             string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
@@ -489,7 +502,7 @@ namespace FluentAssertions.Collections
                     .FailWith("Did not expect dictionaries {0} and {1} to be equal{reason}.", unexpected, Subject);
             }
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         #endregion
@@ -512,7 +525,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation,
+        public AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation,
             string because = "", params object[] becauseArgs)
         {
             return BeEquivalentTo(expectation, options => options, because, becauseArgs);
@@ -542,7 +555,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation,
+        public AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation,
             Func<EquivalencyAssertionOptions<TExpectation>, EquivalencyAssertionOptions<TExpectation>> config, string because = "",
             params object[] becauseArgs)
         {
@@ -564,7 +577,7 @@ namespace FluentAssertions.Collections
             var equivalencyValidator = new EquivalencyValidator(options);
             equivalencyValidator.AssertEquality(context);
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         #region ContainKey
@@ -581,14 +594,14 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public WhichValueConstraint<TKey, TValue> ContainKey(TKey expected,
+        public WhichValueConstraint<TKey, TValue, TAssertions> ContainKey(TKey expected,
             string because = "", params object[] becauseArgs)
         {
-            AndConstraint<GenericDictionaryAssertions<TKey, TValue>> andConstraint = ContainKeys(new[] { expected }, because, becauseArgs);
+            AndConstraint<TAssertions> andConstraint = ContainKeys(new[] { expected }, because, becauseArgs);
 
             _ = Subject.TryGetValue(expected, out TValue value);
 
-            return new WhichValueConstraint<TKey, TValue>(andConstraint.And, value);
+            return new WhichValueConstraint<TKey, TValue, TAssertions>(andConstraint.And, value);
         }
 
         /// <summary>
@@ -596,7 +609,7 @@ namespace FluentAssertions.Collections
         /// Key comparison will honor the equality comparer of the dictionary when applicable.
         /// </summary>
         /// <param name="expected">The expected keys</param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> ContainKeys(params TKey[] expected)
+        public AndConstraint<TAssertions> ContainKeys(params TKey[] expected)
         {
             return ContainKeys(expected, string.Empty);
         }
@@ -613,7 +626,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> ContainKeys(IEnumerable<TKey> expected,
+        public AndConstraint<TAssertions> ContainKeys(IEnumerable<TKey> expected,
             string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot verify key containment against a <null> collection of keys");
@@ -652,7 +665,7 @@ namespace FluentAssertions.Collections
                 }
             }
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         #endregion
@@ -671,7 +684,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainKey(TKey unexpected,
+        public AndConstraint<TAssertions> NotContainKey(TKey unexpected,
             string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
@@ -688,7 +701,7 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} {0} not to contain key {1}{reason}, but found it anyhow.", Subject, unexpected);
             }
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -696,7 +709,7 @@ namespace FluentAssertions.Collections
         /// Key comparison will honor the equality comparer of the dictionary when applicable.
         /// </summary>
         /// <param name="unexpected">The unexpected keys</param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(params TKey[] unexpected)
+        public AndConstraint<TAssertions> NotContainKeys(params TKey[] unexpected)
         {
             return NotContainKeys(unexpected, string.Empty);
         }
@@ -713,7 +726,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(IEnumerable<TKey> unexpected,
+        public AndConstraint<TAssertions> NotContainKeys(IEnumerable<TKey> unexpected,
             string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot verify key containment against a <null> collection of keys");
@@ -752,7 +765,7 @@ namespace FluentAssertions.Collections
                 }
             }
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         #endregion
@@ -771,15 +784,14 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndWhichConstraint<GenericDictionaryAssertions<TKey, TValue>, TValue> ContainValue(TValue expected,
+        public AndWhichConstraint<TAssertions, TValue> ContainValue(TValue expected,
             string because = "", params object[] becauseArgs)
         {
-            AndWhichConstraint<GenericDictionaryAssertions<TKey, TValue>, IEnumerable<TValue>> innerConstraint =
+            AndWhichConstraint<TAssertions, IEnumerable<TValue>> innerConstraint =
                     ContainValuesAndWhich(new[] { expected }, because, becauseArgs);
 
             return
-                new AndWhichConstraint
-                    <GenericDictionaryAssertions<TKey, TValue>, TValue>(
+                new AndWhichConstraint<TAssertions, TValue>(
                     innerConstraint.And, innerConstraint.Which);
         }
 
@@ -788,7 +800,7 @@ namespace FluentAssertions.Collections
         /// their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
         /// <param name="expected">The expected values</param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> ContainValues(params TValue[] expected)
+        public AndConstraint<TAssertions> ContainValues(params TValue[] expected)
         {
             return ContainValues(expected, string.Empty);
         }
@@ -805,13 +817,13 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> ContainValues(IEnumerable<TValue> expected,
+        public AndConstraint<TAssertions> ContainValues(IEnumerable<TValue> expected,
             string because = "", params object[] becauseArgs)
         {
             return ContainValuesAndWhich(expected, because, becauseArgs);
         }
 
-        private AndWhichConstraint<GenericDictionaryAssertions<TKey, TValue>, IEnumerable<TValue>> ContainValuesAndWhich(IEnumerable<TValue> expected, string because = "",
+        private AndWhichConstraint<TAssertions, IEnumerable<TValue>> ContainValuesAndWhich(IEnumerable<TValue> expected, string because = "",
             params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot verify value containment against a <null> collection of values");
@@ -851,9 +863,8 @@ namespace FluentAssertions.Collections
             }
 
             return
-                new AndWhichConstraint
-                    <GenericDictionaryAssertions<TKey, TValue>,
-                        IEnumerable<TValue>>(this,
+                new AndWhichConstraint<TAssertions,
+                        IEnumerable<TValue>>((TAssertions)this,
                             RepetitionPreservingIntersect(Subject.Values, expectedValues));
         }
 
@@ -884,7 +895,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainValue(TValue unexpected,
+        public AndConstraint<TAssertions> NotContainValue(TValue unexpected,
             string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
@@ -901,7 +912,7 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} {0} not to contain value {1}{reason}, but found it anyhow.", Subject, unexpected);
             }
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -909,7 +920,7 @@ namespace FluentAssertions.Collections
         /// their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
         /// <param name="unexpected">The unexpected values</param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainValues(params TValue[] unexpected)
+        public AndConstraint<TAssertions> NotContainValues(params TValue[] unexpected)
         {
             return NotContainValues(unexpected, string.Empty);
         }
@@ -926,7 +937,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainValues(IEnumerable<TValue> unexpected,
+        public AndConstraint<TAssertions> NotContainValues(IEnumerable<TValue> unexpected,
             string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot verify value containment against a <null> collection of values");
@@ -965,7 +976,7 @@ namespace FluentAssertions.Collections
                 }
             }
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         #endregion
@@ -978,7 +989,7 @@ namespace FluentAssertions.Collections
         /// Values are compared using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
         /// <param name="expected">The expected key/value pairs.</param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> Contain(params KeyValuePair<TKey, TValue>[] expected)
+        public AndConstraint<TAssertions> Contain(params KeyValuePair<TKey, TValue>[] expected)
         {
             return Contain(expected, string.Empty);
         }
@@ -996,7 +1007,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> Contain(IEnumerable<KeyValuePair<TKey, TValue>> expected,
+        public AndConstraint<TAssertions> Contain(IEnumerable<KeyValuePair<TKey, TValue>> expected,
             string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare dictionary with <null>.");
@@ -1059,7 +1070,7 @@ namespace FluentAssertions.Collections
                 }
             }
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -1075,7 +1086,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> Contain(KeyValuePair<TKey, TValue> expected,
+        public AndConstraint<TAssertions> Contain(KeyValuePair<TKey, TValue> expected,
             string because = "", params object[] becauseArgs)
         {
             return Contain(expected.Key, expected.Value, because, becauseArgs);
@@ -1096,7 +1107,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value,
+        public AndConstraint<TAssertions> Contain(TKey key, TValue value,
             string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
@@ -1122,7 +1133,7 @@ namespace FluentAssertions.Collections
                         key);
             }
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         #endregion
@@ -1135,7 +1146,7 @@ namespace FluentAssertions.Collections
         /// Values are compared using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
         /// <param name="items">The unexpected key/value pairs</param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContain(params KeyValuePair<TKey, TValue>[] items)
+        public AndConstraint<TAssertions> NotContain(params KeyValuePair<TKey, TValue>[] items)
         {
             return NotContain(items, string.Empty);
         }
@@ -1153,7 +1164,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContain(IEnumerable<KeyValuePair<TKey, TValue>> items,
+        public AndConstraint<TAssertions> NotContain(IEnumerable<KeyValuePair<TKey, TValue>> items,
             string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(items, nameof(items), "Cannot compare dictionary with <null>.");
@@ -1199,7 +1210,7 @@ namespace FluentAssertions.Collections
                 }
             }
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -1215,7 +1226,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContain(KeyValuePair<TKey, TValue> item,
+        public AndConstraint<TAssertions> NotContain(KeyValuePair<TKey, TValue> item,
             string because = "", params object[] becauseArgs)
         {
             return NotContain(item.Key, item.Value, because, becauseArgs);
@@ -1236,7 +1247,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContain(TKey key, TValue value,
+        public AndConstraint<TAssertions> NotContain(TKey key, TValue value,
             string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
@@ -1255,7 +1266,7 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} not to contain value {0} at key {1}{reason}, but found it anyhow.", value, key);
             }
 
-            return new AndConstraint<GenericDictionaryAssertions<TKey, TValue>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         #endregion

--- a/Src/FluentAssertions/Collections/NonGenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/NonGenericCollectionAssertions.cs
@@ -13,9 +13,22 @@ namespace FluentAssertions.Collections
     /// Contains a number of methods to assert that an <see cref="IEnumerable"/> is in the expected state.
     /// </summary>
     [DebuggerNonUserCode]
-    public class NonGenericCollectionAssertions : CollectionAssertions<IEnumerable, NonGenericCollectionAssertions>
+    public class NonGenericCollectionAssertions : NonGenericCollectionAssertions<IEnumerable, NonGenericCollectionAssertions>
     {
         public NonGenericCollectionAssertions(IEnumerable collection) : base(collection)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that an <see cref="IEnumerable"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class NonGenericCollectionAssertions<TCollection, TAssertions> : CollectionAssertions<TCollection, TAssertions>
+        where TCollection : IEnumerable
+        where TAssertions : NonGenericCollectionAssertions<TCollection, TAssertions>
+    {
+        public NonGenericCollectionAssertions(TCollection collection) : base(collection)
         {
         }
 
@@ -30,7 +43,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NonGenericCollectionAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
             {
@@ -46,7 +59,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} to contain {0} item(s){reason}, but found {1}.", expected, actualCount);
 
-            return new AndConstraint<NonGenericCollectionAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -60,7 +73,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NonGenericCollectionAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
             {
@@ -76,7 +89,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} to not contain {0} item(s){reason}, but found {1}.", unexpected, actualCount);
 
-            return new AndConstraint<NonGenericCollectionAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -90,7 +103,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NonGenericCollectionAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
             {
@@ -106,7 +119,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} to contain more than {0} item(s){reason}, but found {1}.", expected, actualCount);
 
-            return new AndConstraint<NonGenericCollectionAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -120,7 +133,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NonGenericCollectionAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
             {
@@ -136,7 +149,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} to contain at least {0} item(s){reason}, but found {1}.", expected, actualCount);
 
-            return new AndConstraint<NonGenericCollectionAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -150,7 +163,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NonGenericCollectionAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
             {
@@ -166,7 +179,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} to contain fewer than {0} item(s){reason}, but found {1}.", expected, actualCount);
 
-            return new AndConstraint<NonGenericCollectionAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -180,7 +193,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NonGenericCollectionAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs)
         {
             if (Subject is null)
             {
@@ -196,7 +209,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} to contain at most {0} item(s){reason}, but found {1}.", expected, actualCount);
 
-            return new AndConstraint<NonGenericCollectionAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -210,7 +223,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NonGenericCollectionAssertions> HaveCount(Expression<Func<int, bool>> countPredicate, string because = "",
+        public AndConstraint<TAssertions> HaveCount(Expression<Func<int, bool>> countPredicate, string because = "",
             params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(countPredicate, nameof(countPredicate), "Cannot compare collection count against a <null> predicate.");
@@ -234,7 +247,7 @@ namespace FluentAssertions.Collections
                         Subject, countPredicate.Body, actualCount);
             }
 
-            return new AndConstraint<NonGenericCollectionAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         private int GetMostLocalCount()
@@ -261,7 +274,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NonGenericCollectionAssertions> Contain(object expected, string because = "",
+        public AndConstraint<TAssertions> Contain(object expected, string because = "",
             params object[] becauseArgs)
         {
             if (expected is IEnumerable enumerable)
@@ -284,7 +297,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NonGenericCollectionAssertions> NotContain(object unexpected, string because = "",
+        public AndConstraint<TAssertions> NotContain(object unexpected, string because = "",
             params object[] becauseArgs)
         {
             if (unexpected is IEnumerable enumerable)

--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -18,6 +18,19 @@ namespace FluentAssertions.Collections
         public SelfReferencingCollectionAssertions(IEnumerable<T> actualValue) : base(actualValue)
         {
         }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that an <see cref="IEnumerable{T}"/> is in the expectation state.
+    /// </summary>
+    public class SelfReferencingCollectionAssertions<TCollection, T, TAssertions> :
+        CollectionAssertions<TCollection, TAssertions>
+        where TCollection : IEnumerable<T>
+        where TAssertions : SelfReferencingCollectionAssertions<TCollection, T, TAssertions>
+    {
+        public SelfReferencingCollectionAssertions(TCollection actualValue) : base(actualValue)
+        {
+        }
 
         /// <summary>
         /// Asserts that the number of items in the collection matches the supplied <paramref name="expected" /> amount.

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -8,9 +8,30 @@ using FluentAssertions.Execution;
 namespace FluentAssertions.Collections
 {
     public class StringCollectionAssertions :
-        SelfReferencingCollectionAssertions<string, StringCollectionAssertions>
+        StringCollectionAssertions<IEnumerable<string>>
     {
         public StringCollectionAssertions(IEnumerable<string> actualValue)
+            : base(actualValue)
+        {
+        }
+    }
+
+    public class StringCollectionAssertions<TCollection> :
+        StringCollectionAssertions<TCollection, StringCollectionAssertions<TCollection>>
+        where TCollection : IEnumerable<string>
+    {
+        public StringCollectionAssertions(TCollection actualValue)
+            : base(actualValue)
+        {
+        }
+    }
+
+    public class StringCollectionAssertions<TCollection, TAssertions> :
+        SelfReferencingCollectionAssertions<TCollection, string, TAssertions>
+        where TCollection : IEnumerable<string>
+        where TAssertions : StringCollectionAssertions<TCollection, TAssertions>
+    {
+        public StringCollectionAssertions(TCollection actualValue)
             : base(actualValue)
         {
         }
@@ -20,7 +41,7 @@ namespace FluentAssertions.Collections
         /// <paramref name="expected" />. Elements are compared using their <see cref="object.Equals(object)" />.
         /// </summary>
         /// <param name="expected">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
-        public new AndConstraint<StringCollectionAssertions> Equal(params string[] expected)
+        public new AndConstraint<TAssertions> Equal(params string[] expected)
         {
             return base.Equal(expected.AsEnumerable());
         }
@@ -30,7 +51,7 @@ namespace FluentAssertions.Collections
         /// <paramref name="expected" />. Elements are compared using their <see cref="object.Equals(object)" />.
         /// </summary>
         /// <param name="expected">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
-        public AndConstraint<StringCollectionAssertions> Equal(IEnumerable<string> expected)
+        public AndConstraint<TAssertions> Equal(IEnumerable<string> expected)
         {
             return base.Equal(expected);
         }
@@ -41,11 +62,11 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// The two collections are equivalent when they both contain the same strings in any order.
         /// </remarks>
-        public AndConstraint<StringCollectionAssertions> BeEquivalentTo(params string[] expectation)
+        public AndConstraint<TAssertions> BeEquivalentTo(params string[] expectation)
         {
             BeEquivalentTo(expectation, config => config);
 
-            return new AndConstraint<StringCollectionAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -61,11 +82,11 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringCollectionAssertions> BeEquivalentTo(IEnumerable<string> expectation, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeEquivalentTo(IEnumerable<string> expectation, string because = "", params object[] becauseArgs)
         {
             BeEquivalentTo(expectation, config => config, because, becauseArgs);
 
-            return new AndConstraint<StringCollectionAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -87,7 +108,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringCollectionAssertions> BeEquivalentTo(IEnumerable<string> expectation,
+        public AndConstraint<TAssertions> BeEquivalentTo(IEnumerable<string> expectation,
             Func<EquivalencyAssertionOptions<string>, EquivalencyAssertionOptions<string>> config, string because = "",
             params object[] becauseArgs)
         {
@@ -109,7 +130,7 @@ namespace FluentAssertions.Collections
             var equivalencyValidator = new EquivalencyValidator(options);
             equivalencyValidator.AssertEquality(context);
 
-            return new AndConstraint<StringCollectionAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -117,7 +138,7 @@ namespace FluentAssertions.Collections
         /// using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
         /// <param name="expected">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
-        public AndConstraint<StringCollectionAssertions> ContainInOrder(params string[] expected)
+        public AndConstraint<TAssertions> ContainInOrder(params string[] expected)
         {
             return base.ContainInOrder(expected.AsEnumerable());
         }
@@ -134,7 +155,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringCollectionAssertions> ContainInOrder(IEnumerable<string> expected, string because = "",
+        public AndConstraint<TAssertions> ContainInOrder(IEnumerable<string> expected, string because = "",
             params object[] becauseArgs)
         {
             return base.ContainInOrder(expected, because, becauseArgs);
@@ -145,7 +166,7 @@ namespace FluentAssertions.Collections
         /// using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>
         /// <param name="expected">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
-        public AndConstraint<StringCollectionAssertions> Contain(IEnumerable<string> expected)
+        public AndConstraint<TAssertions> Contain(IEnumerable<string> expected)
         {
             return base.Contain(expected);
         }
@@ -162,7 +183,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringCollectionAssertions> Contain(IEnumerable<string> expected, string because = null,
+        public AndConstraint<TAssertions> Contain(IEnumerable<string> expected, string because = null,
             object becauseArg = null,
             params object[] becauseArgs)
         {
@@ -183,7 +204,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringCollectionAssertions> NotContain(IEnumerable<string> unexpected, string because = null,
+        public AndConstraint<TAssertions> NotContain(IEnumerable<string> unexpected, string because = null,
             object becauseArg = null,
             params object[] becauseArgs)
         {
@@ -205,7 +226,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndWhichConstraint<StringCollectionAssertions, string> ContainMatch(string wildcardPattern, string because = "",
+        public AndWhichConstraint<TAssertions, string> ContainMatch(string wildcardPattern, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -216,7 +237,7 @@ namespace FluentAssertions.Collections
                 .ForCondition(ContainsMatch(wildcardPattern))
                 .FailWith("Expected {context:collection} {0} to contain a match of {1}{reason}.", Subject, wildcardPattern);
 
-            return new AndWhichConstraint<StringCollectionAssertions, string>(this, AllThatMatch(wildcardPattern));
+            return new AndWhichConstraint<TAssertions, string>((TAssertions)this, AllThatMatch(wildcardPattern));
         }
 
         private bool ContainsMatch(string wildcardPattern)
@@ -256,7 +277,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringCollectionAssertions> NotContainMatch(string wildcardPattern, string because = "",
+        public AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -267,7 +288,7 @@ namespace FluentAssertions.Collections
                 .ForCondition(NotContainsMatch(wildcardPattern))
                 .FailWith("Did not expect {context:collection} {0} to contain a match of {1}{reason}.", Subject, wildcardPattern);
 
-            return new AndConstraint<StringCollectionAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         private bool NotContainsMatch(string wildcardPattern)

--- a/Src/FluentAssertions/Collections/WhichValueConstraint.cs
+++ b/Src/FluentAssertions/Collections/WhichValueConstraint.cs
@@ -1,8 +1,9 @@
 namespace FluentAssertions.Collections
 {
-    public class WhichValueConstraint<TKey, TValue> : AndConstraint<GenericDictionaryAssertions<TKey, TValue>>
+    public class WhichValueConstraint<TKey, TValue, TAssertions> : AndConstraint<TAssertions>
+        where TAssertions : GenericDictionaryAssertions<TKey, TValue, TAssertions>
     {
-        public WhichValueConstraint(GenericDictionaryAssertions<TKey, TValue> parentConstraint, TValue value)
+        public WhichValueConstraint(TAssertions parentConstraint, TValue value)
             : base(parentConstraint)
         {
             WhichValue = value;

--- a/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
@@ -11,7 +11,19 @@ namespace FluentAssertions.Numeric
     /// Contains a number of methods to assert that an <see cref="IComparable{T}"/> is in the expected state.
     /// </summary>
     [DebuggerNonUserCode]
-    public class ComparableTypeAssertions<T> : ReferenceTypeAssertions<IComparable<T>, ComparableTypeAssertions<T>>
+    public class ComparableTypeAssertions<T> : ComparableTypeAssertions<T, ComparableTypeAssertions<T>>
+    {
+        public ComparableTypeAssertions(IComparable<T> value) : base(value)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that an <see cref="IComparable{T}"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class ComparableTypeAssertions<T, TAssertions> : ReferenceTypeAssertions<IComparable<T>, TAssertions>
+        where TAssertions : ComparableTypeAssertions<T, TAssertions>
     {
         private const int Equal = 0;
 
@@ -32,14 +44,14 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.IsSameOrEqualTo(expected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:object} to be equal to {0}{reason}, but found {1}.", expected, Subject);
 
-            return new AndConstraint<ComparableTypeAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -59,7 +71,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "",
+        public AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "",
             params object[] becauseArgs)
         {
             return BeEquivalentTo(expectation, config => config, because, becauseArgs);
@@ -87,7 +99,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation,
+        public AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation,
             Func<EquivalencyAssertionOptions<TExpectation>, EquivalencyAssertionOptions<TExpectation>> config, string because = "",
             params object[] becauseArgs)
         {
@@ -108,7 +120,7 @@ namespace FluentAssertions.Numeric
             var equivalencyValidator = new EquivalencyValidator(options);
             equivalencyValidator.AssertEquality(context);
 
-            return new AndConstraint<ComparableTypeAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -124,14 +136,14 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.IsSameOrEqualTo(unexpected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:object} to be equal to {0}{reason}.", unexpected);
 
-            return new AndConstraint<ComparableTypeAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -148,14 +160,14 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) == Equal)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:object} {0} to be ranked as equal to {1}{reason}.", Subject, expected);
 
-            return new AndConstraint<ComparableTypeAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -172,14 +184,14 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(unexpected) != Equal)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:object} {0} not to be ranked as equal to {1}{reason}.", Subject, unexpected);
 
-            return new AndConstraint<ComparableTypeAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -195,14 +207,14 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) < Equal)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:object} {0} to be less than {1}{reason}.", Subject, expected);
 
-            return new AndConstraint<ComparableTypeAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -218,14 +230,14 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) <= Equal)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:object} {0} to be less or equal to {1}{reason}.", Subject, expected);
 
-            return new AndConstraint<ComparableTypeAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -241,14 +253,14 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) > Equal)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:object} {0} to be greater than {1}{reason}.", Subject, expected);
 
-            return new AndConstraint<ComparableTypeAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -264,14 +276,14 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) >= Equal)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:object} {0} to be greater or equal to {1}{reason}.", Subject, expected);
 
-            return new AndConstraint<ComparableTypeAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -293,7 +305,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "",
+        public AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -302,7 +314,7 @@ namespace FluentAssertions.Numeric
                 .FailWith("Expected {context:object} to be between {0} and {1}{reason}, but found {2}.",
                     minimumValue, maximumValue, Subject);
 
-            return new AndConstraint<ComparableTypeAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -324,7 +336,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "",
+        public AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -333,7 +345,7 @@ namespace FluentAssertions.Numeric
                 .FailWith("Expected {context:object} to not be between {0} and {1}{reason}, but found {2}.",
                     minimumValue, maximumValue, Subject);
 
-            return new AndConstraint<ComparableTypeAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Numeric/NullableNumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableNumericAssertions.cs
@@ -7,8 +7,19 @@ using FluentAssertions.Execution;
 namespace FluentAssertions.Numeric
 {
     [DebuggerNonUserCode]
-    public class NullableNumericAssertions<T> : NumericAssertions<T>
+    public class NullableNumericAssertions<T> : NullableNumericAssertions<T, NullableNumericAssertions<T>>
         where T : struct, IComparable<T>
+    {
+        public NullableNumericAssertions(T? value)
+            : base(value)
+        {
+        }
+    }
+
+    [DebuggerNonUserCode]
+    public class NullableNumericAssertions<T, TAssertions> : NumericAssertions<T, TAssertions>
+        where T : struct, IComparable<T>
+        where TAssertions : NullableNumericAssertions<T, TAssertions>
     {
         public NullableNumericAssertions(T? value)
             : base(value)
@@ -27,14 +38,14 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value{reason}.");
 
-            return new AndConstraint<NullableNumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -47,7 +58,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableNumericAssertions<T>> NotBeNull(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs)
         {
             return HaveValue(because, becauseArgs);
         }
@@ -62,14 +73,14 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect a value{reason}, but found {0}.", Subject);
 
-            return new AndConstraint<NullableNumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -82,7 +93,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs)
         {
             return NotHaveValue(because, becauseArgs);
         }
@@ -100,7 +111,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableNumericAssertions<T>> Match(Expression<Func<T?, bool>> predicate,
+        public AndConstraint<TAssertions> Match(Expression<Func<T?, bool>> predicate,
             string because = "",
             params object[] becauseArgs)
         {
@@ -111,7 +122,7 @@ namespace FluentAssertions.Numeric
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected value to match {0}{reason}, but found {1}.", predicate.Body, Subject);
 
-            return new AndConstraint<NullableNumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
     }
 }

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -13,8 +13,22 @@ namespace FluentAssertions.Numeric
     /// Contains a number of methods to assert that an <see cref="IComparable{T}"/> is in the expected state.
     /// </summary>
     [DebuggerNonUserCode]
-    public class NumericAssertions<T>
+    public class NumericAssertions<T> : NumericAssertions<T, NumericAssertions<T>>
         where T : struct, IComparable<T>
+    {
+        public NumericAssertions(T value)
+            : base(value)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that an <see cref="IComparable{T}"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class NumericAssertions<T, TAssertions>
+        where T : struct, IComparable<T>
+        where TAssertions : NumericAssertions<T, TAssertions>
     {
         public NumericAssertions(T value)
             : this((T?)value)
@@ -41,14 +55,14 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) == 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be {0}{reason}, but found {1}.", expected, SubjectInternal);
 
-            return new AndConstraint<NumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -62,7 +76,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(
@@ -71,7 +85,7 @@ namespace FluentAssertions.Numeric
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be {0}{reason}, but found {1}.", expected, SubjectInternal);
 
-            return new AndConstraint<NumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -85,14 +99,14 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!SubjectInternal.HasValue || SubjectInternal.Value.CompareTo(unexpected) != 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:value} to be {0}{reason}.", unexpected);
 
-            return new AndConstraint<NumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -106,7 +120,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> NotBe(T? unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBe(T? unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(
@@ -115,7 +129,7 @@ namespace FluentAssertions.Numeric
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:value} to be {0}{reason}.", unexpected);
 
-            return new AndConstraint<NumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -128,14 +142,14 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> BePositive(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(default(T)) > 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be positive{reason}, but found {0}.", SubjectInternal);
 
-            return new AndConstraint<NumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -148,14 +162,14 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> BeNegative(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(default(T)) < 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be negative{reason}, but found {0}.", SubjectInternal);
 
-            return new AndConstraint<NumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -169,14 +183,14 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) < 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be less than {0}{reason}, but found {1}.", expected, SubjectInternal);
 
-            return new AndConstraint<NumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -190,7 +204,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> BeLessOrEqualTo(T expected, string because = "",
+        public AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -198,7 +212,7 @@ namespace FluentAssertions.Numeric
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be less or equal to {0}{reason}, but found {1}.", expected, SubjectInternal);
 
-            return new AndConstraint<NumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -212,7 +226,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> BeGreaterThan(T expected, string because = "",
+        public AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -220,7 +234,7 @@ namespace FluentAssertions.Numeric
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be greater than {0}{reason}, but found {1}.", expected, SubjectInternal);
 
-            return new AndConstraint<NumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -234,7 +248,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "",
+        public AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -242,7 +256,7 @@ namespace FluentAssertions.Numeric
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be greater or equal to {0}{reason}, but found {1}.", expected, SubjectInternal);
 
-            return new AndConstraint<NumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -264,7 +278,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "",
+        public AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -273,7 +287,7 @@ namespace FluentAssertions.Numeric
                 .FailWith("Expected {context:value} to be between {0} and {1}{reason}, but found {2}.",
                     minimumValue, maximumValue, SubjectInternal);
 
-            return new AndConstraint<NumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -295,7 +309,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "",
+        public AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -304,7 +318,7 @@ namespace FluentAssertions.Numeric
                 .FailWith("Expected {context:value} to not be between {0} and {1}{reason}, but found {2}.",
                     minimumValue, maximumValue, SubjectInternal);
 
-            return new AndConstraint<NumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -313,7 +327,7 @@ namespace FluentAssertions.Numeric
         /// <param name="validValues">
         /// The values that are valid.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> BeOneOf(params T[] validValues)
+        public AndConstraint<TAssertions> BeOneOf(params T[] validValues)
         {
             return BeOneOf(validValues, string.Empty);
         }
@@ -331,7 +345,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> BeOneOf(IEnumerable<T> validValues, string because = "",
+        public AndConstraint<TAssertions> BeOneOf(IEnumerable<T> validValues, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -339,7 +353,7 @@ namespace FluentAssertions.Numeric
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be one of {0}{reason}, but found {1}.", validValues, SubjectInternal);
 
-            return new AndConstraint<NumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -355,7 +369,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> BeOfType(Type expectedType, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeOfType(Type expectedType, string because = "", params object[] becauseArgs)
         {
             Type subjectType = SubjectInternal.GetType();
             if (expectedType.GetTypeInfo().IsGenericTypeDefinition && subjectType.GetTypeInfo().IsGenericType)
@@ -367,7 +381,7 @@ namespace FluentAssertions.Numeric
                 subjectType.Should().Be(expectedType, because, becauseArgs);
             }
 
-            return new AndConstraint<NumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -383,11 +397,11 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> NotBeOfType(Type unexpectedType, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBeOfType(Type unexpectedType, string because = "", params object[] becauseArgs)
         {
             SubjectInternal.GetType().Should().NotBe(unexpectedType, because, becauseArgs);
 
-            return new AndConstraint<NumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -403,7 +417,7 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NumericAssertions<T>> Match(Expression<Func<T, bool>> predicate,
+        public AndConstraint<TAssertions> Match(Expression<Func<T, bool>> predicate,
             string because = "",
             params object[] becauseArgs)
         {
@@ -414,7 +428,7 @@ namespace FluentAssertions.Numeric
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to match {0}{reason}, but found {1}.", predicate.Body, SubjectInternal);
 
-            return new AndConstraint<NumericAssertions<T>>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
     }
 }

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -8,6 +8,20 @@ namespace FluentAssertions.Primitives
     /// </summary>
     [DebuggerNonUserCode]
     public class BooleanAssertions
+        : BooleanAssertions<BooleanAssertions>
+    {
+        public BooleanAssertions(bool? value)
+            : base(value)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that a <see cref="bool"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class BooleanAssertions<TAssertions>
+        where TAssertions : BooleanAssertions<TAssertions>
     {
         public BooleanAssertions(bool? value)
         {
@@ -29,14 +43,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject == false)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:boolean} to be false{reason}, but found {0}.", Subject);
 
-            return new AndConstraint<BooleanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -49,14 +63,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject == true)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:boolean} to be true{reason}, but found {0}.", Subject);
 
-            return new AndConstraint<BooleanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -70,14 +84,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:boolean} to be {0}{reason}, but found {1}.", expected, Subject);
 
-            return new AndConstraint<BooleanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -91,14 +105,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        public AndConstraint<BooleanAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue || (Subject.Value != unexpected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:boolean} not to be {0}{reason}, but found {1}.", unexpected, Subject);
 
-            return new AndConstraint<BooleanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
     }
 }

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -14,7 +14,24 @@ namespace FluentAssertions.Primitives
     /// for a more fluent way of specifying a <see cref="DateTime"/>.
     /// </remarks>
     [DebuggerNonUserCode]
-    public class DateTimeAssertions
+    public class DateTimeAssertions : DateTimeAssertions<DateTimeAssertions>
+    {
+        public DateTimeAssertions(DateTime? value)
+            : base(value)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that a <see cref="DateTime"/> is in the expected state.
+    /// </summary>
+    /// <remarks>
+    /// You can use the <see cref="FluentAssertions.Extensions.FluentDateTimeExtensions"/>
+    /// for a more fluent way of specifying a <see cref="DateTime"/>.
+    /// </remarks>
+    [DebuggerNonUserCode]
+    public class DateTimeAssertions<TAssertions>
+        where TAssertions : DateTimeAssertions<TAssertions>
     {
         public DateTimeAssertions(DateTime? value)
         {
@@ -37,7 +54,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> Be(DateTime expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> Be(DateTime expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && (Subject.Value == expected))
@@ -45,7 +62,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context:date and time} to be {0}{reason}, but found {1}.",
                     expected, Subject ?? default(DateTime?));
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -59,7 +76,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> NotBe(DateTime unexpected, string because = "",
+        public AndConstraint<TAssertions> NotBe(DateTime unexpected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -67,7 +84,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} not to be {0}{reason}, but it is.", unexpected);
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -91,7 +108,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> BeCloseTo(DateTime nearbyTime, TimeSpan precision, string because = "",
+        public AndConstraint<TAssertions> BeCloseTo(DateTime nearbyTime, TimeSpan precision, string because = "",
             params object[] becauseArgs)
         {
             long distanceToMinInTicks = (nearbyTime - DateTime.MinValue).Ticks;
@@ -107,7 +124,7 @@ namespace FluentAssertions.Primitives
                     precision,
                     nearbyTime, Subject ?? default(DateTime?));
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -131,7 +148,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> NotBeCloseTo(DateTime distantTime, TimeSpan precision, string because = "",
+        public AndConstraint<TAssertions> NotBeCloseTo(DateTime distantTime, TimeSpan precision, string because = "",
             params object[] becauseArgs)
         {
             long distanceToMinInTicks = (distantTime - DateTime.MinValue).Ticks;
@@ -148,7 +165,7 @@ namespace FluentAssertions.Primitives
                     precision,
                     distantTime, Subject ?? default(DateTime?));
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -162,7 +179,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> BeBefore(DateTime expected, string because = "",
+        public AndConstraint<TAssertions> BeBefore(DateTime expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -171,7 +188,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context:the date and time} to be before {0}{reason}, but found {1}.", expected,
                     Subject ?? default(DateTime?));
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -185,7 +202,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> NotBeBefore(DateTime unexpected, string because = "",
+        public AndConstraint<TAssertions> NotBeBefore(DateTime unexpected, string because = "",
             params object[] becauseArgs)
         {
             return BeOnOrAfter(unexpected, because, becauseArgs);
@@ -202,7 +219,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> BeOnOrBefore(DateTime expected, string because = "",
+        public AndConstraint<TAssertions> BeOnOrBefore(DateTime expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -211,7 +228,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context:the date and time} to be on or before {0}{reason}, but found {1}.", expected,
                     Subject ?? default(DateTime?));
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -225,7 +242,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> NotBeOnOrBefore(DateTime unexpected, string because = "",
+        public AndConstraint<TAssertions> NotBeOnOrBefore(DateTime unexpected, string because = "",
             params object[] becauseArgs)
         {
             return BeAfter(unexpected, because, becauseArgs);
@@ -242,7 +259,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> BeAfter(DateTime expected, string because = "",
+        public AndConstraint<TAssertions> BeAfter(DateTime expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -251,7 +268,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context:the date and time} to be after {0}{reason}, but found {1}.", expected,
                     Subject ?? default(DateTime?));
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -265,7 +282,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> NotBeAfter(DateTime unexpected, string because = "",
+        public AndConstraint<TAssertions> NotBeAfter(DateTime unexpected, string because = "",
             params object[] becauseArgs)
         {
             return BeOnOrBefore(unexpected, because, becauseArgs);
@@ -282,7 +299,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> BeOnOrAfter(DateTime expected, string because = "",
+        public AndConstraint<TAssertions> BeOnOrAfter(DateTime expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -291,7 +308,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context:the date and time} to be on or after {0}{reason}, but found {1}.", expected,
                     Subject ?? default(DateTime?));
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -305,7 +322,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> NotBeOnOrAfter(DateTime unexpected, string because = "",
+        public AndConstraint<TAssertions> NotBeOnOrAfter(DateTime unexpected, string because = "",
             params object[] becauseArgs)
         {
             return BeBefore(unexpected, because, becauseArgs);
@@ -322,7 +339,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -335,7 +352,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -349,7 +366,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -360,7 +377,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("Did not expect the year part of {context:the date} to be {0}{reason}, but it was.", unexpected,
                     Subject.Value.Year);
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -374,7 +391,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -387,7 +404,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -401,7 +418,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -414,7 +431,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -428,7 +445,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -441,7 +458,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -455,7 +472,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -468,7 +485,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -482,7 +499,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -495,7 +512,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -509,7 +526,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -522,7 +539,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -536,7 +553,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> HaveMinute(int expected, string because = "",
+        public AndConstraint<TAssertions> HaveMinute(int expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -550,7 +567,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -564,7 +581,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> NotHaveMinute(int unexpected, string because = "",
+        public AndConstraint<TAssertions> NotHaveMinute(int unexpected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -578,7 +595,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -592,7 +609,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> HaveSecond(int expected, string because = "",
+        public AndConstraint<TAssertions> HaveSecond(int expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -606,7 +623,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -620,7 +637,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> NotHaveSecond(int unexpected, string because = "",
+        public AndConstraint<TAssertions> NotHaveSecond(int unexpected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -634,7 +651,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -644,9 +661,9 @@ namespace FluentAssertions.Primitives
         /// <param name="timeSpan">
         /// The amount of time that the current <see cref="DateTime"/>  should exceed compared to another <see cref="DateTime"/>.
         /// </param>
-        public DateTimeRangeAssertions BeMoreThan(TimeSpan timeSpan)
+        public DateTimeRangeAssertions<TAssertions> BeMoreThan(TimeSpan timeSpan)
         {
-            return new DateTimeRangeAssertions(this, Subject, TimeSpanCondition.MoreThan, timeSpan);
+            return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.MoreThan, timeSpan);
         }
 
         /// <summary>
@@ -657,9 +674,9 @@ namespace FluentAssertions.Primitives
         /// The amount of time that the current <see cref="DateTime"/>  should be equal or exceed compared to
         /// another <see cref="DateTime"/>.
         /// </param>
-        public DateTimeRangeAssertions BeAtLeast(TimeSpan timeSpan)
+        public DateTimeRangeAssertions<TAssertions> BeAtLeast(TimeSpan timeSpan)
         {
-            return new DateTimeRangeAssertions(this, Subject, TimeSpanCondition.AtLeast, timeSpan);
+            return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.AtLeast, timeSpan);
         }
 
         /// <summary>
@@ -669,9 +686,9 @@ namespace FluentAssertions.Primitives
         /// <param name="timeSpan">
         /// The amount of time that the current <see cref="DateTime"/>  should differ exactly compared to another <see cref="DateTime"/>.
         /// </param>
-        public DateTimeRangeAssertions BeExactly(TimeSpan timeSpan)
+        public DateTimeRangeAssertions<TAssertions> BeExactly(TimeSpan timeSpan)
         {
-            return new DateTimeRangeAssertions(this, Subject, TimeSpanCondition.Exactly, timeSpan);
+            return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.Exactly, timeSpan);
         }
 
         /// <summary>
@@ -681,9 +698,9 @@ namespace FluentAssertions.Primitives
         /// <param name="timeSpan">
         /// The amount of time that the current <see cref="DateTime"/>  should be within another <see cref="DateTime"/>.
         /// </param>
-        public DateTimeRangeAssertions BeWithin(TimeSpan timeSpan)
+        public DateTimeRangeAssertions<TAssertions> BeWithin(TimeSpan timeSpan)
         {
-            return new DateTimeRangeAssertions(this, Subject, TimeSpanCondition.Within, timeSpan);
+            return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.Within, timeSpan);
         }
 
         /// <summary>
@@ -693,9 +710,9 @@ namespace FluentAssertions.Primitives
         /// <param name="timeSpan">
         /// The maximum amount of time that the current <see cref="DateTime"/>  should differ compared to another <see cref="DateTime"/>.
         /// </param>
-        public DateTimeRangeAssertions BeLessThan(TimeSpan timeSpan)
+        public DateTimeRangeAssertions<TAssertions> BeLessThan(TimeSpan timeSpan)
         {
-            return new DateTimeRangeAssertions(this, Subject, TimeSpanCondition.LessThan, timeSpan);
+            return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.LessThan, timeSpan);
         }
 
         /// <summary>
@@ -709,7 +726,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> BeSameDateAs(DateTime expected, string because = "",
+        public AndConstraint<TAssertions> BeSameDateAs(DateTime expected, string because = "",
             params object[] becauseArgs)
         {
             DateTime expectedDate = expected.Date;
@@ -725,7 +742,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -739,7 +756,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> NotBeSameDateAs(DateTime unexpected, string because = "",
+        public AndConstraint<TAssertions> NotBeSameDateAs(DateTime unexpected, string because = "",
             params object[] becauseArgs)
         {
             DateTime unexpectedDate = unexpected.Date;
@@ -755,7 +772,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -764,7 +781,7 @@ namespace FluentAssertions.Primitives
         /// <param name="validValues">
         /// The values that are valid.
         /// </param>
-        public AndConstraint<DateTimeAssertions> BeOneOf(params DateTime?[] validValues)
+        public AndConstraint<TAssertions> BeOneOf(params DateTime?[] validValues)
         {
             return BeOneOf(validValues, string.Empty);
         }
@@ -775,7 +792,7 @@ namespace FluentAssertions.Primitives
         /// <param name="validValues">
         /// The values that are valid.
         /// </param>
-        public AndConstraint<DateTimeAssertions> BeOneOf(params DateTime[] validValues)
+        public AndConstraint<TAssertions> BeOneOf(params DateTime[] validValues)
         {
             return BeOneOf(validValues.Cast<DateTime?>());
         }
@@ -793,7 +810,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> BeOneOf(IEnumerable<DateTime> validValues, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeOneOf(IEnumerable<DateTime> validValues, string because = "", params object[] becauseArgs)
         {
             return BeOneOf(validValues.Cast<DateTime?>(), because, becauseArgs);
         }
@@ -811,14 +828,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> BeOneOf(IEnumerable<DateTime?> validValues, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeOneOf(IEnumerable<DateTime?> validValues, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(validValues.Contains(Subject))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} to be one of {0}{reason}, but found {1}.", validValues, Subject);
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -834,7 +851,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> BeIn(DateTimeKind expectedKind, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeIn(DateTimeKind expectedKind, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -847,7 +864,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
     }
 }

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -15,6 +15,24 @@ namespace FluentAssertions.Primitives
     /// </remarks>
     [DebuggerNonUserCode]
     public class DateTimeOffsetAssertions
+        : DateTimeOffsetAssertions<DateTimeOffsetAssertions>
+    {
+        public DateTimeOffsetAssertions(DateTimeOffset? value)
+            : base(value)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that a <see cref="DateTimeOffset"/> is in the expected state.
+    /// </summary>
+    /// <remarks>
+    /// You can use the <see cref="FluentAssertions.Extensions.FluentDateTimeExtensions"/>
+    /// for a more fluent way of specifying a <see cref="DateTimeOffset"/>.
+    /// </remarks>
+    [DebuggerNonUserCode]
+    public class DateTimeOffsetAssertions<TAssertions>
+        where TAssertions : DateTimeOffsetAssertions<TAssertions>
     {
         public DateTimeOffsetAssertions(DateTimeOffset? value)
         {
@@ -37,7 +55,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> Be(DateTimeOffset expected, string because = "",
+        public AndConstraint<TAssertions> Be(DateTimeOffset expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -46,7 +64,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context:the date and time} to be {0}{reason}, but it was {1}.",
                     expected, Subject ?? default(DateTimeOffset?));
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -60,7 +78,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> NotBe(DateTimeOffset unexpected, string because = "",
+        public AndConstraint<TAssertions> NotBe(DateTimeOffset unexpected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -68,7 +86,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:the date and time} to be {0}{reason}, but it was.", unexpected);
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -92,7 +110,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> BeCloseTo(DateTimeOffset nearbyTime, TimeSpan precision,
+        public AndConstraint<TAssertions> BeCloseTo(DateTimeOffset nearbyTime, TimeSpan precision,
             string because = "",
             params object[] becauseArgs)
         {
@@ -109,7 +127,7 @@ namespace FluentAssertions.Primitives
                     precision,
                     nearbyTime, Subject ?? default(DateTimeOffset?));
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -133,7 +151,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> NotBeCloseTo(DateTimeOffset distantTime, TimeSpan precision, string because = "",
+        public AndConstraint<TAssertions> NotBeCloseTo(DateTimeOffset distantTime, TimeSpan precision, string because = "",
             params object[] becauseArgs)
         {
             long distanceToMinInTicks = (distantTime - DateTimeOffset.MinValue).Ticks;
@@ -150,7 +168,7 @@ namespace FluentAssertions.Primitives
                     precision,
                     distantTime, Subject ?? default(DateTimeOffset?));
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -164,7 +182,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> BeBefore(DateTimeOffset expected, string because = "",
+        public AndConstraint<TAssertions> BeBefore(DateTimeOffset expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -173,7 +191,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context:the date and time} to be before {0}{reason}, but it was {1}.", expected,
                     Subject ?? default(DateTimeOffset?));
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -187,7 +205,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> NotBeBefore(DateTimeOffset unexpected, string because = "",
+        public AndConstraint<TAssertions> NotBeBefore(DateTimeOffset unexpected, string because = "",
             params object[] becauseArgs)
         {
             return BeOnOrAfter(unexpected, because, becauseArgs);
@@ -204,7 +222,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> BeOnOrBefore(DateTimeOffset expected, string because = "",
+        public AndConstraint<TAssertions> BeOnOrBefore(DateTimeOffset expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -213,7 +231,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context:the date and time} to be on or before {0}{reason}, but it was {1}.", expected,
                     Subject ?? default(DateTimeOffset?));
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -227,7 +245,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> NotBeOnOrBefore(DateTimeOffset unexpected, string because = "",
+        public AndConstraint<TAssertions> NotBeOnOrBefore(DateTimeOffset unexpected, string because = "",
             params object[] becauseArgs)
         {
             return BeAfter(unexpected, because, becauseArgs);
@@ -244,7 +262,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> BeAfter(DateTimeOffset expected, string because = "",
+        public AndConstraint<TAssertions> BeAfter(DateTimeOffset expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -253,7 +271,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context:the date and time} to be after {0}{reason}, but it was {1}.", expected,
                     Subject ?? default(DateTimeOffset?));
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -267,7 +285,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> NotBeAfter(DateTimeOffset unexpected, string because = "",
+        public AndConstraint<TAssertions> NotBeAfter(DateTimeOffset unexpected, string because = "",
             params object[] becauseArgs)
         {
             return BeOnOrBefore(unexpected, because, becauseArgs);
@@ -284,7 +302,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> BeOnOrAfter(DateTimeOffset expected, string because = "",
+        public AndConstraint<TAssertions> BeOnOrAfter(DateTimeOffset expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -293,7 +311,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context:the date and time} to be on or after {0}{reason}, but it was {1}.", expected,
                     Subject ?? default(DateTimeOffset?));
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -307,7 +325,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> NotBeOnOrAfter(DateTimeOffset unexpected, string because = "",
+        public AndConstraint<TAssertions> NotBeOnOrAfter(DateTimeOffset unexpected, string because = "",
             params object[] becauseArgs)
         {
             return BeBefore(unexpected, because, becauseArgs);
@@ -324,7 +342,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> HaveYear(int expected, string because = "",
+        public AndConstraint<TAssertions> HaveYear(int expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -338,7 +356,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -352,7 +370,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -365,7 +383,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -379,7 +397,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> HaveMonth(int expected, string because = "",
+        public AndConstraint<TAssertions> HaveMonth(int expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -393,7 +411,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -407,7 +425,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -420,7 +438,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -434,7 +452,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> HaveDay(int expected, string because = "",
+        public AndConstraint<TAssertions> HaveDay(int expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -448,7 +466,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -462,7 +480,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -475,7 +493,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -489,7 +507,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> HaveHour(int expected, string because = "",
+        public AndConstraint<TAssertions> HaveHour(int expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -503,7 +521,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -517,7 +535,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -530,7 +548,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -544,7 +562,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> HaveMinute(int expected, string because = "",
+        public AndConstraint<TAssertions> HaveMinute(int expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -558,7 +576,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -572,7 +590,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> NotHaveMinute(int unexpected, string because = "",
+        public AndConstraint<TAssertions> NotHaveMinute(int unexpected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -586,7 +604,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -600,7 +618,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> HaveSecond(int expected, string because = "",
+        public AndConstraint<TAssertions> HaveSecond(int expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -614,7 +632,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -628,7 +646,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> NotHaveSecond(int unexpected, string because = "",
+        public AndConstraint<TAssertions> NotHaveSecond(int unexpected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -642,7 +660,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -656,7 +674,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> HaveOffset(TimeSpan expected, string because = "",
+        public AndConstraint<TAssertions> HaveOffset(TimeSpan expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -670,7 +688,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -684,7 +702,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> NotHaveOffset(TimeSpan unexpected, string because = "",
+        public AndConstraint<TAssertions> NotHaveOffset(TimeSpan unexpected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -698,7 +716,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -708,9 +726,9 @@ namespace FluentAssertions.Primitives
         /// <param name="timeSpan">
         /// The amount of time that the current <see cref="DateTimeOffset"/> should exceed compared to another <see cref="DateTimeOffset"/>.
         /// </param>
-        public DateTimeOffsetRangeAssertions BeMoreThan(TimeSpan timeSpan)
+        public DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(TimeSpan timeSpan)
         {
-            return new DateTimeOffsetRangeAssertions(this, Subject, TimeSpanCondition.MoreThan, timeSpan);
+            return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.MoreThan, timeSpan);
         }
 
         /// <summary>
@@ -721,9 +739,9 @@ namespace FluentAssertions.Primitives
         /// The amount of time that the current <see cref="DateTimeOffset"/> should be equal or exceed compared to
         /// another <see cref="DateTimeOffset"/>.
         /// </param>
-        public DateTimeOffsetRangeAssertions BeAtLeast(TimeSpan timeSpan)
+        public DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(TimeSpan timeSpan)
         {
-            return new DateTimeOffsetRangeAssertions(this, Subject, TimeSpanCondition.AtLeast, timeSpan);
+            return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.AtLeast, timeSpan);
         }
 
         /// <summary>
@@ -733,9 +751,9 @@ namespace FluentAssertions.Primitives
         /// <param name="timeSpan">
         /// The amount of time that the current <see cref="DateTimeOffset"/> should differ exactly compared to another <see cref="DateTimeOffset"/>.
         /// </param>
-        public DateTimeOffsetRangeAssertions BeExactly(TimeSpan timeSpan)
+        public DateTimeOffsetRangeAssertions<TAssertions> BeExactly(TimeSpan timeSpan)
         {
-            return new DateTimeOffsetRangeAssertions(this, Subject, TimeSpanCondition.Exactly, timeSpan);
+            return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.Exactly, timeSpan);
         }
 
         /// <summary>
@@ -745,9 +763,9 @@ namespace FluentAssertions.Primitives
         /// <param name="timeSpan">
         /// The amount of time that the current <see cref="DateTimeOffset"/> should be within another <see cref="DateTimeOffset"/>.
         /// </param>
-        public DateTimeOffsetRangeAssertions BeWithin(TimeSpan timeSpan)
+        public DateTimeOffsetRangeAssertions<TAssertions> BeWithin(TimeSpan timeSpan)
         {
-            return new DateTimeOffsetRangeAssertions(this, Subject, TimeSpanCondition.Within, timeSpan);
+            return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.Within, timeSpan);
         }
 
         /// <summary>
@@ -757,9 +775,9 @@ namespace FluentAssertions.Primitives
         /// <param name="timeSpan">
         /// The maximum amount of time that the current <see cref="DateTimeOffset"/> should differ compared to another <see cref="DateTimeOffset"/>.
         /// </param>
-        public DateTimeOffsetRangeAssertions BeLessThan(TimeSpan timeSpan)
+        public DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(TimeSpan timeSpan)
         {
-            return new DateTimeOffsetRangeAssertions(this, Subject, TimeSpanCondition.LessThan, timeSpan);
+            return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.LessThan, timeSpan);
         }
 
         /// <summary>
@@ -773,7 +791,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> BeSameDateAs(DateTimeOffset expected, string because = "",
+        public AndConstraint<TAssertions> BeSameDateAs(DateTimeOffset expected, string because = "",
             params object[] becauseArgs)
         {
             DateTime expectedDate = expected.Date;
@@ -789,7 +807,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -803,7 +821,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> NotBeSameDateAs(DateTimeOffset unexpected, string because = "",
+        public AndConstraint<TAssertions> NotBeSameDateAs(DateTimeOffset unexpected, string because = "",
             params object[] becauseArgs)
         {
             DateTime unexpectedDate = unexpected.Date;
@@ -819,7 +837,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -828,7 +846,7 @@ namespace FluentAssertions.Primitives
         /// <param name="validValues">
         /// The values that are valid.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> BeOneOf(params DateTimeOffset?[] validValues)
+        public AndConstraint<TAssertions> BeOneOf(params DateTimeOffset?[] validValues)
         {
             return BeOneOf(validValues, string.Empty);
         }
@@ -839,7 +857,7 @@ namespace FluentAssertions.Primitives
         /// <param name="validValues">
         /// The values that are valid.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> BeOneOf(params DateTimeOffset[] validValues)
+        public AndConstraint<TAssertions> BeOneOf(params DateTimeOffset[] validValues)
         {
             return BeOneOf(validValues.Cast<DateTimeOffset?>());
         }
@@ -857,7 +875,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> BeOneOf(IEnumerable<DateTimeOffset> validValues, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeOneOf(IEnumerable<DateTimeOffset> validValues, string because = "", params object[] becauseArgs)
         {
             return BeOneOf(validValues.Cast<DateTimeOffset?>(), because, becauseArgs);
         }
@@ -875,14 +893,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> BeOneOf(IEnumerable<DateTimeOffset?> validValues, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeOneOf(IEnumerable<DateTimeOffset?> validValues, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(validValues.Contains(Subject))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be one of {0}{reason}, but it was {1}.", validValues, Subject);
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
     }
 }

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
@@ -13,11 +13,12 @@ namespace FluentAssertions.Primitives
     /// for a more fluent way of specifying a <see cref="DateTime"/> or a <see cref="TimeSpan"/>.
     /// </remarks>
     [DebuggerNonUserCode]
-    public class DateTimeOffsetRangeAssertions
+    public class DateTimeOffsetRangeAssertions<TAssertions>
+        where TAssertions : DateTimeOffsetAssertions<TAssertions>
     {
         #region Private Definitions
 
-        private readonly DateTimeOffsetAssertions parentAssertions;
+        private readonly TAssertions parentAssertions;
         private readonly TimeSpanPredicate predicate;
 
         private readonly Dictionary<TimeSpanCondition, TimeSpanPredicate> predicates = new Dictionary
@@ -35,7 +36,7 @@ namespace FluentAssertions.Primitives
 
         #endregion
 
-        protected internal DateTimeOffsetRangeAssertions(DateTimeOffsetAssertions parentAssertions, DateTimeOffset? subject,
+        protected internal DateTimeOffsetRangeAssertions(TAssertions parentAssertions, DateTimeOffset? subject,
             TimeSpanCondition condition,
             TimeSpan timeSpan)
         {
@@ -59,7 +60,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> Before(DateTimeOffset target, string because = "",
+        public AndConstraint<TAssertions> Before(DateTimeOffset target, string because = "",
             params object[] becauseArgs)
         {
             bool success = Execute.Assertion
@@ -82,7 +83,7 @@ namespace FluentAssertions.Primitives
                 }
             }
 
-            return new AndConstraint<DateTimeOffsetAssertions>(parentAssertions);
+            return new AndConstraint<TAssertions>(parentAssertions);
         }
 
         /// <summary>
@@ -98,7 +99,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> After(DateTimeOffset target, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> After(DateTimeOffset target, string because = "", params object[] becauseArgs)
         {
             bool success = Execute.Assertion
                 .ForCondition(subject.HasValue)
@@ -121,7 +122,7 @@ namespace FluentAssertions.Primitives
                 }
             }
 
-            return new AndConstraint<DateTimeOffsetAssertions>(parentAssertions);
+            return new AndConstraint<TAssertions>(parentAssertions);
         }
     }
 }

--- a/Src/FluentAssertions/Primitives/DateTimeRangeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeRangeAssertions.cs
@@ -14,11 +14,12 @@ namespace FluentAssertions.Primitives
     /// way of specifying a <see cref="DateTime"/> or a <see cref="TimeSpan"/>.
     /// </remarks>
     [DebuggerNonUserCode]
-    public class DateTimeRangeAssertions
+    public class DateTimeRangeAssertions<TAssertions>
+        where TAssertions : DateTimeAssertions<TAssertions>
     {
         #region Private Definitions
 
-        private readonly DateTimeAssertions parentAssertions;
+        private readonly TAssertions parentAssertions;
         private readonly TimeSpanPredicate predicate;
 
         private readonly Dictionary<TimeSpanCondition, TimeSpanPredicate> predicates = new Dictionary
@@ -36,7 +37,7 @@ namespace FluentAssertions.Primitives
 
         #endregion
 
-        protected internal DateTimeRangeAssertions(DateTimeAssertions parentAssertions, DateTime? subject,
+        protected internal DateTimeRangeAssertions(TAssertions parentAssertions, DateTime? subject,
             TimeSpanCondition condition,
             TimeSpan timeSpan)
         {
@@ -60,7 +61,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public AndConstraint<DateTimeAssertions> Before(DateTime target, string because = "",
+        public AndConstraint<TAssertions> Before(DateTime target, string because = "",
             params object[] becauseArgs)
         {
             bool success = Execute.Assertion
@@ -85,7 +86,7 @@ namespace FluentAssertions.Primitives
                 }
             }
 
-            return new AndConstraint<DateTimeAssertions>(parentAssertions);
+            return new AndConstraint<TAssertions>(parentAssertions);
         }
 
         /// <summary>
@@ -101,7 +102,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        public AndConstraint<DateTimeAssertions> After(DateTime target, string because = "",
+        public AndConstraint<TAssertions> After(DateTime target, string because = "",
             params object[] becauseArgs)
         {
             bool success = Execute.Assertion
@@ -126,7 +127,7 @@ namespace FluentAssertions.Primitives
                 }
             }
 
-            return new AndConstraint<DateTimeAssertions>(parentAssertions);
+            return new AndConstraint<TAssertions>(parentAssertions);
         }
     }
 }

--- a/Src/FluentAssertions/Primitives/GuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/GuidAssertions.cs
@@ -8,7 +8,20 @@ namespace FluentAssertions.Primitives
     /// Contains a number of methods to assert that a <see cref="Guid"/> is in the correct state.
     /// </summary>
     [DebuggerNonUserCode]
-    public class GuidAssertions
+    public class GuidAssertions : GuidAssertions<GuidAssertions>
+    {
+        public GuidAssertions(Guid? value)
+            : base(value)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that a <see cref="Guid"/> is in the correct state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class GuidAssertions<TAssertions>
+        where TAssertions : GuidAssertions<TAssertions>
     {
         public GuidAssertions(Guid? value)
         {
@@ -32,14 +45,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GuidAssertions> BeEmpty(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition((Subject.HasValue) && (Subject.Value == Guid.Empty))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:Guid} to be empty{reason}, but found {0}.", Subject);
 
-            return new AndConstraint<GuidAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -52,14 +65,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GuidAssertions> NotBeEmpty(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition((Subject.HasValue) && (Subject.Value != Guid.Empty))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:Guid} to be empty{reason}.");
 
-            return new AndConstraint<GuidAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         #endregion
@@ -77,7 +90,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GuidAssertions> Be(string expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs)
         {
             var expectedGuid = new Guid(expected);
             return Be(expectedGuid, because, becauseArgs);
@@ -94,14 +107,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GuidAssertions> Be(Guid expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> Be(Guid expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:Guid} to be {0}{reason}, but found {1}.", expected, Subject);
 
-            return new AndConstraint<GuidAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -115,14 +128,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<GuidAssertions> NotBe(Guid unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBe(Guid unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue || Subject.Value != unexpected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:Guid} to be {0}{reason}.", Subject);
 
-            return new AndConstraint<GuidAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         #endregion

--- a/Src/FluentAssertions/Primitives/NullableBooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableBooleanAssertions.cs
@@ -7,7 +7,20 @@ namespace FluentAssertions.Primitives
     /// Contains a number of methods to assert that a nullable <see cref="bool"/> is in the expected state.
     /// </summary>
     [DebuggerNonUserCode]
-    public class NullableBooleanAssertions : BooleanAssertions
+    public class NullableBooleanAssertions : NullableBooleanAssertions<NullableBooleanAssertions>
+    {
+        public NullableBooleanAssertions(bool? value)
+            : base(value)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <see cref="bool"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class NullableBooleanAssertions<TAssertions> : BooleanAssertions<TAssertions>
+        where TAssertions : NullableBooleanAssertions<TAssertions>
     {
         public NullableBooleanAssertions(bool? value)
             : base(value)
@@ -24,14 +37,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableBooleanAssertions> HaveValue(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value{reason}.");
 
-            return new AndConstraint<NullableBooleanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -44,7 +57,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableBooleanAssertions> NotBeNull(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs)
         {
             return HaveValue(because, becauseArgs);
         }
@@ -59,14 +72,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableBooleanAssertions> NotHaveValue(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect a value{reason}, but found {0}.", Subject);
 
-            return new AndConstraint<NullableBooleanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -79,7 +92,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableBooleanAssertions> BeNull(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs)
         {
             return NotHaveValue(because, becauseArgs);
         }
@@ -95,14 +108,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<BooleanAssertions> Be(bool? expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> Be(bool? expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but found {1}.", expected, Subject);
 
-            return new AndConstraint<BooleanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -115,14 +128,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<BooleanAssertions> NotBeFalse(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBeFalse(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue || Subject.Value)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:nullable boolean} not to be {0}{reason}, but found {1}.", false, Subject);
 
-            return new AndConstraint<BooleanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -135,14 +148,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<BooleanAssertions> NotBeTrue(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBeTrue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue || !Subject.Value)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:nullable boolean} not to be {0}{reason}, but found {1}.", true, Subject);
 
-            return new AndConstraint<BooleanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
     }
 }

--- a/Src/FluentAssertions/Primitives/NullableDateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateTimeAssertions.cs
@@ -12,7 +12,24 @@ namespace FluentAssertions.Primitives
     /// You can use the <see cref="FluentDateTimeExtensions"/> for a more fluent way of specifying a <see cref="DateTime"/>.
     /// </remarks>
     [DebuggerNonUserCode]
-    public class NullableDateTimeAssertions : DateTimeAssertions
+    public class NullableDateTimeAssertions : NullableDateTimeAssertions<NullableDateTimeAssertions>
+    {
+        public NullableDateTimeAssertions(DateTime? expected)
+            : base(expected)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <see cref="DateTime"/> or
+    /// <see cref="DateTimeOffset"/> is in the expected state.
+    /// </summary>
+    /// <remarks>
+    /// You can use the <see cref="FluentDateTimeExtensions"/> for a more fluent way of specifying a <see cref="DateTime"/>.
+    /// </remarks>
+    [DebuggerNonUserCode]
+    public class NullableDateTimeAssertions<TAssertions> : DateTimeAssertions<TAssertions>
+        where TAssertions : NullableDateTimeAssertions<TAssertions>
     {
         public NullableDateTimeAssertions(DateTime? expected)
             : base(expected)
@@ -29,14 +46,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableDateTimeAssertions> HaveValue(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:nullable date and time} to have a value{reason}, but found {0}.", Subject);
 
-            return new AndConstraint<NullableDateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -49,7 +66,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableDateTimeAssertions> NotBeNull(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs)
         {
             return HaveValue(because, becauseArgs);
         }
@@ -64,14 +81,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableDateTimeAssertions> NotHaveValue(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:nullable date and time} to have a value{reason}, but found {0}.", Subject);
 
-            return new AndConstraint<NullableDateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -84,7 +101,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableDateTimeAssertions> BeNull(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs)
         {
             return NotHaveValue(because, becauseArgs);
         }
@@ -100,14 +117,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeAssertions> Be(DateTime? expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> Be(DateTime? expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but found {1}.", expected, Subject);
 
-            return new AndConstraint<DateTimeAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
     }
 }

--- a/Src/FluentAssertions/Primitives/NullableDateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateTimeOffsetAssertions.cs
@@ -12,7 +12,24 @@ namespace FluentAssertions.Primitives
     /// for a more fluent way of specifying a <see cref="DateTime"/>.
     /// </remarks>
     [DebuggerNonUserCode]
-    public class NullableDateTimeOffsetAssertions : DateTimeOffsetAssertions
+    public class NullableDateTimeOffsetAssertions : NullableDateTimeOffsetAssertions<NullableDateTimeOffsetAssertions>
+    {
+        public NullableDateTimeOffsetAssertions(DateTimeOffset? expected)
+            : base(expected)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <see cref="DateTimeOffset"/> is in the expected state.
+    /// </summary>
+    /// <remarks>
+    /// You can use the <see cref="FluentAssertions.Extensions.FluentDateTimeExtensions"/>
+    /// for a more fluent way of specifying a <see cref="DateTime"/>.
+    /// </remarks>
+    [DebuggerNonUserCode]
+    public class NullableDateTimeOffsetAssertions<TAssertions> : DateTimeOffsetAssertions<TAssertions>
+        where TAssertions : NullableDateTimeOffsetAssertions<TAssertions>
     {
         public NullableDateTimeOffsetAssertions(DateTimeOffset? expected)
             : base(expected)
@@ -29,14 +46,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableDateTimeOffsetAssertions> HaveValue(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:variable} to have a value{reason}, but found {0}", Subject);
 
-            return new AndConstraint<NullableDateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -49,7 +66,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableDateTimeOffsetAssertions> NotBeNull(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs)
         {
             return HaveValue(because, becauseArgs);
         }
@@ -64,7 +81,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableDateTimeOffsetAssertions> NotHaveValue(string because = "",
+        public AndConstraint<TAssertions> NotHaveValue(string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -72,7 +89,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:variable} to have a value{reason}, but found {0}", Subject);
 
-            return new AndConstraint<NullableDateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -85,7 +102,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableDateTimeOffsetAssertions> BeNull(string because = "",
+        public AndConstraint<TAssertions> BeNull(string because = "",
             params object[] becauseArgs)
         {
             return NotHaveValue(because, becauseArgs);
@@ -102,7 +119,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<DateTimeOffsetAssertions> Be(DateTimeOffset? expected, string because = "",
+        public AndConstraint<TAssertions> Be(DateTimeOffset? expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -110,7 +127,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be {0}{reason}, but it was {1}.", expected, Subject);
 
-            return new AndConstraint<DateTimeOffsetAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
     }
 }

--- a/Src/FluentAssertions/Primitives/NullableGuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableGuidAssertions.cs
@@ -8,7 +8,20 @@ namespace FluentAssertions.Primitives
     /// Contains a number of methods to assert that a nullable <see cref="Guid"/> is in the expected state.
     /// </summary>
     [DebuggerNonUserCode]
-    public class NullableGuidAssertions : GuidAssertions
+    public class NullableGuidAssertions : NullableGuidAssertions<NullableGuidAssertions>
+    {
+        public NullableGuidAssertions(Guid? value)
+            : base(value)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <see cref="Guid"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class NullableGuidAssertions<TAssertions> : GuidAssertions<TAssertions>
+        where TAssertions : NullableGuidAssertions<TAssertions>
     {
         public NullableGuidAssertions(Guid? value)
             : base(value)
@@ -25,14 +38,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableGuidAssertions> HaveValue(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value{reason}.");
 
-            return new AndConstraint<NullableGuidAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -45,7 +58,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableGuidAssertions> NotBeNull(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs)
         {
             return HaveValue(because, becauseArgs);
         }
@@ -60,14 +73,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableGuidAssertions> NotHaveValue(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect a value{reason}, but found {0}.", Subject);
 
-            return new AndConstraint<NullableGuidAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -80,7 +93,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableGuidAssertions> BeNull(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs)
         {
             return NotHaveValue(because, becauseArgs);
         }
@@ -96,14 +109,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableGuidAssertions> Be(Guid? expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> Be(Guid? expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:Guid} to be {0}{reason}, but found {1}.", expected, Subject);
 
-            return new AndConstraint<NullableGuidAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
     }
 }

--- a/Src/FluentAssertions/Primitives/NullableSimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableSimpleTimeSpanAssertions.cs
@@ -12,7 +12,24 @@ namespace FluentAssertions.Primitives
     /// for a more fluent way of specifying a <see cref="TimeSpan"/>.
     /// </remarks>
     [DebuggerNonUserCode]
-    public class NullableSimpleTimeSpanAssertions : SimpleTimeSpanAssertions
+    public class NullableSimpleTimeSpanAssertions : NullableSimpleTimeSpanAssertions<NullableSimpleTimeSpanAssertions>
+    {
+        public NullableSimpleTimeSpanAssertions(TimeSpan? value)
+            : base(value)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <see cref="TimeSpan"/> is in the expected state.
+    /// </summary>
+    /// <remarks>
+    /// You can use the <see cref="FluentAssertions.Extensions.FluentTimeSpanExtensions"/>
+    /// for a more fluent way of specifying a <see cref="TimeSpan"/>.
+    /// </remarks>
+    [DebuggerNonUserCode]
+    public class NullableSimpleTimeSpanAssertions<TAssertions> : SimpleTimeSpanAssertions<TAssertions>
+        where TAssertions : NullableSimpleTimeSpanAssertions<TAssertions>
     {
         public NullableSimpleTimeSpanAssertions(TimeSpan? value)
             : base(value)
@@ -29,14 +46,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableSimpleTimeSpanAssertions> HaveValue(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value{reason}.");
 
-            return new AndConstraint<NullableSimpleTimeSpanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -49,7 +66,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableSimpleTimeSpanAssertions> NotBeNull(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs)
         {
             return HaveValue(because, becauseArgs);
         }
@@ -64,14 +81,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableSimpleTimeSpanAssertions> NotHaveValue(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect a value{reason}, but found {0}.", Subject);
 
-            return new AndConstraint<NullableSimpleTimeSpanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -84,7 +101,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableSimpleTimeSpanAssertions> BeNull(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs)
         {
             return NotHaveValue(because, becauseArgs);
         }
@@ -100,7 +117,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<NullableSimpleTimeSpanAssertions> Be(TimeSpan? expected, string because = "",
+        public AndConstraint<TAssertions> Be(TimeSpan? expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -108,7 +125,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but found {1}.", expected, Subject);
 
-            return new AndConstraint<NullableSimpleTimeSpanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
     }
 }

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -8,7 +8,20 @@ namespace FluentAssertions.Primitives
     /// Contains a number of methods to assert that a nullable <see cref="TimeSpan"/> is in the expected state.
     /// </summary>
     [DebuggerNonUserCode]
-    public class SimpleTimeSpanAssertions
+    public class SimpleTimeSpanAssertions : SimpleTimeSpanAssertions<SimpleTimeSpanAssertions>
+    {
+        public SimpleTimeSpanAssertions(TimeSpan? value)
+            : base(value)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <see cref="TimeSpan"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class SimpleTimeSpanAssertions<TAssertions>
+        where TAssertions : SimpleTimeSpanAssertions<TAssertions>
     {
         public SimpleTimeSpanAssertions(TimeSpan? value)
         {
@@ -30,7 +43,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -43,7 +56,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<SimpleTimeSpanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -56,7 +69,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -69,7 +82,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<SimpleTimeSpanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -84,7 +97,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> Be(TimeSpan expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> Be(TimeSpan expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -97,7 +110,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<SimpleTimeSpanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -112,14 +125,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> NotBe(TimeSpan unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBe(TimeSpan unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue || Subject.Value.CompareTo(unexpected) != 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {0}{reason}.", unexpected);
 
-            return new AndConstraint<SimpleTimeSpanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -134,7 +147,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> BeLessThan(TimeSpan expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeLessThan(TimeSpan expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -147,7 +160,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<SimpleTimeSpanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -162,7 +175,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> BeLessOrEqualTo(TimeSpan expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeLessOrEqualTo(TimeSpan expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -175,7 +188,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<SimpleTimeSpanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -190,7 +203,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> BeGreaterThan(TimeSpan expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeGreaterThan(TimeSpan expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -203,7 +216,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<SimpleTimeSpanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -218,7 +231,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> BeGreaterOrEqualTo(TimeSpan expected, string because = "",
+        public AndConstraint<TAssertions> BeGreaterOrEqualTo(TimeSpan expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -232,7 +245,7 @@ namespace FluentAssertions.Primitives
                 .Then
                 .ClearExpectation();
 
-            return new AndConstraint<SimpleTimeSpanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -256,7 +269,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> BeCloseTo(TimeSpan nearbyTime, TimeSpan precision, string because = "",
+        public AndConstraint<TAssertions> BeCloseTo(TimeSpan nearbyTime, TimeSpan precision, string because = "",
             params object[] becauseArgs)
         {
             TimeSpan minimumValue = nearbyTime - precision;
@@ -269,7 +282,7 @@ namespace FluentAssertions.Primitives
                     precision,
                     nearbyTime, Subject ?? default(TimeSpan?));
 
-            return new AndConstraint<SimpleTimeSpanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -293,7 +306,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<SimpleTimeSpanAssertions> NotBeCloseTo(TimeSpan distantTime, TimeSpan precision, string because = "",
+        public AndConstraint<TAssertions> NotBeCloseTo(TimeSpan distantTime, TimeSpan precision, string because = "",
             params object[] becauseArgs)
         {
             TimeSpan minimumValue = distantTime - precision;
@@ -306,7 +319,7 @@ namespace FluentAssertions.Primitives
                     precision,
                     distantTime, Subject ?? default(TimeSpan?));
 
-            return new AndConstraint<SimpleTimeSpanAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
     }
 }

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -13,7 +13,23 @@ namespace FluentAssertions.Primitives
     /// Contains a number of methods to assert that a <see cref="string"/> is in the expected state.
     /// </summary>
     [DebuggerNonUserCode]
-    public class StringAssertions : ReferenceTypeAssertions<string, StringAssertions>
+    public class StringAssertions : StringAssertions<StringAssertions>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="System.Object" /> class.
+        /// </summary>
+        public StringAssertions(string value)
+            : base(value)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that a <see cref="string"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class StringAssertions<TAssertions> : ReferenceTypeAssertions<string, TAssertions>
+        where TAssertions : StringAssertions<TAssertions>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="System.Object" /> class.
@@ -33,12 +49,12 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> Be(string expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs)
         {
             var stringEqualityValidator = new StringEqualityValidator(Subject, expected, StringComparison.Ordinal, because, becauseArgs);
             stringEqualityValidator.Validate();
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -47,7 +63,7 @@ namespace FluentAssertions.Primitives
         /// <param name="validValues">
         /// The values that are valid.
         /// </param>
-        public AndConstraint<StringAssertions> BeOneOf(params string[] validValues)
+        public AndConstraint<TAssertions> BeOneOf(params string[] validValues)
         {
             return BeOneOf(validValues, string.Empty);
         }
@@ -65,14 +81,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> BeOneOf(IEnumerable<string> validValues, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeOneOf(IEnumerable<string> validValues, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(validValues.Contains(Subject))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} to be one of {0}{reason}, but found {1}.", validValues, Subject);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -89,7 +105,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> BeEquivalentTo(string expected, string because = "",
+        public AndConstraint<TAssertions> BeEquivalentTo(string expected, string because = "",
             params object[] becauseArgs)
         {
             var expectation = new StringEqualityValidator(
@@ -97,7 +113,7 @@ namespace FluentAssertions.Primitives
 
             expectation.Validate();
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -114,7 +130,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotBeEquivalentTo(string unexpected, string because = "",
+        public AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "",
             params object[] becauseArgs)
         {
             bool notEquivalent;
@@ -129,7 +145,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} not to be equivalent to {0}{reason}, but they are.", unexpected);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -144,14 +160,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject != unexpected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} not to be {0}{reason}.", unexpected);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -167,12 +183,12 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs)
         {
             var stringWildcardMatchingValidator = new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs);
             stringWildcardMatchingValidator.Validate();
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -188,14 +204,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs)
         {
             new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs)
             {
                 Negate = true
             }.Validate();
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -211,7 +227,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "",
+        public AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "",
             params object[] becauseArgs)
         {
             var validator = new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs)
@@ -222,7 +238,7 @@ namespace FluentAssertions.Primitives
 
             validator.Validate();
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -238,7 +254,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "",
+        public AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "",
             params object[] becauseArgs)
         {
             var validator = new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs)
@@ -250,7 +266,7 @@ namespace FluentAssertions.Primitives
 
             validator.Validate();
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -266,7 +282,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> MatchRegex([RegexPattern] string regularExpression, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> MatchRegex([RegexPattern] string regularExpression, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>.");
 
@@ -290,7 +306,7 @@ namespace FluentAssertions.Primitives
                     .FailWith("Cannot match {context:string} against {0} because it is not a valid regular expression.", regularExpression);
             }
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -306,7 +322,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotMatchRegex([RegexPattern] string regularExpression, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotMatchRegex([RegexPattern] string regularExpression, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>.");
 
@@ -330,7 +346,7 @@ namespace FluentAssertions.Primitives
                     regularExpression);
             }
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -345,7 +361,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> StartWith(string expected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare start of string with <null>.");
 
@@ -357,7 +373,7 @@ namespace FluentAssertions.Primitives
             var stringStartValidator = new StringStartValidator(Subject, expected, StringComparison.Ordinal, because, becauseArgs);
             stringStartValidator.Validate();
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -372,7 +388,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare start of string with <null>.");
 
@@ -384,7 +400,7 @@ namespace FluentAssertions.Primitives
             var negatedStringStartValidator = new NegatedStringStartValidator(Subject, unexpected, StringComparison.Ordinal, because, becauseArgs);
             negatedStringStartValidator.Validate();
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -399,7 +415,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> StartWithEquivalentOf(string expected, string because = "",
+        public AndConstraint<TAssertions> StartWithEquivalentOf(string expected, string because = "",
             params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare string start equivalence with <null>.");
@@ -412,7 +428,7 @@ namespace FluentAssertions.Primitives
             var stringStartValidator = new StringStartValidator(Subject, expected, StringComparison.OrdinalIgnoreCase, because, becauseArgs);
             stringStartValidator.Validate();
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -427,7 +443,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare start of string with <null>.");
 
@@ -439,7 +455,7 @@ namespace FluentAssertions.Primitives
             var negatedStringStartValidator = new NegatedStringStartValidator(Subject, unexpected, StringComparison.OrdinalIgnoreCase, because, becauseArgs);
             negatedStringStartValidator.Validate();
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -454,7 +470,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> EndWith(string expected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare string end with <null>.");
 
@@ -482,7 +498,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} {0} to end with {1}{reason}.", Subject, expected);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -497,7 +513,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare end of string with <null>.");
 
@@ -518,7 +534,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} {0} not to end with {1}{reason}.", Subject, unexpected);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -533,7 +549,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare string end equivalence with <null>.");
 
@@ -561,7 +577,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} that ends with equivalent of {0}{reason}, but found {1}.", expected, Subject);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -576,7 +592,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare end of string with <null>.");
 
@@ -597,7 +613,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} that does not end with equivalent of {0}{reason}, but found {1}.", unexpected, Subject);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -613,7 +629,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> Contain(string expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot assert string containment against <null>.");
 
@@ -627,7 +643,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} {0} to contain {1}{reason}.", Subject, expected);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -649,7 +665,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> Contain(string expected, OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> Contain(string expected, OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot assert string containment against <null>.");
 
@@ -667,7 +683,7 @@ namespace FluentAssertions.Primitives
                     $"Expected {{context:string}} {{0}} to contain {{1}} {occurrenceConstraint.Mode} {occurrenceConstraint.ExpectedCount.Times()}{{reason}}, but found it {actual.Times()}.",
                     Subject, expected);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -682,7 +698,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot assert string containment against <null>.");
 
@@ -696,7 +712,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} {0} to contain the equivalent of {1}{reason}.", Subject, expected);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -719,7 +735,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> ContainEquivalentOf(string expected, OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> ContainEquivalentOf(string expected, OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot assert string containment against <null>.");
 
@@ -737,7 +753,7 @@ namespace FluentAssertions.Primitives
                     $"Expected {{context:string}} {{0}} to contain equivalent of {{1}} {occurrenceConstraint.Mode} {occurrenceConstraint.ExpectedCount.Times()}{{reason}}, but found it {actual.Times()}.",
                     Subject, expected);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -753,7 +769,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> ContainAll(IEnumerable<string> values, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> ContainAll(IEnumerable<string> values, string because = "", params object[] becauseArgs)
         {
             ThrowIfValuesNullOrEmpty(values);
 
@@ -763,7 +779,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} {0} to contain the strings: {1}{reason}.", Subject, missing);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -772,7 +788,7 @@ namespace FluentAssertions.Primitives
         /// <param name="values">
         /// The values that should all be present in the string
         /// </param>
-        public AndConstraint<StringAssertions> ContainAll(params string[] values)
+        public AndConstraint<TAssertions> ContainAll(params string[] values)
         {
             return ContainAll(values, because: string.Empty);
         }
@@ -790,7 +806,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> ContainAny(IEnumerable<string> values, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> ContainAny(IEnumerable<string> values, string because = "", params object[] becauseArgs)
         {
             ThrowIfValuesNullOrEmpty(values);
 
@@ -799,7 +815,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} {0} to contain at least one of the strings: {1}{reason}.", Subject, values.ToArray());
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -808,7 +824,7 @@ namespace FluentAssertions.Primitives
         /// <param name="values">
         /// The values that should will be tested against the string
         /// </param>
-        public AndConstraint<StringAssertions> ContainAny(params string[] values)
+        public AndConstraint<TAssertions> ContainAny(params string[] values)
         {
             return ContainAny(values, because: string.Empty);
         }
@@ -826,7 +842,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotContain(string unexpected, string because = "",
+        public AndConstraint<TAssertions> NotContain(string unexpected, string because = "",
             params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot assert string containment against <null>.");
@@ -841,7 +857,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:string} {0} to contain {1}{reason}.", Subject, unexpected);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -858,7 +874,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotContainAll(IEnumerable<string> values, string because = "",
+        public AndConstraint<TAssertions> NotContainAll(IEnumerable<string> values, string because = "",
             params object[] becauseArgs)
         {
             ThrowIfValuesNullOrEmpty(values);
@@ -870,7 +886,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:string} {0} to contain all of the strings: {1}{reason}.", Subject, values);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -880,7 +896,7 @@ namespace FluentAssertions.Primitives
         /// <param name="values">
         /// The values that should not be present in the string
         /// </param>
-        public AndConstraint<StringAssertions> NotContainAll(params string[] values)
+        public AndConstraint<TAssertions> NotContainAll(params string[] values)
         {
             return NotContainAll(values, because: string.Empty);
         }
@@ -898,7 +914,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotContainAny(IEnumerable<string> values, string because = "",
+        public AndConstraint<TAssertions> NotContainAny(IEnumerable<string> values, string because = "",
             params object[] becauseArgs)
         {
             ThrowIfValuesNullOrEmpty(values);
@@ -910,7 +926,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:string} {0} to contain any of the strings: {1}{reason}.", Subject, matches);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -919,7 +935,7 @@ namespace FluentAssertions.Primitives
         /// <param name="values">
         /// The values that should not be present in the string
         /// </param>
-        public AndConstraint<StringAssertions> NotContainAny(params string[] values)
+        public AndConstraint<TAssertions> NotContainAny(params string[] values)
         {
             return NotContainAny(values, because: string.Empty);
         }
@@ -936,7 +952,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotContainEquivalentOf(string unexpected, string because = "",
+        public AndConstraint<TAssertions> NotContainEquivalentOf(string unexpected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
@@ -944,7 +960,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:string} to contain equivalent of {0}{reason} but found {1}.", unexpected, Subject);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         private static bool Contains(string actual, string expected, StringComparison comparison)
@@ -962,14 +978,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> BeEmpty(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject?.Length == 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} to be empty{reason}, but found {0}.", Subject);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -982,14 +998,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> NotBeEmpty(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.Length > 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:string} to be empty{reason}.");
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -1003,7 +1019,7 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.Length == expected)
@@ -1011,7 +1027,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context:string} with length {0}{reason}, but found string {1} with length {2}.",
                     expected, Subject, Subject.Length);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -1024,14 +1040,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
         /// </param>
-        public AndConstraint<StringAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!string.IsNullOrEmpty(Subject))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} not to be <null> or empty{reason}, but found {0}.", Subject);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -1044,14 +1060,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
         /// </param>
-        public AndConstraint<StringAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(string.IsNullOrEmpty(Subject))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} to be <null> or empty{reason}, but found {0}.", Subject);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -1064,14 +1080,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
         /// </param>
-        public AndConstraint<StringAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(!string.IsNullOrWhiteSpace(Subject))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} not to be <null> or whitespace{reason}, but found {0}.", Subject);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -1084,14 +1100,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])" /> compatible placeholders.
         /// </param>
-        public AndConstraint<StringAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(string.IsNullOrWhiteSpace(Subject))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} to be <null> or whitespace{reason}, but found {0}.", Subject);
 
-            return new AndConstraint<StringAssertions>(this);
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         private static void ThrowIfValuesNullOrEmpty(IEnumerable<string> values)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -314,84 +314,112 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith(object element, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
+    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.GenericCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
     {
         public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
-            where TKey :  class { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    public class GenericCollectionAssertions<TCollection, T> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T>>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+    {
+        public GenericCollectionAssertions(TCollection actualValue) { }
+    }
+    public class GenericCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, T, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+        where TAssertions : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, TAssertions>
+    {
+        public GenericCollectionAssertions(TCollection actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+            where TKey :  class { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TAssertions>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
     {
         public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(params TKey[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(params TValue[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotBeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(params TKey[] unexpected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(params TValue[] unexpected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainKeys(params TKey[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainValues(params TValue[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKeys(params TKey[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValues(params TValue[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
     }
-    public class NonGenericCollectionAssertions : FluentAssertions.Collections.CollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
+    public class NonGenericCollectionAssertions : FluentAssertions.Collections.NonGenericCollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
     {
         public NonGenericCollectionAssertions(System.Collections.IEnumerable collection) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class NonGenericCollectionAssertions<TCollection, TAssertions> : FluentAssertions.Collections.CollectionAssertions<TCollection, TAssertions>
+        where TCollection : System.Collections.IEnumerable
+        where TAssertions : FluentAssertions.Collections.NonGenericCollectionAssertions<TCollection, TAssertions>
+    {
+        public NonGenericCollectionAssertions(TCollection collection) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
         where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
     {
         public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+    }
+    public class SelfReferencingCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<TCollection, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, T, TAssertions>
+    {
+        public SelfReferencingCollectionAssertions(TCollection actualValue) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
@@ -417,25 +445,37 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
     }
-    public class StringCollectionAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<string, FluentAssertions.Collections.StringCollectionAssertions>
+    public class StringCollectionAssertions : FluentAssertions.Collections.StringCollectionAssertions<System.Collections.Generic.IEnumerable<string>>
     {
         public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(params string[] expectation) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(params string[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
-    public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    public class StringCollectionAssertions<TCollection> : FluentAssertions.Collections.StringCollectionAssertions<TCollection, FluentAssertions.Collections.StringCollectionAssertions<TCollection>>
+        where TCollection : System.Collections.Generic.IEnumerable<string>
     {
-        public WhichValueConstraint(FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> parentConstraint, TValue value) { }
+        public StringCollectionAssertions(TCollection actualValue) { }
+    }
+    public class StringCollectionAssertions<TCollection, TAssertions> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, string, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<string>
+        where TAssertions : FluentAssertions.Collections.StringCollectionAssertions<TCollection, TAssertions>
+    {
+        public StringCollectionAssertions(TCollection actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params string[] expectation) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params string[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params string[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+    }
+    public class WhichValueConstraint<TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
+    {
+        public WhichValueConstraint(TAssertions parentConstraint, TValue value) { }
         public TValue WhichValue { get; }
     }
 }
@@ -1306,220 +1346,284 @@ namespace FluentAssertions.Formatting
 }
 namespace FluentAssertions.Numeric
 {
-    public class ComparableTypeAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    public class ComparableTypeAssertions<T> : FluentAssertions.Numeric.ComparableTypeAssertions<T, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    {
+        public ComparableTypeAssertions(System.IComparable<T> value) { }
+    }
+    public class ComparableTypeAssertions<T, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, TAssertions>
+        where TAssertions : FluentAssertions.Numeric.ComparableTypeAssertions<T, TAssertions>
     {
         public ComparableTypeAssertions(System.IComparable<T> value) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
+    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NullableNumericAssertions<T, FluentAssertions.Numeric.NullableNumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
         public NullableNumericAssertions(T? value) { }
-        public T? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NumericAssertions<T>
+    public class NullableNumericAssertions<T, TAssertions> : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
+        where T :  struct, System.IComparable<T>
+        where TAssertions : FluentAssertions.Numeric.NullableNumericAssertions<T, TAssertions>
+    {
+        public NullableNumericAssertions(T? value) { }
+        public T? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T, FluentAssertions.Numeric.NumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
         public NumericAssertions(T value) { }
+    }
+    public class NumericAssertions<T, TAssertions>
+        where T :  struct, System.IComparable<T>
+        where TAssertions : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
+    {
+        public NumericAssertions(T value) { }
         public T Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeNegative(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(params T[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BePositive(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params T[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Primitives
 {
-    public class BooleanAssertions
+    public class BooleanAssertions : FluentAssertions.Primitives.BooleanAssertions<FluentAssertions.Primitives.BooleanAssertions>
+    {
+        public BooleanAssertions(bool? value) { }
+    }
+    public class BooleanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
     {
         public BooleanAssertions(bool? value) { }
         public bool? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeAssertions
+    public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>
+    {
+        public DateTimeAssertions(System.DateTime? value) { }
+    }
+    public class DateTimeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
         public DateTimeAssertions(System.DateTime? value) { }
         public System.DateTime? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.DateTime[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.DateTime[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeOffsetAssertions
+    public class DateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<FluentAssertions.Primitives.DateTimeOffsetAssertions>
+    {
+        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
+    }
+    public class DateTimeOffsetAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
         public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
         public System.DateTimeOffset? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeOffsetRangeAssertions
+    public class DateTimeOffsetRangeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
-        protected DateTimeOffsetRangeAssertions(FluentAssertions.Primitives.DateTimeOffsetAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        protected DateTimeOffsetRangeAssertions(TAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeRangeAssertions
+    public class DateTimeRangeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
-        protected DateTimeRangeAssertions(FluentAssertions.Primitives.DateTimeAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        protected DateTimeRangeAssertions(TAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
     }
-    public class GuidAssertions
+    public class GuidAssertions : FluentAssertions.Primitives.GuidAssertions<FluentAssertions.Primitives.GuidAssertions>
+    {
+        public GuidAssertions(System.Guid? value) { }
+    }
+    public class GuidAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions>
     {
         public GuidAssertions(System.Guid? value) { }
         public System.Guid? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableBooleanAssertions : FluentAssertions.Primitives.BooleanAssertions
+    public class NullableBooleanAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<FluentAssertions.Primitives.NullableBooleanAssertions>
     {
         public NullableBooleanAssertions(bool? value) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableDateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions
+    public class NullableBooleanAssertions<TAssertions> : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<TAssertions>
+    {
+        public NullableBooleanAssertions(bool? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<FluentAssertions.Primitives.NullableDateTimeAssertions>
     {
         public NullableDateTimeAssertions(System.DateTime? expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions
+    public class NullableDateTimeAssertions<TAssertions> : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<TAssertions>
+    {
+        public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions>
     {
         public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableGuidAssertions : FluentAssertions.Primitives.GuidAssertions
+    public class NullableDateTimeOffsetAssertions<TAssertions> : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<TAssertions>
+    {
+        public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableGuidAssertions : FluentAssertions.Primitives.NullableGuidAssertions<FluentAssertions.Primitives.NullableGuidAssertions>
     {
         public NullableGuidAssertions(System.Guid? value) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions
+    public class NullableGuidAssertions<TAssertions> : FluentAssertions.Primitives.GuidAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableGuidAssertions<TAssertions>
+    {
+        public NullableGuidAssertions(System.Guid? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions>
     {
         public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions<TAssertions> : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<TAssertions>
+    {
+        public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
     public class ObjectAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
     {
@@ -1556,66 +1660,76 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class SimpleTimeSpanAssertions
+    public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>
+    {
+        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
+    }
+    public class SimpleTimeSpanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
     {
         public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
         public System.TimeSpan? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
     }
-    public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>
+    public class StringAssertions : FluentAssertions.Primitives.StringAssertions<FluentAssertions.Primitives.StringAssertions>
+    {
+        public StringAssertions(string value) { }
+    }
+    public class StringAssertions<TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<string, TAssertions>
+        where TAssertions : FluentAssertions.Primitives.StringAssertions<TAssertions>
     {
         public StringAssertions(string value) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(params string[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params string[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
     }
     public enum TimeSpanCondition
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -314,84 +314,112 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith(object element, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
+    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.GenericCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
     {
         public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
-            where TKey :  class { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    public class GenericCollectionAssertions<TCollection, T> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T>>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+    {
+        public GenericCollectionAssertions(TCollection actualValue) { }
+    }
+    public class GenericCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, T, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+        where TAssertions : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, TAssertions>
+    {
+        public GenericCollectionAssertions(TCollection actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+            where TKey :  class { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TAssertions>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
     {
         public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(params TKey[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(params TValue[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotBeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(params TKey[] unexpected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(params TValue[] unexpected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainKeys(params TKey[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainValues(params TValue[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKeys(params TKey[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValues(params TValue[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
     }
-    public class NonGenericCollectionAssertions : FluentAssertions.Collections.CollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
+    public class NonGenericCollectionAssertions : FluentAssertions.Collections.NonGenericCollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
     {
         public NonGenericCollectionAssertions(System.Collections.IEnumerable collection) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class NonGenericCollectionAssertions<TCollection, TAssertions> : FluentAssertions.Collections.CollectionAssertions<TCollection, TAssertions>
+        where TCollection : System.Collections.IEnumerable
+        where TAssertions : FluentAssertions.Collections.NonGenericCollectionAssertions<TCollection, TAssertions>
+    {
+        public NonGenericCollectionAssertions(TCollection collection) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
         where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
     {
         public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+    }
+    public class SelfReferencingCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<TCollection, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, T, TAssertions>
+    {
+        public SelfReferencingCollectionAssertions(TCollection actualValue) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
@@ -417,25 +445,37 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
     }
-    public class StringCollectionAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<string, FluentAssertions.Collections.StringCollectionAssertions>
+    public class StringCollectionAssertions : FluentAssertions.Collections.StringCollectionAssertions<System.Collections.Generic.IEnumerable<string>>
     {
         public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(params string[] expectation) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(params string[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
-    public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    public class StringCollectionAssertions<TCollection> : FluentAssertions.Collections.StringCollectionAssertions<TCollection, FluentAssertions.Collections.StringCollectionAssertions<TCollection>>
+        where TCollection : System.Collections.Generic.IEnumerable<string>
     {
-        public WhichValueConstraint(FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> parentConstraint, TValue value) { }
+        public StringCollectionAssertions(TCollection actualValue) { }
+    }
+    public class StringCollectionAssertions<TCollection, TAssertions> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, string, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<string>
+        where TAssertions : FluentAssertions.Collections.StringCollectionAssertions<TCollection, TAssertions>
+    {
+        public StringCollectionAssertions(TCollection actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params string[] expectation) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params string[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params string[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+    }
+    public class WhichValueConstraint<TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
+    {
+        public WhichValueConstraint(TAssertions parentConstraint, TValue value) { }
         public TValue WhichValue { get; }
     }
 }
@@ -1306,220 +1346,284 @@ namespace FluentAssertions.Formatting
 }
 namespace FluentAssertions.Numeric
 {
-    public class ComparableTypeAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    public class ComparableTypeAssertions<T> : FluentAssertions.Numeric.ComparableTypeAssertions<T, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    {
+        public ComparableTypeAssertions(System.IComparable<T> value) { }
+    }
+    public class ComparableTypeAssertions<T, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, TAssertions>
+        where TAssertions : FluentAssertions.Numeric.ComparableTypeAssertions<T, TAssertions>
     {
         public ComparableTypeAssertions(System.IComparable<T> value) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
+    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NullableNumericAssertions<T, FluentAssertions.Numeric.NullableNumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
         public NullableNumericAssertions(T? value) { }
-        public T? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NumericAssertions<T>
+    public class NullableNumericAssertions<T, TAssertions> : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
+        where T :  struct, System.IComparable<T>
+        where TAssertions : FluentAssertions.Numeric.NullableNumericAssertions<T, TAssertions>
+    {
+        public NullableNumericAssertions(T? value) { }
+        public T? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T, FluentAssertions.Numeric.NumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
         public NumericAssertions(T value) { }
+    }
+    public class NumericAssertions<T, TAssertions>
+        where T :  struct, System.IComparable<T>
+        where TAssertions : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
+    {
+        public NumericAssertions(T value) { }
         public T Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeNegative(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(params T[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BePositive(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params T[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Primitives
 {
-    public class BooleanAssertions
+    public class BooleanAssertions : FluentAssertions.Primitives.BooleanAssertions<FluentAssertions.Primitives.BooleanAssertions>
+    {
+        public BooleanAssertions(bool? value) { }
+    }
+    public class BooleanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
     {
         public BooleanAssertions(bool? value) { }
         public bool? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeAssertions
+    public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>
+    {
+        public DateTimeAssertions(System.DateTime? value) { }
+    }
+    public class DateTimeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
         public DateTimeAssertions(System.DateTime? value) { }
         public System.DateTime? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.DateTime[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.DateTime[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeOffsetAssertions
+    public class DateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<FluentAssertions.Primitives.DateTimeOffsetAssertions>
+    {
+        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
+    }
+    public class DateTimeOffsetAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
         public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
         public System.DateTimeOffset? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeOffsetRangeAssertions
+    public class DateTimeOffsetRangeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
-        protected DateTimeOffsetRangeAssertions(FluentAssertions.Primitives.DateTimeOffsetAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        protected DateTimeOffsetRangeAssertions(TAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeRangeAssertions
+    public class DateTimeRangeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
-        protected DateTimeRangeAssertions(FluentAssertions.Primitives.DateTimeAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        protected DateTimeRangeAssertions(TAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
     }
-    public class GuidAssertions
+    public class GuidAssertions : FluentAssertions.Primitives.GuidAssertions<FluentAssertions.Primitives.GuidAssertions>
+    {
+        public GuidAssertions(System.Guid? value) { }
+    }
+    public class GuidAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions>
     {
         public GuidAssertions(System.Guid? value) { }
         public System.Guid? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableBooleanAssertions : FluentAssertions.Primitives.BooleanAssertions
+    public class NullableBooleanAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<FluentAssertions.Primitives.NullableBooleanAssertions>
     {
         public NullableBooleanAssertions(bool? value) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableDateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions
+    public class NullableBooleanAssertions<TAssertions> : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<TAssertions>
+    {
+        public NullableBooleanAssertions(bool? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<FluentAssertions.Primitives.NullableDateTimeAssertions>
     {
         public NullableDateTimeAssertions(System.DateTime? expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions
+    public class NullableDateTimeAssertions<TAssertions> : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<TAssertions>
+    {
+        public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions>
     {
         public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableGuidAssertions : FluentAssertions.Primitives.GuidAssertions
+    public class NullableDateTimeOffsetAssertions<TAssertions> : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<TAssertions>
+    {
+        public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableGuidAssertions : FluentAssertions.Primitives.NullableGuidAssertions<FluentAssertions.Primitives.NullableGuidAssertions>
     {
         public NullableGuidAssertions(System.Guid? value) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions
+    public class NullableGuidAssertions<TAssertions> : FluentAssertions.Primitives.GuidAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableGuidAssertions<TAssertions>
+    {
+        public NullableGuidAssertions(System.Guid? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions>
     {
         public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions<TAssertions> : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<TAssertions>
+    {
+        public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
     public class ObjectAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
     {
@@ -1556,66 +1660,76 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class SimpleTimeSpanAssertions
+    public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>
+    {
+        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
+    }
+    public class SimpleTimeSpanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
     {
         public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
         public System.TimeSpan? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
     }
-    public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>
+    public class StringAssertions : FluentAssertions.Primitives.StringAssertions<FluentAssertions.Primitives.StringAssertions>
+    {
+        public StringAssertions(string value) { }
+    }
+    public class StringAssertions<TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<string, TAssertions>
+        where TAssertions : FluentAssertions.Primitives.StringAssertions<TAssertions>
     {
         public StringAssertions(string value) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(params string[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params string[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
     }
     public enum TimeSpanCondition
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -314,84 +314,112 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith(object element, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
+    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.GenericCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
     {
         public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
-            where TKey :  class { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    public class GenericCollectionAssertions<TCollection, T> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T>>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+    {
+        public GenericCollectionAssertions(TCollection actualValue) { }
+    }
+    public class GenericCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, T, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+        where TAssertions : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, TAssertions>
+    {
+        public GenericCollectionAssertions(TCollection actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+            where TKey :  class { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TAssertions>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
     {
         public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(params TKey[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(params TValue[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotBeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(params TKey[] unexpected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(params TValue[] unexpected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainKeys(params TKey[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainValues(params TValue[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKeys(params TKey[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValues(params TValue[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
     }
-    public class NonGenericCollectionAssertions : FluentAssertions.Collections.CollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
+    public class NonGenericCollectionAssertions : FluentAssertions.Collections.NonGenericCollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
     {
         public NonGenericCollectionAssertions(System.Collections.IEnumerable collection) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class NonGenericCollectionAssertions<TCollection, TAssertions> : FluentAssertions.Collections.CollectionAssertions<TCollection, TAssertions>
+        where TCollection : System.Collections.IEnumerable
+        where TAssertions : FluentAssertions.Collections.NonGenericCollectionAssertions<TCollection, TAssertions>
+    {
+        public NonGenericCollectionAssertions(TCollection collection) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
         where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
     {
         public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+    }
+    public class SelfReferencingCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<TCollection, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, T, TAssertions>
+    {
+        public SelfReferencingCollectionAssertions(TCollection actualValue) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
@@ -417,25 +445,37 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
     }
-    public class StringCollectionAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<string, FluentAssertions.Collections.StringCollectionAssertions>
+    public class StringCollectionAssertions : FluentAssertions.Collections.StringCollectionAssertions<System.Collections.Generic.IEnumerable<string>>
     {
         public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(params string[] expectation) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(params string[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
-    public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    public class StringCollectionAssertions<TCollection> : FluentAssertions.Collections.StringCollectionAssertions<TCollection, FluentAssertions.Collections.StringCollectionAssertions<TCollection>>
+        where TCollection : System.Collections.Generic.IEnumerable<string>
     {
-        public WhichValueConstraint(FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> parentConstraint, TValue value) { }
+        public StringCollectionAssertions(TCollection actualValue) { }
+    }
+    public class StringCollectionAssertions<TCollection, TAssertions> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, string, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<string>
+        where TAssertions : FluentAssertions.Collections.StringCollectionAssertions<TCollection, TAssertions>
+    {
+        public StringCollectionAssertions(TCollection actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params string[] expectation) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params string[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params string[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+    }
+    public class WhichValueConstraint<TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
+    {
+        public WhichValueConstraint(TAssertions parentConstraint, TValue value) { }
         public TValue WhichValue { get; }
     }
 }
@@ -1306,220 +1346,284 @@ namespace FluentAssertions.Formatting
 }
 namespace FluentAssertions.Numeric
 {
-    public class ComparableTypeAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    public class ComparableTypeAssertions<T> : FluentAssertions.Numeric.ComparableTypeAssertions<T, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    {
+        public ComparableTypeAssertions(System.IComparable<T> value) { }
+    }
+    public class ComparableTypeAssertions<T, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, TAssertions>
+        where TAssertions : FluentAssertions.Numeric.ComparableTypeAssertions<T, TAssertions>
     {
         public ComparableTypeAssertions(System.IComparable<T> value) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
+    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NullableNumericAssertions<T, FluentAssertions.Numeric.NullableNumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
         public NullableNumericAssertions(T? value) { }
-        public T? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NumericAssertions<T>
+    public class NullableNumericAssertions<T, TAssertions> : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
+        where T :  struct, System.IComparable<T>
+        where TAssertions : FluentAssertions.Numeric.NullableNumericAssertions<T, TAssertions>
+    {
+        public NullableNumericAssertions(T? value) { }
+        public T? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T, FluentAssertions.Numeric.NumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
         public NumericAssertions(T value) { }
+    }
+    public class NumericAssertions<T, TAssertions>
+        where T :  struct, System.IComparable<T>
+        where TAssertions : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
+    {
+        public NumericAssertions(T value) { }
         public T Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeNegative(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(params T[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BePositive(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params T[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Primitives
 {
-    public class BooleanAssertions
+    public class BooleanAssertions : FluentAssertions.Primitives.BooleanAssertions<FluentAssertions.Primitives.BooleanAssertions>
+    {
+        public BooleanAssertions(bool? value) { }
+    }
+    public class BooleanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
     {
         public BooleanAssertions(bool? value) { }
         public bool? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeAssertions
+    public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>
+    {
+        public DateTimeAssertions(System.DateTime? value) { }
+    }
+    public class DateTimeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
         public DateTimeAssertions(System.DateTime? value) { }
         public System.DateTime? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.DateTime[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.DateTime[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeOffsetAssertions
+    public class DateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<FluentAssertions.Primitives.DateTimeOffsetAssertions>
+    {
+        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
+    }
+    public class DateTimeOffsetAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
         public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
         public System.DateTimeOffset? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeOffsetRangeAssertions
+    public class DateTimeOffsetRangeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
-        protected DateTimeOffsetRangeAssertions(FluentAssertions.Primitives.DateTimeOffsetAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        protected DateTimeOffsetRangeAssertions(TAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeRangeAssertions
+    public class DateTimeRangeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
-        protected DateTimeRangeAssertions(FluentAssertions.Primitives.DateTimeAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        protected DateTimeRangeAssertions(TAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
     }
-    public class GuidAssertions
+    public class GuidAssertions : FluentAssertions.Primitives.GuidAssertions<FluentAssertions.Primitives.GuidAssertions>
+    {
+        public GuidAssertions(System.Guid? value) { }
+    }
+    public class GuidAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions>
     {
         public GuidAssertions(System.Guid? value) { }
         public System.Guid? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableBooleanAssertions : FluentAssertions.Primitives.BooleanAssertions
+    public class NullableBooleanAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<FluentAssertions.Primitives.NullableBooleanAssertions>
     {
         public NullableBooleanAssertions(bool? value) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableDateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions
+    public class NullableBooleanAssertions<TAssertions> : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<TAssertions>
+    {
+        public NullableBooleanAssertions(bool? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<FluentAssertions.Primitives.NullableDateTimeAssertions>
     {
         public NullableDateTimeAssertions(System.DateTime? expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions
+    public class NullableDateTimeAssertions<TAssertions> : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<TAssertions>
+    {
+        public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions>
     {
         public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableGuidAssertions : FluentAssertions.Primitives.GuidAssertions
+    public class NullableDateTimeOffsetAssertions<TAssertions> : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<TAssertions>
+    {
+        public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableGuidAssertions : FluentAssertions.Primitives.NullableGuidAssertions<FluentAssertions.Primitives.NullableGuidAssertions>
     {
         public NullableGuidAssertions(System.Guid? value) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions
+    public class NullableGuidAssertions<TAssertions> : FluentAssertions.Primitives.GuidAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableGuidAssertions<TAssertions>
+    {
+        public NullableGuidAssertions(System.Guid? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions>
     {
         public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions<TAssertions> : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<TAssertions>
+    {
+        public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
     public class ObjectAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
     {
@@ -1556,66 +1660,76 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class SimpleTimeSpanAssertions
+    public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>
+    {
+        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
+    }
+    public class SimpleTimeSpanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
     {
         public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
         public System.TimeSpan? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
     }
-    public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>
+    public class StringAssertions : FluentAssertions.Primitives.StringAssertions<FluentAssertions.Primitives.StringAssertions>
+    {
+        public StringAssertions(string value) { }
+    }
+    public class StringAssertions<TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<string, TAssertions>
+        where TAssertions : FluentAssertions.Primitives.StringAssertions<TAssertions>
     {
         public StringAssertions(string value) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(params string[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params string[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
     }
     public enum TimeSpanCondition
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -313,84 +313,112 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith(object element, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
+    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.GenericCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
     {
         public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
-            where TKey :  class { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    public class GenericCollectionAssertions<TCollection, T> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T>>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+    {
+        public GenericCollectionAssertions(TCollection actualValue) { }
+    }
+    public class GenericCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, T, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+        where TAssertions : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, TAssertions>
+    {
+        public GenericCollectionAssertions(TCollection actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+            where TKey :  class { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TAssertions>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
     {
         public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(params TKey[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(params TValue[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotBeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(params TKey[] unexpected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(params TValue[] unexpected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainKeys(params TKey[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainValues(params TValue[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKeys(params TKey[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValues(params TValue[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
     }
-    public class NonGenericCollectionAssertions : FluentAssertions.Collections.CollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
+    public class NonGenericCollectionAssertions : FluentAssertions.Collections.NonGenericCollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
     {
         public NonGenericCollectionAssertions(System.Collections.IEnumerable collection) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class NonGenericCollectionAssertions<TCollection, TAssertions> : FluentAssertions.Collections.CollectionAssertions<TCollection, TAssertions>
+        where TCollection : System.Collections.IEnumerable
+        where TAssertions : FluentAssertions.Collections.NonGenericCollectionAssertions<TCollection, TAssertions>
+    {
+        public NonGenericCollectionAssertions(TCollection collection) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
         where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
     {
         public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+    }
+    public class SelfReferencingCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<TCollection, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, T, TAssertions>
+    {
+        public SelfReferencingCollectionAssertions(TCollection actualValue) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
@@ -416,25 +444,37 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
     }
-    public class StringCollectionAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<string, FluentAssertions.Collections.StringCollectionAssertions>
+    public class StringCollectionAssertions : FluentAssertions.Collections.StringCollectionAssertions<System.Collections.Generic.IEnumerable<string>>
     {
         public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(params string[] expectation) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(params string[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
-    public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    public class StringCollectionAssertions<TCollection> : FluentAssertions.Collections.StringCollectionAssertions<TCollection, FluentAssertions.Collections.StringCollectionAssertions<TCollection>>
+        where TCollection : System.Collections.Generic.IEnumerable<string>
     {
-        public WhichValueConstraint(FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> parentConstraint, TValue value) { }
+        public StringCollectionAssertions(TCollection actualValue) { }
+    }
+    public class StringCollectionAssertions<TCollection, TAssertions> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, string, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<string>
+        where TAssertions : FluentAssertions.Collections.StringCollectionAssertions<TCollection, TAssertions>
+    {
+        public StringCollectionAssertions(TCollection actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params string[] expectation) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params string[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params string[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+    }
+    public class WhichValueConstraint<TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
+    {
+        public WhichValueConstraint(TAssertions parentConstraint, TValue value) { }
         public TValue WhichValue { get; }
     }
 }
@@ -1262,220 +1302,284 @@ namespace FluentAssertions.Formatting
 }
 namespace FluentAssertions.Numeric
 {
-    public class ComparableTypeAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    public class ComparableTypeAssertions<T> : FluentAssertions.Numeric.ComparableTypeAssertions<T, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    {
+        public ComparableTypeAssertions(System.IComparable<T> value) { }
+    }
+    public class ComparableTypeAssertions<T, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, TAssertions>
+        where TAssertions : FluentAssertions.Numeric.ComparableTypeAssertions<T, TAssertions>
     {
         public ComparableTypeAssertions(System.IComparable<T> value) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
+    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NullableNumericAssertions<T, FluentAssertions.Numeric.NullableNumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
         public NullableNumericAssertions(T? value) { }
-        public T? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NumericAssertions<T>
+    public class NullableNumericAssertions<T, TAssertions> : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
+        where T :  struct, System.IComparable<T>
+        where TAssertions : FluentAssertions.Numeric.NullableNumericAssertions<T, TAssertions>
+    {
+        public NullableNumericAssertions(T? value) { }
+        public T? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T, FluentAssertions.Numeric.NumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
         public NumericAssertions(T value) { }
+    }
+    public class NumericAssertions<T, TAssertions>
+        where T :  struct, System.IComparable<T>
+        where TAssertions : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
+    {
+        public NumericAssertions(T value) { }
         public T Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeNegative(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(params T[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BePositive(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params T[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Primitives
 {
-    public class BooleanAssertions
+    public class BooleanAssertions : FluentAssertions.Primitives.BooleanAssertions<FluentAssertions.Primitives.BooleanAssertions>
+    {
+        public BooleanAssertions(bool? value) { }
+    }
+    public class BooleanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
     {
         public BooleanAssertions(bool? value) { }
         public bool? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeAssertions
+    public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>
+    {
+        public DateTimeAssertions(System.DateTime? value) { }
+    }
+    public class DateTimeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
         public DateTimeAssertions(System.DateTime? value) { }
         public System.DateTime? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.DateTime[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.DateTime[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeOffsetAssertions
+    public class DateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<FluentAssertions.Primitives.DateTimeOffsetAssertions>
+    {
+        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
+    }
+    public class DateTimeOffsetAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
         public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
         public System.DateTimeOffset? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeOffsetRangeAssertions
+    public class DateTimeOffsetRangeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
-        protected DateTimeOffsetRangeAssertions(FluentAssertions.Primitives.DateTimeOffsetAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        protected DateTimeOffsetRangeAssertions(TAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeRangeAssertions
+    public class DateTimeRangeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
-        protected DateTimeRangeAssertions(FluentAssertions.Primitives.DateTimeAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        protected DateTimeRangeAssertions(TAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
     }
-    public class GuidAssertions
+    public class GuidAssertions : FluentAssertions.Primitives.GuidAssertions<FluentAssertions.Primitives.GuidAssertions>
+    {
+        public GuidAssertions(System.Guid? value) { }
+    }
+    public class GuidAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions>
     {
         public GuidAssertions(System.Guid? value) { }
         public System.Guid? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableBooleanAssertions : FluentAssertions.Primitives.BooleanAssertions
+    public class NullableBooleanAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<FluentAssertions.Primitives.NullableBooleanAssertions>
     {
         public NullableBooleanAssertions(bool? value) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableDateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions
+    public class NullableBooleanAssertions<TAssertions> : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<TAssertions>
+    {
+        public NullableBooleanAssertions(bool? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<FluentAssertions.Primitives.NullableDateTimeAssertions>
     {
         public NullableDateTimeAssertions(System.DateTime? expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions
+    public class NullableDateTimeAssertions<TAssertions> : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<TAssertions>
+    {
+        public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions>
     {
         public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableGuidAssertions : FluentAssertions.Primitives.GuidAssertions
+    public class NullableDateTimeOffsetAssertions<TAssertions> : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<TAssertions>
+    {
+        public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableGuidAssertions : FluentAssertions.Primitives.NullableGuidAssertions<FluentAssertions.Primitives.NullableGuidAssertions>
     {
         public NullableGuidAssertions(System.Guid? value) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions
+    public class NullableGuidAssertions<TAssertions> : FluentAssertions.Primitives.GuidAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableGuidAssertions<TAssertions>
+    {
+        public NullableGuidAssertions(System.Guid? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions>
     {
         public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions<TAssertions> : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<TAssertions>
+    {
+        public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
     public class ObjectAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
     {
@@ -1512,66 +1616,76 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class SimpleTimeSpanAssertions
+    public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>
+    {
+        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
+    }
+    public class SimpleTimeSpanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
     {
         public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
         public System.TimeSpan? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
     }
-    public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>
+    public class StringAssertions : FluentAssertions.Primitives.StringAssertions<FluentAssertions.Primitives.StringAssertions>
+    {
+        public StringAssertions(string value) { }
+    }
+    public class StringAssertions<TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<string, TAssertions>
+        where TAssertions : FluentAssertions.Primitives.StringAssertions<TAssertions>
     {
         public StringAssertions(string value) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(params string[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params string[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
     }
     public enum TimeSpanCondition
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -314,84 +314,112 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith(object element, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
+    public class GenericCollectionAssertions<T> : FluentAssertions.Collections.GenericCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, FluentAssertions.Collections.GenericCollectionAssertions<T>>
     {
         public GenericCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
-            where TKey :  class { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    public class GenericCollectionAssertions<TCollection, T> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T>>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+    {
+        public GenericCollectionAssertions(TCollection actualValue) { }
+    }
+    public class GenericCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, T, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+        where TAssertions : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, T, TAssertions>
+    {
+        public GenericCollectionAssertions(TCollection actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(System.Collections.Generic.IComparer<T> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] args) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainNulls<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
+            where TKey :  class { }
+        public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    {
+        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+    }
+    public class GenericDictionaryAssertions<TKey, TValue, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TAssertions>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
     {
         public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(params TKey[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(params TValue[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotBeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(params TKey[] unexpected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(params TValue[] unexpected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainKeys(params TKey[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainValues(params TValue[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKey(TKey unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKeys(params TKey[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainKeys(System.Collections.Generic.IEnumerable<TKey> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValues(params TValue[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
     }
-    public class NonGenericCollectionAssertions : FluentAssertions.Collections.CollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
+    public class NonGenericCollectionAssertions : FluentAssertions.Collections.NonGenericCollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
     {
         public NonGenericCollectionAssertions(System.Collections.IEnumerable collection) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.NonGenericCollectionAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class NonGenericCollectionAssertions<TCollection, TAssertions> : FluentAssertions.Collections.CollectionAssertions<TCollection, TAssertions>
+        where TCollection : System.Collections.IEnumerable
+        where TAssertions : FluentAssertions.Collections.NonGenericCollectionAssertions<TCollection, TAssertions>
+    {
+        public NonGenericCollectionAssertions(TCollection collection) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(object expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
         where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
     {
         public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
+    }
+    public class SelfReferencingCollectionAssertions<TCollection, T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<TCollection, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<T>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, T, TAssertions>
+    {
+        public SelfReferencingCollectionAssertions(TCollection actualValue) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
@@ -417,25 +445,37 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
     }
-    public class StringCollectionAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<string, FluentAssertions.Collections.StringCollectionAssertions>
+    public class StringCollectionAssertions : FluentAssertions.Collections.StringCollectionAssertions<System.Collections.Generic.IEnumerable<string>>
     {
         public StringCollectionAssertions(System.Collections.Generic.IEnumerable<string> actualValue) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(params string[] expectation) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(params string[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndWhichConstraint<FluentAssertions.Collections.StringCollectionAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> Equal(params string[] expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Collections.StringCollectionAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
-    public class WhichValueConstraint<TKey, TValue> : FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    public class StringCollectionAssertions<TCollection> : FluentAssertions.Collections.StringCollectionAssertions<TCollection, FluentAssertions.Collections.StringCollectionAssertions<TCollection>>
+        where TCollection : System.Collections.Generic.IEnumerable<string>
     {
-        public WhichValueConstraint(FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> parentConstraint, TValue value) { }
+        public StringCollectionAssertions(TCollection actualValue) { }
+    }
+    public class StringCollectionAssertions<TCollection, TAssertions> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, string, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<string>
+        where TAssertions : FluentAssertions.Collections.StringCollectionAssertions<TCollection, TAssertions>
+    {
+        public StringCollectionAssertions(TCollection actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params string[] expectation) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params string[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal(params string[] expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+    }
+    public class WhichValueConstraint<TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
+    {
+        public WhichValueConstraint(TAssertions parentConstraint, TValue value) { }
         public TValue WhichValue { get; }
     }
 }
@@ -1306,220 +1346,284 @@ namespace FluentAssertions.Formatting
 }
 namespace FluentAssertions.Numeric
 {
-    public class ComparableTypeAssertions<T> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    public class ComparableTypeAssertions<T> : FluentAssertions.Numeric.ComparableTypeAssertions<T, FluentAssertions.Numeric.ComparableTypeAssertions<T>>
+    {
+        public ComparableTypeAssertions(System.IComparable<T> value) { }
+    }
+    public class ComparableTypeAssertions<T, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.IComparable<T>, TAssertions>
+        where TAssertions : FluentAssertions.Numeric.ComparableTypeAssertions<T, TAssertions>
     {
         public ComparableTypeAssertions(System.IComparable<T> value) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.ComparableTypeAssertions<T>> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T>
+    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NullableNumericAssertions<T, FluentAssertions.Numeric.NullableNumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
         public NullableNumericAssertions(T? value) { }
-        public T? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NullableNumericAssertions<T>> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NumericAssertions<T>
+    public class NullableNumericAssertions<T, TAssertions> : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
+        where T :  struct, System.IComparable<T>
+        where TAssertions : FluentAssertions.Numeric.NullableNumericAssertions<T, TAssertions>
+    {
+        public NullableNumericAssertions(T? value) { }
+        public T? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T, FluentAssertions.Numeric.NumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
         public NumericAssertions(T value) { }
+    }
+    public class NumericAssertions<T, TAssertions>
+        where T :  struct, System.IComparable<T>
+        where TAssertions : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
+    {
+        public NumericAssertions(T value) { }
         public T Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Be(T? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeNegative(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(params T[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> BePositive(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Numeric.NumericAssertions<T>> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params T[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<T> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(T? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Primitives
 {
-    public class BooleanAssertions
+    public class BooleanAssertions : FluentAssertions.Primitives.BooleanAssertions<FluentAssertions.Primitives.BooleanAssertions>
+    {
+        public BooleanAssertions(bool? value) { }
+    }
+    public class BooleanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
     {
         public BooleanAssertions(bool? value) { }
         public bool? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeAssertions
+    public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>
+    {
+        public DateTimeAssertions(System.DateTime? value) { }
+    }
+    public class DateTimeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
         public DateTimeAssertions(System.DateTime? value) { }
         public System.DateTime? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.DateTime[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTime nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeIn(System.DateTimeKind expectedKind, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.DateTime[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTime?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeOffsetAssertions
+    public class DateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<FluentAssertions.Primitives.DateTimeOffsetAssertions>
+    {
+        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
+    }
+    public class DateTimeOffsetAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
         public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
         public System.DateTimeOffset? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeAtLeast(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeExactly(System.TimeSpan timeSpan) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeLessThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeMoreThan(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions BeWithin(System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOnOrBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.DateTimeOffset[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params System.Nullable<>[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<System.DateTimeOffset?> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSameDateAs(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeWithin(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveDay(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveHour(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMinute(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveMonth(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveOffset(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveDay(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveHour(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMinute(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveMonth(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveOffset(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSecond(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveYear(int unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeOffsetRangeAssertions
+    public class DateTimeOffsetRangeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
-        protected DateTimeOffsetRangeAssertions(FluentAssertions.Primitives.DateTimeOffsetAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        protected DateTimeOffsetRangeAssertions(TAssertions parentAssertions, System.DateTimeOffset? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> After(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTimeOffset target, string because = "", params object[] becauseArgs) { }
     }
-    public class DateTimeRangeAssertions
+    public class DateTimeRangeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
-        protected DateTimeRangeAssertions(FluentAssertions.Primitives.DateTimeAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        protected DateTimeRangeAssertions(TAssertions parentAssertions, System.DateTime? subject, FluentAssertions.Primitives.TimeSpanCondition condition, System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
     }
-    public class GuidAssertions
+    public class GuidAssertions : FluentAssertions.Primitives.GuidAssertions<FluentAssertions.Primitives.GuidAssertions>
+    {
+        public GuidAssertions(System.Guid? value) { }
+    }
+    public class GuidAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions>
     {
         public GuidAssertions(System.Guid? value) { }
         public System.Guid? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.GuidAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableBooleanAssertions : FluentAssertions.Primitives.BooleanAssertions
+    public class NullableBooleanAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<FluentAssertions.Primitives.NullableBooleanAssertions>
     {
         public NullableBooleanAssertions(bool? value) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.BooleanAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableBooleanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableDateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions
+    public class NullableBooleanAssertions<TAssertions> : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<TAssertions>
+    {
+        public NullableBooleanAssertions(bool? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeFalse(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<FluentAssertions.Primitives.NullableDateTimeAssertions>
     {
         public NullableDateTimeAssertions(System.DateTime? expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions
+    public class NullableDateTimeAssertions<TAssertions> : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<TAssertions>
+    {
+        public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableDateTimeOffsetAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions>
     {
         public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.DateTimeOffsetAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableDateTimeOffsetAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableGuidAssertions : FluentAssertions.Primitives.GuidAssertions
+    public class NullableDateTimeOffsetAssertions<TAssertions> : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<TAssertions>
+    {
+        public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableGuidAssertions : FluentAssertions.Primitives.NullableGuidAssertions<FluentAssertions.Primitives.NullableGuidAssertions>
     {
         public NullableGuidAssertions(System.Guid? value) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableGuidAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions
+    public class NullableGuidAssertions<TAssertions> : FluentAssertions.Primitives.GuidAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableGuidAssertions<TAssertions>
+    {
+        public NullableGuidAssertions(System.Guid? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions>
     {
         public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> BeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableSimpleTimeSpanAssertions<TAssertions> : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<TAssertions>
+    {
+        public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
     public class ObjectAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
     {
@@ -1556,66 +1660,76 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class SimpleTimeSpanAssertions
+    public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>
+    {
+        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
+    }
+    public class SimpleTimeSpanAssertions<TAssertions>
+        where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
     {
         public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
         public System.TimeSpan? Subject { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> BePositive(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.SimpleTimeSpanAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.TimeSpan distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
     }
-    public class StringAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<string, FluentAssertions.Primitives.StringAssertions>
+    public class StringAssertions : FluentAssertions.Primitives.StringAssertions<FluentAssertions.Primitives.StringAssertions>
+    {
+        public StringAssertions(string value) { }
+    }
+    public class StringAssertions<TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<string, TAssertions>
+        where TAssertions : FluentAssertions.Primitives.StringAssertions<TAssertions>
     {
         public StringAssertions(string value) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(params string[] validValues) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(params string[] values) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<FluentAssertions.Primitives.StringAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params string[] validValues) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> ContainEquivalentOf(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAll(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAny(params string[] values) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainAny(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEndWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> StartWithEquivalentOf(string expected, string because = "", params object[] becauseArgs) { }
     }
     public enum TimeSpanCondition
     {

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -1528,7 +1528,7 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             MethodInfo[] methodInfo =
-                typeof(StringCollectionAssertions).GetMethods(
+                typeof(StringCollectionAssertions<IEnumerable<string>>).GetMethods(
                     BindingFlags.Public | BindingFlags.Instance);
 
             // Act
@@ -1540,7 +1540,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             methods.Should().OnlyContain(method =>
-                typeof(AndConstraint<StringCollectionAssertions>)
+                typeof(AndConstraint<StringCollectionAssertions<IEnumerable<string>>>)
                     .GetTypeInfo()
                     .IsAssignableFrom(method.ReturnType.GetTypeInfo()));
         }


### PR DESCRIPTION
This PR makes most assertions generic in `TAssertions`.
This benefits deriving from one of those assertion classes, as chaining
with `.And` allows you to continue use assertions from the derived class instead
of only from the base class.

Utilizing the generic type system this way also caught wrong return types.
`NullableDateTimeAssertions.Be` returned an `DateTimeAssertions`, 
where it could return an `NullableDateTimeAssertions`.
Similar "bugs" were also caught in `NullableDateTimeOffsetAssertions` and
`NullableBooleanAssertions`.

Child classes are included to match the current signatures, which is
seen by noticing that all return types of `Should`s remain the same.

The only types that do not have child classes are
* `AndWhichConstraint`
* `DateTimeRangeAssertions`
* `DateTimeOffsetRangeAssertions`

This PR also serves as a preparation for an upcoming PRs that will improve dictionary assertions.