### PR TITLE
Use `using` statements to reduce indentation

### DIFF
--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -115,18 +115,16 @@ namespace FluentAssertions
 
             try
             {
-                using (StreamReader reader = new StreamReader(File.OpenRead(fileName)))
+                using StreamReader reader = new StreamReader(File.OpenRead(fileName));
+                string line;
+                int currentLine = 1;
+
+                while ((line = reader.ReadLine()) != null && currentLine < expectedLineNumber)
                 {
-                    string line;
-                    int currentLine = 1;
-
-                    while ((line = reader.ReadLine()) != null && currentLine < expectedLineNumber)
-                    {
-                        currentLine++;
-                    }
-
-                    return (currentLine == expectedLineNumber) ? line : null;
+                    currentLine++;
                 }
+
+                return (currentLine == expectedLineNumber) ? line : null;
             }
             catch
             {

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -603,12 +603,10 @@ namespace FluentAssertions.Collections
 
         private static IEnumerable<TExpectation> RepeatAsManyAsIterator<TExpectation>(TExpectation value, IEnumerable<T> enumerable)
         {
-            using (IEnumerator<T> enumerator = enumerable.GetEnumerator())
+            using IEnumerator<T> enumerator = enumerable.GetEnumerator();
+            while (enumerator.MoveNext())
             {
-                while (enumerator.MoveNext())
-                {
-                    yield return value;
-                }
+                yield return value;
             }
         }
     }

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -259,25 +259,21 @@ namespace FluentAssertions.Collections
 
         private bool ContainsMatch(string wildcardPattern)
         {
-            using (var scope = new AssertionScope())
+            using var scope = new AssertionScope();
+            return Subject.Any(item =>
             {
-                return Subject.Any(item =>
-                {
-                    item.Should().Match(wildcardPattern);
-                    return !scope.Discard().Any();
-                });
-            }
+                item.Should().Match(wildcardPattern);
+                return !scope.Discard().Any();
+            });
         }
 
         private IEnumerable<string> AllThatMatch(string wildcardPattern)
         {
             return Subject.Where(item =>
             {
-                using (var scope = new AssertionScope())
-                {
-                    item.Should().Match(wildcardPattern);
-                    return !scope.Discard().Any();
-                }
+                using var scope = new AssertionScope();
+                item.Should().Match(wildcardPattern);
+                return !scope.Discard().Any();
             });
         }
 
@@ -310,14 +306,12 @@ namespace FluentAssertions.Collections
 
         private bool NotContainsMatch(string wildcardPattern)
         {
-            using (var scope = new AssertionScope())
+            using var scope = new AssertionScope();
+            return Subject.All(item =>
             {
-                return Subject.All(item =>
-                {
-                    item.Should().NotMatch(wildcardPattern);
-                    return !scope.Discard().Any();
-                });
-            }
+                item.Should().NotMatch(wildcardPattern);
+                return !scope.Discard().Any();
+            });
         }
     }
 }

--- a/Src/FluentAssertions/Common/Clock.cs
+++ b/Src/FluentAssertions/Common/Clock.cs
@@ -19,10 +19,8 @@ namespace FluentAssertions.Common
 
         public bool Wait(Task task, TimeSpan timeout)
         {
-            using (NoSynchronizationContextScope.Enter())
-            {
-                return task.Wait(timeout);
-            }
+            using var _ = NoSynchronizationContextScope.Enter();
+            return task.Wait(timeout);
         }
 
         public ITimer StartTimer() => new StopwatchTimer();

--- a/Src/FluentAssertions/Common/EnumerableExtensions.cs
+++ b/Src/FluentAssertions/Common/EnumerableExtensions.cs
@@ -38,32 +38,30 @@ namespace FluentAssertions.Common
         /// <returns>Index at which two sequences have elements that are not equal, or -1 if enumerables are equal</returns>
         public static int IndexOfFirstDifferenceWith<TFirst, TSecond>(this IEnumerable<TFirst> first, IEnumerable<TSecond> second, Func<TFirst, TSecond, bool> equalityComparison)
         {
-            using (IEnumerator<TFirst> firstEnumerator = first.GetEnumerator())
-            using (IEnumerator<TSecond> secondEnumerator = second.GetEnumerator())
+            using IEnumerator<TFirst> firstEnumerator = first.GetEnumerator();
+            using IEnumerator<TSecond> secondEnumerator = second.GetEnumerator();
+            int index = 0;
+            while (true)
             {
-                int index = 0;
-                while (true)
+                bool isFirstCompleted = !firstEnumerator.MoveNext();
+                bool isSecondCompleted = !secondEnumerator.MoveNext();
+
+                if (isFirstCompleted && isSecondCompleted)
                 {
-                    bool isFirstCompleted = !firstEnumerator.MoveNext();
-                    bool isSecondCompleted = !secondEnumerator.MoveNext();
-
-                    if (isFirstCompleted && isSecondCompleted)
-                    {
-                        return -1;
-                    }
-
-                    if (isFirstCompleted ^ isSecondCompleted)
-                    {
-                        return index;
-                    }
-
-                    if (!equalityComparison(firstEnumerator.Current, secondEnumerator.Current))
-                    {
-                        return index;
-                    }
-
-                    index++;
+                    return -1;
                 }
+
+                if (isFirstCompleted ^ isSecondCompleted)
+                {
+                    return index;
+                }
+
+                if (!equalityComparison(firstEnumerator.Current, secondEnumerator.Current))
+                {
+                    return index;
+                }
+
+                index++;
             }
         }
     }

