### PR TITLE
WIP: Reactive assertions

### DIFF
--- a/Src/FluentAssertions/Common/TaskExtensions.cs
+++ b/Src/FluentAssertions/Common/TaskExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace FluentAssertions.Common
 {
@@ -23,6 +24,15 @@ namespace FluentAssertions.Common
             using (NoSynchronizationContextScope.Enter())
             {
                 return action();
+            }
+        }
+
+        public static TResult ExecuteInDefaultSynchronizationContext<TResult>(this Task<TResult> task)
+        {
+            using (NoSynchronizationContextScope.Enter())
+            {
+                task.Wait();
+                return task.Result;
             }
         }
     }

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -43,7 +43,6 @@
     <None Include="..\FluentAssertions.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
   </ItemGroup>
@@ -54,12 +53,12 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="4.4.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/FluentAssertions/Reactive/FluentTestObserver.cs
+++ b/Src/FluentAssertions/Reactive/FluentTestObserver.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Threading;
+using Microsoft.Reactive.Testing;
+
+namespace FluentAssertions.Reactive
+{
+    /// <summary>
+    /// Observer for testing <see cref="Observable"/>s using the FluentAssertions framework
+    /// </summary>
+    /// <typeparam name="TPayload"></typeparam>
+    public class FluentTestObserver<TPayload> : IObserver<TPayload>, IDisposable
+    {
+        private readonly IDisposable _subscription;
+        private readonly EventLoopScheduler _observeScheduler = new EventLoopScheduler();
+        private readonly RollingReplaySubject<Recorded<Notification<TPayload>>> _rollingReplaySubject = new RollingReplaySubject<Recorded<Notification<TPayload>>>();
+
+        /// <summary>
+        /// The observable which is observed by this instance
+        /// </summary>
+        public IObservable<TPayload> Subject { get; }
+
+        /// <summary>
+        /// The stream of recorded <see cref="Notification{T}"/>s
+        /// </summary>
+        public IObservable<Recorded<Notification<TPayload>>> RecordedNotificationStream => _rollingReplaySubject.AsObservable();
+
+        /// <summary>
+        /// The recorded <see cref="Notification{T}"/>s
+        /// </summary>
+        public IEnumerable<Recorded<Notification<TPayload>>> RecordedNotifications =>
+            _rollingReplaySubject.GetSnapshot();
+
+        /// <summary>
+        /// The recorded messages
+        /// </summary>
+        public IEnumerable<TPayload> RecordedMessages =>
+            RecordedNotifications.GetMessages();
+
+        /// <summary>
+        /// Creates a new <see cref="FluentTestObserver{TPayload}"/> which subscribes to the supplied <see cref="IObservable{T}"/>
+        /// </summary>
+        /// <param name="subject">the <see cref="IObservable{T}"/> under test</param>
+        public FluentTestObserver(IObservable<TPayload> subject)
+        {
+            Subject = subject;
+            _observeScheduler.Schedule(() =>
+                Debug.WriteLine($"Observe scheduler thread id: {Thread.CurrentThread.ManagedThreadId}"));
+
+            _subscription = subject.ObserveOn(_observeScheduler).Subscribe(this);
+        }
+
+        /// <summary>
+        /// Clears the recorded notifications and messages as well as the recorded notifications stream buffer
+        /// </summary>
+        public void Clear() => _rollingReplaySubject.Clear();
+
+        /// <inheritdoc />
+        public void OnNext(TPayload value) =>
+            _rollingReplaySubject.OnNext(new Recorded<Notification<TPayload>>(_observeScheduler.Now.UtcTicks, Notification.CreateOnNext(value)));
+
+        /// <inheritdoc />
+        public void OnError(Exception exception) =>
+            _rollingReplaySubject.OnNext(new Recorded<Notification<TPayload>>(_observeScheduler.Now.UtcTicks, Notification.CreateOnError<TPayload>(exception)));
+
+        /// <inheritdoc />
+        public void OnCompleted() =>
+            _rollingReplaySubject.OnNext(new Recorded<Notification<TPayload>>(_observeScheduler.Now.UtcTicks, Notification.CreateOnCompleted<TPayload>()));
+        
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _subscription?.Dispose();
+            _observeScheduler.Dispose();
+            _rollingReplaySubject?.Dispose();
+        }
+
+        /// <summary>
+        /// Returns an <see cref="ReactiveAssertions{TPayload}"/> object that can be used to assert the observed <see cref="IObservable{T}"/>
+        /// </summary>
+        /// <returns></returns>
+        public ReactiveAssertions<TPayload> Should() => new ReactiveAssertions<TPayload>(this);
+    }
+}

