### PR TITLE
Add support for IImmutableDictionary and IReadOnlyDictionary

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -286,13 +286,34 @@ namespace FluentAssertions
         }
 
         /// <summary>
-        /// Returns an <see cref="GenericDictionaryAssertions{TKey, TValue}"/> object that can be used to assert the
+        /// Returns an <see cref="GenericDictionaryAssertions{TCollection, TKey, TValue}"/> object that can be used to assert the
         /// current <see cref="IDictionary{TKey, TValue}"/>.
         /// </summary>
         [Pure]
-        public static GenericDictionaryAssertions<TKey, TValue> Should<TKey, TValue>(this IDictionary<TKey, TValue> actualValue)
+        public static GenericDictionaryAssertions<IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>(this IDictionary<TKey, TValue> actualValue)
         {
-            return new GenericDictionaryAssertions<TKey, TValue>(actualValue);
+            return new GenericDictionaryAssertions<IDictionary<TKey, TValue>, TKey, TValue>(actualValue);
+        }
+
+        /// <summary>
+        /// Returns an <see cref="GenericDictionaryAssertions{TCollection, TKey, TValue}"/> object that can be used to assert the
+        /// current <see cref="IEnumerable{T}"/> of <see cref="KeyValuePair{TKey, TValue}"/>.
+        /// </summary>
+        [Pure]
+        public static GenericDictionaryAssertions<IEnumerable<KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> actualValue)
+        {
+            return new GenericDictionaryAssertions<IEnumerable<KeyValuePair<TKey, TValue>>, TKey, TValue>(actualValue);
+        }
+
+        /// <summary>
+        /// Returns an <see cref="GenericDictionaryAssertions{TCollection, TKey, TValue}"/> object that can be used to assert the
+        /// current <typeparamref name="TCollection"/>.
+        /// </summary>
+        [Pure]
+        public static GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>(this TCollection actualValue)
+            where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
+        {
+            return new GenericDictionaryAssertions<TCollection, TKey, TValue>(actualValue);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -1,402 +1,40 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Linq.Expressions;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Execution;
-using FluentAssertions.Primitives;
 
 namespace FluentAssertions.Collections
 {
     /// <summary>
-    /// Contains a number of methods to assert that an <see cref="IDictionary{TKey,TValue}"/> is in the expected state.
+    /// Contains a number of methods to assert that a <typeparamref name="TCollection"/> is in the expected state.
     /// </summary>
     [DebuggerNonUserCode]
-    public class GenericDictionaryAssertions<TKey, TValue> :
-        GenericDictionaryAssertions<TKey, TValue, GenericDictionaryAssertions<TKey, TValue>>
+    public class GenericDictionaryAssertions<TCollection, TKey, TValue> :
+        GenericDictionaryAssertions<TCollection, TKey, TValue, GenericDictionaryAssertions<TCollection, TKey, TValue>>
+        where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
     {
-        public GenericDictionaryAssertions(IDictionary<TKey, TValue> dictionary) : base(dictionary)
+        public GenericDictionaryAssertions(TCollection keyValuePairs)
+            : base(keyValuePairs)
         {
         }
     }
 
     /// <summary>
-    /// Contains a number of methods to assert that an <see cref="IDictionary{TKey,TValue}"/> is in the expected state.
+    /// Contains a number of methods to assert that a <typeparamref name="TCollection"/> is in the expected state.
     /// </summary>
     [DebuggerNonUserCode]
-    public class GenericDictionaryAssertions<TKey, TValue, TAssertions> :
-        ReferenceTypeAssertions<IDictionary<TKey, TValue>, TAssertions>
-        where TAssertions : GenericDictionaryAssertions<TKey, TValue, TAssertions>
+    public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions> :
+        GenericCollectionAssertions<TCollection, KeyValuePair<TKey, TValue>, TAssertions>
+        where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
+        where TAssertions : GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
-        public GenericDictionaryAssertions(IDictionary<TKey, TValue> dictionary) : base(dictionary)
+        public GenericDictionaryAssertions(TCollection keyValuePairs)
+            : base(keyValuePairs)
         {
         }
-
-        #region HaveCount
-
-        /// <summary>
-        /// Asserts that the number of items in the dictionary matches the supplied <paramref name="expected" /> amount.
-        /// </summary>
-        /// <param name="expected">The expected number of items.</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-        /// </param>
-        public AndConstraint<TAssertions> HaveCount(int expected,
-            string because = "", params object[] becauseArgs)
-        {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {0} item(s){reason}, but found {1}.", expected, Subject);
-            }
-
-            int actualCount = Subject.Count;
-
-            Execute.Assertion
-                .ForCondition(actualCount == expected)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} {0} to have {1} item(s){reason}, but found {2}.", Subject, expected, actualCount);
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-
-        /// <summary>
-        /// Asserts that the number of items in the dictionary does not match the supplied <paramref name="unexpected" /> amount.
-        /// </summary>
-        /// <param name="unexpected">The unexpected number of items.</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-        /// </param>
-        public AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs)
-        {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} to not have {0} item(s){reason}, but found <null>.", unexpected);
-            }
-
-            int actualCount = Subject.Count;
-
-            Execute.Assertion
-                .ForCondition(actualCount != unexpected)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} {0} to not have {1} item(s){reason}, but found {2}.", Subject, unexpected, actualCount);
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-
-        /// <summary>
-        /// Asserts that the number of items in the dictionary is greater than the supplied <paramref name="expected" /> amount.
-        /// </summary>
-        /// <param name="expected">The number to which the actual number items in the dictionary will be compared.</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-        /// </param>
-        public AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs)
-        {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} to contain more than {0} item(s){reason}, but found <null>.", expected);
-            }
-
-            int actualCount = Subject.Count;
-
-            Execute.Assertion
-                .ForCondition(actualCount > expected)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} {0} to contain more than {1} item(s){reason}, but found {2}.", Subject, expected, actualCount);
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-
-        /// <summary>
-        /// Asserts that the number of items in the dictionary is greater or equal to the supplied <paramref name="expected" /> amount.
-        /// </summary>
-        /// <param name="expected">The number to which the actual number items in the dictionary will be compared.</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-        /// </param>
-        public AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs)
-        {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} to contain at least {0} item(s){reason}, but found <null>.", expected);
-            }
-
-            int actualCount = Subject.Count;
-
-            Execute.Assertion
-                .ForCondition(actualCount >= expected)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} {0} to contain at least {1} item(s){reason}, but found {2}.", Subject, expected, actualCount);
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-
-        /// <summary>
-        /// Asserts that the number of items in the dictionary is less than the supplied <paramref name="expected" /> amount.
-        /// </summary>
-        /// <param name="expected">The number to which the actual number items in the dictionary will be compared.</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-        /// </param>
-        public AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs)
-        {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} to contain fewer than {0} item(s){reason}, but found <null>.", expected);
-            }
-
-            int actualCount = Subject.Count;
-
-            Execute.Assertion
-                .ForCondition(actualCount < expected)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} {0} to contain fewer than {1} item(s){reason}, but found {2}.", Subject, expected, actualCount);
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-
-        /// <summary>
-        /// Asserts that the number of items in the dictionary is less or equal to the supplied <paramref name="expected" /> amount.
-        /// </summary>
-        /// <param name="expected">The number to which the actual number items in the dictionary will be compared.</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-        /// </param>
-        public AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs)
-        {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} to contain at most {0} item(s){reason}, but found <null>.", expected);
-            }
-
-            int actualCount = Subject.Count;
-
-            Execute.Assertion
-                .ForCondition(actualCount <= expected)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} {0} to contain at most {1} item(s){reason}, but found {2}.", Subject, expected, actualCount);
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-
-        /// <summary>
-        /// Asserts that the number of items in the dictionary matches a condition stated by a predicate.
-        /// </summary>
-        /// <param name="countPredicate">The predicate which must be satisfied by the amount of items.</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-        /// </param>
-        public AndConstraint<TAssertions> HaveCount(Expression<Func<int, bool>> countPredicate,
-            string because = "", params object[] becauseArgs)
-        {
-            Guard.ThrowIfArgumentIsNull(countPredicate, nameof(countPredicate), "Cannot compare dictionary count against a <null> predicate.");
-
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} to have {0} items{reason}, but found {1}.", countPredicate.Body, Subject);
-            }
-
-            Func<int, bool> compiledPredicate = countPredicate.Compile();
-
-            int actualCount = Subject.Count;
-
-            if (!compiledPredicate(actualCount))
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} {0} to have a count {1}{reason}, but count is {2}.",
-                        Subject, countPredicate.Body, actualCount);
-            }
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-
-        /// <summary>
-        /// Assert that the current dictionary has the same number of elements as <paramref name="otherCollection" />.
-        /// </summary>
-        /// <param name="otherCollection">The other collection with the same expected number of elements</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-        /// </param>
-        public AndConstraint<TAssertions> HaveSameCount(IEnumerable otherCollection, string because = "",
-            params object[] becauseArgs)
-        {
-            Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot compare dictionary count against a <null> collection.");
-
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} to have the same count as {0}{reason}, but found {1}.",
-                        otherCollection,
-                        Subject);
-            }
-
-            int actualCount = Subject.Count;
-            int expectedCount = otherCollection.Cast<object>().Count();
-
-            Execute.Assertion
-                .ForCondition(actualCount == expectedCount)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to have {0} item(s){reason}, but count is {1}.", expectedCount, actualCount);
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-
-        /// <summary>
-        /// Assert that the current collection does not have the same number of elements as <paramref name="otherCollection" />.
-        /// </summary>
-        /// <param name="otherCollection">The other collection with the unexpected number of elements</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-        /// </param>
-        public AndConstraint<TAssertions> NotHaveSameCount(IEnumerable otherCollection, string because = "",
-            params object[] becauseArgs)
-        {
-            Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot compare dictionary count against a <null> collection.");
-
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} to not have the same count as {0}{reason}, but found {1}.",
-                        otherCollection,
-                        Subject);
-            }
-
-            if (ReferenceEquals(Subject, otherCollection))
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} {0} to not have the same count as {1}{reason}, but they both reference the same object.",
-                        Subject,
-                        otherCollection);
-            }
-
-            int actualCount = Subject.Count;
-            int expectedCount = otherCollection.Cast<object>().Count();
-
-            Execute.Assertion
-                .ForCondition(actualCount != expectedCount)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to not have {0} item(s){reason}, but count is {1}.", expectedCount, actualCount);
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-
-        #endregion
-
-        #region BeEmpty
-
-        /// <summary>
-        /// Asserts that the dictionary does not contain any items.
-        /// </summary>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-        /// </param>
-        public AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs)
-        {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} to be empty{reason}, but found {0}.", Subject);
-            }
-
-            Execute.Assertion
-                .ForCondition(!Subject.Any())
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:dictionary} to not have any items{reason}, but found {0}.", Subject.Count);
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-
-        /// <summary>
-        /// Asserts that the dictionary contains at least 1 item.
-        /// </summary>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-        /// </param>
-        public AndConstraint<TAssertions> NotBeEmpty(string because = "",
-            params object[] becauseArgs)
-        {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:dictionary} not to be empty{reason}, but found {0}.", Subject);
-            }
-
-            Execute.Assertion
-                .ForCondition(Subject.Any())
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected one or more items{reason}, but found none.");
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-
-        #endregion
 
         #region Equal
 