--- a/Src/FluentAssertions/Common/TaskExtensions.cs
+++ b/Src/FluentAssertions/Common/TaskExtensions.cs
@@ -12,18 +12,14 @@ namespace FluentAssertions.Common
     {
         public static void ExecuteInDefaultSynchronizationContext(this Action action)
         {
-            using (NoSynchronizationContextScope.Enter())
-            {
-                action();
-            }
+            using var _ = NoSynchronizationContextScope.Enter();
+            action();
         }
 
         public static TResult ExecuteInDefaultSynchronizationContext<TResult>(this Func<TResult> action)
         {
-            using (NoSynchronizationContextScope.Enter())
-            {
-                return action();
-            }
+            using var _ = NoSynchronizationContextScope.Enter();
+            return action();
         }
     }
 }

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -28,18 +28,16 @@ namespace FluentAssertions.Equivalency
 
         public void AssertEquality(EquivalencyValidationContext context)
         {
-            using (var scope = new AssertionScope())
+            using var scope = new AssertionScope();
+            scope.AddReportable("configuration", config.ToString());
+
+            scope.BecauseOf(context.Because, context.BecauseArgs);
+
+            AssertEqualityUsing(context);
+
+            if (context.Tracer != null)
             {
-                scope.AddReportable("configuration", config.ToString());
-
-                scope.BecauseOf(context.Because, context.BecauseArgs);
-
-                AssertEqualityUsing(context);
-
-                if (context.Tracer != null)
-                {
-                    scope.AddReportable("trace", context.Tracer.ToString());
-                }
+                scope.AddReportable("trace", context.Tracer.ToString());
             }
         }
 

--- a/Src/FluentAssertions/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ObjectAssertionsExtensions.cs
@@ -126,17 +126,15 @@ namespace FluentAssertions
 
         private static object CreateCloneUsingBinarySerializer(object subject)
         {
-            using (var stream = new MemoryStream())
+            using var stream = new MemoryStream();
+            var binaryFormatter = new BinaryFormatter
             {
-                var binaryFormatter = new BinaryFormatter
-                {
-                    Binder = new SimpleBinder(subject.GetType())
-                };
+                Binder = new SimpleBinder(subject.GetType())
+            };
 
-                binaryFormatter.Serialize(stream, subject);
-                stream.Position = 0;
-                return binaryFormatter.Deserialize(stream);
-            }
+            binaryFormatter.Serialize(stream, subject);
+            stream.Position = 0;
+            return binaryFormatter.Deserialize(stream);
         }
 
         private class SimpleBinder : SerializationBinder
@@ -163,13 +161,11 @@ namespace FluentAssertions
 
         private static object CreateCloneUsingDataContractSerializer(object subject)
         {
-            using (var stream = new MemoryStream())
-            {
-                var serializer = new DataContractSerializer(subject.GetType());
-                serializer.WriteObject(stream, subject);
-                stream.Position = 0;
-                return serializer.ReadObject(stream);
-            }
+            using var stream = new MemoryStream();
+            var serializer = new DataContractSerializer(subject.GetType());
+            serializer.WriteObject(stream, subject);
+            stream.Position = 0;
+            return serializer.ReadObject(stream);
         }
 
         /// <summary>
@@ -208,14 +204,12 @@ namespace FluentAssertions
 
         private static object CreateCloneUsingXmlSerializer(object subject)
         {
-            using (var stream = new MemoryStream())
-            {
-                var binaryFormatter = new XmlSerializer(subject.GetType());
-                binaryFormatter.Serialize(stream, subject);
+            using var stream = new MemoryStream();
+            var binaryFormatter = new XmlSerializer(subject.GetType());
+            binaryFormatter.Serialize(stream, subject);
 
-                stream.Position = 0;
-                return binaryFormatter.Deserialize(stream);
-            }
+            stream.Position = 0;
+            return binaryFormatter.Deserialize(stream);
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -25,16 +25,15 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitoredSubject = subject.Monitor())
-            {
-                // Act
-                // ReSharper disable once AccessToDisposedClosure
-                Action act = () => monitoredSubject.Should().Raise("NonExistingEvent");
+            using var monitoredSubject = subject.Monitor();
 
-                // Assert
-                act.Should().Throw<InvalidOperationException>().WithMessage(
-                    "Not monitoring any events named \"NonExistingEvent\".");
-            }
+            // Act
+            // ReSharper disable once AccessToDisposedClosure
+            Action act = () => monitoredSubject.Should().Raise("NonExistingEvent");
+
+            // Assert
+            act.Should().Throw<InvalidOperationException>().WithMessage(
+                "Not monitoring any events named \"NonExistingEvent\".");
         }
 
         [Fact]
