### PR TITLE
Make xml references syntactically correct

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -55,8 +55,8 @@ csharp_style_var_when_type_is_apparent = false:none
 csharp_style_var_elsewhere = false:suggestion
 
 # use language keywords instead of BCL types
-dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
-dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:error
+dotnet_style_predefined_type_for_member_access = true:error
 
 # name all constant fields using PascalCase
 dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
@@ -90,13 +90,16 @@ csharp_style_expression_bodied_indexers = true:none
 csharp_style_expression_bodied_accessors = true:none
 
 # Pattern matching
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:error
+csharp_style_pattern_matching_over_as_with_null_check = true:error
+csharp_style_inlined_variable_declaration = true:error
 
 # Null checking preferences
 csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
+
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:error
+dotnet_style_readonly_field = true:error
 
 # Space preferences
 csharp_space_after_cast = false
@@ -131,6 +134,26 @@ dotnet_diagnostic.CA1305.severity = none
 dotnet_diagnostic.CA1307.severity = error
 dotnet_diagnostic.CA1308.severity = error
 dotnet_diagnostic.CA1309.severity = error
+dotnet_diagnostic.CA3075.severity = none
+dotnet_diagnostic.CA5369.severity = none
 
 # Banned API Analyzers
 dotnet_diagnostic.RS0030.severity = error
+
+# IDE0004: Remove unnecessary cast
+dotnet_diagnostic.IDE0004.severity = error
+
+# IDE0005: Remove unnecessary usings/imports
+dotnet_diagnostic.IDE0005.severity = error
+
+# IDE0051: Remove unused private members (no reads or writes)
+dotnet_diagnostic.IDE0051.severity = error
+
+# IDE0052: Remove unread private members (writes but no reads)
+dotnet_diagnostic.IDE0052.severity = error
+
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = suggestion
+
+# CS1574: XML comment on 'construct' has syntactically incorrect cref attribute 'name'
+dotnet_diagnostic.CS1574.severity = error

--- a/Build/.editorconfig
+++ b/Build/.editorconfig
@@ -8,3 +8,6 @@ dotnet_style_require_accessibility_modifiers = never:warning
 csharp_style_expression_bodied_properties = true:warning
 csharp_style_expression_bodied_indexers = true:warning
 csharp_style_expression_bodied_accessors = true:warning