@@ -413,8 +51,9 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> Equal(IDictionary<TKey, TValue> expected,
+        public AndConstraint<TAssertions> Equal<T>(T expected,
             string because = "", params object[] becauseArgs)
+            where T : IEnumerable<KeyValuePair<TKey, TValue>>
         {
             if (Subject is null)
             {
@@ -425,8 +64,10 @@ namespace FluentAssertions.Collections
 
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare dictionary with <null>.");
 
-            IEnumerable<TKey> missingKeys = expected.Keys.Except(Subject.Keys);
-            IEnumerable<TKey> additionalKeys = Subject.Keys.Except(expected.Keys);
+            IEnumerable<TKey> subjectKeys = GetKeys(Subject);
+            IEnumerable<TKey> expectedKeys = GetKeys(expected);
+            IEnumerable<TKey> missingKeys = expectedKeys.Except(subjectKeys);
+            IEnumerable<TKey> additionalKeys = subjectKeys.Except(expectedKeys);
 
             if (missingKeys.Any())
             {
@@ -444,10 +85,10 @@ namespace FluentAssertions.Collections
                         additionalKeys);
             }
 
-            foreach (var key in expected.Keys)
+            foreach (var key in expectedKeys)
             {
                 Execute.Assertion
-                    .ForCondition(Subject[key].IsSameOrEqualTo(expected[key]))
+                    .ForCondition(GetValue(Subject, key).IsSameOrEqualTo(GetValue(expected, key)))
                     .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:dictionary} to be equal to {0}{reason}, but {1} differs at key {2}.",
                     expected, Subject, key);
@@ -469,8 +110,9 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotEqual(IDictionary<TKey, TValue> unexpected,
+        public AndConstraint<TAssertions> NotEqual<T>(T unexpected,
             string because = "", params object[] becauseArgs)
+            where T : IEnumerable<KeyValuePair<TKey, TValue>>
         {
             if (Subject is null)
             {
@@ -488,12 +130,14 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected dictionaries not to be equal{reason}, but they both reference the same object.");
             }
 
-            IEnumerable<TKey> missingKeys = unexpected.Keys.Except(Subject.Keys);
-            IEnumerable<TKey> additionalKeys = Subject.Keys.Except(unexpected.Keys);
+            IEnumerable<TKey> subjectKeys = GetKeys(Subject);
+            IEnumerable<TKey> unexpectedKeys = GetKeys(unexpected);
+            IEnumerable<TKey> missingKeys = unexpectedKeys.Except(subjectKeys);
+            IEnumerable<TKey> additionalKeys = subjectKeys.Except(unexpectedKeys);
 
             bool foundDifference = missingKeys.Any()
                 || additionalKeys.Any()
-                    || (Subject.Keys.Any(key => !Subject[key].IsSameOrEqualTo(unexpected[key])));
+                    || (subjectKeys.Any(key => !GetValue(Subject, key).IsSameOrEqualTo(GetValue(unexpected, key))));
 
             if (!foundDifference)
             {
@@ -594,14 +238,14 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public WhichValueConstraint<TKey, TValue, TAssertions> ContainKey(TKey expected,
+        public WhichValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected,
             string because = "", params object[] becauseArgs)
         {
             AndConstraint<TAssertions> andConstraint = ContainKeys(new[] { expected }, because, becauseArgs);
 
-            _ = Subject.TryGetValue(expected, out TValue value);
+            _ = TryGetValue(Subject, expected, out TValue value);
 
-            return new WhichValueConstraint<TKey, TValue, TAssertions>(andConstraint.And, value);
+            return new WhichValueConstraint<TCollection, TKey, TValue, TAssertions>(andConstraint.And, value);
         }
 
         /// <summary>
@@ -645,7 +289,7 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} to contain keys {0}{reason}, but found {1}.", expected, Subject);
             }
 
-            IEnumerable<TKey> missingKeys = expectedKeys.Where(key => !Subject.ContainsKey(key));
+            IEnumerable<TKey> missingKeys = expectedKeys.Where(key => !ContainsKey(Subject, key));
 
             if (missingKeys.Any())
             {
@@ -694,7 +338,7 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} not to contain key {0}{reason}, but found {1}.", unexpected, Subject);
             }
 
-            if (Subject.ContainsKey(unexpected))
+            if (ContainsKey(Subject, unexpected))
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -745,7 +389,7 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} to contain keys {0}{reason}, but found {1}.", unexpected, Subject);
             }
 