@@ -42,15 +41,14 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                // Act
-                Action act = () => monitor.Should().NotRaise("NonExistingEvent");
+            using var monitor = subject.Monitor();
 
-                // Assert
-                act.Should().Throw<InvalidOperationException>().WithMessage(
-                    "Not monitoring any events named \"NonExistingEvent\".");
-            }
+            // Act
+            Action act = () => monitor.Should().NotRaise("NonExistingEvent");
+
+            // Assert
+            act.Should().Throw<InvalidOperationException>().WithMessage(
+                "Not monitoring any events named \"NonExistingEvent\".");
         }
 
         [Fact]
@@ -58,16 +56,15 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                // Act
-                Action act = () => monitor.Should().Raise("PropertyChanged", "{0} should cause the event to get raised", "Foo()");
+            using var monitor = subject.Monitor();
 
-                // Assert
-                act.Should().Throw<XunitException>().WithMessage(
-                    "Expected object " + Formatter.ToString(subject) +
-                    " to raise event \"PropertyChanged\" because Foo() should cause the event to get raised, but it did not.");
-            }
+            // Act
+            Action act = () => monitor.Should().Raise("PropertyChanged", "{0} should cause the event to get raised", "Foo()");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected object " + Formatter.ToString(subject) +
+                " to raise event \"PropertyChanged\" because Foo() should cause the event to get raised, but it did not.");
         }
 
         [Fact]
@@ -75,16 +72,14 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                subject.RaiseEventWithoutSender();
+            using var monitor = subject.Monitor();
+            subject.RaiseEventWithoutSender();
 
-                // Act
-                Action act = () => monitor.Should().Raise("PropertyChanged");
+            // Act
+            Action act = () => monitor.Should().Raise("PropertyChanged");
 
-                // Assert
-                act.Should().NotThrow();
-            }
+            // Assert
+            act.Should().NotThrow();
         }
 
         [Fact]
@@ -92,19 +87,17 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                subject.RaiseEventWithoutSender();
+            using var monitor = subject.Monitor();
+            subject.RaiseEventWithoutSender();
 
-                // Act
-                Action act = () =>
-                    monitor.Should().NotRaise("PropertyChanged", "{0} should cause the event to get raised", "Foo()");
+            // Act
+            Action act = () =>
+                monitor.Should().NotRaise("PropertyChanged", "{0} should cause the event to get raised", "Foo()");
 
-                // Assert
-                act.Should().Throw<XunitException>()
-                    .WithMessage("Expected object " + Formatter.ToString(subject) +
-                                 " to not raise event \"PropertyChanged\" because Foo() should cause the event to get raised, but it did.");
-            }
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected object " + Formatter.ToString(subject) +
+                             " to not raise event \"PropertyChanged\" because Foo() should cause the event to get raised, but it did.");
         }
 
         [Fact]
@@ -112,14 +105,13 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                // Act
-                Action act = () => monitor.Should().NotRaise("PropertyChanged");
+            using var monitor = subject.Monitor();
 
-                // Assert
-                act.Should().NotThrow();
-            }
+            // Act
+            Action act = () => monitor.Should().NotRaise("PropertyChanged");
+
+            // Assert
+            act.Should().NotThrow();
         }
 
         [Fact]
@@ -127,17 +119,15 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                subject.RaiseEventWithoutSender();
+            using var monitor = subject.Monitor();
+            subject.RaiseEventWithoutSender();
 
-                // Act
-                Action act = () => monitor.Should().Raise("PropertyChanged").WithSender(subject);
+            // Act
+            Action act = () => monitor.Should().Raise("PropertyChanged").WithSender(subject);
 
-                // Assert
-                act.Should().Throw<XunitException>()
-                    .WithMessage($"Expected sender {Formatter.ToString(subject)}, but found <null>.");
-            }
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage($"Expected sender {Formatter.ToString(subject)}, but found <null>.");
         }
 
         [Fact]
@@ -145,16 +135,14 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                subject.RaiseEventWithSender();
+            using var monitor = subject.Monitor();
+            subject.RaiseEventWithSender();
 
-                // Act
-                Action act = () => monitor.Should().Raise("PropertyChanged").WithSender(subject);
+            // Act
+            Action act = () => monitor.Should().Raise("PropertyChanged").WithSender(subject);
 
-                // Assert
-                act.Should().NotThrow();
-            }
+            // Assert
+            act.Should().NotThrow();
         }
 
         [Fact]
@@ -162,19 +150,17 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
+            using var monitor = subject.Monitor();
+            subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
 
-                // Act
-                Action act = () => monitor.Should()
-                    .Raise("NonConventionalEvent")
-                    .WithArgs<string>(predicate: null);
+            // Act
+            Action act = () => monitor.Should()
+                .Raise("NonConventionalEvent")
+                .WithArgs<string>(predicate: null);
 
-                // Assert
-                act.Should().ThrowExactly<ArgumentNullException>()
-                    .Which.ParamName.Should().Be("predicate");
-            }
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .Which.ParamName.Should().Be("predicate");
         }
 
         [Fact]
