### PR TITLE
NRE for GetPropertyInfo with unexpected Expression

### DIFF
--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -4,43 +4,15 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
-using FluentAssertions.Equivalency;
-
 namespace FluentAssertions.Common
 {
     internal static class ExpressionExtensions
     {
-        public static SelectedMemberInfo GetSelectedMemberInfo<T, TValue>(this Expression<Func<T, TValue>> expression)
-        {
-            Guard.ThrowIfArgumentIsNull(expression, nameof(expression), "Expected an expression, but found <null>.");
-
-            MemberInfo memberInfo = AttemptToGetMemberInfoFromCastExpression(expression) ??
-                                    AttemptToGetMemberInfoFromMemberExpression(expression);
-
-            if (memberInfo != null)
-            {
-                if (memberInfo is PropertyInfo propertyInfo)
-                {
-                    return SelectedMemberInfo.Create(propertyInfo);
-                }
-
-                if (memberInfo is FieldInfo fieldInfo)
-                {
-                    return SelectedMemberInfo.Create(fieldInfo);
-                }
-            }
-
-            throw new ArgumentException(
-                string.Format("Expression <{0}> cannot be used to select a member.", expression.Body),
-                nameof(expression));
-        }
-
         public static PropertyInfo GetPropertyInfo<T, TValue>(this Expression<Func<T, TValue>> expression)
         {
             Guard.ThrowIfArgumentIsNull(expression, nameof(expression), "Expected a property expression, but found <null>.");
 
-            MemberInfo memberInfo = AttemptToGetMemberInfoFromCastExpression(expression) ??
-                             AttemptToGetMemberInfoFromMemberExpression(expression);
+            MemberInfo memberInfo = AttemptToGetMemberInfoFromExpression(expression);
 
             if (!(memberInfo is PropertyInfo propertyInfo))
             {
@@ -51,26 +23,8 @@ namespace FluentAssertions.Common
             return propertyInfo;
         }
 
-        private static MemberInfo AttemptToGetMemberInfoFromMemberExpression<T, TValue>(
-            Expression<Func<T, TValue>> expression)
-        {
-            if (expression.Body is MemberExpression memberExpression)
-            {
-                return memberExpression.Member;
-            }
-
-            return null;
-        }
-
-        private static MemberInfo AttemptToGetMemberInfoFromCastExpression<T, TValue>(Expression<Func<T, TValue>> expression)
-        {
-            if (expression.Body is UnaryExpression castExpression)
-            {
-                return ((MemberExpression)castExpression.Operand).Member;
-            }
-
-            return null;
-        }
+        private static MemberInfo AttemptToGetMemberInfoFromExpression<T, TValue>(Expression<Func<T, TValue>> expression) =>
+            (((expression.Body as UnaryExpression)?.Operand ?? expression.Body) as MemberExpression)?.Member;
 
         /// <summary>
         /// Gets a dotted path of property names representing the property expression, including the declaring type.

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -489,6 +489,22 @@ namespace FluentAssertions.Specs
             ((object)innerScope).Should().NotBeSameAs(outerScope);
         }
 
+        [Fact]
+        public void When_monitoring_an_object_with_invalid_property_expression_it_should_throw()
+        {
+            // Arrange
+            var eventSource = new EventRaisingClass();
+            using var monitor = eventSource.Monitor();
+            Func<EventRaisingClass, int> func = e => e.SomeOtherProperty;
+
+            // Act
+            Action act = () => monitor.Should().RaisePropertyChangeFor(e => func(e));
+
+            // Assert
+            act.Should().Throw<ArgumentException>()
+                .Which.ParamName.Should().Be("expression");
+        }
+
         #endregion
 
         #region Metadata
@@ -714,6 +730,8 @@ namespace FluentAssertions.Specs
         public class EventRaisingClass : INotifyPropertyChanged
         {
             public string SomeProperty { get; set; }
+
+            public int SomeOtherProperty { get; set; }
 
             public event PropertyChangedEventHandler PropertyChanged = delegate { };
 


### PR DESCRIPTION
Not all `Operand`s of `UnaryExpression` are `MemberExpression`s.

I was confused with the naming `AttemptToGetMemberInfoFromCastExpression`, so had to read up on when the `Body` of `Expression<Func<T, TValue>>` would be a `MemberExpression` vs `UnaryExpression`.
https://stackoverflow.com/a/12975480/1087627
Apparently it happens when `TValue` is a value type, that's why I added `int SomeOtherProperty`.

`GetSelectedMemberInfo` wasn't used anywhere, so out it goes.