-            IEnumerable<TKey> foundKeys = unexpected.Where(key => Subject.ContainsKey(key));
+            IEnumerable<TKey> foundKeys = unexpected.Where(key => ContainsKey(Subject, key));
 
             if (foundKeys.Any())
             {
@@ -842,7 +486,8 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} to contain value {0}{reason}, but found {1}.", expected, Subject);
             }
 
-            IEnumerable<TValue> missingValues = expectedValues.Except(Subject.Values);
+            IEnumerable<TValue> subjectValues = GetValues(Subject);
+            IEnumerable<TValue> missingValues = expectedValues.Except(subjectValues);
 
             if (missingValues.Any())
             {
@@ -865,7 +510,7 @@ namespace FluentAssertions.Collections
             return
                 new AndWhichConstraint<TAssertions,
                         IEnumerable<TValue>>((TAssertions)this,
-                            RepetitionPreservingIntersect(Subject.Values, expectedValues));
+                            RepetitionPreservingIntersect(subjectValues, expectedValues));
         }
 
         /// <summary>
@@ -905,7 +550,7 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} not to contain value {0}{reason}, but found {1}.", unexpected, Subject);
             }
 
-            if (Subject.Values.Contains(unexpected))
+            if (GetValues(Subject).Contains(unexpected))
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -956,7 +601,7 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} to not contain value {0}{reason}, but found {1}.", unexpected, Subject);
             }
 
-            IEnumerable<TValue> foundValues = unexpectedValues.Intersect(Subject.Values);
+            IEnumerable<TValue> foundValues = unexpectedValues.Intersect(GetValues(Subject));
 
             if (foundValues.Any())
             {
@@ -1028,7 +673,7 @@ namespace FluentAssertions.Collections
             }
 
             TKey[] expectedKeys = expectedKeyValuePairs.Select(keyValuePair => keyValuePair.Key).ToArray();
-            IEnumerable<TKey> missingKeys = expectedKeys.Where(key => !Subject.ContainsKey(key));
+            IEnumerable<TKey> missingKeys = expectedKeys.Where(key => !ContainsKey(Subject, key));
 
             if (missingKeys.Any())
             {
@@ -1048,7 +693,7 @@ namespace FluentAssertions.Collections
                 }
             }
 