@@ -182,21 +168,19 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                subject.RaiseEventWithoutSender();
+            using var monitor = subject.Monitor();
+            subject.RaiseEventWithoutSender();
 
-                // Act
-                Action act = () => monitor
-                    .Should().Raise("PropertyChanged")
-                    .WithArgs<PropertyChangedEventArgs>(args => args.PropertyName == "SomeProperty");
+            // Act
+            Action act = () => monitor
+                .Should().Raise("PropertyChanged")
+                .WithArgs<PropertyChangedEventArgs>(args => args.PropertyName == "SomeProperty");
 
-                // Assert
-                act
-                    .Should().Throw<XunitException>()
-                    .WithMessage(
-                        "Expected at least one event with arguments matching (args.PropertyName == \"SomeProperty\"), but found none.");
-            }
+            // Assert
+            act
+                .Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected at least one event with arguments matching (args.PropertyName == \"SomeProperty\"), but found none.");
         }
 
         [Fact]
@@ -204,20 +188,18 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
+            using var monitor = subject.Monitor();
+            subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
 
-                // Act
-                Action act = () => monitor
-                    .Should().Raise("PropertyChanged")
-                    .WithArgs<CancelEventArgs>(args => args.Cancel);
+            // Act
+            Action act = () => monitor
+                .Should().Raise("PropertyChanged")
+                .WithArgs<CancelEventArgs>(args => args.Cancel);
 
-                // Assert
-                act
-                    .Should().Throw<ArgumentException>()
-                    .WithMessage("No argument of event PropertyChanged is of type *CancelEventArgs>*");
-            }
+            // Assert
+            act
+                .Should().Throw<ArgumentException>()
+                .WithMessage("No argument of event PropertyChanged is of type *CancelEventArgs>*");
         }
 
         [Fact]
@@ -225,18 +207,16 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
+            using var monitor = subject.Monitor();
+            subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
 
-                // Act
-                Action act = () => monitor
-                    .Should().Raise("PropertyChanged")
-                    .WithArgs<PropertyChangedEventArgs>(args => args.PropertyName == "SomeProperty");
+            // Act
+            Action act = () => monitor
+                .Should().Raise("PropertyChanged")
+                .WithArgs<PropertyChangedEventArgs>(args => args.PropertyName == "SomeProperty");
 
-                // Assert
-                act.Should().NotThrow();
-            }
+            // Assert
+            act.Should().NotThrow();
         }
 
         [Fact]
@@ -246,11 +226,9 @@ namespace FluentAssertions.Specs
             void Action(int _)
             {
                 EventRaisingClass subject = new EventRaisingClass();
-                using (var monitor = subject.Monitor())
-                {
-                    subject.RaiseEventWithSender();
-                    monitor.Should().Raise("PropertyChanged");
-                }
+                using var monitor = subject.Monitor();
+                subject.RaiseEventWithSender();
+                monitor.Should().Raise("PropertyChanged");
             }
 
             // Act
@@ -267,16 +245,14 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var eventMonitor = subject.Monitor())
-            {
-                subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
+            using var eventMonitor = subject.Monitor();
+            subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
 
-                // Act
-                eventMonitor.Clear();
+            // Act
+            eventMonitor.Clear();
 
-                // Assert
-                eventMonitor.Should().NotRaise("PropertyChanged");
-            }
+            // Assert
+            eventMonitor.Should().NotRaise("PropertyChanged");
         }
 
         [Fact]
@@ -284,18 +260,16 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
+            using var monitor = subject.Monitor();
+            subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
 
-                // Act
-                Action act = () => monitor
-                    .Should().Raise("NonConventionalEvent")
-                    .WithArgs<string>(args => args == "third argument");
+            // Act
+            Action act = () => monitor
+                .Should().Raise("NonConventionalEvent")
+                .WithArgs<string>(args => args == "third argument");
 
-                // Assert
-                act.Should().NotThrow();
-            }
+            // Assert
+            act.Should().NotThrow();
         }
 
         [Fact]
@@ -303,18 +277,16 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
+            using var monitor = subject.Monitor();
+            subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
 
-                // Act
-                Action act = () => monitor
-                    .Should().Raise("NonConventionalEvent")
-                    .WithArgs<string>(null, args => args == "third argument");
+            // Act
+            Action act = () => monitor
+                .Should().Raise("NonConventionalEvent")
+                .WithArgs<string>(null, args => args == "third argument");
 
-                // Assert
-                act.Should().NotThrow();
-            }
+            // Assert
+            act.Should().NotThrow();
         }
 
         [Fact]
@@ -323,19 +295,17 @@ namespace FluentAssertions.Specs
             // Arrange
             const int wrongArgument = 3;
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
+            using var monitor = subject.Monitor();
+            subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
 
-                // Act
-                Action act = () => monitor
-                    .Should().Raise("NonConventionalEvent")
-                    .WithArgs<int>(args => args == wrongArgument);
+            // Act
+            Action act = () => monitor
+                .Should().Raise("NonConventionalEvent")
+                .WithArgs<int>(args => args == wrongArgument);
 