--- a/Src/FluentAssertions/Reactive/FluentTestObserver.cs
+++ b/Src/FluentAssertions/Reactive/FluentTestObserver.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reactive;
 using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Threading;
 using Microsoft.Reactive.Testing;
@@ -16,7 +18,7 @@ namespace FluentAssertions.Reactive
     public class FluentTestObserver<TPayload> : IObserver<TPayload>, IDisposable
     {
         private readonly IDisposable _subscription;
-        private readonly EventLoopScheduler _observeScheduler = new EventLoopScheduler();
+        private readonly IScheduler _observeScheduler;
         private readonly RollingReplaySubject<Recorded<Notification<TPayload>>> _rollingReplaySubject = new RollingReplaySubject<Recorded<Notification<TPayload>>>();
 
         /// <summary>
@@ -40,6 +42,22 @@ namespace FluentAssertions.Reactive
         /// </summary>
         public IEnumerable<TPayload> RecordedMessages =>
             RecordedNotifications.GetMessages();
+        
+        /// <summary>
+        /// The exception 
+        /// </summary>
+        public Exception Error =>
+            RecordedNotifications
+                .Where(r => r.Value.Kind == NotificationKind.OnError)
+                .Select(r => r.Value.Exception)
+                .FirstOrDefault();
+        
+        /// <summary>
+        /// The recorded messages
+        /// </summary>
+        public bool Completed =>
+            RecordedNotifications
+                .Any(r => r.Value.Kind == NotificationKind.OnCompleted);
 
         /// <summary>
         /// Creates a new <see cref="FluentTestObserver{TPayload}"/> which subscribes to the supplied <see cref="IObservable{T}"/>
@@ -48,10 +66,30 @@ namespace FluentAssertions.Reactive
         public FluentTestObserver(IObservable<TPayload> subject)
         {
             Subject = subject;
-            _observeScheduler.Schedule(() =>
-                Debug.WriteLine($"Observe scheduler thread id: {Thread.CurrentThread.ManagedThreadId}"));
+            _observeScheduler = new EventLoopScheduler();
+            _subscription = new CompositeDisposable(); subject.ObserveOn(_observeScheduler).Subscribe(this);
+        }
 
-            _subscription = subject.ObserveOn(_observeScheduler).Subscribe(this);
+        /// <summary>
+        /// Creates a new <see cref="FluentTestObserver{TPayload}"/> which subscribes to the supplied <see cref="IObservable{T}"/>
+        /// </summary>
+        /// <param name="subject">the <see cref="IObservable{T}"/> under test</param>
+        public FluentTestObserver(IObservable<TPayload> subject, IScheduler scheduler)
+        {
+            Subject = subject;
+            _observeScheduler = scheduler;
+            _subscription = subject.ObserveOn(scheduler).Subscribe(this);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="FluentTestObserver{TPayload}"/> which subscribes to the supplied <see cref="IObservable{T}"/>
+        /// </summary>
+        /// <param name="subject">the <see cref="IObservable{T}"/> under test</param>
+        public FluentTestObserver(IObservable<TPayload> subject, TestScheduler testScheduler)
+        {
+            Subject = subject;
+            _observeScheduler = testScheduler;
+            _subscription = subject.ObserveOn(Scheduler.CurrentThread).Subscribe(this);
         }
 
         /// <summary>
@@ -60,8 +98,11 @@ namespace FluentAssertions.Reactive
         public void Clear() => _rollingReplaySubject.Clear();
 
         /// <inheritdoc />
-        public void OnNext(TPayload value) =>
-            _rollingReplaySubject.OnNext(new Recorded<Notification<TPayload>>(_observeScheduler.Now.UtcTicks, Notification.CreateOnNext(value)));
+        public void OnNext(TPayload value)
+        {
+            _rollingReplaySubject.OnNext(
+                new Recorded<Notification<TPayload>>(_observeScheduler.Now.UtcTicks, Notification.CreateOnNext(value)));
+        }
 
         /// <inheritdoc />
         public void OnError(Exception exception) =>
@@ -75,7 +116,6 @@ namespace FluentAssertions.Reactive
         public void Dispose()
         {
             _subscription?.Dispose();
-            _observeScheduler.Dispose();
             _rollingReplaySubject?.Dispose();
         }
 

--- a/Src/FluentAssertions/Reactive/ReactiveAssertions.cs
+++ b/Src/FluentAssertions/Reactive/ReactiveAssertions.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using FluentAssertions.Common;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+using Microsoft.Reactive.Testing;
+
+namespace FluentAssertions.Reactive
+{
+    /// <summary>
+    /// Provides methods to assert an <see cref="IObservable{T}"/> observed by a <see cref="FluentTestObserver{TPayload}"/>
+    /// </summary>
+    /// <typeparam name="TPayload"></typeparam>
+    public class ReactiveAssertions<TPayload> : ReferenceTypeAssertions<IObservable<TPayload>, ReactiveAssertions<TPayload>>
+    {
+        public FluentTestObserver<TPayload> Observer { get; }
+
+        protected internal ReactiveAssertions(FluentTestObserver<TPayload> observer): base(observer.Subject)
+        {
+            Observer = observer;
+        }
+
+        protected override string Identifier => "Subscription";
+
+        /// <summary>
+        /// Asserts that at least <paramref name="numberOfNotifications"/> notifications were pushed to the <see cref="FluentTestObserver{TPayload}"/> within the specified <paramref name="timeout"/>.<br />
+        /// This includes any previously recorded notifications since it has been created or cleared.
+        /// </summary> 
+        /// <param name="numberOfNotifications">the number of notifications the observer should have recorded by now</param>
+        /// <param name="timeout">the maximum time to wait for the notifications to arrive</param>
+        /// <param name="because"></param>
+        /// <param name="becauseArgs"></param>
+        public AndWhichConstraint<ReactiveAssertions<TPayload>, IEnumerable<TPayload>> Push(int numberOfNotifications, TimeSpan timeout,
+            string because = "", params object[] becauseArgs)
+        {
+            IList<TPayload> notifications = new List<TPayload>();
+            var assertion = Execute.Assertion
+                .WithExpectation($"Expected {{context}} to push at least {numberOfNotifications} {(numberOfNotifications == 1 ? "notification" : "notifications")}, ")
+                .BecauseOf(because, becauseArgs);
+
+            try
+            {
+                notifications = Observer.RecordedNotificationStream
+                    .Select(r => r.Value)
+                    .Dematerialize()
+                    .Take(numberOfNotifications)
+                    .Timeout(timeout)
+                    .Catch<TPayload, TimeoutException>(exception => Observable.Empty<TPayload>())
+                    .ToList()
+                    .ToTask()
+                    .ExecuteInDefaultSynchronizationContext();
+            }
+            catch (Exception e)
+            {
+                assertion.FailWith("but it failed with exception {0}.", e);
+            }
+
+            assertion
+                .ForCondition(notifications.Count >= numberOfNotifications)
+                .FailWith("but {0} were received within {1}.", notifications.Count, timeout);
+
+            return new AndWhichConstraint<ReactiveAssertions<TPayload>, IEnumerable<TPayload>>(this, notifications);
+        }
+
+        /// <inheritdoc cref="Push(int,TimeSpan,string,object[])"/>
+        public async Task<AndWhichConstraint<ReactiveAssertions<TPayload>, IEnumerable<TPayload>>> PushAsync(int numberOfNotifications, TimeSpan timeout,
+            string because = "", params object[] becauseArgs)
+        {
+            IList<TPayload> notifications = new List<TPayload>();
+            var assertion = Execute.Assertion
+                .WithExpectation($"Expected {{context}} to push at least {numberOfNotifications} {(numberOfNotifications == 1 ? "notification" : "notifications")}, ")
+                .BecauseOf(because, becauseArgs);
+
+            try
+            {
+                notifications = await Observer.RecordedNotificationStream
+                    .Select(r => r.Value)
+                    .Dematerialize()
+                    .Take(numberOfNotifications)
+                    .Timeout(timeout)
+                    .Catch<TPayload, TimeoutException>(exception => Observable.Empty<TPayload>())
+                    .ToList()
+                    .ToTask();
+            }
+            catch (Exception e)
+            {
+                assertion.FailWith("but it failed with exception {0}.", e);
+            }
+
+            assertion
+                .ForCondition(notifications.Count >= numberOfNotifications)
+                .FailWith("but {0} were received within {1}.", notifications.Count, timeout);
+
+            return new AndWhichConstraint<ReactiveAssertions<TPayload>, IEnumerable<TPayload>>(this, notifications);
+        }
+
+        /// <summary>
+        /// Asserts that at least <paramref name="numberOfNotifications"/> notifications are pushed to the <see cref="FluentTestObserver{TPayload}"/> within the next 1 second.<br />
+        /// This includes any previously recorded notifications since it has been created or cleared. 
+        /// </summary>
+        /// <param name="numberOfNotifications">the number of notifications the observer should have recorded by now</param>
+        /// <param name="because"></param>
+        /// <param name="becauseArgs"></param>
+        public AndWhichConstraint<ReactiveAssertions<TPayload>, IEnumerable<TPayload>> Push(int numberOfNotifications, string because = "", params object[] becauseArgs)
+            => Push(numberOfNotifications, TimeSpan.FromSeconds(10), because, becauseArgs);
+
+        /// <inheritdoc cref="Push(int,string,object[])"/>
+        public Task<AndWhichConstraint<ReactiveAssertions<TPayload>, IEnumerable<TPayload>>> PushAsync(int numberOfNotifications, string because = "", params object[] becauseArgs)
+            => PushAsync(numberOfNotifications, TimeSpan.FromSeconds(10), because, becauseArgs);
+
+        /// <summary>
+        /// Asserts that at least 1 notification is pushed to the <see cref="FluentTestObserver{TPayload}"/> within the next 1 second.<br />
+        /// This includes any previously recorded notifications since it has been created or cleared. 
+        /// </summary>
+        public AndWhichConstraint<ReactiveAssertions<TPayload>, IEnumerable<TPayload>> Push(string because = "", params object[] becauseArgs)
+            => Push(1, TimeSpan.FromSeconds(1), because, becauseArgs);
+
+        /// <inheritdoc cref="Push(string,object[])"/>
+        public Task<AndWhichConstraint<ReactiveAssertions<TPayload>, IEnumerable<TPayload>>> PushAsync(string because = "", params object[] becauseArgs)
+            => PushAsync(1, TimeSpan.FromSeconds(1), because, becauseArgs);
+
+        /// <summary>
+        /// Asserts that the <see cref="FluentTestObserver{TPayload}"/> does not receive any notifications within the specified <paramref name="timeout"/>.<br />
+        /// This includes any previously recorded notifications since it has been created or cleared. 
+        /// </summary>
+        public AndConstraint<ReactiveAssertions<TPayload>> NotPush(TimeSpan timeout,
+            string because = "", params object[] becauseArgs)
+        {
+            bool anyNotifications = Observer.RecordedNotificationStream
+                .Any(recorded => recorded.Value.Kind == NotificationKind.OnNext)
+                .Timeout(timeout)
+                .Catch(Observable.Return(false))
+                .ToTask()
+                .ExecuteInDefaultSynchronizationContext();
+
+            Execute.Assertion
+                .ForCondition(!anyNotifications)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context} to not push any notifications{reason}, but it did.");
+            
+            return new AndConstraint<ReactiveAssertions<TPayload>>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the <see cref="FluentTestObserver{TPayload}"/> does not receive any notifications within the next 100 milliseconds.<br />
+        /// This includes any previously recorded notifications since it has been created or last cleared. 
+        /// </summary>
+        public AndConstraint<ReactiveAssertions<TPayload>> NotPush(string because = "", params object[] becauseArgs)
+            => NotPush(TimeSpan.FromMilliseconds(100), because, becauseArgs);
+
+        /// <summary>
+        /// Asserts that the <see cref="IObservable{T}"/> observed by the <see cref="FluentTestObserver{TPayload}"/> fails within the specified <paramref name="timeout"/>. 
+        /// </summary>
+        public AndWhichConstraint<ReactiveAssertions<TPayload>, Exception> Fail(TimeSpan timeout,
+            string because = "", params object[] becauseArgs)
+        {
+            var exception = Observer.RecordedNotificationStream
+                .Timeout(timeout)
+                .Catch(Observable.Empty<Recorded<Notification<TPayload>>>())
+                .FirstOrDefaultAsync(recorded => recorded.Value.Kind == NotificationKind.OnError)
+                .Select(recorded => recorded.Value.Exception)
+                .ToTask()
+                .ExecuteInDefaultSynchronizationContext();
+
+            Execute.Assertion
+                .ForCondition(exception != null)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context} to fail within {0}{reason}, but it did not.", timeout);
+            
+            return new AndWhichConstraint<ReactiveAssertions<TPayload>, Exception>(this, exception);
+        }
+
+        /// <inheritdoc cref="Fail(TimeSpan,string,object[])"/>
+        public async Task<AndWhichConstraint<ReactiveAssertions<TPayload>, Exception>> FailAsync(TimeSpan timeout,
+            string because = "", params object[] becauseArgs)
+        {
+            var exception = await Observer.RecordedNotificationStream
+                .Timeout(timeout)
+                .Catch(Observable.Empty<Recorded<Notification<TPayload>>>())
+                .FirstOrDefaultAsync(recorded => recorded.Value.Kind == NotificationKind.OnError)
+                .Select(recorded => recorded.Value.Exception)
+                .ToTask();
+
+            Execute.Assertion
+                .ForCondition(exception != null)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context} to fail within {0}{reason}, but it did not.", timeout);
+
+            return new AndWhichConstraint<ReactiveAssertions<TPayload>, Exception>(this, exception);
+        }
+
+        /// <summary>
+        /// Asserts that the <see cref="IObservable{T}"/> observed by the <see cref="FluentTestObserver{TPayload}"/> fails within the next 1 second. 
+        /// </summary>
+        public AndWhichConstraint<ReactiveAssertions<TPayload>, Exception> Fail(string because = "", params object[] becauseArgs)
+            => Fail(TimeSpan.FromSeconds(1), because, becauseArgs);
+
+        /// <inheritdoc cref="Fail(string,object[])"/>
+        public Task<AndWhichConstraint<ReactiveAssertions<TPayload>, Exception>> FailAsync(string because = "", params object[] becauseArgs)
+            => FailAsync(TimeSpan.FromSeconds(1), because, becauseArgs);
+
+        /// <summary>
+        /// Asserts that the <see cref="IObservable{T}"/> observed by the <see cref="FluentTestObserver{TPayload}"/> completes within the specified <paramref name="timeout"/>. 
+        /// </summary>
+        public AndConstraint<ReactiveAssertions<TPayload>> Complete(TimeSpan timeout,
+            string because = "", params object[] becauseArgs)
+        {
+            bool completed = Observer.RecordedNotificationStream
+                .Any(recorded => recorded.Value.Kind == NotificationKind.OnCompleted)
+                .Timeout(timeout)
+                .Catch(Observable.Return(false))
+                .ToTask()
+                .ExecuteInDefaultSynchronizationContext();
+            
+            Execute.Assertion
+                .ForCondition(completed)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context} to complete within {0}{reason}, but it did not.", timeout);
+
+            return new AndConstraint<ReactiveAssertions<TPayload>>(this);
+        }
+
+        /// <inheritdoc cref="Complete(System.TimeSpan,string,object[])"/>
+        public async Task<AndConstraint<ReactiveAssertions<TPayload>>> CompleteAsync(TimeSpan timeout,
+            string because = "", params object[] becauseArgs)
+        {
+            bool completed = await Observer.RecordedNotificationStream
+                .Any(recorded => recorded.Value.Kind == NotificationKind.OnCompleted)
+                .Timeout(timeout)
+                .Catch(Observable.Return(false))
+                .ToTask();
+
+            Execute.Assertion
+                .ForCondition(completed)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context} to complete within {0}{reason}, but it did not.", timeout);
+
+            return new AndConstraint<ReactiveAssertions<TPayload>>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the <see cref="IObservable{T}"/> observed by the <see cref="FluentTestObserver{TPayload}"/> completes within the next 1 second. 
+        /// </summary>
+        public AndConstraint<ReactiveAssertions<TPayload>> Complete(string because = "", params object[] becauseArgs)
+            => Complete(TimeSpan.FromSeconds(1), because, becauseArgs);
+
+        /// <inheritdoc cref="Complete(string,object[])"/>
+        public Task<AndConstraint<ReactiveAssertions<TPayload>>> CompleteAsync(string because = "", params object[] becauseArgs)
+            => CompleteAsync(TimeSpan.FromSeconds(1), because, becauseArgs);
+
+        /// <summary>
+        /// Asserts that the <see cref="IObservable{T}"/> observed by the <see cref="FluentTestObserver{TPayload}"/> does not complete within the specified <paramref name="timeout"/>. 
+        /// </summary>
+        public AndConstraint<ReactiveAssertions<TPayload>> NotComplete(TimeSpan timeout,
+            string because = "", params object[] becauseArgs)
+        {
+            bool completed = Observer.RecordedNotificationStream
+                .Any(recorded => recorded.Value.Kind == NotificationKind.OnCompleted)
+                .Timeout(timeout)
+                .Catch(Observable.Return(false))
+                .ToTask()
+                .ExecuteInDefaultSynchronizationContext();
+
+            Execute.Assertion
+                .ForCondition(!completed)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context} to not complete{reason}, but it did.");
+            
+            return new AndConstraint<ReactiveAssertions<TPayload>>(this);
+        }
+
+        /// <summary>
+        /// Asserts that the <see cref="IObservable{T}"/> observed by the <see cref="FluentTestObserver{TPayload}"/> does not complete within the next 100 milliseconds. 
+        /// </summary>
+        public AndConstraint<ReactiveAssertions<TPayload>> NotComplete(string because = "", params object[] becauseArgs)
+            => NotComplete(TimeSpan.FromMilliseconds(100), because, becauseArgs);
+    }
+}

