### PR TITLE
Use named parameters for boolean literals

### DIFF
--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -22,7 +22,7 @@ namespace FluentAssertions
 
             try
             {
-                StackTrace stack = new StackTrace(true);
+                StackTrace stack = new StackTrace(fNeedFileInfo: true);
 
                 foreach (StackFrame frame in stack.GetFrames())
                 {

--- a/Src/FluentAssertions/Common/Configuration.cs
+++ b/Src/FluentAssertions/Common/Configuration.cs
@@ -62,7 +62,7 @@ namespace FluentAssertions.Common
             {
                 try
                 {
-                    return (ValueFormatterDetectionMode)Enum.Parse(typeof(ValueFormatterDetectionMode), setting, true);
+                    return (ValueFormatterDetectionMode)Enum.Parse(typeof(ValueFormatterDetectionMode), setting, ignoreCase: true);
                 }
                 catch (ArgumentException)
                 {

--- a/Src/FluentAssertions/Common/MethodInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/MethodInfoExtensions.cs
@@ -24,7 +24,7 @@ namespace FluentAssertions.Common
         internal static IEnumerable<TAttribute> GetMatchingAttributes<TAttribute>(this MemberInfo memberInfo, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
             where TAttribute : Attribute
         {
-            var customAttributes = memberInfo.GetCustomAttributes<TAttribute>(false).ToList();
+            var customAttributes = memberInfo.GetCustomAttributes<TAttribute>(inherit: false).ToList();
 
             if (typeof(TAttribute) == typeof(MethodImplAttribute) && memberInfo is MethodBase methodBase)
             {

--- a/Src/FluentAssertions/Common/PropertyInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/PropertyInfoExtensions.cs
@@ -6,7 +6,7 @@ namespace FluentAssertions.Common
     {
         internal static bool IsVirtual(this PropertyInfo property)
         {
-            MethodInfo methodInfo = property.GetGetMethod(true) ?? property.GetSetMethod(true);
+            MethodInfo methodInfo = property.GetGetMethod(nonPublic: true) ?? property.GetSetMethod(nonPublic: true);
             return !methodInfo.IsNonVirtual();
         }
     }

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -19,13 +19,13 @@ namespace FluentAssertions.Common
         public static bool IsDecoratedWith<TAttribute>(this Type type)
             where TAttribute : Attribute
         {
-            return type.IsDefined(typeof(TAttribute), false);
+            return type.IsDefined(typeof(TAttribute), inherit: false);
         }
 
         public static bool IsDecoratedWith<TAttribute>(this TypeInfo type)
             where TAttribute : Attribute
         {
-            return type.IsDefined(typeof(TAttribute), false);
+            return type.IsDefined(typeof(TAttribute), inherit: false);
         }
 
         public static bool IsDecoratedWith<TAttribute>(this MemberInfo type)
@@ -34,19 +34,19 @@ namespace FluentAssertions.Common
             // Do not use MemberInfo.IsDefined
             // There is an issue with PropertyInfo and EventInfo preventing the inherit option to work.
             // https://github.com/dotnet/runtime/issues/30219
-            return Attribute.IsDefined(type, typeof(TAttribute), false);
+            return Attribute.IsDefined(type, typeof(TAttribute), inherit: false);
         }
 
         public static bool IsDecoratedWithOrInherit<TAttribute>(this Type type)
             where TAttribute : Attribute
         {
-            return type.IsDefined(typeof(TAttribute), true);
+            return type.IsDefined(typeof(TAttribute), inherit: true);
         }
 
         public static bool IsDecoratedWithOrInherit<TAttribute>(this TypeInfo type)
             where TAttribute : Attribute
         {
-            return type.IsDefined(typeof(TAttribute), true);
+            return type.IsDefined(typeof(TAttribute), inherit: true);
         }
 
         public static bool IsDecoratedWithOrInherit<TAttribute>(this MemberInfo type)
@@ -55,7 +55,7 @@ namespace FluentAssertions.Common
             // Do not use MemberInfo.IsDefined
             // There is an issue with PropertyInfo and EventInfo preventing the inherit option to work.
             // https://github.com/dotnet/runtime/issues/30219
-            return Attribute.IsDefined(type, typeof(TAttribute), true);
+            return Attribute.IsDefined(type, typeof(TAttribute), inherit: true);
         }
 
         public static bool IsDecoratedWith<TAttribute>(this Type type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
@@ -79,19 +79,19 @@ namespace FluentAssertions.Common
         public static bool IsDecoratedWithOrInherit<TAttribute>(this Type type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
             where TAttribute : Attribute
         {
-            return GetCustomAttributes(type, isMatchingAttributePredicate, true).Any();
+            return GetCustomAttributes(type, isMatchingAttributePredicate, inherit: true).Any();
         }
 
         public static bool IsDecoratedWithOrInherit<TAttribute>(this TypeInfo type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
             where TAttribute : Attribute
         {
-            return GetCustomAttributes(type, isMatchingAttributePredicate, true).Any();
+            return GetCustomAttributes(type, isMatchingAttributePredicate, inherit: true).Any();
         }
 
         public static bool IsDecoratedWithOrInherit<TAttribute>(this MemberInfo type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
             where TAttribute : Attribute
         {
-            return GetCustomAttributes(type, isMatchingAttributePredicate, true).Any();
+            return GetCustomAttributes(type, isMatchingAttributePredicate, inherit: true).Any();
         }
 
         internal static IEnumerable<TAttribute> GetMatchingAttributes<TAttribute>(this Type type)
@@ -109,13 +109,13 @@ namespace FluentAssertions.Common
         internal static IEnumerable<TAttribute> GetMatchingOrInheritedAttributes<TAttribute>(this Type type)
             where TAttribute : Attribute
         {
-            return GetCustomAttributes<TAttribute>(type, true);
+            return GetCustomAttributes<TAttribute>(type, inherit: true);
         }
 
         internal static IEnumerable<TAttribute> GetMatchingOrInheritedAttributes<TAttribute>(this Type type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
             where TAttribute : Attribute
         {
-            return GetCustomAttributes(type, isMatchingAttributePredicate, true);
+            return GetCustomAttributes(type, isMatchingAttributePredicate, inherit: true);
         }
 
         internal static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(this MemberInfo type, bool inherit = false)
@@ -362,7 +362,7 @@ namespace FluentAssertions.Common
 
         private static bool HasNonPrivateGetter(PropertyInfo propertyInfo)
         {
-            MethodInfo getMethod = propertyInfo.GetGetMethod(true);
+            MethodInfo getMethod = propertyInfo.GetGetMethod(nonPublic: true);
             return getMethod != null && !getMethod.IsPrivate && !getMethod.IsFamily;
         }
 

--- a/Src/FluentAssertions/Equivalency/PropertySelectedMemberInfo.cs
+++ b/Src/FluentAssertions/Equivalency/PropertySelectedMemberInfo.cs
@@ -19,9 +19,9 @@ namespace FluentAssertions.Equivalency
 
         public override Type MemberType => propertyInfo.PropertyType;
 
-        internal override CSharpAccessModifier GetGetAccessModifier() => propertyInfo.GetGetMethod(true).GetCSharpAccessModifier();
+        internal override CSharpAccessModifier GetGetAccessModifier() => propertyInfo.GetGetMethod(nonPublic: true).GetCSharpAccessModifier();
 
-        internal override CSharpAccessModifier GetSetAccessModifier() => propertyInfo.GetSetMethod(true).GetCSharpAccessModifier();
+        internal override CSharpAccessModifier GetSetAccessModifier() => propertyInfo.GetSetMethod(nonPublic: true).GetCSharpAccessModifier();
 
         public override object GetValue(object obj, object[] index)
         {

--- a/Src/FluentAssertions/Execution/ContinuedAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/ContinuedAssertionScope.cs
@@ -42,7 +42,7 @@ namespace FluentAssertions.Execution
                 return predecessor.FailWith(failReasonFunc);
             }
 
-            return new Continuation(predecessor, false);
+            return new Continuation(predecessor, sourceSucceeded: false);
         }
 
         public Continuation FailWith(string message, params object[] args)
@@ -52,7 +52,7 @@ namespace FluentAssertions.Execution
                 return predecessor.FailWith(message, args);
             }
 
-            return new Continuation(predecessor, false);
+            return new Continuation(predecessor, sourceSucceeded: false);
         }
 
         public IAssertionScope BecauseOf(string because, params object[] becauseArgs)

--- a/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
@@ -102,7 +102,7 @@ namespace FluentAssertions.Types
         {
             Subject.Should().BeWritable(because, becauseArgs);
 
-            Subject.GetSetMethod(true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
+            Subject.GetSetMethod(nonPublic: true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
 
             return new AndConstraint<PropertyInfoAssertions>(this);
         }
@@ -164,7 +164,7 @@ namespace FluentAssertions.Types
         {
             Subject.Should().BeReadable(because, becauseArgs);
 
-            Subject.GetGetMethod(true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
+            Subject.GetGetMethod(nonPublic: true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
 
             return new AndConstraint<PropertyInfoAssertions>(this);
         }

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -42,7 +42,7 @@ namespace FluentAssertions.Types
             {
                 selectedProperties = selectedProperties.Where(property =>
                 {
-                    MethodInfo getter = property.GetGetMethod(true);
+                    MethodInfo getter = property.GetGetMethod(nonPublic: true);
                     return ((getter != null) && (getter.IsPublic || getter.IsAssembly));
                 });
 

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -85,7 +85,7 @@ namespace FluentAssertions.Xml
             using (XmlReader otherReader = expected.CreateReader())
             {
                 var xmlReaderValidator = new XmlReaderValidator(subjectReader, otherReader, because, becauseArgs);
-                xmlReaderValidator.Validate(true);
+                xmlReaderValidator.Validate(shouldBeEquivalent: true);
             }
 
             return new AndConstraint<XDocumentAssertions>(this);
@@ -109,7 +109,7 @@ namespace FluentAssertions.Xml
             using (XmlReader otherReader = unexpected.CreateReader())
             {
                 var xmlReaderValidator = new XmlReaderValidator(subjectReader, otherReader, because, becauseArgs);
-                xmlReaderValidator.Validate(false);
+                xmlReaderValidator.Validate(shouldBeEquivalent: false);
             }
 
             return new AndConstraint<XDocumentAssertions>(this);

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -86,7 +86,7 @@ namespace FluentAssertions.Xml
             using (XmlReader expectedReader = expected.CreateReader())
             {
                 var xmlReaderValidator = new XmlReaderValidator(subjectReader, expectedReader, because, becauseArgs);
-                xmlReaderValidator.Validate(true);
+                xmlReaderValidator.Validate(shouldBeEquivalent: true);
             }
 
             return new AndConstraint<XElementAssertions>(this);
@@ -111,7 +111,7 @@ namespace FluentAssertions.Xml
             using (XmlReader otherReader = unexpected.CreateReader())
             {
                 var xmlReaderValidator = new XmlReaderValidator(subjectReader, otherReader, because, becauseArgs);
-                xmlReaderValidator.Validate(false);
+                xmlReaderValidator.Validate(shouldBeEquivalent: false);
             }
 
             return new AndConstraint<XElementAssertions>(this);

--- a/Src/FluentAssertions/Xml/XmlNodeAssertionsofTSubjectTAssertions.cs
+++ b/Src/FluentAssertions/Xml/XmlNodeAssertionsofTSubjectTAssertions.cs
@@ -35,7 +35,7 @@ namespace FluentAssertions.Xml
             using (XmlNodeReader expectedReader = new XmlNodeReader(expected))
             {
                 var xmlReaderValidator = new XmlReaderValidator(subjectReader, expectedReader, because, reasonArgs);
-                xmlReaderValidator.Validate(true);
+                xmlReaderValidator.Validate(shouldBeEquivalent: true);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)(this));
@@ -60,7 +60,7 @@ namespace FluentAssertions.Xml
             using (XmlNodeReader unexpectedReader = new XmlNodeReader(unexpected))
             {
                 var xmlReaderValidator = new XmlReaderValidator(subjectReader, unexpectedReader, because, reasonArgs);
-                xmlReaderValidator.Validate(false);
+                xmlReaderValidator.Validate(shouldBeEquivalent: false);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);


### PR DESCRIPTION
As pointed out by @lg2de it's difficult to review code when it's sprinkled with boolean literals.