-            KeyValuePair<TKey, TValue>[] keyValuePairsNotSameOrEqualInSubject = expectedKeyValuePairs.Where(keyValuePair => !Subject[keyValuePair.Key].IsSameOrEqualTo(keyValuePair.Value)).ToArray();
+            KeyValuePair<TKey, TValue>[] keyValuePairsNotSameOrEqualInSubject = expectedKeyValuePairs.Where(keyValuePair => !GetValue(Subject, keyValuePair.Key).IsSameOrEqualTo(keyValuePair.Value)).ToArray();
 
             if (keyValuePairsNotSameOrEqualInSubject.Any())
             {
@@ -1062,7 +707,7 @@ namespace FluentAssertions.Collections
                 else
                 {
                     KeyValuePair<TKey, TValue> expectedKeyValuePair = keyValuePairsNotSameOrEqualInSubject[0];
-                    TValue actual = Subject[expectedKeyValuePair.Key];
+                    TValue actual = GetValue(Subject, expectedKeyValuePair.Key);
 
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
@@ -1086,7 +731,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> Contain(KeyValuePair<TKey, TValue> expected,
+        public new AndConstraint<TAssertions> Contain(KeyValuePair<TKey, TValue> expected,
             string because = "", params object[] becauseArgs)
         {
             return Contain(expected.Key, expected.Value, because, becauseArgs);
@@ -1118,7 +763,7 @@ namespace FluentAssertions.Collections
                         Subject);
             }
 
-            if (Subject.TryGetValue(key, out TValue actual))
+            if (TryGetValue(Subject, key, out TValue actual))
             {
                 Execute.Assertion
                     .ForCondition(actual.IsSameOrEqualTo(value))
@@ -1184,12 +829,12 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:dictionary} to not contain key/value pairs {0}{reason}, but dictionary is {1}.", items, Subject);
             }
 
-            KeyValuePair<TKey, TValue>[] keyValuePairsFound = keyValuePairs.Where(keyValuePair => Subject.ContainsKey(keyValuePair.Key)).ToArray();
+            KeyValuePair<TKey, TValue>[] keyValuePairsFound = keyValuePairs.Where(keyValuePair => ContainsKey(Subject, keyValuePair.Key)).ToArray();
 
             if (keyValuePairsFound.Any())
             {
                 KeyValuePair<TKey, TValue>[] keyValuePairsSameOrEqualInSubject = keyValuePairsFound
-                    .Where(keyValuePair => Subject[keyValuePair.Key].IsSameOrEqualTo(keyValuePair.Value)).ToArray();
+                    .Where(keyValuePair => GetValue(Subject, keyValuePair.Key).IsSameOrEqualTo(keyValuePair.Value)).ToArray();
 
                 if (keyValuePairsSameOrEqualInSubject.Any())
                 {
@@ -1226,7 +871,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotContain(KeyValuePair<TKey, TValue> item,
+        public new AndConstraint<TAssertions> NotContain(KeyValuePair<TKey, TValue> item,
             string because = "", params object[] becauseArgs)
         {
             return NotContain(item.Key, item.Value, because, becauseArgs);
@@ -1258,7 +903,7 @@ namespace FluentAssertions.Collections
                         key, Subject);
             }
 
-            if (Subject.TryGetValue(key, out TValue actual))
+            if (TryGetValue(Subject, key, out TValue actual))
             {
                 Execute.Assertion
                     .ForCondition(!actual.IsSameOrEqualTo(value))
@@ -1275,5 +920,28 @@ namespace FluentAssertions.Collections
         /// Returns the type of the subject the assertion applies on.
         /// </summary>
         protected override string Identifier => "dictionary";
+
+        private static IEnumerable<TKey> GetKeys(TCollection collection) =>
+            collection.GetKeys<TCollection, TKey, TValue>();
+
+        private static IEnumerable<TKey> GetKeys<T>(T collection)
+            where T : IEnumerable<KeyValuePair<TKey, TValue>> =>
+            collection.GetKeys<T, TKey, TValue>();
+
+        private static IEnumerable<TValue> GetValues(TCollection collection) =>
+            collection.GetValues<TCollection, TKey, TValue>();
+
+        private static bool ContainsKey(TCollection collection, TKey key) =>
+            collection.ContainsKey<TCollection, TKey, TValue>(key);
+
+        private static bool TryGetValue(TCollection collection, TKey key, out TValue value) =>
+            collection.TryGetValue(key, out value);
+
+        private static TValue GetValue(TCollection collection, TKey key) =>
+            collection.GetValue<TCollection, TKey, TValue>(key);
+
+        private static TValue GetValue<T>(T collection, TKey key)
+            where T : IEnumerable<KeyValuePair<TKey, TValue>> =>
+            collection.GetValue<T, TKey, TValue>(key);
     }
 }

--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -12,8 +12,8 @@ namespace FluentAssertions.Collections
     /// <summary>
     /// Contains a number of methods to assert that an <see cref="IEnumerable{T}"/> is in the expectation state.
     /// </summary>
-    public class SelfReferencingCollectionAssertions<T, TAssertions> : CollectionAssertions<IEnumerable<T>, TAssertions>
-        where TAssertions : SelfReferencingCollectionAssertions<T, TAssertions>
+    public class SelfReferencingCollectionAssertions<T, TAssertions> : SelfReferencingCollectionAssertions<IEnumerable<T>, T, TAssertions>
+        where TAssertions : SelfReferencingCollectionAssertions<IEnumerable<T>, T, TAssertions>
     {
         public SelfReferencingCollectionAssertions(IEnumerable<T> actualValue) : base(actualValue)
         {
@@ -21,7 +21,7 @@ namespace FluentAssertions.Collections
     }
 
     /// <summary>
-    /// Contains a number of methods to assert that an <see cref="IEnumerable{T}"/> is in the expectation state.
+    /// Contains a number of methods to assert that an <typeparamref name="TAssertions"/> is in the expectation state.
     /// </summary>
     public class SelfReferencingCollectionAssertions<TCollection, T, TAssertions> :
         CollectionAssertions<TCollection, TAssertions>
@@ -57,7 +57,7 @@ namespace FluentAssertions.Collections
             Execute.Assertion
                 .ForCondition(actualCount == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:collection} to contain {0} item(s){reason}, but found {1}.", expected, actualCount);
+                .FailWith("Expected {context:collection} {0} to contain {1} item(s){reason}, but found {2}.", Subject, expected, actualCount);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Collections/WhichValueConstraint.cs
+++ b/Src/FluentAssertions/Collections/WhichValueConstraint.cs
@@ -1,7 +1,10 @@
+using System.Collections.Generic;
+
 namespace FluentAssertions.Collections
 {
-    public class WhichValueConstraint<TKey, TValue, TAssertions> : AndConstraint<TAssertions>
-        where TAssertions : GenericDictionaryAssertions<TKey, TValue, TAssertions>
+    public class WhichValueConstraint<TCollection, TKey, TValue, TAssertions> : AndConstraint<TAssertions>
+        where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
+        where TAssertions : GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
         public WhichValueConstraint(TAssertions parentConstraint, TValue value)
             : base(parentConstraint)

--- a/Src/FluentAssertions/Common/DictionaryHelpers.cs
+++ b/Src/FluentAssertions/Common/DictionaryHelpers.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace FluentAssertions.Common
+{
+    internal static class DictionaryHelpers
+    {
+        public static IEnumerable<TKey> GetKeys<TCollection, TKey, TValue>(this TCollection collection)
+            where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
+        {
+            return collection switch
+            {
+                IDictionary<TKey, TValue> dictionary => dictionary.Keys,
+                IReadOnlyDictionary<TKey, TValue> readOnlyDictionary => readOnlyDictionary.Keys,
+                _ => collection.Select(kvp => kvp.Key),
+            };
+        }
+
+        public static IEnumerable<TValue> GetValues<TCollection, TKey, TValue>(this TCollection collection)
+            where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
+        {
+            return collection switch
+            {
+                IDictionary<TKey, TValue> dictionary => dictionary.Values,
+                IReadOnlyDictionary<TKey, TValue> readOnlyDictionary => readOnlyDictionary.Values,
+                _ => collection.Select(kvp => kvp.Value),
+            };
+        }
+
+        public static bool ContainsKey<TCollection, TKey, TValue>(this TCollection collection, TKey key)
+            where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
+        {
+            return collection switch
+            {
+                IDictionary<TKey, TValue> dictionary => dictionary.ContainsKey(key),
+                IReadOnlyDictionary<TKey, TValue> readOnlyDictionary => readOnlyDictionary.ContainsKey(key),
+                _ => collection.Any(kvp => kvp.Key.IsSameOrEqualTo(key)),
+            };
+        }
+
+        public static bool TryGetValue<TCollection, TKey, TValue>(this TCollection collection, TKey key, out TValue value)
+            where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
+        {
+            return collection switch
+            {
+                IDictionary<TKey, TValue> dictionary => dictionary.TryGetValue(key, out value),
+                IReadOnlyDictionary<TKey, TValue> readOnlyDictionary => readOnlyDictionary.TryGetValue(key, out value),
+                _ => TryGetValueInternal(collection, key, out value),
+            };
+        }
+
+        private static bool TryGetValueInternal<TCollection, TKey, TValue>(this TCollection collection, TKey key, out TValue value)
+            where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
+        {
+            KeyValuePair<TKey, TValue> matchingPair = collection.FirstOrDefault(kvp => kvp.Key.IsSameOrEqualTo(key));
+            value = matchingPair.Value;
+            return matchingPair.Equals(default(KeyValuePair<TKey, TValue>));
+        }
+
+        public static TValue GetValue<TCollection, TKey, TValue>(this TCollection collection, TKey key)
+            where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
+        {
+            return collection switch
+            {
+                IDictionary<TKey, TValue> dictionary => dictionary[key],
+                IReadOnlyDictionary<TKey, TValue> readOnlyDictionary => readOnlyDictionary[key],
+                _ => collection.First(kvp => kvp.Key.IsSameOrEqualTo(key)).Value,
+            };
+        }
+    }
+}

--- a/Src/FluentAssertions/Common/Guard.cs
+++ b/Src/FluentAssertions/Common/Guard.cs
@@ -5,7 +5,6 @@ namespace FluentAssertions.Common
     internal static class Guard
     {
         public static void ThrowIfArgumentIsNull<T>(T obj, string paramName)
-            where T : class
         {
             if (obj is null)
             {
@@ -14,7 +13,6 @@ namespace FluentAssertions.Common
         }
 
         public static void ThrowIfArgumentIsNull<T>(T obj, string paramName, string message)
-            where T : class
         {
             if (obj is null)
             {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -89,7 +89,10 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
         public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
-        public static FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>(this TCollection actualValue)
+            where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
@@ -346,37 +349,31 @@ namespace FluentAssertions.Collections
             where TKey :  class { }
         public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    public class GenericDictionaryAssertions<TCollection, TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue>>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
     {
-        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
     }
-    public class GenericDictionaryAssertions<TKey, TValue, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TAssertions>
-        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
+    public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, System.Collections.Generic.KeyValuePair<TKey, TValue>, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
-        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(params TKey[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainValues(params TValue[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal<T>(T expected, string because = "", params object[] becauseArgs)
+            where T : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
@@ -387,9 +384,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainValues(params TValue[] unexpected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
     }
     public class NonGenericCollectionAssertions : FluentAssertions.Collections.NonGenericCollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
     {
@@ -410,8 +406,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
-        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
+    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, TAssertions>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, TAssertions>
     {
         public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
     }
@@ -472,8 +468,9 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
-    public class WhichValueConstraint<TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
-        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
+    public class WhichValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
         public WhichValueConstraint(TAssertions parentConstraint, TValue value) { }
         public TValue WhichValue { get; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -89,7 +89,10 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
         public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
-        public static FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>(this TCollection actualValue)
+            where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
@@ -346,37 +349,31 @@ namespace FluentAssertions.Collections
             where TKey :  class { }
         public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    public class GenericDictionaryAssertions<TCollection, TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue>>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
     {
-        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
     }
-    public class GenericDictionaryAssertions<TKey, TValue, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TAssertions>
-        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
+    public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, System.Collections.Generic.KeyValuePair<TKey, TValue>, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
-        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(params TKey[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainValues(params TValue[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal<T>(T expected, string because = "", params object[] becauseArgs)
+            where T : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
@@ -387,9 +384,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainValues(params TValue[] unexpected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
     }
     public class NonGenericCollectionAssertions : FluentAssertions.Collections.NonGenericCollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
     {
@@ -410,8 +406,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
-        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
+    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, TAssertions>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, TAssertions>
     {
         public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
     }
@@ -472,8 +468,9 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
-    public class WhichValueConstraint<TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
-        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
+    public class WhichValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
         public WhichValueConstraint(TAssertions parentConstraint, TValue value) { }
         public TValue WhichValue { get; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -89,7 +89,10 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
         public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
-        public static FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>(this TCollection actualValue)
+            where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
@@ -346,37 +349,31 @@ namespace FluentAssertions.Collections
             where TKey :  class { }
         public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    public class GenericDictionaryAssertions<TCollection, TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue>>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
     {
-        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
     }
-    public class GenericDictionaryAssertions<TKey, TValue, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TAssertions>
-        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
+    public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, System.Collections.Generic.KeyValuePair<TKey, TValue>, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
-        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(params TKey[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainValues(params TValue[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal<T>(T expected, string because = "", params object[] becauseArgs)
+            where T : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
@@ -387,9 +384,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainValues(params TValue[] unexpected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
     }
     public class NonGenericCollectionAssertions : FluentAssertions.Collections.NonGenericCollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
     {
@@ -410,8 +406,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
-        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
+    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, TAssertions>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, TAssertions>
     {
         public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
     }
@@ -472,8 +468,9 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
-    public class WhichValueConstraint<TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
-        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
+    public class WhichValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
         public WhichValueConstraint(TAssertions parentConstraint, TValue value) { }
         public TValue WhichValue { get; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -88,7 +88,10 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
         public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
-        public static FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>(this TCollection actualValue)
+            where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
@@ -345,37 +348,31 @@ namespace FluentAssertions.Collections
             where TKey :  class { }
         public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    public class GenericDictionaryAssertions<TCollection, TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue>>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
     {
-        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
     }
-    public class GenericDictionaryAssertions<TKey, TValue, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TAssertions>
-        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
+    public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, System.Collections.Generic.KeyValuePair<TKey, TValue>, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
-        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(params TKey[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainValues(params TValue[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal<T>(T expected, string because = "", params object[] becauseArgs)
+            where T : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
@@ -386,9 +383,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainValues(params TValue[] unexpected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
     }
     public class NonGenericCollectionAssertions : FluentAssertions.Collections.NonGenericCollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
     {
@@ -409,8 +405,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
-        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
+    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, TAssertions>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, TAssertions>
     {
         public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
     }
@@ -471,8 +467,9 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
-    public class WhichValueConstraint<TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
-        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
+    public class WhichValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
         public WhichValueConstraint(TAssertions parentConstraint, TValue value) { }
         public TValue WhichValue { get; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -89,7 +89,10 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.FunctionAssertions<T> Should<T>(this System.Func<T> func) { }
         public static FluentAssertions.Numeric.ComparableTypeAssertions<T> Should<T>(this System.IComparable<T> comparableValue) { }
         public static FluentAssertions.Specialized.TaskCompletionSourceAssertions<T> Should<T>(this System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
-        public static FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, TKey, TValue> Should<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> actualValue) { }
+        public static FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue> Should<TCollection, TKey, TValue>(this TCollection actualValue)
+            where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
@@ -346,37 +349,31 @@ namespace FluentAssertions.Collections
             where TKey :  class { }
         public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems<TKey>(System.Linq.Expressions.Expression<System.Func<T, TKey>> predicate, string because = "", params object[] becauseArgs) { }
     }
-    public class GenericDictionaryAssertions<TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue>>
+    public class GenericDictionaryAssertions<TCollection, TKey, TValue> : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue>>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
     {
-        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
     }
-    public class GenericDictionaryAssertions<TKey, TValue, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Collections.Generic.IDictionary<TKey, TValue>, TAssertions>
-        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
+    public class GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions> : FluentAssertions.Collections.GenericCollectionAssertions<TCollection, System.Collections.Generic.KeyValuePair<TKey, TValue>, TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
-        public GenericDictionaryAssertions(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        public GenericDictionaryAssertions(TCollection keyValuePairs) { }
         protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(params System.Collections.Generic.KeyValuePair<, >[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Collections.WhichValueConstraint<TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhichValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(params TKey[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainValues(params TValue[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainValues(System.Collections.Generic.IEnumerable<TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IDictionary<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Equal<T>(T expected, string because = "", params object[] becauseArgs)
+            where T : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(params System.Collections.Generic.KeyValuePair<, >[] items) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> items, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.KeyValuePair<TKey, TValue> item, string because = "", params object[] becauseArgs) { }
@@ -387,9 +384,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContainValue(TValue unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainValues(params TValue[] unexpected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainValues(System.Collections.Generic.IEnumerable<TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.Generic.IDictionary<TKey, TValue> unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotEqual<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> { }
     }
     public class NonGenericCollectionAssertions : FluentAssertions.Collections.NonGenericCollectionAssertions<System.Collections.IEnumerable, FluentAssertions.Collections.NonGenericCollectionAssertions>
     {
@@ -410,8 +406,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContain(object unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.CollectionAssertions<System.Collections.Generic.IEnumerable<T>, TAssertions>
-        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<T, TAssertions>
+    public class SelfReferencingCollectionAssertions<T, TAssertions> : FluentAssertions.Collections.SelfReferencingCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, TAssertions>
+        where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<System.Collections.Generic.IEnumerable<T>, T, TAssertions>
     {
         public SelfReferencingCollectionAssertions(System.Collections.Generic.IEnumerable<T> actualValue) { }
     }
@@ -472,8 +468,9 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
-    public class WhichValueConstraint<TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
-        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TKey, TValue, TAssertions>
+    public class WhichValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
+        where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
+        where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
         public WhichValueConstraint(TAssertions parentConstraint, TValue value) { }
         public TValue WhichValue { get; }

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -1074,7 +1074,7 @@ namespace FluentAssertions.Specs
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected collection to contain 4 item(s) because we want to test the failure message, but found 3.");
+                    "Expected collection {\"one\", \"two\", \"three\"} to contain 4 item(s) because we want to test the failure message, but found 3.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
@@ -172,7 +172,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary {[1, One], [2, Two], [3, Three]} to have 4 item(s) because we want to test the failure message, but found 3.");
+                .WithMessage("Expected dictionary {[1, One], [2, Two], [3, Three]} to contain 4 item(s) because we want to test the failure message, but found 3.");
         }
 
         [Fact]
@@ -225,7 +225,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot compare dictionary count against a <null> predicate.*");
+                "Cannot compare collection count against a <null> predicate.*");
         }
 
         [Fact]
@@ -239,7 +239,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected 1 item(s) because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected dictionary to contain 1 item(s) because we want to test the behaviour with a null subject, but found <null>.");
         }
 
         [Fact]
@@ -253,7 +253,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to have (c < 3) items because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected dictionary to contain (c < 3) items because we want to test the behaviour with a null subject, but found <null>.");
         }
 
         #endregion
@@ -309,7 +309,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("*not have*3*because we want to test the failure message*3*");
+                .WithMessage("*not contain*3*because we want to test the failure message*3*");
         }
 
         [Fact]
@@ -322,7 +322,7 @@ namespace FluentAssertions.Specs
             Action act = () => dictionary.Should().NotHaveCount(1, "we want to test the behaviour with a null subject");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("*not have*1*we want to test the behaviour with a null subject*found <null>*");
+            act.Should().Throw<XunitException>().WithMessage("*not contain*1*we want to test the behaviour with a null subject*found <null>*");
         }
 
         #endregion
@@ -638,7 +638,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to have 2 item(s), but count is 3.");
+                "Expected dictionary to have 2 item(s), but found 3.");
         }
 
         [Fact]
@@ -658,7 +658,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to have 2 item(s) because we want to test the reason, but count is 3.");
+                "Expected dictionary to have 2 item(s) because we want to test the reason, but found 3.");
         }
 
         [Fact]
@@ -694,7 +694,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot compare dictionary count against a <null> collection.*");
+                "Cannot verify count against a <null> collection.*");
         }
 
         #endregion
@@ -734,7 +734,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to not have 3 item(s), but count is 3.");
+                "Expected dictionary to not have 3 item(s), but found 3.");
         }
 
         [Fact]
@@ -754,7 +754,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary to not have 3 item(s) because we want to test the reason, but count is 3.");
+                "Expected dictionary to not have 3 item(s) because we want to test the reason, but found 3.");
         }
 
         [Fact]
@@ -790,7 +790,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<ArgumentNullException>().WithMessage(
-                "Cannot compare dictionary count against a <null> collection.*");
+                "Cannot verify count against a <null> collection.*");
         }
 
         [Fact]
@@ -858,7 +858,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary to not have any items because we want to test the failure message, but found 1.");
+                .WithMessage("Expected dictionary to be empty because we want to test the failure message, but found {[1, One]}.");
         }
 
         [Fact]
@@ -911,7 +911,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected one or more items because we want to test the failure message, but found none.");
+                .WithMessage("Expected dictionary not to be empty because we want to test the failure message.");
         }
 
         [Fact]
@@ -2588,6 +2588,120 @@ namespace FluentAssertions.Specs
         }
 
         #endregion
+
+        [Theory]
+        [MemberData(nameof(DictionariesData))]
+        public void When_comparing_dictionary_like_collections_for_equality_it_should_succeed<T1, T2>(T1 subject, T2 expected)
+            where T1 : IEnumerable<KeyValuePair<int, int>>
+            where T2 : IEnumerable<KeyValuePair<int, int>>
+        {
+            // Act
+            Action act = () => subject.Should().Equal(expected);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Theory]
+        [MemberData(nameof(DictionariesData))]
+        public void When_comparing_dictionary_like_collections_for_inequality_it_should_throw<T1, T2>(T1 subject, T2 expected)
+            where T1 : IEnumerable<KeyValuePair<int, int>>
+            where T2 : IEnumerable<KeyValuePair<int, int>>
+        {
+            // Act
+            Action act = () => subject.Should().NotEqual(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        public static IEnumerable<object[]> DictionariesData()
+        {
+            return from x in Dictionaries()
+                   from y in Dictionaries()
+                   select new[] { x, y };
+        }
+
+        [Theory]
+        [MemberData(nameof(SingleDictionaryData))]
+        public void When_a_dictionary_like_collection_contains_the_expected_key_it_should_succeed<T>(T subject)
+            where T : IEnumerable<KeyValuePair<int, int>>
+        {
+            // Act
+            Action act = () => subject.Should().ContainKey(1);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Theory]
+        [MemberData(nameof(SingleDictionaryData))]
+        public void When_a_dictionary_like_collection_contains_the_expected_value_it_should_succeed<T>(T subject)
+            where T : IEnumerable<KeyValuePair<int, int>>
+        {
+            // Act
+            Action act = () => subject.Should().ContainValue(42);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Theory]
+        [MemberData(nameof(SingleDictionaryData))]
+        public void When_using_a_dictionary_like_collection_it_should_preserve_reference_equality<T>(T subject)
+            where T : IEnumerable<KeyValuePair<int, int>>
+        {
+            // Act
+            Action act = () => subject.Should().BeSameAs(subject);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        public static IEnumerable<object[]> SingleDictionaryData() =>
+            Dictionaries().Select(x => new[] { x });
+
+        private static object[] Dictionaries()
+        {
+            return new object[]
+            {
+                new Dictionary<int, int>() { [1] = 42 },
+                new TrueReadOnlyDictionary<int, int>(new Dictionary<int, int>() { [1] = 42 }),
+                new List<KeyValuePair<int, int>> { new KeyValuePair<int, int>(1, 42) }
+            };
+        }
+
+        /// <summary>
+        /// This class only implements <see cref="IReadOnlyDictionary{TKey, TValue}"/>,
+        /// as <see cref="ReadOnlyDictionary{TKey, TValue}"/> also implements <see cref="IDictionary{TKey, TValue}"/>.
+        /// </summary>
+        /// <typeparam name="TKey"></typeparam>
+        /// <typeparam name="TValue"></typeparam>
+        private class TrueReadOnlyDictionary<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>
+        {
+            private readonly IReadOnlyDictionary<TKey, TValue> dictionary;
+
+            public TrueReadOnlyDictionary(IReadOnlyDictionary<TKey, TValue> dictionary)
+            {
+                this.dictionary = dictionary;
+            }
+
+            public TValue this[TKey key] => dictionary[key];
+
+            public IEnumerable<TKey> Keys => dictionary.Keys;
+
+            public IEnumerable<TValue> Values => dictionary.Values;
+
+            public int Count => dictionary.Count;
+
+            public bool ContainsKey(TKey key) => dictionary.ContainsKey(key);
+
+            public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => dictionary.GetEnumerator();
+
+            public bool TryGetValue(TKey key, out TValue value) => dictionary.TryGetValue(key, out value);
+
+            IEnumerator IEnumerable.GetEnumerator() => dictionary.GetEnumerator();
+        }
     }
 
     internal class TrackingTestDictionary : IDictionary<int, string>

--- a/Tests/FluentAssertions.Specs/Equivalency/DictionaryEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DictionaryEquivalencySpecs.cs
@@ -356,7 +356,7 @@ namespace FluentAssertions.Specs
             });
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected item[0]*Value3*Value2*");
+            act.Should().Throw<XunitException>().WithMessage("Expected pair[Key2][0]*Value3*Value2*");
         }
 
         [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -19,6 +19,7 @@ sidebar:
 * Added the ability to pass an `IEqualityComparer<T>` through `BeEquivalentTo(x => x.Using<MyComparer>())` - [#1284](https://github.com/fluentassertions/fluentassertions/pull/1284).
 * Added `NotBe` to `BooleanAssertions` to be able to assert that a boolean is not the expected value - [#1290](https://github.com/fluentassertions/fluentassertions/pull/1290).
 * Make `DefaultValueFormatter` and `EnumerableValueFormatter` suitable for inheritance - [#1295](https://github.com/fluentassertions/fluentassertions/pull/1295).
+* Added support for dictionary assertions on `IReadOnlyDictionary<TKey, TValue>` - [#1298](https://github.com/fluentassertions/fluentassertions/pull/1298).
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).


### PR DESCRIPTION
This PR enables using `GenericDictionaryAssertions` on `IReadOnlyDictionary`.
More precisely it enables support for any 
```
TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
```

### `Should` analysis:
Added two new overloads:
```c#
Should<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>>)
Should<TCollection, TKey, TValue>(TCollection)
    where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
```

The first one is picked by both:
* `IEnumerable<KeyValuePair<TKey, TValue>>`
* `IReadOnlyDictionary<TKey, TValue>`

The second overload is not picked up by anything and probably never will(?), as being an interface is regarded a better match than being *generic* in an interface.
[Related article](https://dotnetfalcon.com/back-to-the-basics-overload-resolution-in-c/)
Thus not sure if having the second one is better/worse that *not* having it.

As noted in previous discussions we cannot add 
```c#
Should(IReadOnlyDictionary<TKey, TValue>)
```
because that leads to ambiguity when writing
```c#
new Dictionary<int,int>().Should()
```
as it cannot tie-break picking `IReadOnlyDictionary` or `IDictionary`.

### `GenericCollectionAssertions` inheritance
`GenericDictionaryAssertions` now inherits from `GenericCollectionAssertions` where it previously inherited from `ReferenceTypeAssertions`.
This has at least two benefits:
All `Count`/`Empty` assertions now comes for free.
Their failure messages were *slightly* different, which are the changes to `GenericCollectionAssertions` and failure message assertions in existing tests.

The *only* assertions for `IEnumerable<kvp>.Should()` that *might* be different 
are `[Not]Contain(KeyValuePair<TKey, TValue>` as they are marked with `new` modifier.

### `[Not]Equal`
I've made `Equal` and `NotEqual` such that they do not require the subject and expectation to be the same `TCollection`.
So an `IDictionary` can be compared against an `IReadOnlyDictionary` and vice versa.

### What's up with all the helper methods?
I wanted to avoid littering the calls to e.g. `GetValue` in assertion bodies with type parameters.
I.e. I wanted to be able to write `GetValues(Subject)` instead of `GetValues<TCollection, TKey, TValue>(Subject)`.
This way compiled and worked.
If there is a nicer way to accomplish this, I'm all eager to know.

### Tests
I've added a set of tests to verify that all cases in all helper methods are hit.
I attached a debugger to verify that the expected cases were hit.
For a proper testing of this I would normally use a mock.

If we allowed to expose `internal` members to the test project it could also be tested with the existing `TrackingTestDictionary` class.
Any opinion/concerns?


A huge thanks to *everyone* who participated in the discussions over the years(!) on how to solve this.
@Evangelink @krajek @somewhatabstract 

This fixes #568 
This fixes #357
This closes #1132 
This closes #963 