-                // Assert
-                act.Should().Throw<XunitException>().WithMessage(
-                    "Expected at least one event with arguments matching (args == " + wrongArgument + "), but found none.");
-            }
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected at least one event with arguments matching (args == " + wrongArgument + "), but found none.");
         }
 
         [Fact]
@@ -344,20 +314,18 @@ namespace FluentAssertions.Specs
             // Arrange
             const string wrongArgument = "not a third argument";
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
+            using var monitor = subject.Monitor();
+            subject.RaiseNonConventionalEvent("first argument", 2, "third argument");
 
-                // Act
-                Action act = () => monitor
-                    .Should().Raise("NonConventionalEvent")
-                    .WithArgs<string>(null, args => args == wrongArgument);
+            // Act
+            Action act = () => monitor
+                .Should().Raise("NonConventionalEvent")
+                .WithArgs<string>(null, args => args == wrongArgument);
 
-                // Assert
-                act.Should().Throw<XunitException>().WithMessage(
-                    "Expected at least one event with arguments matching \"(args == \"" + wrongArgument +
-                    "\")\", but found none.");
-            }
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected at least one event with arguments matching \"(args == \"" + wrongArgument +
+                "\")\", but found none.");
         }
 
         #endregion
@@ -369,17 +337,15 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
-                subject.RaiseEventWithSenderAndPropertyName("SomeOtherProperty");
+            using var monitor = subject.Monitor();
+            subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
+            subject.RaiseEventWithSenderAndPropertyName("SomeOtherProperty");
 
-                // Act
-                Action act = () => monitor.Should().RaisePropertyChangeFor(x => x.SomeProperty);
+            // Act
+            Action act = () => monitor.Should().RaisePropertyChangeFor(x => x.SomeProperty);
 
-                // Assert
-                act.Should().NotThrow();
-            }
+            // Assert
+            act.Should().NotThrow();
         }
 
         [Fact]
@@ -387,16 +353,14 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                subject.RaiseEventWithSenderAndPropertyName(null);
+            using var monitor = subject.Monitor();
+            subject.RaiseEventWithSenderAndPropertyName(null);
 
-                // Act
-                Action act = () => monitor.Should().RaisePropertyChangeFor(null);
+            // Act
+            Action act = () => monitor.Should().RaisePropertyChangeFor(null);
 
-                // Assert
-                act.Should().NotThrow();
-            }
+            // Assert
+            act.Should().NotThrow();
         }
 
         [Fact]
@@ -404,16 +368,14 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var eventMonitor = subject.Monitor())
-            {
-                subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
+            using var eventMonitor = subject.Monitor();
+            subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
 
-                // Act
-                eventMonitor.Clear();
+            // Act
+            eventMonitor.Clear();
 
-                // Assert
-                eventMonitor.Should().NotRaisePropertyChangeFor(e => e.SomeProperty);
-            }
+            // Assert
+            eventMonitor.Should().NotRaisePropertyChangeFor(e => e.SomeProperty);
         }
 
         [Fact]
@@ -421,18 +383,16 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
+            using var monitor = subject.Monitor();
+            subject.RaiseEventWithSenderAndPropertyName("SomeProperty");
 
-                // Act
-                Action act = () => monitor.Should().NotRaisePropertyChangeFor(x => x.SomeProperty, "nothing happened");
+            // Act
+            Action act = () => monitor.Should().NotRaisePropertyChangeFor(x => x.SomeProperty, "nothing happened");
 
-                // Assert
-                act.Should().Throw<XunitException>().WithMessage(
-                    "Did not expect object " + Formatter.ToString(subject) +
-                    " to raise the \"PropertyChanged\" event for property \"SomeProperty\" because nothing happened, but it did.");
-            }
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect object " + Formatter.ToString(subject) +
+                " to raise the \"PropertyChanged\" event for property \"SomeProperty\" because nothing happened, but it did.");
         }
 
         [Fact]
@@ -440,16 +400,15 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                // Act
-                Action act = () => monitor.Should().RaisePropertyChangeFor(x => x.SomeProperty, "the property was changed");
+            using var monitor = subject.Monitor();
 
-                // Assert
-                act.Should().Throw<XunitException>().WithMessage(
-                    "Expected object " + Formatter.ToString(subject) +
-                    " to raise event \"PropertyChanged\" for property \"SomeProperty\" because the property was changed, but it did not.");
-            }
+            // Act
+            Action act = () => monitor.Should().RaisePropertyChangeFor(x => x.SomeProperty, "the property was changed");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected object " + Formatter.ToString(subject) +
+                " to raise event \"PropertyChanged\" for property \"SomeProperty\" because the property was changed, but it did not.");
         }
 
         [Fact]
@@ -457,16 +416,15 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                // Act
-                Action act = () => monitor.Should().RaisePropertyChangeFor(null);
+            using var monitor = subject.Monitor();
 
