### PR TITLE
Remove unnecessary usage of GetTypeInfo

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Execution;
@@ -1651,7 +1650,7 @@ namespace FluentAssertions.Collections
                 .ForCondition(subject => subject.All(x => x != null))
                 .FailWith("but found a null element.")
                 .Then
-                .ForCondition(subject => subject.All(x => typeof(T).GetTypeInfo().IsAssignableFrom(GetType(x).GetTypeInfo())))
+                .ForCondition(subject => subject.All(x => typeof(T).IsAssignableFrom(GetType(x))))
                 .FailWith("but found {0}.", subject => $"[{string.Join(", ", subject.Select(x => GetType(x).FullName))}]")
                 .Then
                 .ClearExpectation();
@@ -1679,7 +1678,7 @@ namespace FluentAssertions.Collections
                 .ForCondition(subject => subject.All(x => x != null))
                 .FailWith("but found a null element.")
                 .Then
-                .ForCondition(subject => subject.All(x => expectedType.GetTypeInfo().IsAssignableFrom(GetType(x).GetTypeInfo())))
+                .ForCondition(subject => subject.All(x => expectedType.IsAssignableFrom(GetType(x))))
                 .FailWith("but found {0}.", subject => $"[{string.Join(", ", subject.Select(x => GetType(x).FullName))}]")
                 .Then
                 .ClearExpectation();