--- a/Src/FluentAssertions/Reactive/ReactiveExtensions.cs
+++ b/Src/FluentAssertions/Reactive/ReactiveExtensions.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reactive;
+using System.Threading.Tasks;
+using FluentAssertions.Execution;
+using Microsoft.Reactive.Testing;
+
+namespace FluentAssertions.Reactive
+{
+    public static class ReactiveExtensions
+    {
+        /// <summary>
+        /// Create a new <see cref="FluentTestObserver{TPayload}"/> subscribed to this <paramref name="observable"/>
+        /// </summary>
+        public static FluentTestObserver<T> Observe<T>(this IObservable<T> observable) => new FluentTestObserver<T>(observable);
+
+        /// <summary>
+        /// Asserts that the recorded messages contain at lease one item which matches the <paramref name="predicate"/>
+        /// </summary>
+        public static AndWhichConstraint<ReactiveAssertions<TPayload>, IEnumerable<TPayload>> WithMessage<TPayload>(
+            this AndWhichConstraint<ReactiveAssertions<TPayload>, IEnumerable<TPayload>> recorderConstraint, Expression<Func<TPayload, bool>> predicate)
+        {
+            if (predicate is null) throw new ArgumentNullException(nameof(predicate));
+            
+            var compiledPredicate = predicate.Compile();
+            bool match = recorderConstraint.Subject.Any(compiledPredicate);
+            
+            Execute.Assertion
+                .ForCondition(match)
+                .FailWith("Expected at least one message from {0} to match {1}, but found none.", recorderConstraint.And.Subject, predicate.Body);
+
+            return recorderConstraint;
+        }
+
+        /// <summary>
+        /// Asserts that the last recorded message matches the <paramref name="predicate"/>
+        /// </summary>
+        public static AndWhichConstraint<ReactiveAssertions<TPayload>, IEnumerable<TPayload>> WithLastMessage<TPayload>(
+            this AndWhichConstraint<ReactiveAssertions<TPayload>, IEnumerable<TPayload>> recorderConstraint, Expression<Func<TPayload, bool>> predicate)
+        {
+            if (predicate is null)
+                throw new ArgumentNullException(nameof(predicate));
+
+            bool match = predicate.Compile().Invoke(recorderConstraint.GetLastMessage());
+
+            Execute.Assertion
+                .ForCondition(match)
+                .FailWith("Expected the last message from {0} to match {1}, but it did not.", recorderConstraint.And.Subject, predicate.Body);
+            
+            return recorderConstraint;
+        }
+
+        /// <summary>
+        /// Extracts the last recorded message
+        /// </summary>
+        public static TPayload GetLastMessage<TPayload>(
+            this AndWhichConstraint<ReactiveAssertions<TPayload>, IEnumerable<TPayload>>
+                recorderConstraint) =>
+            recorderConstraint.Subject.LastOrDefault();
+
+        /// <summary>
+        /// Extracts the last recorded message
+        /// </summary>
+        public static async Task<TPayload> GetLastMessageAsync<TPayload>(
+            this Task<AndWhichConstraint<ReactiveAssertions<TPayload>, IEnumerable<TPayload>>>
+                assertionTask)
+        {
+            var constraint = await assertionTask;
+            return constraint.Subject.LastOrDefault();
+        }
+        
+        /// <summary>
+        /// Extracts the recorded messages from a number of recorded notifications
+        /// </summary>
+        public static IEnumerable<TPayload> GetMessages<TPayload>(
+            this IEnumerable<Recorded<Notification<TPayload>>> recordedNotifications) => recordedNotifications
+            .Where(r => r.Value.Kind == NotificationKind.OnNext)
+            .Select(recorded => recorded.Value.Value);
+
+        /// <summary>
+        /// Extracts the last recorded message from a number of recorded notifications
+        /// </summary>
+        public static TPayload GetLastMessage<TPayload>(
+            this IEnumerable<Recorded<Notification<TPayload>>> recordedNotifications) =>
+            recordedNotifications.GetMessages().LastOrDefault();
+        
+        /// <summary>
+        /// Clears the recorded notifications on the underlying <see cref="FluentTestObserver{TPayload}"/>
+        /// </summary>
+        public static void Clear<TPayload>(
+            this AndWhichConstraint<ReactiveAssertions<TPayload>, IEnumerable<Recorded<Notification<TPayload>>>>
+                recorderConstraint) => recorderConstraint.And.Observer.Clear();
+    }
+}