-                // Assert
-                act.Should().Throw<XunitException>().WithMessage(
-                    "Expected object " + Formatter.ToString(subject) +
-                    " to raise event \"PropertyChanged\" for property <null>, but it did not.");
-            }
+            // Act
+            Action act = () => monitor.Should().RaisePropertyChangeFor(null);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected object " + Formatter.ToString(subject) +
+                " to raise event \"PropertyChanged\" for property <null>, but it did not.");
         }
 
         [Fact]
@@ -474,16 +432,14 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new EventRaisingClass();
-            using (var monitor = subject.Monitor())
-            {
-                subject.RaiseEventWithSenderAndPropertyName("SomeOtherProperty");
+            using var monitor = subject.Monitor();
+            subject.RaiseEventWithSenderAndPropertyName("SomeOtherProperty");
 
-                // Act
-                Action act = () => monitor.Should().NotRaisePropertyChangeFor(x => x.SomeProperty);
+            // Act
+            Action act = () => monitor.Should().NotRaisePropertyChangeFor(x => x.SomeProperty);
 
-                // Assert
-                act.Should().NotThrow();
-            }
+            // Assert
+            act.Should().NotThrow();
         }
 
         [Fact]
@@ -491,16 +447,15 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var subject = new TestEventRaising();
-            using (var outerMonitor = subject.Monitor<IEventRaisingInterface>())
-            using (var innerMonitor = subject.Monitor<IEventRaisingInterface2>())
-            {
-                // Act
-                subject.RaiseBothEvents();
+            using var outerMonitor = subject.Monitor<IEventRaisingInterface>();
+            using var innerMonitor = subject.Monitor<IEventRaisingInterface2>();
 
-                // Assert
-                outerMonitor.Should().Raise("InterfaceEvent");
-                innerMonitor.Should().Raise("Interface2Event");
-            }
+            // Act
+            subject.RaiseBothEvents();
+
+            // Assert
+            outerMonitor.Should().Raise("InterfaceEvent");
+            innerMonitor.Should().Raise("Interface2Event");
         }
 
         #endregion
@@ -526,15 +481,12 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var eventSource = new EventRaisingClass();
-            using (var outerScope = eventSource.Monitor())
-            {
-                // Act
-                using (var innerScope = eventSource.Monitor())
-                {
-                    // Assert
-                    ((object)innerScope).Should().NotBeSameAs(outerScope);
-                }
-            }
+            using var outerScope = eventSource.Monitor();
+
+            // Act
+            using var innerScope = eventSource.Monitor();
+            // Assert
+            ((object)innerScope).Should().NotBeSameAs(outerScope);
         }
 
         #endregion
@@ -546,26 +498,25 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var eventSource = new ClassThatRaisesEventsItself();
-            using (var eventMonitor = eventSource.Monitor())
-            {
-                // Act
-                EventMetadata[] metadata = eventMonitor.MonitoredEvents;
+            using var eventMonitor = eventSource.Monitor();
 
-                // Assert
-                metadata.Should().BeEquivalentTo(new[]
+            // Act
+            EventMetadata[] metadata = eventMonitor.MonitoredEvents;
+
+            // Assert
+            metadata.Should().BeEquivalentTo(new[]
+            {
+                new
                 {
-                    new
-                    {
-                        EventName = nameof(ClassThatRaisesEventsItself.InterfaceEvent),
-                        HandlerType = typeof(EventHandler)
-                    },
-                    new
-                    {
-                        EventName = nameof(ClassThatRaisesEventsItself.PropertyChanged),
-                        HandlerType = typeof(PropertyChangedEventHandler)
-                    }
-                });
-            }
+                    EventName = nameof(ClassThatRaisesEventsItself.InterfaceEvent),
+                    HandlerType = typeof(EventHandler)
+                },
+                new
+                {
+                    EventName = nameof(ClassThatRaisesEventsItself.PropertyChanged),
+                    HandlerType = typeof(PropertyChangedEventHandler)
+                }
+             });
         }
 
         [Fact]
@@ -573,21 +524,20 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var eventSource = new ClassThatRaisesEventsItself();
-            using (var monitor = eventSource.Monitor<IEventRaisingInterface>())
-            {
-                // Act
-                EventMetadata[] metadata = monitor.MonitoredEvents;
+            using var monitor = eventSource.Monitor<IEventRaisingInterface>();
 
-                // Assert
-                metadata.Should().BeEquivalentTo(new[]
+            // Act
+            EventMetadata[] metadata = monitor.MonitoredEvents;
+
+            // Assert
+            metadata.Should().BeEquivalentTo(new[]
+            {
+                new
                 {
-                    new
-                    {
-                        EventName = nameof(IEventRaisingInterface.InterfaceEvent),
-                        HandlerType = typeof(EventHandler)
-                    }
-                });
-            }
+                    EventName = nameof(IEventRaisingInterface.InterfaceEvent),
+                    HandlerType = typeof(EventHandler)
+                }
+            });
         }
 
 #if NET47 // DefineDynamicAssembly is obsolete in .NET Core