--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
@@ -266,7 +265,7 @@ namespace FluentAssertions.Collections
 
         private static Func<T, T, bool> GetComparer()
         {
-            if (typeof(T).GetTypeInfo().IsValueType)
+            if (typeof(T).IsValueType)
             {
                 return (T s, T e) => s.Equals(e);
             }

--- a/Src/FluentAssertions/Common/CSharpAccessModifierExtensions.cs
+++ b/Src/FluentAssertions/Common/CSharpAccessModifierExtensions.cs
@@ -77,29 +77,27 @@ namespace FluentAssertions.Common
 
         internal static CSharpAccessModifier GetCSharpAccessModifier(this Type type)
         {
-            TypeInfo typeInfo = type.GetTypeInfo();
-
-            if (typeInfo.IsNestedPrivate)
+            if (type.IsNestedPrivate)
             {
                 return CSharpAccessModifier.Private;
             }
 
-            if (typeInfo.IsNestedFamily)
+            if (type.IsNestedFamily)
             {
                 return CSharpAccessModifier.Protected;
             }
 
-            if (typeInfo.IsNestedAssembly || (typeInfo.IsClass && typeInfo.IsNotPublic))
+            if (type.IsNestedAssembly || (type.IsClass && type.IsNotPublic))
             {
                 return CSharpAccessModifier.Internal;
             }
 
-            if (typeInfo.IsPublic || typeInfo.IsNestedPublic)
+            if (type.IsPublic || type.IsNestedPublic)
             {
                 return CSharpAccessModifier.Public;
             }
 
-            if (typeInfo.IsNestedFamORAssem)
+            if (type.IsNestedFamORAssem)
             {
                 return CSharpAccessModifier.ProtectedInternal;
             }

--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -5,7 +5,6 @@ using System.Linq.Expressions;
 using System.Reflection;
 
 using FluentAssertions.Equivalency;
-using FluentAssertions.Equivalency.Selection;
 
 namespace FluentAssertions.Common
 {

--- a/Src/FluentAssertions/Common/MethodInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/MethodInfoExtensions.cs
@@ -24,10 +24,7 @@ namespace FluentAssertions.Common
         internal static IEnumerable<TAttribute> GetMatchingAttributes<TAttribute>(this MemberInfo memberInfo, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
             where TAttribute : Attribute
         {
-            var customAttributes = memberInfo.GetCustomAttributes(
-                typeof(TAttribute), false)
-                .Cast<TAttribute>()
-                .ToList();
+            var customAttributes = memberInfo.GetCustomAttributes<TAttribute>(false).ToList();
 
             if (typeof(TAttribute) == typeof(MethodImplAttribute) && memberInfo is MethodBase methodBase)
             {

--- a/Src/FluentAssertions/Common/ObjectExtensions.cs
+++ b/Src/FluentAssertions/Common/ObjectExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Globalization;
-using System.Reflection;
 
 namespace FluentAssertions.Common
 {
@@ -32,8 +31,8 @@ namespace FluentAssertions.Common
             Type actualType = actual.GetType();
 
             return actualType != expectedType
-                && (actual.IsNumericType() || actualType.IsEnumType())
-                && (expected.IsNumericType() || expectedType.IsEnumType())
+                && (actual.IsNumericType() || actualType.IsEnum)
+                && (expected.IsNumericType() || expectedType.IsEnum)
                 && CanConvert(actual, expected, actualType, expectedType)
                 && CanConvert(expected, actual, expectedType, actualType);
         }
@@ -56,7 +55,7 @@ namespace FluentAssertions.Common
 
         private static object ConvertTo(this object source, Type targetType)
         {
-            return IsEnumType(targetType)
+            return targetType.IsEnum
                 ? Enum.ToObject(targetType, source)
                 : Convert.ChangeType(source, targetType, CultureInfo.InvariantCulture);
         }
@@ -81,7 +80,5 @@ namespace FluentAssertions.Common
                     return false;
             }
         }
-
-        private static bool IsEnumType(this Type type) => type.GetTypeInfo().IsEnum;
     }
 }

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -19,37 +19,43 @@ namespace FluentAssertions.Common
         public static bool IsDecoratedWith<TAttribute>(this Type type)
             where TAttribute : Attribute
         {
-            return GetCustomAttributes<TAttribute>(type).Any();
+            return type.IsDefined(typeof(TAttribute), false);
         }
 
         public static bool IsDecoratedWith<TAttribute>(this TypeInfo type)
             where TAttribute : Attribute
         {
-            return GetCustomAttributes<TAttribute>(type).Any();
+            return type.IsDefined(typeof(TAttribute), false);
         }
 
         public static bool IsDecoratedWith<TAttribute>(this MemberInfo type)
             where TAttribute : Attribute
         {
-            return GetCustomAttributes<TAttribute>(type).Any();
+            // Do not use MemberInfo.IsDefined
+            // There is an issue with PropertyInfo and EventInfo preventing the inherit option to work.
+            // https://github.com/dotnet/runtime/issues/30219
+            return Attribute.IsDefined(type, typeof(TAttribute), false);
         }
 
         public static bool IsDecoratedWithOrInherit<TAttribute>(this Type type)
             where TAttribute : Attribute
         {
-            return GetCustomAttributes<TAttribute>(type, true).Any();
+            return type.IsDefined(typeof(TAttribute), true);
         }
 
         public static bool IsDecoratedWithOrInherit<TAttribute>(this TypeInfo type)
             where TAttribute : Attribute
         {
-            return GetCustomAttributes<TAttribute>(type, true).Any();
+            return type.IsDefined(typeof(TAttribute), true);
         }
 
         public static bool IsDecoratedWithOrInherit<TAttribute>(this MemberInfo type)
             where TAttribute : Attribute
         {
-            return GetCustomAttributes<TAttribute>(type, true).Any();
+            // Do not use MemberInfo.IsDefined
+            // There is an issue with PropertyInfo and EventInfo preventing the inherit option to work.
+            // https://github.com/dotnet/runtime/issues/30219
+            return Attribute.IsDefined(type, typeof(TAttribute), true);
         }
 
         public static bool IsDecoratedWith<TAttribute>(this Type type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
@@ -112,12 +118,13 @@ namespace FluentAssertions.Common
             return GetCustomAttributes(type, isMatchingAttributePredicate, true);
         }
 
-        private static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(MemberInfo type, bool inherit = false)
+        internal static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(this MemberInfo type, bool inherit = false)
             where TAttribute : Attribute
         {
-            // Do not use as extension method here, there is an issue with PropertyInfo and EventInfo
-            // preventing the inherit option to work.
-            return CustomAttributeExtensions.GetCustomAttributes(type, inherit).OfType<TAttribute>();
+            // Do not use MemberInfo.GetCustomAttributes.
+            // There is an issue with PropertyInfo and EventInfo preventing the inherit option to work.
+            // https://github.com/dotnet/runtime/issues/30219
+            return CustomAttributeExtensions.GetCustomAttributes<TAttribute>(type, inherit);
         }
 
         private static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(MemberInfo type,
@@ -131,7 +138,7 @@ namespace FluentAssertions.Common
         private static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(this Type type, bool inherit = false)
             where TAttribute : Attribute
         {
-            return GetCustomAttributes<TAttribute>(type.GetTypeInfo(), inherit);
+            return (IEnumerable<TAttribute>)type.GetCustomAttributes(typeof(TAttribute), inherit);
         }
 
         private static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(Type type,
@@ -145,7 +152,7 @@ namespace FluentAssertions.Common
         private static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(TypeInfo typeInfo, bool inherit = false)
             where TAttribute : Attribute
         {
-            return typeInfo.GetCustomAttributes(inherit).OfType<TAttribute>();
+            return (IEnumerable<TAttribute>)typeInfo.GetCustomAttributes(typeof(TAttribute), inherit);
         }
 
         private static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(TypeInfo typeInfo,
@@ -185,7 +192,7 @@ namespace FluentAssertions.Common
 
         internal static Type[] GetClosedGenericInterfaces(Type type, Type openGenericType)
         {
-            if (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == openGenericType)
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == openGenericType)
             {
                 return new[] { type };
             }
@@ -193,13 +200,13 @@ namespace FluentAssertions.Common
             Type[] interfaces = type.GetInterfaces();
             return
                 interfaces
-                    .Where(t => t.GetTypeInfo().IsGenericType && t.GetGenericTypeDefinition() == openGenericType)
+                    .Where(t => t.IsGenericType && t.GetGenericTypeDefinition() == openGenericType)
                     .ToArray();
         }
 
         public static bool OverridesEquals(this Type type)
         {
-            MethodInfo method = type.GetTypeInfo()
+            MethodInfo method = type
                 .GetMethod("Equals", new[] { typeof(object) });
 
             return method != null
@@ -302,7 +309,7 @@ namespace FluentAssertions.Common
             Func<Type, IEnumerable<TMemberInfo>> getMembers)
             where TMemberInfo : MemberInfo
         {
-            if (IsInterface(typeToReflect))
+            if (typeToReflect.IsInterface)
             {
                 var propertyInfos = new List<TMemberInfo>();
 
@@ -338,11 +345,6 @@ namespace FluentAssertions.Common
             return getMembers(typeToReflect);
         }
 
-        private static bool IsInterface(Type typeToReflect)
-        {
-            return typeToReflect.GetTypeInfo().IsInterface;
-        }
-
         private static Type[] GetInterfaces(Type type)
         {
             return type.GetInterfaces();
@@ -371,8 +373,7 @@ namespace FluentAssertions.Common
         /// <returns></returns>
         public static bool IsCSharpAbstract(this Type type)
         {
-            TypeInfo typeInfo = type.GetTypeInfo();
-            return typeInfo.IsAbstract && !typeInfo.IsSealed;
+            return type.IsAbstract && !type.IsSealed;
         }
 
         /// <summary>
@@ -382,8 +383,7 @@ namespace FluentAssertions.Common
         /// <returns></returns>
         public static bool IsCSharpSealed(this Type type)
         {
-            TypeInfo typeInfo = type.GetTypeInfo();
-            return typeInfo.IsSealed && !typeInfo.IsAbstract;
+            return type.IsSealed && !type.IsAbstract;
         }
 
         /// <summary>
@@ -393,8 +393,7 @@ namespace FluentAssertions.Common
         /// <returns></returns>
         public static bool IsCSharpStatic(this Type type)
         {
-            TypeInfo typeInfo = type.GetTypeInfo();
-            return typeInfo.IsSealed && typeInfo.IsAbstract;
+            return type.IsSealed && type.IsAbstract;
         }
 
         public static MethodInfo GetMethod(this Type type, string methodName, IEnumerable<Type> parameterTypes)
@@ -491,7 +490,7 @@ namespace FluentAssertions.Common
 
         private static bool IsKeyValuePair(Type type)
         {
-            return type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>);
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>);
         }
 
         private static bool IsAnonymousType(this Type type)
@@ -504,14 +503,14 @@ namespace FluentAssertions.Common
             }
 
             bool hasCompilerGeneratedAttribute =
-                type.GetTypeInfo().IsDecoratedWith<CompilerGeneratedAttribute>();
+                type.IsDecoratedWith<CompilerGeneratedAttribute>();
 
             return hasCompilerGeneratedAttribute;
         }
 
         private static bool IsTuple(this Type type)
         {
-            if (!type.GetTypeInfo().IsGenericType)
+            if (!type.IsGenericType)
             {
                 return false;
             }
@@ -541,7 +540,7 @@ namespace FluentAssertions.Common
             // For the purposes of test assertions, the user probably means that the subject type is
             // assignable to any generic type based on the given generic type definition.
 
-            if (definition.GetTypeInfo().IsInterface)
+            if (definition.IsInterface)
             {
                 return type.IsImplementationOfOpenGeneric(definition);
             }
@@ -554,16 +553,14 @@ namespace FluentAssertions.Common
         internal static bool IsImplementationOfOpenGeneric(this Type type, Type definition)
         {
             // check subject against definition
-            TypeInfo subjectInfo = type.GetTypeInfo();
-            if (subjectInfo.IsInterface && subjectInfo.IsGenericType &&
-                subjectInfo.GetGenericTypeDefinition() == definition)
+            if (type.IsInterface && type.IsGenericType &&
+                type.GetGenericTypeDefinition() == definition)
             {
                 return true;
             }
 
             // check subject's interfaces against definition
-            return subjectInfo.ImplementedInterfaces
-                .Select(i => i.GetTypeInfo())
+            return type.GetInterfaces()
                 .Where(i => i.IsGenericType)
                 .Select(i => i.GetGenericTypeDefinition())
                 .Contains(definition);
@@ -578,8 +575,8 @@ namespace FluentAssertions.Common
             }
 
             // check subject and its base types against definition
-            for (TypeInfo baseType = type.GetTypeInfo(); baseType != null;
-                    baseType = baseType.BaseType?.GetTypeInfo())
+            for (Type baseType = type; baseType != null;
+                    baseType = baseType.BaseType)
             {
                 if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == definition)
                 {

--- a/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
+++ b/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Globalization;
-using System.Reflection;
 using FluentAssertions.Execution;
 
 #endregion
@@ -18,8 +17,8 @@ namespace FluentAssertions.Equivalency
         {
             Type subjectType = config.GetExpectationType(context);
 
-            return (subjectType?.GetTypeInfo().IsEnum == true) ||
-                   (context.Expectation?.GetType().GetTypeInfo().IsEnum == true);
+            return (subjectType?.IsEnum == true) ||
+                   (context.Expectation?.GetType().IsEnum == true);
         }
 
         /// <summary>
@@ -95,7 +94,7 @@ namespace FluentAssertions.Equivalency
                 return "null";
             }
 
-            if (o.GetType().GetTypeInfo().IsEnum)
+            if (o.GetType().IsEnum)
             {
                 string typePart = o.GetType().Name;
                 string namePart = Enum.GetName(o.GetType(), o);

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyStep.cs
@@ -2,7 +2,6 @@ using System;
 
 using System.Collections;
 using System.Linq;
-using System.Reflection;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency

--- a/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions.Common;

--- a/Src/FluentAssertions/Events/EventHandlerFactory.cs
+++ b/Src/FluentAssertions/Events/EventHandlerFactory.cs
@@ -21,7 +21,6 @@ namespace FluentAssertions.Events
             Type[] parameters = GetDelegateParameterTypes(eventSignature);
 
             Module module = recorder.GetType()
-                .GetTypeInfo()
                 .Module;
 
             var eventHandler = new DynamicMethod(
@@ -55,8 +54,7 @@ namespace FluentAssertions.Events
                 ilGen.Emit(OpCodes.Ldarg, index + 1);
 
                 // Box value-type parameters
-                if (parameters[index].GetTypeInfo()
-                    .IsValueType)
+                if (parameters[index].IsValueType)
                 {
                     ilGen.Emit(OpCodes.Box, parameters[index]);
                 }
@@ -128,8 +126,7 @@ namespace FluentAssertions.Events
         /// </summary>
         private static bool TypeIsDelegate(Type d)
         {
-            if (d.GetTypeInfo()
-                .BaseType != typeof(MulticastDelegate))
+            if (d.BaseType != typeof(MulticastDelegate))
             {
                 return false;
             }

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
@@ -372,7 +371,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<TAssertions> BeOfType(Type expectedType, string because = "", params object[] becauseArgs)
         {
             Type subjectType = SubjectInternal.GetType();
-            if (expectedType.GetTypeInfo().IsGenericTypeDefinition && subjectType.GetTypeInfo().IsGenericType)
+            if (expectedType.IsGenericTypeDefinition && subjectType.IsGenericType)
             {
                 subjectType.GetGenericTypeDefinition().Should().Be(expectedType, because, becauseArgs);
             }

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.Linq.Expressions;
-using System.Reflection;
 
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
@@ -157,7 +156,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context} to be {0}{reason}, but found <null>.", expectedType);
 
             Type subjectType = Subject.GetType();
-            if (expectedType.GetTypeInfo().IsGenericTypeDefinition && subjectType.GetTypeInfo().IsGenericType)
+            if (expectedType.IsGenericTypeDefinition && subjectType.IsGenericType)
             {
                 subjectType.GetGenericTypeDefinition().Should().Be(expectedType, because, becauseArgs);
             }
@@ -209,7 +208,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context} not to be {0}{reason}, but found <null>.", unexpectedType);
 
             Type subjectType = Subject.GetType();
-            if (unexpectedType.GetTypeInfo().IsGenericTypeDefinition && subjectType.GetTypeInfo().IsGenericType)
+            if (unexpectedType.IsGenericTypeDefinition && subjectType.IsGenericType)
             {
                 subjectType.GetGenericTypeDefinition().Should().NotBe(unexpectedType, because, becauseArgs);
             }
@@ -261,7 +260,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context} to be assignable to {0}{reason}, but found <null>.", type);
 
             bool isAssignable;
-            if (type.GetTypeInfo().IsGenericTypeDefinition)
+            if (type.IsGenericTypeDefinition)
             {
                 isAssignable = Subject.GetType().IsAssignableToOpenGeneric(type);
             }
@@ -309,7 +308,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context} to not be assignable to {0}{reason}, but found <null>.", type);
 
             bool isAssignable;
-            if (type.GetTypeInfo().IsGenericTypeDefinition)
+            if (type.IsGenericTypeDefinition)
             {
                 isAssignable = Subject.GetType().IsAssignableToOpenGeneric(type);
             }

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -81,7 +81,7 @@ namespace FluentAssertions.Types
         public new AndConstraint<TypeAssertions> BeAssignableTo(Type type, string because = "", params object[] becauseArgs)
         {
             bool isAssignable;
-            if (type.GetTypeInfo().IsGenericTypeDefinition)
+            if (type.IsGenericTypeDefinition)
             {
                 isAssignable = Subject.IsAssignableToOpenGeneric(type);
             }
@@ -123,7 +123,7 @@ namespace FluentAssertions.Types
         public new AndConstraint<TypeAssertions> NotBeAssignableTo(Type type, string because = "", params object[] becauseArgs)
         {
             bool isAssignable;
-            if (type.GetTypeInfo().IsGenericTypeDefinition)
+            if (type.IsGenericTypeDefinition)
             {
                 isAssignable = Subject.IsAssignableToOpenGeneric(type);
             }
@@ -433,7 +433,7 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because" />.</param>
         public AndConstraint<TypeAssertions> Implement(Type interfaceType, string because = "", params object[] becauseArgs)
         {
-            if (!interfaceType.GetTypeInfo().IsInterface)
+            if (!interfaceType.IsInterface)
             {
                 throw new ArgumentException("Must be an interface Type.", nameof(interfaceType));
             }
@@ -467,7 +467,7 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because" />.</param>
         public AndConstraint<TypeAssertions> NotImplement(Type interfaceType, string because = "", params object[] becauseArgs)
         {
-            if (!interfaceType.GetTypeInfo().IsInterface)
+            if (!interfaceType.IsInterface)
             {
                 throw new ArgumentException("Must be an interface Type.", nameof(interfaceType));
             }
@@ -501,19 +501,19 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because" />.</param>
         public AndConstraint<TypeAssertions> BeDerivedFrom(Type baseType, string because = "", params object[] becauseArgs)
         {
-            if (baseType.GetTypeInfo().IsInterface)
+            if (baseType.IsInterface)
             {
                 throw new ArgumentException("Must not be an interface Type.", nameof(baseType));
             }
 
             bool isDerivedFrom;
-            if (baseType.GetTypeInfo().IsGenericTypeDefinition)
+            if (baseType.IsGenericTypeDefinition)
             {
                 isDerivedFrom = Subject.IsDerivedFromOpenGeneric(baseType);
             }
             else
             {
-                isDerivedFrom = Subject.GetTypeInfo().IsSubclassOf(baseType);
+                isDerivedFrom = Subject.IsSubclassOf(baseType);
             }
 
             Execute.Assertion.ForCondition(isDerivedFrom)
@@ -545,19 +545,19 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">Zero or more objects to format using the placeholders in <paramref name="because" />.</param>
         public AndConstraint<TypeAssertions> NotBeDerivedFrom(Type baseType, string because = "", params object[] becauseArgs)
         {
-            if (baseType.GetTypeInfo().IsInterface)
+            if (baseType.IsInterface)
             {
                 throw new ArgumentException("Must not be an interface Type.", nameof(baseType));
             }
 
             bool isDerivedFrom;
-            if (baseType.GetTypeInfo().IsGenericTypeDefinition)
+            if (baseType.IsGenericTypeDefinition)
             {
                 isDerivedFrom = Subject.IsDerivedFromOpenGeneric(baseType);
             }
             else
             {
-                isDerivedFrom = Subject.GetTypeInfo().IsSubclassOf(baseType);
+                isDerivedFrom = Subject.IsSubclassOf(baseType);
             }
 
             Execute.Assertion
@@ -1276,8 +1276,7 @@ namespace FluentAssertions.Types
 
         private void AssertThatSubjectIsClass()
         {
-            TypeInfo typeInfo = Subject.GetTypeInfo();
-            if (typeInfo.IsInterface || typeInfo.IsValueType || typeof(Delegate).IsAssignableFrom(typeInfo.BaseType))
+            if (Subject.IsInterface || Subject.IsValueType || typeof(Delegate).IsAssignableFrom(Subject.BaseType))
             {
                 throw new InvalidOperationException($"{Subject} must be a class.");
             }

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Types
@@ -37,7 +36,7 @@ namespace FluentAssertions.Types
         /// </summary>
         public TypeSelector ThatDeriveFrom<TBase>()
         {
-            types = types.Where(type => type.GetTypeInfo().IsSubclassOf(typeof(TBase))).ToList();
+            types = types.Where(type => type.IsSubclassOf(typeof(TBase))).ToList();
             return this;
         }
 
@@ -46,7 +45,7 @@ namespace FluentAssertions.Types
         /// </summary>
         public TypeSelector ThatDoNotDeriveFrom<TBase>()
         {
-            types = types.Where(type => !type.GetTypeInfo().IsSubclassOf(typeof(TBase))).ToList();
+            types = types.Where(type => !type.IsSubclassOf(typeof(TBase))).ToList();
             return this;
         }
 
@@ -82,7 +81,7 @@ namespace FluentAssertions.Types
         {
             types = types
 
-                .Where(t => t.GetTypeInfo().IsDecoratedWith<TAttribute>())
+                .Where(t => t.IsDecoratedWith<TAttribute>())
                 .ToList();
 
             return this;
@@ -96,7 +95,7 @@ namespace FluentAssertions.Types
         {
             types = types
 
-                .Where(t => t.GetTypeInfo().IsDecoratedWithOrInherit<TAttribute>())
+                .Where(t => t.IsDecoratedWithOrInherit<TAttribute>())
                 .ToList();
 
             return this;
@@ -110,7 +109,7 @@ namespace FluentAssertions.Types
         {
             types = types
 
-                .Where(t => !t.GetTypeInfo().IsDecoratedWith<TAttribute>())
+                .Where(t => !t.IsDecoratedWith<TAttribute>())
                 .ToList();
 
             return this;
@@ -124,7 +123,7 @@ namespace FluentAssertions.Types
         {
             types = types
 
-                .Where(t => !t.GetTypeInfo().IsDecoratedWithOrInherit<TAttribute>())
+                .Where(t => !t.IsDecoratedWithOrInherit<TAttribute>())
                 .ToList();
 
             return this;

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -1541,8 +1541,7 @@ namespace FluentAssertions.Specs
             // Assert
             methods.Should().OnlyContain(method =>
                 typeof(AndConstraint<StringCollectionAssertions<IEnumerable<string>>>)
-                    .GetTypeInfo()
-                    .IsAssignableFrom(method.ReturnType.GetTypeInfo()));
+                    .IsAssignableFrom(method.ReturnType));
         }
 
         #region ContainMatch

--- a/Tests/FluentAssertions.Specs/FindAssembly.cs
+++ b/Tests/FluentAssertions.Specs/FindAssembly.cs
@@ -6,7 +6,7 @@ namespace FluentAssertions
     {
         public static Assembly Containing<T>()
         {
-            return typeof(T).GetTypeInfo().Assembly;
+            return typeof(T).Assembly;
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
@@ -13,7 +13,7 @@ namespace FluentAssertions.Specs
         public void When_selecting_methods_from_types_in_an_assembly_it_should_return_the_applicable_methods()
         {
             // Arrange
-            Assembly assembly = typeof(ClassWithSomeAttribute).GetTypeInfo().Assembly;
+            Assembly assembly = typeof(ClassWithSomeAttribute).Assembly;
 
             // Act
             IEnumerable<MethodInfo> methods = assembly.Types()

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
@@ -13,7 +13,7 @@ namespace FluentAssertions.Specs
         public void When_selecting_properties_from_types_in_an_assembly_it_should_return_the_applicable_properties()
         {
             // Arrange
-            Assembly assembly = typeof(ClassWithSomeAttribute).GetTypeInfo().Assembly;
+            Assembly assembly = typeof(ClassWithSomeAttribute).Assembly;
 
             // Act
             IEnumerable<PropertyInfo> properties = assembly.Types()

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
@@ -118,7 +118,7 @@ namespace FluentAssertions.Specs
             Type typeFromThisAssembly = typeof(ObjectAssertions);
 
             Type typeFromOtherAssembly =
-                typeof(TypeAssertions).GetTypeInfo().Assembly.GetType("FluentAssertions.Primitives.ObjectAssertions");
+                typeof(TypeAssertions).Assembly.GetType("FluentAssertions.Primitives.ObjectAssertions");
 
 #pragma warning restore 436
 

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
@@ -17,7 +17,7 @@ namespace FluentAssertions.Specs
         public void When_selecting_types_that_derive_from_a_specific_class_it_should_return_the_correct_types()
         {
             // Arrange
-            Assembly assembly = typeof(ClassDerivedFromSomeBaseClass).GetTypeInfo().Assembly;
+            Assembly assembly = typeof(ClassDerivedFromSomeBaseClass).Assembly;
 
             // Act
             IEnumerable<Type> types = AllTypes.From(assembly).ThatDeriveFrom<SomeBaseClass>();
@@ -31,7 +31,7 @@ namespace FluentAssertions.Specs
         public void When_selecting_types_that_derive_from_a_specific_generic_class_it_should_return_the_correct_types()
         {
             // Arrange
-            Assembly assembly = typeof(ClassDerivedFromSomeGenericBaseClass).GetTypeInfo().Assembly;
+            Assembly assembly = typeof(ClassDerivedFromSomeGenericBaseClass).Assembly;
 
             // Act
             TypeSelector types = AllTypes.From(assembly).ThatDeriveFrom<SomeGenericBaseClass<int>>();
@@ -45,7 +45,7 @@ namespace FluentAssertions.Specs
         public void When_selecting_types_that_do_not_derive_from_a_specific_class_it_should_return_the_correct_types()
         {
             // Arrange
-            Assembly assembly = typeof(ClassDerivedFromSomeBaseClass).GetTypeInfo().Assembly;
+            Assembly assembly = typeof(ClassDerivedFromSomeBaseClass).Assembly;
 
             // Act
             IEnumerable<Type> types = AllTypes.From(assembly)
@@ -61,7 +61,7 @@ namespace FluentAssertions.Specs
         public void When_selecting_types_that_do_not_derive_from_a_specific_generic_class_it_should_return_the_correct_types()
         {
             // Arrange
-            Assembly assembly = typeof(ClassDerivedFromSomeGenericBaseClass).GetTypeInfo().Assembly;
+            Assembly assembly = typeof(ClassDerivedFromSomeGenericBaseClass).Assembly;
 
             // Act
             TypeSelector types = AllTypes.From(assembly)
@@ -77,7 +77,7 @@ namespace FluentAssertions.Specs
         public void When_selecting_types_that_implement_a_specific_interface_it_should_return_the_correct_types()
         {
             // Arrange
-            Assembly assembly = typeof(ClassImplementingSomeInterface).GetTypeInfo().Assembly;
+            Assembly assembly = typeof(ClassImplementingSomeInterface).Assembly;
 
             // Act
             IEnumerable<Type> types = AllTypes.From(assembly).ThatImplement<ISomeInterface>();
@@ -93,7 +93,7 @@ namespace FluentAssertions.Specs
         public void When_selecting_types_that_do_not_implement_a_specific_interface_it_should_return_the_correct_types()
         {
             // Arrange
-            Assembly assembly = typeof(ClassImplementingSomeInterface).GetTypeInfo().Assembly;
+            Assembly assembly = typeof(ClassImplementingSomeInterface).Assembly;
 
             // Act
             IEnumerable<Type> types = AllTypes.From(assembly)
@@ -109,7 +109,7 @@ namespace FluentAssertions.Specs
         public void When_selecting_types_that_are_decorated_with_a_specific_attribute_it_should_return_the_correct_types()
         {
             // Arrange
-            Assembly assembly = typeof(ClassWithSomeAttribute).GetTypeInfo().Assembly;
+            Assembly assembly = typeof(ClassWithSomeAttribute).Assembly;
 
             // Act
             IEnumerable<Type> types = AllTypes.From(assembly).ThatAreDecoratedWith<SomeAttribute>();
@@ -125,7 +125,7 @@ namespace FluentAssertions.Specs
         public void When_selecting_types_that_are_not_decorated_with_a_specific_attribute_it_should_return_the_correct_types()
         {
             // Arrange
-            Assembly assembly = typeof(ClassWithSomeAttribute).GetTypeInfo().Assembly;
+            Assembly assembly = typeof(ClassWithSomeAttribute).Assembly;
 
             // Act
             IEnumerable<Type> types = AllTypes.From(assembly).ThatAreNotDecoratedWith<SomeAttribute>();
@@ -141,7 +141,7 @@ namespace FluentAssertions.Specs
         public void When_selecting_types_from_specific_namespace_it_should_return_the_correct_types()
         {
             // Arrange
-            Assembly assembly = typeof(ClassWithSomeAttribute).GetTypeInfo().Assembly;
+            Assembly assembly = typeof(ClassWithSomeAttribute).Assembly;
 
             // Act
             IEnumerable<Type> types = AllTypes.From(assembly).ThatAreInNamespace("Internal.Other.Test");
@@ -155,7 +155,7 @@ namespace FluentAssertions.Specs
         public void When_selecting_types_other_than_from_specific_namespace_it_should_return_the_correct_types()
         {
             // Arrange
-            Assembly assembly = typeof(ClassWithSomeAttribute).GetTypeInfo().Assembly;
+            Assembly assembly = typeof(ClassWithSomeAttribute).Assembly;
 
             // Act
             IEnumerable<Type> types = AllTypes.From(assembly)
@@ -172,7 +172,7 @@ namespace FluentAssertions.Specs
         public void When_selecting_types_from_specific_namespace_or_sub_namespaces_it_should_return_the_correct_types()
         {
             // Arrange
-            Assembly assembly = typeof(ClassWithSomeAttribute).GetTypeInfo().Assembly;
+            Assembly assembly = typeof(ClassWithSomeAttribute).Assembly;
 
             // Act
             IEnumerable<Type> types = AllTypes.From(assembly).ThatAreUnderNamespace("Internal.Other.Test");
@@ -188,7 +188,7 @@ namespace FluentAssertions.Specs
         public void When_selecting_types_other_than_from_specific_namespace_or_sub_namespaces_it_should_return_the_correct_types()
         {
             // Arrange
-            Assembly assembly = typeof(ClassWithSomeAttribute).GetTypeInfo().Assembly;
+            Assembly assembly = typeof(ClassWithSomeAttribute).Assembly;
 
             // Act
             IEnumerable<Type> types = AllTypes.From(assembly)
@@ -204,7 +204,7 @@ namespace FluentAssertions.Specs
         public void When_combining_type_selection_filters_it_should_return_the_correct_types()
         {
             // Arrange
-            Assembly assembly = typeof(ClassWithSomeAttribute).GetTypeInfo().Assembly;
+            Assembly assembly = typeof(ClassWithSomeAttribute).Assembly;
 
             // Act
             IEnumerable<Type> types = AllTypes.From(assembly)


### PR DESCRIPTION
Since we've moved away from netstandard 1.3 and 1.6 it's no longer
necessary to call `GetTypeInfo` as `Type` now has all the members we
need.

Also removed some usage of LINQ by using the library method `IsDefined`.