--- a/Src/FluentAssertions/Reactive/ReactiveExtensions.cs
+++ b/Src/FluentAssertions/Reactive/ReactiveExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reactive;
+using System.Reactive.Concurrency;
 using System.Threading.Tasks;
 using FluentAssertions.Execution;
 using Microsoft.Reactive.Testing;
@@ -15,6 +16,16 @@ namespace FluentAssertions.Reactive
         /// Create a new <see cref="FluentTestObserver{TPayload}"/> subscribed to this <paramref name="observable"/>
         /// </summary>
         public static FluentTestObserver<T> Observe<T>(this IObservable<T> observable) => new FluentTestObserver<T>(observable);
+
+        /// <summary>
+        /// Create a new <see cref="FluentTestObserver{TPayload}"/> subscribed to this <paramref name="observable"/>
+        /// </summary>
+        public static FluentTestObserver<T> Observe<T>(this IObservable<T> observable, IScheduler scheduler) => new FluentTestObserver<T>(observable, scheduler);
+
+        /// <summary>
+        /// Create a new <see cref="FluentTestObserver{TPayload}"/> subscribed to this <paramref name="observable"/>
+        /// </summary>
+        public static FluentTestObserver<T> Observe<T>(this IObservable<T> observable, TestScheduler scheduler) => new FluentTestObserver<T>(observable, scheduler);
 
         /// <summary>
         /// Asserts that the recorded messages contain at lease one item which matches the <paramref name="predicate"/>