@@ -610,15 +560,14 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var eventSource = (IEventRaisingInterface)CreateProxyObject();
-            using (var eventMonitor = eventSource.Monitor())
-            {
-                // Act
-                Action action = () => eventMonitor.GetEventRecorder("SomeEvent");
+            using var eventMonitor = eventSource.Monitor();
 
-                // Assert
-                action.Should().Throw<InvalidOperationException>()
-                    .WithMessage("Not monitoring any events named \"SomeEvent\".");
-            }
+            // Act
+            Action action = () => eventMonitor.GetEventRecorder("SomeEvent");
+
+            // Assert
+            action.Should().Throw<InvalidOperationException>()
+                .WithMessage("Not monitoring any events named \"SomeEvent\".");
         }
 
         private object CreateProxyObject()
@@ -662,15 +611,14 @@ namespace FluentAssertions.Specs
         {
             // Arrange
             var eventSource = new ClassThatRaisesEventsItself();
-            using (var eventMonitor = eventSource.Monitor<IEventRaisingInterface>())
-            {
-                // Act
-                Action action = () => eventMonitor.GetEventRecorder("PropertyChanged");
+            using var eventMonitor = eventSource.Monitor<IEventRaisingInterface>();
 
-                // Assert
-                action.Should().Throw<InvalidOperationException>()
-                    .WithMessage("Not monitoring any events named \"PropertyChanged\".");
-            }
+            // Act
+            Action action = () => eventMonitor.GetEventRecorder("PropertyChanged");
+
+            // Assert
+            action.Should().Throw<InvalidOperationException>()
+                .WithMessage("Not monitoring any events named \"PropertyChanged\".");
         }
 
         [Fact]
@@ -680,32 +628,31 @@ namespace FluentAssertions.Specs
             DateTime utcNow = 17.September(2017).At(21, 00);
 
             var eventSource = new EventRaisingClass();
-            using (var monitor = eventSource.Monitor(() => utcNow))
+            using var monitor = eventSource.Monitor(() => utcNow);
+
+            // Act
+            eventSource.RaiseEventWithSenderAndPropertyName("theProperty");
+
+            utcNow += 1.Hours();
+
+            eventSource.RaiseNonConventionalEvent("first", 123, "third");
+
+            // Assert
+            monitor.OccurredEvents.Should().BeEquivalentTo(new[]
             {
-                // Act
-                eventSource.RaiseEventWithSenderAndPropertyName("theProperty");
-
-                utcNow += 1.Hours();
-
-                eventSource.RaiseNonConventionalEvent("first", 123, "third");
-
-                // Assert
-                monitor.OccurredEvents.Should().BeEquivalentTo(new[]
+                new
                 {
-                    new
-                    {
-                        EventName = "PropertyChanged",
-                        TimestampUtc = utcNow - 1.Hours(),
-                        Parameters = new object[] { eventSource, new PropertyChangedEventArgs("theProperty") }
-                    },
-                    new
-                    {
-                        EventName = "NonConventionalEvent",
-                        TimestampUtc = utcNow,
-                        Parameters = new object[] { "first", 123, "third" }
-                    }
-                }, o => o.WithStrictOrdering());
-            }
+                    EventName = "PropertyChanged",
+                    TimestampUtc = utcNow - 1.Hours(),
+                    Parameters = new object[] { eventSource, new PropertyChangedEventArgs("theProperty") }
+                },
+                new
+                {
+                    EventName = "NonConventionalEvent",
+                    TimestampUtc = utcNow,
+                    Parameters = new object[] { "first", 123, "third" }
+                }
+            }, o => o.WithStrictOrdering());
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
@@ -419,11 +419,9 @@ namespace FluentAssertions.Specs
             // Act
             Action act = () =>
             {
-                using (new AssertionScope())
-                {
-                    throwingFunction.Should().NotThrow()
-                        .And.BeNull();
-                }
+                using var _ = new AssertionScope();
+                throwingFunction.Should().NotThrow()
+                    .And.BeNull();
             };
 
             // Assert
@@ -580,11 +578,9 @@ namespace FluentAssertions.Specs
             // Act
             Action act = () =>
             {
-                using (new AssertionScope())
-                {
-                    throwingFunction.Should().NotThrowAfter(waitTime, pollInterval)
-                        .And.BeNull();
-                }
+                using var _ = new AssertionScope();
+                throwingFunction.Should().NotThrowAfter(waitTime, pollInterval)
+                    .And.BeNull();
             };
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -141,10 +141,8 @@ namespace FluentAssertions.Specs
             {
                 nestedScope.FailWith("Failure2");
 
-                using (var deeplyNestedScope = new AssertionScope())
-                {
-                    deeplyNestedScope.FailWith("Failure3");
-                }
+                using var deeplyNestedScope = new AssertionScope();
+                deeplyNestedScope.FailWith("Failure3");
             }
 
             // Act