+
+dotnet_diagnostic.IDE0044.severity = none
+dotnet_diagnostic.IDE0051.severity = none

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -16,11 +16,13 @@ using static Nuke.Common.Tools.Xunit.XunitTasks;
 [DotNetVerbosityMapping]
 class Build : NukeBuild
 {
-    /// Support plugins are available for:
-    ///   - JetBrains ReSharper        https://nuke.build/resharper
-    ///   - JetBrains Rider            https://nuke.build/rider
-    ///   - Microsoft VisualStudio     https://nuke.build/visualstudio
-    ///   - Microsoft VSCode           https://nuke.build/vscode
+    /* Support plugins are available for:
+       - JetBrains ReSharper        https://nuke.build/resharper
+       - JetBrains Rider            https://nuke.build/rider
+       - Microsoft VisualStudio     https://nuke.build/visualstudio
+       - Microsoft VSCode           https://nuke.build/vscode
+    */
+
     public static int Main() => Execute<Build>(
         x => x.UnitTests,
         x => x.Pack);

--- a/Src/FluentAssertions/AndConstraint.cs
+++ b/Src/FluentAssertions/AndConstraint.cs
@@ -8,7 +8,7 @@ namespace FluentAssertions
         public T And { get; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="System.Object"/> class.
+        /// Initializes a new instance of the <see cref="AndConstraint{T}"/> class.
         /// </summary>
         public AndConstraint(T parentConstraint)
         {

--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -8,7 +8,9 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions.Collections;
 using FluentAssertions.Common;
+#if !NETSTANDARD2_0
 using FluentAssertions.Events;
+#endif
 using FluentAssertions.Numeric;
 using FluentAssertions.Primitives;
 using FluentAssertions.Reflection;
@@ -129,7 +131,7 @@ namespace FluentAssertions
 
         /// <summary>
         /// Returns an <see cref="ExecutionTimeAssertions"/> object that can be used to assert the
-        /// current <see cref="ExecutionTime"/>.
+        /// current <see cref="FluentAssertions.Specialized.ExecutionTime"/>.
         /// </summary>
         [Pure]
         public static ExecutionTimeAssertions Should(this ExecutionTime executionTime)
@@ -772,17 +774,18 @@ namespace FluentAssertions
         }
 
         /// <summary>
-        /// Asserts that the thrown exception has a message that matches <paramref name = "expectedWildcardPattern" />.
+        /// Asserts that the thrown exception has a message that matches <paramref name="expectedWildcardPattern" />.
         /// </summary>
-        /// <param name = "expectedWildcardPattern">
+        /// <param name="task">The <see cref="ExceptionAssertions{TException}"/> containing the thrown exception.</param>
+        /// <param name="expectedWildcardPattern">
         /// The wildcard pattern with which the exception message is matched, where * and ? have special meanings.
         /// </param>
-        /// <param name = "because">
+        /// <param name="because">
         /// A formatted phrase as is supported by <see cref = "string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name = "becauseArgs">
-        /// Zero or more objects to format using the placeholders in <see cref = "because" />.
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
         public static async Task<ExceptionAssertions<TException>> WithMessage<TException>(
             this Task<ExceptionAssertions<TException>> task,

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -155,6 +155,5 @@ namespace FluentAssertions
         {
             return candidate == "true" || candidate == "false";
         }
-
     }
 }

--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Common;
@@ -321,6 +320,7 @@ namespace FluentAssertions.Collections
         /// items in the collection are structurally equal.
         /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
         /// </remarks>
+        /// <param name="expectation">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
         /// <param name="because">
         /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the
         /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -365,6 +365,7 @@ namespace FluentAssertions.Collections
         /// items in the collection are structurally equal.
         /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
         /// </remarks>
+        /// <param name="expectation">An <see cref="IEnumerable"/> with the expected elements.</param>
         /// <param name="because">
         /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the
         /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -390,6 +391,7 @@ namespace FluentAssertions.Collections
         /// items in the collection are structurally equal.
         /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
         /// </remarks>
+        /// <param name="expectation">An <see cref="IEnumerable"/> with the expected elements.</param>
         /// <param name="config">
         /// A reference to the <see cref="EquivalencyAssertionOptions{TSubject}"/> configuration object that can be used
         /// to influence the way the object graphs are compared. You can also provide an alternative instance of the
@@ -438,6 +440,7 @@ namespace FluentAssertions.Collections
         /// The type of a collection property is ignored as long as the collection implements <see cref="IEnumerable"/> and all
         /// items in the collection are structurally equal.
         /// </remarks>
+        /// <param name="expectation">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
         /// <param name="config">
         /// A reference to the <see cref="EquivalencyAssertionOptions{TSubject}"/> configuration object that can be used
         /// to influence the way the object graphs are compared. You can also provide an alternative instance of the
@@ -550,6 +553,7 @@ namespace FluentAssertions.Collections
         /// and the result is equal.
         /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
         /// </remarks>
+        /// <param name="expectation">The expected element.</param>
         /// <param name="because">
         /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the
         /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -572,6 +576,7 @@ namespace FluentAssertions.Collections
         /// and the result is equal.
         /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
         /// </remarks>
+        /// <param name="expectation">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
         /// <param name="config">
         /// A reference to the <see cref="EquivalencyAssertionOptions{TSubject}"/> configuration object that can be used
         /// to influence the way the object graphs are compared. You can also provide an alternative instance of the
@@ -1539,6 +1544,8 @@ namespace FluentAssertions.Collections
         /// <summary>
         /// Asserts that the <paramref name="expectation"/> element directly precedes the <paramref name="successor"/>.
         /// </summary>
+        /// <param name="successor">The element that should succeed <paramref name="expectation"/>.</param>
+        /// <param name="expectation">The expected element that should precede <paramref name="successor"/>.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -1582,6 +1589,8 @@ namespace FluentAssertions.Collections
         /// <summary>
         /// Asserts that the <paramref name="expectation"/> element directly succeeds the <paramref name="predecessor"/>.
         /// </summary>
+        /// <param name="predecessor">The element that should precede <paramref name="expectation"/>.</param>
+        /// <param name="expectation">The element that should succeed <paramref name="predecessor"/>.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -162,6 +162,7 @@ namespace FluentAssertions.Collections
         /// the values for each key are structurally equivalent. Notice that actual behavior is determined by the global
         /// defaults managed by the <see cref="AssertionOptions"/> class.
         /// </remarks>
+        /// <param name="expectation">The expected element.</param>
         /// <param name="because">
         /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the
         /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -186,6 +187,7 @@ namespace FluentAssertions.Collections
         /// the values for each key are structurally equivalent. Notice that actual behavior is determined by the global
         /// defaults managed by the <see cref="AssertionOptions"/> class.
         /// </remarks>
+        /// <param name="expectation">The expected element.</param>
         /// <param name="config">
         /// A reference to the <see cref="EquivalencyAssertionOptions{TSubject}"/> configuration object that can be used
         /// to influence the way the object graphs are compared. You can also provide an alternative instance of the

--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -252,7 +252,7 @@ namespace FluentAssertions.Collections
 
         /// <summary>
         /// Expects the current collection to contain all the same elements in the same order as the collection identified by
-        /// <paramref name="elements" />. Elements are compared using their <see cref="T.Equals(object)" /> method.
+        /// <paramref name="elements" />. Elements are compared using their <see cref="object.Equals(object)" /> method.
         /// </summary>
         /// <param name="elements">A params array with the expected elements.</param>
         public AndConstraint<TAssertions> Equal(params T[] elements)

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -10,6 +10,9 @@ namespace FluentAssertions.Collections
     public class StringCollectionAssertions :
         StringCollectionAssertions<IEnumerable<string>>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringCollectionAssertions"/> class.
+        /// </summary>
         public StringCollectionAssertions(IEnumerable<string> actualValue)
             : base(actualValue)
         {
@@ -20,6 +23,9 @@ namespace FluentAssertions.Collections
         StringCollectionAssertions<TCollection, StringCollectionAssertions<TCollection>>
         where TCollection : IEnumerable<string>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringCollectionAssertions{TCollection}"/> class.
+        /// </summary>
         public StringCollectionAssertions(TCollection actualValue)
             : base(actualValue)
         {
@@ -31,6 +37,9 @@ namespace FluentAssertions.Collections
         where TCollection : IEnumerable<string>
         where TAssertions : StringCollectionAssertions<TCollection, TAssertions>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringCollectionAssertions{TCollection, TAssertions}"/> class.
+        /// </summary>
         public StringCollectionAssertions(TCollection actualValue)
             : base(actualValue)
         {
@@ -75,6 +84,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// The two collections are equivalent when they both contain the same strings in any order.
         /// </remarks>
+        /// <param name="expectation">An <see cref="IEnumerable{String}"/> with the expected elements.</param>
         /// <param name="because">
         /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the
         /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -95,6 +105,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// The two collections are equivalent when they both contain the same strings in any order.
         /// </remarks>
+        /// <param name="expectation">An <see cref="IEnumerable{String}"/> with the expected elements.</param>
         /// <param name="config">
         /// A reference to the <see cref="EquivalencyAssertionOptions{String}"/> configuration object that can be used
         /// to influence the way the object graphs are compared. You can also provide an alternative instance of the
@@ -180,6 +191,9 @@ namespace FluentAssertions.Collections
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
+        /// <param name="becauseArg">
+        /// An object to format using the placeholders in <paramref name="because" />.
+        /// </param>
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
@@ -200,6 +214,9 @@ namespace FluentAssertions.Collections
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArg">
+        /// An object to format using the placeholders in <paramref name="because" />.
         /// </param>
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.

--- a/Src/FluentAssertions/Collections/WhichValueConstraint.cs
+++ b/Src/FluentAssertions/Collections/WhichValueConstraint.cs
@@ -6,6 +6,9 @@ namespace FluentAssertions.Collections
         where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
         where TAssertions : GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WhichValueConstraint{TCollection, TKey, TValue, TAssertions}"/> class.
+        /// </summary>
         public WhichValueConstraint(TAssertions parentConstraint, TValue value)
             : base(parentConstraint)
         {

--- a/Src/FluentAssertions/Common/ConfigurationStoreExceptionInterceptor.cs
+++ b/Src/FluentAssertions/Common/ConfigurationStoreExceptionInterceptor.cs
@@ -1,4 +1,4 @@
-﻿
+﻿#if NET47 || NETCOREAPP2_1 || NETCOREAPP3_0
 namespace FluentAssertions.Common
 {
     internal class ConfigurationStoreExceptionInterceptor : IConfigurationStore
@@ -31,4 +31,4 @@ namespace FluentAssertions.Common
         }
     }
 }
-
+#endif

--- a/Src/FluentAssertions/Common/NullConfigurationStore.cs
+++ b/Src/FluentAssertions/Common/NullConfigurationStore.cs
@@ -1,3 +1,4 @@
+#if !(NET47 || NETCOREAPP2_1 || NETCOREAPP3_0)
 namespace FluentAssertions.Common
 {
     internal class NullConfigurationStore : IConfigurationStore
@@ -8,3 +9,4 @@ namespace FluentAssertions.Common
         }
     }
 }
+#endif

--- a/Src/FluentAssertions/Equivalency/DictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DictionaryEquivalencyStep.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace FluentAssertions.Equivalency
 {
+    /// <summary>
+    /// Provides information on a particular property during an assertion for structural equality of two object graphs.
+    /// </summary>
     public class EquivalencyValidationContext : IEquivalencyValidationContext
     {
         private Type compileTimeType;
@@ -19,12 +22,12 @@ namespace FluentAssertions.Equivalency
         public string SelectedMemberDescription { get; set; }
 
         /// <summary>
-        /// Gets the value of the <see cref="IMemberInfo.SelectedMemberInfo" />
+        /// Gets the value of the subject object graph.
         /// </summary>
         public object Subject { get; set; }
 
         /// <summary>
-        /// Gets the value of the <see cref="IEquivalencyValidationContext.MatchingExpectationProperty" />.
+        /// Gets the value of the expected object graph..
         /// </summary>
         public object Expectation { get; set; }
 

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidationContextExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidationContextExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency

--- a/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
@@ -7,10 +7,6 @@ using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency
 {
-    /// <remarks>
-    /// I think (but did not try) this would have been easier using 'dynamic' but that is
-    /// precluded by some of the PCL targets.
-    /// </remarks>
     public class GenericDictionaryEquivalencyStep : IEquivalencyStep
     {
         private static readonly MethodInfo AssertSameLengthMethod = new Func<IDictionary<object, object>, IDictionary<object, object>, bool>

--- a/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
@@ -84,12 +84,12 @@ namespace FluentAssertions.Equivalency
     public enum EqualityStrategy
     {
         /// <summary>
-        /// The object overrides <see cref="object.Equals"/>, so use that.
+        /// The object overrides <see cref="object.Equals(object)"/>, so use that.
         /// </summary>
         Equals,
 
         /// <summary>
-        /// The object does not seem to override <see cref="object.Equals"/>, so compare by members
+        /// The object does not seem to override <see cref="object.Equals(object)"/>, so compare by members
         /// </summary>
         Members,
 

--- a/Src/FluentAssertions/Equivalency/IEquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyValidationContext.cs
@@ -8,7 +8,7 @@ namespace FluentAssertions.Equivalency
     public interface IEquivalencyValidationContext : IMemberInfo
     {
         /// <summary>
-        /// Gets the value of the <see cref="MatchingExpectationProperty"/>.
+        /// Gets the value of the expected object graph.
         /// </summary>
         object Expectation { get; }
 
@@ -29,7 +29,7 @@ namespace FluentAssertions.Equivalency
         bool IsRoot { get; }
 
         /// <summary>
-        /// Gets the value of the <see cref="ISelectionContext.PropertyInfo"/>
+        /// Gets the value of the subject object graph.
         /// </summary>
         object Subject { get; set; }
 

--- a/Src/FluentAssertions/Equivalency/IMemberInfo.cs
+++ b/Src/FluentAssertions/Equivalency/IMemberInfo.cs
@@ -8,7 +8,7 @@ namespace FluentAssertions.Equivalency
     public interface IMemberInfo
     {
         /// <summary>
-        /// Gets the <see cref="SelectedMemberInfo"/> of the member that returned the current object, or <c>null</c> if the current
+        /// Gets the <see cref="Equivalency.SelectedMemberInfo"/> of the member that returned the current object, or <c>null</c> if the current
         /// object represents the root object.
         /// </summary>
         SelectedMemberInfo SelectedMemberInfo { get; }

--- a/Src/FluentAssertions/Equivalency/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/ObjectReference.cs
@@ -22,12 +22,12 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Determines whether the specified <see cref="System.Object"/> is equal to the current <see cref="System.Object"/>.
+        /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="object"/>.
         /// </summary>
         /// <returns>
-        /// true if the specified <see cref="System.Object"/> is equal to the current <see cref="System.Object"/>; otherwise, false.
+        /// true if the specified <see cref="object"/> is equal to the current <see cref="object"/>; otherwise, false.
         /// </returns>
-        /// <param name="obj">The <see cref="System.Object"/> to compare with the current <see cref="System.Object"/>. </param><filterpriority>2</filterpriority>
+        /// <param name="obj">The <see cref="object"/> to compare with the current <see cref="object"/>. </param><filterpriority>2</filterpriority>
         public override bool Equals(object obj)
         {
             if (!(obj is ObjectReference other))
@@ -53,7 +53,7 @@ namespace FluentAssertions.Equivalency
         /// Serves as a hash function for a particular type.
         /// </summary>
         /// <returns>
-        /// A hash code for the current <see cref="System.Object"/>.
+        /// A hash code for the current <see cref="object"/>.
         /// </returns>
         /// <filterpriority>2</filterpriority>
         public override int GetHashCode()

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -330,7 +330,10 @@ namespace FluentAssertions.Equivalency
             return (TSelf)this;
         }
 
-        /// <summary></summary>
+        /// <summary>
+        /// Overrides the comparison of subject and expectation to use provided <paramref name="action"/>
+        /// when the predicate is met.
+        /// </summary>
         /// <param name="action">
         /// The assertion to execute when the predicate is met.
         /// </param>
@@ -639,7 +642,7 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Defines additional overrides when used with <see cref="EquivalencyAssertionOptions.When" />
+        /// Defines additional overrides when used with <see cref="SelfReferenceEquivalencyAssertionOptions{T}" />
         /// </summary>
         public class Restriction<TMember>
         {

--- a/Src/FluentAssertions/Events/EventAssertions.cs
+++ b/Src/FluentAssertions/Events/EventAssertions.cs
@@ -69,7 +69,7 @@ namespace FluentAssertions.Events
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
         /// <remarks>
-        /// You must call <see cref="MonitorEvents"/> on the same object prior to this call so that Fluent Assertions can
+        /// You must call <see cref="AssertionExtensions.Monitor"/> on the same object prior to this call so that Fluent Assertions can
         /// subscribe for the events of the object.
         /// </remarks>
         public void NotRaise(string eventName, string because = "", params object[] becauseArgs)

--- a/Src/FluentAssertions/Events/EventMonitor.cs
+++ b/Src/FluentAssertions/Events/EventMonitor.cs
@@ -93,7 +93,7 @@ namespace FluentAssertions.Events
             }
         }
 
-        private EventInfo[] GetPublicEvents(Type type)
+        private static EventInfo[] GetPublicEvents(Type type)
         {
             if (!type.IsInterface)
             {
@@ -120,11 +120,17 @@ namespace FluentAssertions.Events
         {
             if (!recorderMap.TryGetValue(eventInfo.Name, out _))
             {
+#pragma warning disable CA2000 // Ownership is transfered to recorderMap
                 var recorder = new EventRecorder(subject.Target, eventInfo.Name, utcNow);
                 if (recorderMap.TryAdd(eventInfo.Name, recorder))
                 {
                     recorder.Attach(subject, eventInfo);
                 }
+                else
+                {
+                    recorder.Dispose();
+                }
+#pragma warning restore CA2000 
             }
         }
 

--- a/Src/FluentAssertions/Events/EventRecorder.cs
+++ b/Src/FluentAssertions/Events/EventRecorder.cs
@@ -23,9 +23,10 @@ namespace FluentAssertions.Events
         private Action cleanup;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="EventRecorder"/> class.
         /// </summary>
-        /// <param name = "eventRaiser">The object events are recorded from</param>
-        /// <param name = "eventName">The name of the event that's recorded</param>
+        /// <param name="eventRaiser">The object events are recorded from</param>
+        /// <param name="eventName">The name of the event that's recorded</param>
         /// <param name="utcNow">A delegate to get the current date and time in UTC format.</param>
         public EventRecorder(object eventRaiser, string eventName, Func<DateTime> utcNow)
         {

--- a/Src/FluentAssertions/Events/IEventRecorder.cs
+++ b/Src/FluentAssertions/Events/IEventRecorder.cs
@@ -11,7 +11,7 @@ namespace FluentAssertions.Events
         /// <summary>
         /// Store information about a raised event
         /// </summary>
-        /// <param name = "parameters">Parameters the event was raised with</param>
+        /// <param name="parameters">Parameters the event was raised with</param>
         void RecordEvent(params object[] parameters);
 
         /// <summary>

--- a/Src/FluentAssertions/Events/IMonitor.cs
+++ b/Src/FluentAssertions/Events/IMonitor.cs
@@ -1,7 +1,6 @@
 ﻿#if !NETSTANDARD2_0
 
 using System;
-using System.Reflection;
 
 namespace FluentAssertions.Events
 {

--- a/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
@@ -27,7 +27,7 @@ namespace FluentAssertions.Execution
         }
 
         /// <summary>
-        /// Will throw a combined exception for any failures have been collected since <see cref="StartCollecting"/> was called.
+        /// Will throw a combined exception for any failures have been collected.
         /// </summary>
         public void ThrowIfAny(IDictionary<string, object> context)
         {

--- a/Src/FluentAssertions/Execution/Continuation.cs
+++ b/Src/FluentAssertions/Execution/Continuation.cs
@@ -1,11 +1,8 @@
-using System;
-
 namespace FluentAssertions.Execution
 {
     /// <summary>
     /// Enables chaining multiple assertions on an <see cref="AssertionScope"/>.
     /// </summary>
-
     public class Continuation
     {
         private readonly AssertionScope sourceScope;
@@ -24,7 +21,7 @@ namespace FluentAssertions.Execution
         public bool SourceSucceeded { get; }
 
         /// <summary>
-        /// Provides back-wards compatibility for code that expects <see cref="AssertionScope.FailWith"/> to return a boolean.
+        /// Provides back-wards compatibility for code that expects <see cref="AssertionScope.FailWith(string, object[])"/> to return a boolean.
         /// </summary>
         public static implicit operator bool(Continuation continuation)
         {

--- a/Src/FluentAssertions/Execution/ContinuationOfGiven.cs
+++ b/Src/FluentAssertions/Execution/ContinuationOfGiven.cs
@@ -23,7 +23,7 @@ namespace FluentAssertions.Execution
         public GivenSelector<TSubject> Then { get; }
 
         /// <summary>
-        /// Provides back-wards compatibility for code that expects <see cref="AssertionScope.FailWith"/> to return a boolean.
+        /// Provides back-wards compatibility for code that expects <see cref="AssertionScope.FailWith(string, object[])"/> to return a boolean.
         /// </summary>
         public static implicit operator bool(ContinuationOfGiven<TSubject> continuationOfGiven)
         {

--- a/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/DefaultAssertionStrategy.cs
@@ -34,7 +34,7 @@ namespace FluentAssertions.Execution
         }
 
         /// <summary>
-        /// Will throw a combined exception for any failures have been collected since <see cref="StartCollecting"/> was called.
+        /// Will throw a combined exception for any failures have been collected.
         /// </summary>
         public void ThrowIfAny(IDictionary<string, object> context)
         {

--- a/Src/FluentAssertions/Execution/GivenSelector.cs
+++ b/Src/FluentAssertions/Execution/GivenSelector.cs
@@ -135,7 +135,7 @@ namespace FluentAssertions.Execution
         }
 
         /// <summary>
-        /// Clears the expectation set by <see cref="WithExpectation"/>.
+        /// Clears the expectation set by <see cref="AssertionScope.WithExpectation"/>.
         /// </summary>
         public ContinuationOfGiven<T> ClearExpectation()
         {

--- a/Src/FluentAssertions/Execution/IAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/IAssertionScope.cs
@@ -94,7 +94,7 @@ namespace FluentAssertions.Execution
         IAssertionScope WithDefaultIdentifier(string identifier);
 
         /// <summary>
-        /// Indicates that every argument passed into <see cref="FailWith"/> is displayed on a separate line.
+        /// Indicates that every argument passed into <see cref="FailWith(string, object[])"/> is displayed on a separate line.
         /// </summary>
         IAssertionScope UsingLineBreaks { get; }
 

--- a/Src/FluentAssertions/Execution/IAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/IAssertionStrategy.cs
@@ -23,7 +23,7 @@ namespace FluentAssertions.Execution
         IEnumerable<string> DiscardFailures();
 
         /// <summary>
-        /// Will throw a combined exception for any failures have been collected since <see cref="StartCollecting"/> was called.
+        /// Will throw a combined exception for any failures have been collected.
         /// </summary>
         void ThrowIfAny(IDictionary<string, object> context);
     }

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -1,13 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>FluentAssertions.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>1701;1702;1705;1591;1574;1572;1573;419</NoWarn>
+    <NoWarn>1591;1573</NoWarn>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <CodeAnalysisRuleSet>..\..\Rules.ruleset</CodeAnalysisRuleSet>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <OutputPath>..\..\Artifacts\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>Dennis Doomen;Jonas Nyrup</Authors>
@@ -25,12 +26,6 @@
     <PackageReleaseNotes>See https://fluentassertions.com/releases/</PackageReleaseNotes>
     <Copyright>Copyright Dennis Doomen 2010-2020</Copyright>
     <LangVersion>8.0</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OutputPath>..\..\Artifacts\Debug\</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <OutputPath>..\..\Artifacts\Release</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="BannedSymbols.txt" />

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -20,7 +20,7 @@ namespace FluentAssertions.Formatting
         /// <summary>
         /// Determines whether this instance can handle the specified value.
         /// </summary>
-        /// <param name = "value">The value.</param>
+        /// <param name="value">The value.</param>
         /// <returns>
         /// <c>true</c> if this instance can handle the specified value; otherwise, <c>false</c>.
         /// </returns>

--- a/Src/FluentAssertions/Formatting/DoubleValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DoubleValueFormatter.cs
@@ -8,7 +8,7 @@ namespace FluentAssertions.Formatting
         /// <summary>
         /// Indicates whether the current <see cref="IValueFormatter"/> can handle the specified <paramref name="value"/>.
         /// </summary>
-        /// <param name="value">The value for which to create a <see cref="System.String"/>.</param>
+        /// <param name="value">The value for which to create a <see cref="string"/>.</param>
         /// <returns>
         /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
         /// </returns>

--- a/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
@@ -60,10 +60,9 @@ namespace FluentAssertions.Numeric
         /// <remarks>
         /// Objects are equivalent when both object graphs have equally named properties with the same value,
         /// irrespective of the type of those objects. Two properties are also equal if one type can be converted to another and the result is equal.
-        /// The type of a collection property is ignored as long as the collection implements <see cref="IEnumerable{T}"/> and all
-        /// items in the collection are structurally equal.
         /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
         /// </remarks>
+        /// <param name="expectation">The expected element.</param>
         /// <param name="because">
         /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the
         /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -83,9 +82,8 @@ namespace FluentAssertions.Numeric
         /// <remarks>
         /// Objects are equivalent when both object graphs have equally named properties with the same value,
         /// irrespective of the type of those objects. Two properties are also equal if one type can be converted to another and the result is equal.
-        /// The type of a collection property is ignored as long as the collection implements <see cref="IEnumerable{T}"/> and all
-        /// items in the collection are structurally equal.
         /// </remarks>
+        /// <param name="expectation">The expected element.</param>
         /// <param name="config">
         /// A reference to the <see cref="EquivalencyAssertionOptions{TSubject}"/> configuration object that can be used
         /// to influence the way the object graphs are compared. You can also provide an alternative instance of the

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -655,7 +655,7 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Returns a <see cref="DateTimeRangeAssertions"/> object that can be used to assert that the current <see cref="DateTime"/>
+        /// Returns a <see cref="DateTimeRangeAssertions{TAssertions}"/> object that can be used to assert that the current <see cref="DateTime"/>
         /// exceeds the specified <paramref name="timeSpan"/> compared to another <see cref="DateTime"/>.
         /// </summary>
         /// <param name="timeSpan">
@@ -667,7 +667,7 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Returns a <see cref="DateTimeRangeAssertions"/> object that can be used to assert that the current <see cref="DateTime"/>
+        /// Returns a <see cref="DateTimeRangeAssertions{TAssertions}"/> object that can be used to assert that the current <see cref="DateTime"/>
         /// is equal to or exceeds the specified <paramref name="timeSpan"/> compared to another <see cref="DateTime"/>.
         /// </summary>
         /// <param name="timeSpan">
@@ -680,7 +680,7 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Returns a <see cref="DateTimeRangeAssertions"/> object that can be used to assert that the current <see cref="DateTime"/>
+        /// Returns a <see cref="DateTimeRangeAssertions{TAssertions}"/> object that can be used to assert that the current <see cref="DateTime"/>
         /// differs exactly the specified <paramref name="timeSpan"/> compared to another <see cref="DateTime"/>.
         /// </summary>
         /// <param name="timeSpan">
@@ -692,7 +692,7 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Returns a <see cref="DateTimeRangeAssertions"/> object that can be used to assert that the current <see cref="DateTime"/>
+        /// Returns a <see cref="DateTimeRangeAssertions{TAssertions}"/> object that can be used to assert that the current <see cref="DateTime"/>
         /// is within the specified <paramref name="timeSpan"/> compared to another <see cref="DateTime"/>.
         /// </summary>
         /// <param name="timeSpan">
@@ -704,7 +704,7 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Returns a <see cref="DateTimeRangeAssertions"/> object that can be used to assert that the current <see cref="DateTime"/>
+        /// Returns a <see cref="DateTimeRangeAssertions{TAssertions}"/> object that can be used to assert that the current <see cref="DateTime"/>
         /// differs at maximum the specified <paramref name="timeSpan"/> compared to another <see cref="DateTime"/>.
         /// </summary>
         /// <param name="timeSpan">

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -117,7 +117,7 @@ namespace FluentAssertions.Primitives
             long distanceToMinInTicks = (nearbyTime - DateTimeOffset.MinValue).Ticks;
             DateTimeOffset minimumValue = nearbyTime.AddTicks(-Math.Min(precision.Ticks, distanceToMinInTicks));
 
-            long distanceToMaxInTicks = (long)(DateTimeOffset.MaxValue - nearbyTime).Ticks;
+            long distanceToMaxInTicks = (DateTimeOffset.MaxValue - nearbyTime).Ticks;
             DateTimeOffset maximumValue = nearbyTime.AddTicks(Math.Min(precision.Ticks, distanceToMaxInTicks));
 
             Execute.Assertion
@@ -125,7 +125,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be within {0} from {1}{reason}, but it was {2}.",
                     precision,
-                    nearbyTime, Subject ?? default(DateTimeOffset?));
+                    nearbyTime, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -720,7 +720,7 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Returns a <see cref="DateTimeOffsetRangeAssertions"/> object that can be used to assert that the current <see cref="DateTimeOffset"/>
+        /// Returns a <see cref="DateTimeOffsetRangeAssertions{TAssertions}"/> object that can be used to assert that the current <see cref="DateTimeOffset"/>
         /// exceeds the specified <paramref name="timeSpan"/> compared to another <see cref="DateTimeOffset"/>.
         /// </summary>
         /// <param name="timeSpan">
@@ -732,7 +732,7 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Returns a <see cref="DateTimeOffsetRangeAssertions"/> object that can be used to assert that the current <see cref="DateTimeOffset"/>
+        /// Returns a <see cref="DateTimeOffsetRangeAssertions{TAssertions}"/> object that can be used to assert that the current <see cref="DateTimeOffset"/>
         /// is equal to or exceeds the specified <paramref name="timeSpan"/> compared to another <see cref="DateTimeOffset"/>.
         /// </summary>
         /// <param name="timeSpan">
@@ -745,7 +745,7 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Returns a <see cref="DateTimeOffsetRangeAssertions"/> object that can be used to assert that the current <see cref="DateTimeOffset"/>
+        /// Returns a <see cref="DateTimeOffsetRangeAssertions{TAssertions}"/> object that can be used to assert that the current <see cref="DateTimeOffset"/>
         /// differs exactly the specified <paramref name="timeSpan"/> compared to another <see cref="DateTimeOffset"/>.
         /// </summary>
         /// <param name="timeSpan">
@@ -757,7 +757,7 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Returns a <see cref="DateTimeOffsetRangeAssertions"/> object that can be used to assert that the current <see cref="DateTimeOffset"/>
+        /// Returns a <see cref="DateTimeOffsetRangeAssertions{TAssertions}"/> object that can be used to assert that the current <see cref="DateTimeOffset"/>
         /// is within the specified <paramref name="timeSpan"/> compared to another <see cref="DateTimeOffset"/>.
         /// </summary>
         /// <param name="timeSpan">
@@ -769,7 +769,7 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Returns a <see cref="DateTimeOffsetRangeAssertions"/> object that can be used to assert that the current <see cref="DateTimeOffset"/>
+        /// Returns a <see cref="DateTimeOffsetRangeAssertions{TAssertions}"/> object that can be used to assert that the current <see cref="DateTimeOffset"/>
         /// differs at maximum the specified <paramref name="timeSpan"/> compared to another <see cref="DateTimeOffset"/>.
         /// </summary>
         /// <param name="timeSpan">

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using FluentAssertions.Execution;
+using FluentAssertions.Extensions;
 
 namespace FluentAssertions.Primitives
 {
@@ -9,7 +10,7 @@ namespace FluentAssertions.Primitives
     /// Contains a number of methods to assert that two <see cref="DateTime"/> objects differ in the expected way.
     /// </summary>
     /// <remarks>
-    /// You can use the <see cref="FluentDateTimeExtensions"/> and <see cref="TimeSpanConversionExtensions"/>
+    /// You can use the <see cref="FluentDateTimeExtensions"/> and <see cref="FluentTimeSpanExtensions"/>
     /// for a more fluent way of specifying a <see cref="DateTime"/> or a <see cref="TimeSpan"/>.
     /// </remarks>
     [DebuggerNonUserCode]

--- a/Src/FluentAssertions/Primitives/NullableDateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateTimeAssertions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using FluentAssertions.Execution;
+using FluentAssertions.Extensions;
 
 namespace FluentAssertions.Primitives
 {

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -16,7 +16,7 @@ namespace FluentAssertions.Primitives
     public class StringAssertions : StringAssertions<StringAssertions>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="System.Object" /> class.
+        /// Initializes a new instance of the <see cref="StringAssertions"/> class.
         /// </summary>
         public StringAssertions(string value)
             : base(value)
@@ -32,7 +32,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : StringAssertions<TAssertions>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="System.Object" /> class.
+        /// Initializes a new instance of the <see cref="StringAssertions{TAssertions}"/> class.
         /// </summary>
         public StringAssertions(string value) : base(value)
         {

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -46,17 +46,17 @@ namespace FluentAssertions.Specialized
         protected override string Identifier => "exception";
 
         /// <summary>
-        /// Asserts that the thrown exception has a message that matches <paramref name = "expectedWildcardPattern" />.
+        /// Asserts that the thrown exception has a message that matches <paramref name="expectedWildcardPattern" />.
         /// </summary>
-        /// <param name = "expectedWildcardPattern">
+        /// <param name="expectedWildcardPattern">
         /// The wildcard pattern with which the exception message is matched, where * and ? have special meanings.
         /// </param>
-        /// <param name = "because">
+        /// <param name="because">
         /// A formatted phrase as is supported by <see cref = "string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
         /// </param>
-        /// <param name = "becauseArgs">
-        /// Zero or more objects to format using the placeholders in <see cref = "because" />.
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
         public virtual ExceptionAssertions<TException> WithMessage(string expectedWildcardPattern, string because = "",
             params object[] becauseArgs)
@@ -73,11 +73,11 @@ namespace FluentAssertions.Specialized
         }
 
         /// <summary>
-        /// Asserts that the thrown exception contains an inner exception of type <typeparamref name = "TInnerException" />.
+        /// Asserts that the thrown exception contains an inner exception of type <typeparamref name="TInnerException" />.
         /// </summary>
-        /// <typeparam name = "TInnerException">The expected type of the inner exception.</typeparam>
-        /// <param name = "because">The reason why the inner exception should be of the supplied type.</param>
-        /// <param name = "becauseArgs">The parameters used when formatting the <paramref name = "because" />.</param>
+        /// <typeparam name="TInnerException">The expected type of the inner exception.</typeparam>
+        /// <param name="because">The reason why the inner exception should be of the supplied type.</param>
+        /// <param name="becauseArgs">The parameters used when formatting the <paramref name="because" />.</param>
         public virtual ExceptionAssertions<TInnerException> WithInnerException<TInnerException>(string because = null,
             params object[] becauseArgs)
             where TInnerException : Exception
@@ -107,11 +107,11 @@ namespace FluentAssertions.Specialized
         }
 
         /// <summary>
-        /// Asserts that the thrown exception contains an inner exception of the exact type <typeparamref name = "TInnerException" /> (and not a derived exception type).
+        /// Asserts that the thrown exception contains an inner exception of the exact type <typeparamref name="TInnerException" /> (and not a derived exception type).
         /// </summary>
-        /// <typeparam name = "TInnerException">The expected type of the inner exception.</typeparam>
-        /// <param name = "because">The reason why the inner exception should be of the supplied type.</param>
-        /// <param name = "becauseArgs">The parameters used when formatting the <paramref name = "because" />.</param>
+        /// <typeparam name="TInnerException">The expected type of the inner exception.</typeparam>
+        /// <param name="because">The reason why the inner exception should be of the supplied type.</param>
+        /// <param name="becauseArgs">The parameters used when formatting the <paramref name="because" />.</param>
         public virtual ExceptionAssertions<TInnerException> WithInnerExceptionExactly<TInnerException>(string because = null,
             params object[] becauseArgs)
             where TInnerException : Exception
@@ -134,14 +134,14 @@ namespace FluentAssertions.Specialized
         /// <summary>
         /// Asserts that the exception matches a particular condition.
         /// </summary>
-        /// <param name = "exceptionExpression">
+        /// <param name="exceptionExpression">
         /// The condition that the exception must match.
         /// </param>
-        /// <param name = "because">
+        /// <param name="because">
         /// A formatted phrase explaining why the assertion should be satisfied. If the phrase does not
         /// start with the word <i>because</i>, it is prepended to the message.
         /// </param>
-        /// <param name = "becauseArgs">
+        /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref = "string.Format(string,object[])" /> compatible placeholders.
         /// </param>
         public ExceptionAssertions<TException> Where(Expression<Func<TException, bool>> exceptionExpression,

--- a/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
@@ -229,11 +229,20 @@ namespace FluentAssertions.Specialized
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExecutionTime"/> class.
+        /// </summary>
+        /// <param name="action">The action of which the execution time must be asserted.</param>
         public ExecutionTime(Func<Task> action)
             : this(action, "the action")
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExecutionTime"/> class.
+        /// </summary>
+        /// <param name="action">The action of which the execution time must be asserted.</param>
+        /// <param name="actionDescription">The description of the action to be asserted.</param>
         protected ExecutionTime(Action action, string actionDescription)
         {
             ActionDescription = actionDescription;
@@ -261,6 +270,11 @@ namespace FluentAssertions.Specialized
             });
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExecutionTime"/> class.
+        /// </summary>
+        /// <param name="action">The action of which the execution time must be asserted.</param>
+        /// <param name="actionDescription">The description of the action to be asserted.</param>
         /// <remarks>
         /// This constructor is almost exact copy of the one accepting <see cref="Action"/>.
         /// The original constructor shall stay in place in order to keep backward-compatibility
@@ -309,7 +323,7 @@ namespace FluentAssertions.Specialized
     public class MemberExecutionTime<T> : ExecutionTime
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="MemberExecutionTime&lt;T&gt;"/> class.
+        /// Initializes a new instance of the <see cref="MemberExecutionTime{T}"/> class.
         /// </summary>
         /// <param name="subject">The object that exposes the method or property.</param>
         /// <param name="action">A reference to the method or property to measure the execution time of.</param>

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
@@ -18,7 +17,7 @@ namespace FluentAssertions.Types
     public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="System.Object" /> class.
+        /// Initializes a new instance of the <see cref="TypeAssertions"/> class.
         /// </summary>
         public TypeAssertions(Type type) : base(type)
         {

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -16,7 +16,7 @@ namespace FluentAssertions.Types
     public class TypeSelectorAssertions
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="System.Object" /> class.
+        /// Initializes a new instance of the <see cref="TypeSelectorAssertions"/> class.
         /// </summary>
         public TypeSelectorAssertions(params Type[] types)
         {

--- a/Src/FluentAssertions/Xml/Equivalency/XmlReaderValidator.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/XmlReaderValidator.cs
@@ -190,6 +190,5 @@ namespace FluentAssertions.Xml.Equivalency
 
             return null;
         }
-
     }
 }

--- a/Src/JetBrainsAnnotations.cs
+++ b/Src/JetBrainsAnnotations.cs
@@ -38,7 +38,7 @@ namespace JetBrains.Annotations
     /// </summary>
     /// <example><code>
     /// [CanBeNull] object Test() => null;
-    /// 
+    ///
     /// void UseTest() {
     ///   var p = Test();
     ///   var s = p.ToString(); // Warning: Possible 'System.NullReferenceException'
@@ -100,7 +100,7 @@ namespace JetBrains.Annotations
     /// <example><code>
     /// [StringFormatMethod("message")]
     /// void ShowError(string message, params object[] args) { /* do something */ }
-    /// 
+    ///
     /// void Foo() {
     ///   ShowError("Failed: {0}"); // Warning: Non-existing argument in format string
     /// }
@@ -110,6 +110,9 @@ namespace JetBrains.Annotations
       AttributeTargets.Property | AttributeTargets.Delegate)]
     internal sealed class StringFormatMethodAttribute : Attribute
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringFormatMethodAttribute" /> class.
+        /// </summary>
         /// <param name="formatParameterName">
         /// Specifies which parameter of an annotated method should be treated as format-string
         /// </param>
@@ -170,12 +173,12 @@ namespace JetBrains.Annotations
     /// <example><code>
     /// public class Foo : INotifyPropertyChanged {
     ///   public event PropertyChangedEventHandler PropertyChanged;
-    /// 
+    ///
     ///   [NotifyPropertyChangedInvocator]
     ///   protected virtual void NotifyChanged(string propertyName) { … }
     ///
     ///   string _name;
-    /// 
+    ///
     ///   public string Name {
     ///     get { return _name; }
     ///     set { _name = value; NotifyChanged("LastName"); /* Warning */ }
@@ -239,7 +242,7 @@ namespace JetBrains.Annotations
     /// // A method that returns null if the parameter is null,
     /// // and not null if the parameter is not null
     /// [ContractAnnotation("null => null; notnull => notnull")]
-    /// public object Transform(object data) 
+    /// public object Transform(object data)
     /// </code></item>
     /// <item><code>
     /// [ContractAnnotation("s:null=>false; =>true,result:notnull; =>false, result:null")]
@@ -293,7 +296,7 @@ namespace JetBrains.Annotations
     /// <example><code>
     /// [CannotApplyEqualityOperator]
     /// class NoEquality { }
-    /// 
+    ///
     /// class UsesNoEquality {
     ///   void Test() {
     ///     var ca1 = new NoEquality();
@@ -314,7 +317,7 @@ namespace JetBrains.Annotations
     /// <example><code>
     /// [BaseTypeRequired(typeof(IComponent)] // Specify requirement
     /// class ComponentAttribute : Attribute { }
-    /// 
+    ///
     /// [Component] // ComponentAttribute requires implementing IComponent interface
     /// class MyComponent : IComponent { }
     /// </code></example>
@@ -449,7 +452,7 @@ namespace JetBrains.Annotations
     /// </summary>
     /// <example><code>
     /// [Pure] int Multiply(int x, int y) => x * y;
-    /// 
+    ///
     /// void M() {
     ///   Multiply(123, 42); // Waring: Return value of pure method is not used
     /// }
@@ -481,7 +484,7 @@ namespace JetBrains.Annotations
     /// <example><code>
     /// class Foo {
     ///   [ProvidesContext] IBarService _barService = …;
-    /// 
+    ///
     ///   void ProcessNode(INode node) {
     ///     DoSomething(node, node.GetGlobalServices().Bar);
     ///     //              ^ Warning: use value of '_barService' field
@@ -748,7 +751,7 @@ namespace JetBrains.Annotations
 
     /// <summary>
     /// ASP.NET MVC attribute. Indicates that a parameter is an MVC display template.
-    /// Use this attribute for custom wrappers similar to 
+    /// Use this attribute for custom wrappers similar to
     /// <c>System.Web.Mvc.Html.DisplayExtensions.DisplayForModel(HtmlHelper, String)</c>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter)]
@@ -834,7 +837,7 @@ namespace JetBrains.Annotations
 
     /// <summary>
     /// Razor attribute. Indicates that a parameter or a method is a Razor section.
-    /// Use this attribute for custom wrappers similar to 
+    /// Use this attribute for custom wrappers similar to
     /// <c>System.Web.WebPages.WebPageBase.RenderSection(String)</c>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
@@ -870,7 +873,7 @@ namespace JetBrains.Annotations
 
     /// <summary>
     /// Indicates that the marked method is assertion method, i.e. it halts control flow if
-    /// one of the conditions is satisfied. To set the condition, mark one of the parameters with 
+    /// one of the conditions is satisfied. To set the condition, mark one of the parameters with
     /// <see cref="AssertionConditionAttribute"/> attribute.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -1921,7 +1921,6 @@ namespace FluentAssertions.Specs
 
                 "Expected subset to be a subset of {1, 2, 4, 5} because we want to test the failure message, " +
                     "but items {3, 6} are not part of the superset.");
-
         }
 
         [Fact]
@@ -2318,7 +2317,6 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected ints to contain {4} in order because we're checking how it reacts to a null subject, but found <null>.");
-
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -1732,7 +1732,6 @@ namespace FluentAssertions.Specs
             action.Should().NotThrow<XunitException>();
         }
 
-
         [Fact]
         public void When_asserting_null_collection_for_not_match_it_should_throw()
         {
@@ -1746,7 +1745,6 @@ namespace FluentAssertions.Specs
             action.Should().Throw<XunitException>()
                 .WithMessage("Did not expect collection to contain a match of <null>, but found <null>.");
         }
-
 
         #endregion
 

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
@@ -1214,7 +1214,7 @@ namespace FluentAssertions.Specs
             var collection = Enumerable.Empty<SomeClass>();
 
             // Act
-            Action act = () => collection.Should().BeInAscendingOrder((IComparer<SomeClass>)null);
+            Action act = () => collection.Should().BeInAscendingOrder(null);
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
@@ -1243,7 +1243,7 @@ namespace FluentAssertions.Specs
             var collection = Enumerable.Empty<SomeClass>();
 
             // Act
-            Action act = () => collection.Should().NotBeInAscendingOrder((IComparer<SomeClass>)null);
+            Action act = () => collection.Should().NotBeInAscendingOrder(null);
 
             // Assert
             act.Should().Throw<ArgumentNullException>()

--- a/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
@@ -1027,12 +1027,12 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>().WithMessage("Expected member Property*-*-*-*-*but*");
         }
 
-        class ClassWithGuidProperty
+        private class ClassWithGuidProperty
         {
             public string Property { get; set; } = Guid.NewGuid().ToString();
         }
 
-        class ClassThatHidesBaseClassProperty : ClassWithGuidProperty
+        private class ClassThatHidesBaseClassProperty : ClassWithGuidProperty
         {
             public new string[] Property { get; set; }
         }
@@ -2381,7 +2381,7 @@ namespace FluentAssertions.Specs
             };
 
             // Act
-            Action act = () => subject.Should().BeEquivalentTo(expectation, opt =>  opt
+            Action act = () => subject.Should().BeEquivalentTo(expectation, opt => opt
                 .RespectingRuntimeTypes()
                 .Using<ConcreteClass, ConcreteClassEqualityComparer>());
 
@@ -2391,12 +2391,11 @@ namespace FluentAssertions.Specs
 
         private interface IInterface
         {
-
         }
 
         private class ConcreteClass : IInterface
         {
-            private string property;
+            private readonly string property;
 
             public ConcreteClass(string propertyValue)
             {
@@ -3843,7 +3842,7 @@ namespace FluentAssertions.Specs
 
     internal class ClassWithAPrivateField : ClassWithOnlyAField
     {
-        private int value;
+        private readonly int value;
 
         public ClassWithAPrivateField(int value)
         {
@@ -4152,7 +4151,7 @@ namespace FluentAssertions.Specs
         protected string ProtectedField;
         internal string InternalField;
         protected internal string ProtectedInternalField;
-        private string PrivateField;
+        private readonly string PrivateField;
         private protected string PrivateProtectedField;
 
         public string PublicProperty { get; set; }

--- a/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
@@ -1361,7 +1361,7 @@ namespace FluentAssertions.Specs
 
             // Act
             Action act = () => subject.Should().BeEquivalentTo(expectation, opts => opts
-                .Using<int>(ctx => ((int)ctx.Subject).Should().BeInRange(ctx.Expectation - 1, ctx.Expectation + 1))
+                .Using<int>(ctx => ctx.Subject.Should().BeInRange(ctx.Expectation - 1, ctx.Expectation + 1))
                 .WhenTypeIs<int>()
             );
 

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -3,15 +3,15 @@
 using System;
 using System.ComponentModel;
 using System.Linq;
-
+#if NET47
+using System.Reflection;
+using System.Reflection.Emit;
+#endif
 using FluentAssertions.Events;
 using FluentAssertions.Extensions;
 using FluentAssertions.Formatting;
 using Xunit;
 using Xunit.Sdk;
-
-using System.Reflection;
-using System.Reflection.Emit;
 
 namespace FluentAssertions.Specs
 {

--- a/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Xunit;

--- a/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;

--- a/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
+++ b/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
@@ -5,6 +5,7 @@
     <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>..\..\TestRules.ruleset</CodeAnalysisRuleSet>
+    <NoWarn>IDE0052</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
@@ -847,7 +847,6 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected subject to be on or before <2016-06-03>, but found <2016-06-04>.");
-
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
@@ -847,7 +847,6 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected subject to be on or before <2016-06-03>, but it was <2016-06-04>.");
-
         }
 
         [Fact]
@@ -1886,7 +1885,6 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected subject to be within 2d and 2h before <2010-04-10 12:00:00> because 50 hours is enough, but <2010-04-08 09:59:59> differs 2d, 2h and 1s.");
-
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/NullableBooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/NullableBooleanAssertionSpecs.cs
@@ -167,7 +167,6 @@ namespace FluentAssertions.Specs
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected nullableBoolean to be false because we want to test the failure message, but found <null>.");
-
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
@@ -407,7 +407,6 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected nullTimeSpan to be less than 1s because we want to test the failure message, but found <null>.");
-
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
@@ -3223,11 +3223,5 @@ namespace FluentAssertions.Specs
         }
 
         #endregion
-
-        private static string WrapMessageWithPunctuation(string msg, string because)
-        {
-            var ending = string.IsNullOrEmpty(because) ? "." : string.Format(" because {0}.", because);
-            return msg + ending;
-        }
     }
 }


### PR DESCRIPTION
We had several references in xml summaries that were incorrect.
Most of them either referenced long gone classes or those classes are now
generic.

Fixes methods were only some parameters were documented.