--- a/Src/FluentAssertions/Reactive/RollingReplaySubject.cs
+++ b/Src/FluentAssertions/Reactive/RollingReplaySubject.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace FluentAssertions.Reactive
+{
+    /// <summary>
+    /// Clearable <see cref="ReplaySubject{T}"/> taken from James World: https://stackoverflow.com/a/28945444/4340541
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class RollingReplaySubject<T> : ISubject<T>, IDisposable
+    {
+        private readonly ReplaySubject<IObservable<T>> _subjects;
+        private readonly IObservable<T> _concatenatedSubjects;
+        private ISubject<T> _currentSubject;
+
+        public RollingReplaySubject()
+        {
+            _subjects = new ReplaySubject<IObservable<T>>(1);
+            _concatenatedSubjects = _subjects.Concat();
+            _currentSubject = new ReplaySubject<T>();
+            _subjects.OnNext(_currentSubject);
+        }
+
+        public void Clear()
+        {
+            _currentSubject.OnCompleted();
+            _currentSubject = new ReplaySubject<T>();
+            _subjects.OnNext(_currentSubject);
+        }
+
+        public void OnNext(T value) => _currentSubject.OnNext(value);
+
+        public void OnError(Exception error) => _currentSubject.OnError(error);
+
+        public void OnCompleted()
+        {
+            _currentSubject.OnCompleted();
+            _subjects.OnCompleted();
+            // a quick way to make the current ReplaySubject unreachable
+            // except to in-flight observers, and not hold up collection
+            _currentSubject = new Subject<T>();
+        }
+
+        public IDisposable Subscribe(IObserver<T> observer) => _concatenatedSubjects.Subscribe(observer);
+
+        public IEnumerable<T> GetSnapshot()
+        {
+            var snapshot = new List<T>();
+            using (this.Subscribe(item => snapshot.Add(item)))
+            {
+                // Deliberately empty; subscribing will add everything to the list.
+            }
+            return snapshot;
+        }
+
+        public void Dispose()
+        {
+            OnCompleted();
+            _subjects?.Dispose();
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Reactive/ReactiveAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Reactive/ReactiveAssertionSpecs.cs
@@ -1,0 +1,164 @@
+﻿
+using System;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using FluentAssertions.Formatting;
+using FluentAssertions.Reactive;
+using Microsoft.Reactive.Testing;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs
+{
+    [Collection("Reactive")]
+    public class ReactiveAssertionSpecs: ReactiveTest
+    {
+        [Fact]
+        public void When_the_expected_number_of_notifications_where_pushed_it_should_not_throw()
+        {
+            var scheduler = new TestScheduler();
+            var observable = scheduler.CreateColdObservable(
+                OnNext(100, 1),
+                OnNext(200, 2),
+                OnNext(300, 3));
+
+            // observe the sequence
+            using var observer = observable.Observe(scheduler);
+            // push subscriptions
+            scheduler.AdvanceTo(400);
+
+            // Act
+            Action act = () => observer.Should().Push(3);
+
+            // Assert
+            act.Should().NotThrow();
+
+            observer.RecordedNotifications.Should().BeEquivalentTo(observable.Messages);
+        }
+
+        [Fact]
+        public void When_the_expected_number_of_notifications_where_not_pushed_it_should_throw()
+        {
+            var scheduler = new TestScheduler();
+            var observable = scheduler.CreateColdObservable(
+                OnNext(100, 1),
+                OnNext(200, 2),
+                OnNext(300, 3));
+
+            // observe the sequence
+            using var observer = observable.Observe(scheduler);
+
+            // assert a single notification
+            // Act
+            Action act = () => observer.Should().Push(1, TimeSpan.Zero);
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                $"Expected observable to push at least 1 notification, but 0 were received within {Formatter.ToString(TimeSpan.Zero)}.");
+            observer.RecordedNotifications.Should().BeEmpty("because no messages have been pushed");
+
+            // assert multiple notifications
+            scheduler.AdvanceTo(250);
+
+            // Act
+            act = () => observer.Should().Push(3, TimeSpan.Zero);
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                $"Expected observable to push at least 3 notifications, but 2 were received within {Formatter.ToString(TimeSpan.Zero)}.");
+            observer.RecordedNotifications.Should().BeEquivalentTo(observable.Messages.Take(2));
+        }
+
+        [Fact]
+        public void When_the_observable_fails_instead_of_pushing_notifications_it_should_throw()
+        {
+            var exception = new ArgumentException("That was wrong.");
+            var scheduler = new TestScheduler();
+            var observable = scheduler.CreateColdObservable(
+                OnError<Unit>(1, exception));
+            
+            // observe the sequence
+            using var observer = observable.Observe(scheduler);
+            scheduler.AdvanceTo(10);
+            // Act
+            Action act = () => observer.Should().Push();
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                $"Expected observable to push at least 1 notification, but it failed with a {Formatter.ToString(exception)}.");
+            observer.Error.Should().BeEquivalentTo(exception);
+        }
+
+        [Fact]
+        public void When_the_observable_fails_as_expected_it_should_not_throw()
+        {
+            var exception = new ArgumentException("That was wrong.");
+            var scheduler = new TestScheduler();
+            var observable = scheduler.CreateColdObservable(
+                OnError<Unit>(1, exception));
+
+            // observe the sequence
+            using var observer = observable.Observe(scheduler);
+            scheduler.AdvanceTo(10);
+
+            // Act
+            Action act = () => observer.Should().Throw<ArgumentException>()
+                .WithMessage(exception.Message);
+
+            // Assert
+            act.Should().NotThrow();
+            observer.Error.Should().BeEquivalentTo(exception);
+        }
+
+        [Fact]
+        public void When_the_observable_is_expected_to_fail_but_does_not_it_should_throw()
+        {
+            var exception = new ArgumentException("That was wrong.");
+            var observable = Observable.Return(false);
+
+            // observe the sequence
+            using var observer = observable.Observe();
+
+            // Act
+            Action act = () => observer.Should().Throw<ArgumentException>(TimeSpan.Zero);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                $"Expected observable to throw a <System.ArgumentException>, but no exception was thrown.");
+
+            observer.Error.Should().BeNull();
+        }
+
+
+        [Fact]
+        public void When_the_observable_completes_as_expected_it_should_not_throw()
+        {
+            var observable = Observable.Empty<Unit>();
+
+            // observe the sequence
+            using var observer = observable.Observe();
+
+            // Act
+            Action act = () => observer.Should().Complete();
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_the_observable_is_expected_to_complete_but_does_not_it_should_throw()
+        {
+            var exception = new ArgumentException("That was wrong.");
+            var observable = new Subject<Unit>();
+
+            // observe the sequence
+            using var observer = observable.Observe();
+
+            // Act
+            Action act = () => observer.Should().Complete(TimeSpan.Zero);
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                $"Expected observable to complete within {Formatter.ToString(TimeSpan.Zero)}, but it did not.");
+            observer.Error.Should().BeNull();
+        }
+
+    }
+}


### PR DESCRIPTION
An attempt to create fluent assertions for observables (#197).

Im not sure if the "fluent" syntax is in line with the rest of this project, please propose changes if you have a better alternative.

The prototype of this is currently in use at https://github.com/graphql-dotnet/graphql-client/pull/213, but the test run by GitHub Actions fails randomly on one of these assertions. 

Tests are still incomplete, documentation only exists in form of doccomments so far...

Im welcoming any comments and reviews!

## IMPORTANT 

* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/master/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com).