@@ -175,11 +173,9 @@ namespace FluentAssertions.Specs
             {
                 nestedScope.FailWith("Failure2");
 
-                using (var deeplyNestedScope = new AssertionScope())
-                {
-                    deeplyNestedScope.FailWith("Failure3");
-                    deeplyNestedScope.Discard();
-                }
+                using var deeplyNestedScope = new AssertionScope();
+                deeplyNestedScope.FailWith("Failure3");
+                deeplyNestedScope.Discard();
             }
 
             // Act
@@ -235,10 +231,8 @@ namespace FluentAssertions.Specs
             // Act
             Action act = () =>
             {
-                using (new AssertionScope("foo"))
-                {
-                    new[] { 1, 2, 3 }.Should().Equal(3, 2, 1);
-                }
+                using var _ = new AssertionScope("foo");
+                new[] { 1, 2, 3 }.Should().Equal(3, 2, 1);
             };
 
             // Assert
@@ -252,12 +246,10 @@ namespace FluentAssertions.Specs
             // Act
             Action act = () =>
             {
-                using (new AssertionScope())
-                {
-                    var values = new Dictionary<int, int>();
-                    values.Should().ContainKey(0);
-                    values.Should().ContainKey(1);
-                }
+                using var _ = new AssertionScope();
+                var values = new Dictionary<int, int>();
+                values.Should().ContainKey(0);
+                values.Should().ContainKey(1);
             };
 
             // Assert
@@ -271,12 +263,10 @@ namespace FluentAssertions.Specs
             // Act
             Action act = () =>
             {
-                using (new AssertionScope())
-                {
-                    var values = new List<int>();
-                    values.Should().ContainSingle();
-                    values.Should().ContainSingle();
-                }
+                using var _ = new AssertionScope();
+                var values = new List<int>();
+                values.Should().ContainSingle();
+                values.Should().ContainSingle();
             };
 
             // Assert
@@ -291,12 +281,10 @@ namespace FluentAssertions.Specs
             // Act
             Action act = () =>
             {
-                using (new AssertionScope())
-                {
-                    var item = string.Empty;
-                    item.Should().BeOfType<int>();
-                    item.Should().BeOfType<long>();
-                }
+                using var _ = new AssertionScope();
+                var item = string.Empty;
+                item.Should().BeOfType<int>();
+                item.Should().BeOfType<long>();
             };
 
             // Assert
@@ -312,12 +300,10 @@ namespace FluentAssertions.Specs
             // Act
             Action act = () =>
             {
-                using (new AssertionScope())
-                {
-                    var item = string.Empty;
-                    item.Should().BeAssignableTo<int>();
-                    item.Should().BeAssignableTo<long>();
-                }
+                using var _ = new AssertionScope();
+                var item = string.Empty;
+                item.Should().BeAssignableTo<int>();
+                item.Should().BeAssignableTo<long>();
             };
 
             // Assert
@@ -378,10 +364,8 @@ namespace FluentAssertions.Specs
             // Act
             Action act = () =>
             {
-                using (new AssertionScope("{}"))
-                {
-                    default(Array).Should().Equal(3, 2, 1);
-                }
+                using var _ = new AssertionScope("{}");
+                default(Array).Should().Equal(3, 2, 1);
             };
 
             // Assert
@@ -560,10 +544,8 @@ namespace FluentAssertions.Specs
         [Fact]
         public async Task When_using_AssertionScope_across_thread_boundaries_it_should_work()
         {
-            using (var semaphore = new SemaphoreSlim(0, 1))
-            {
-                await Task.WhenAll(SemaphoreYieldAndWait(semaphore), SemaphoreYieldAndRelease(semaphore));
-            }
+            using var semaphore = new SemaphoreSlim(0, 1);
+            await Task.WhenAll(SemaphoreYieldAndWait(semaphore), SemaphoreYieldAndRelease(semaphore));
         }
 
         private static async Task SemaphoreYieldAndWait(SemaphoreSlim semaphore)

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
@@ -587,10 +587,8 @@ namespace FluentAssertions.Specs
             // Act
             Action act = () =>
             {
-                using (new AssertionScope())
-                {
-                    subject.Should().MatchRegex(invalidRegex);
-                }
+                using var _ = new AssertionScope();
+                subject.Should().MatchRegex(invalidRegex);
             };
 
             // Assert
@@ -684,10 +682,8 @@ namespace FluentAssertions.Specs
             // Act
             Action act = () =>
             {
-                using (new AssertionScope())
-                {
-                    subject.Should().NotMatchRegex(invalidRegex);
-                }
+                using var _ = new AssertionScope();
+                subject.Should().NotMatchRegex(invalidRegex);
             };
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -382,11 +382,9 @@ namespace FluentAssertions.Specs
             // Act
             Action act = () =>
             {
-                using (new AssertionScope())
-                {
-                    throwingFunction.Should().NotThrowAfter(waitTime, pollInterval)
-                        .And.BeNull();
-                }
+                using var _ = new AssertionScope();
+                throwingFunction.Should().NotThrowAfter(waitTime, pollInterval)
+                    .And.BeNull();
             };
 
             // Assert


### PR DESCRIPTION
This is a clear statement about using `using` statements!

Best viewed ~using IE6 in 1024x768~ ignoring whitespace.