### PR TITLE
Optimize IndexOfFirstMismatch

### DIFF
--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -12,9 +12,11 @@ namespace FluentAssertions.Common
         /// </summary>
         public static int IndexOfFirstMismatch(this string value, string expected, StringComparison stringComparison)
         {
+            Func<char, char, bool> comparer = GetCharComparer(stringComparison);
+
             for (int index = 0; index < value.Length; index++)
             {
-                if ((index >= expected.Length) || !value[index].ToString().Equals(expected[index].ToString(), stringComparison))
+                if ((index >= expected.Length) || !comparer(value[index], expected[index]))
                 {
                     return index;
                 }
@@ -22,6 +24,11 @@ namespace FluentAssertions.Common
 
             return -1;
         }
+
+        private static Func<char, char, bool> GetCharComparer(StringComparison stringComparison) =>
+            stringComparison == StringComparison.Ordinal
+                ? (Func<char, char, bool>)((x, y) => x == y)
+                : (x, y) => char.ToUpperInvariant(x) == char.ToUpperInvariant(y);
 
         /// <summary>
         /// Gets the quoted three characters at the specified index of a string, including the index itself.


### PR DESCRIPTION
`StringAssertions.Be[EquivalentTo]` uses an `StringEqualityValidator`
and in there `IndexOfFirstMismatch` to compare if two `string`s are
equal/equivalent.

It had annoyed me for some time that we compared strings characterwise by
slicing of `char`s and converting them to single character `string`s
that we then compare.

The benchmark is calling `IndexOfFirstMismatch` two identical strings using
`Ordinal`/`OrdinalIgnoreCase` and for different lengths.

```
|                  Method |    N |        Comparison | Character |         Mean |      Error |     StdDev | Ratio | RatioSD |   Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |----- |------------------ |---------- |-------------:|-----------:|-----------:|------:|--------:|--------:|------:|------:|----------:|
|    IndexOfFirstMismatch |   10 |           Ordinal |         A |    155.13 ns |   3.061 ns |   2.863 ns |  1.00 |    0.00 |  0.1528 |     - |     - |     480 B |
| IndexOfFirstMismatchNew |   10 |           Ordinal |         A |     25.48 ns |   0.439 ns |   0.367 ns |  0.16 |    0.00 |       - |     - |     - |         - |
|                         |      |                   |           |              |            |            |       |         |         |       |       |           |
|    IndexOfFirstMismatch |   10 |           Ordinal |         a |    153.99 ns |   2.850 ns |   2.527 ns |  1.00 |    0.00 |  0.1528 |     - |     - |     480 B |
| IndexOfFirstMismatchNew |   10 |           Ordinal |         a |     25.12 ns |   0.509 ns |   0.476 ns |  0.16 |    0.01 |       - |     - |     - |         - |
|                         |      |                   |           |              |            |            |       |         |         |       |       |           |
|    IndexOfFirstMismatch |   10 | OrdinalIgnoreCase |         A |    156.03 ns |   2.405 ns |   1.878 ns |  1.00 |    0.00 |  0.1528 |     - |     - |     480 B |
| IndexOfFirstMismatchNew |   10 | OrdinalIgnoreCase |         A |    123.76 ns |   2.462 ns |   2.303 ns |  0.79 |    0.02 |       - |     - |     - |         - |
|                         |      |                   |           |              |            |            |       |         |         |       |       |           |
|    IndexOfFirstMismatch |   10 | OrdinalIgnoreCase |         a |    154.37 ns |   2.778 ns |   2.462 ns |  1.00 |    0.00 |  0.1528 |     - |     - |     480 B |
| IndexOfFirstMismatchNew |   10 | OrdinalIgnoreCase |         a |    122.06 ns |   2.325 ns |   2.284 ns |  0.79 |    0.02 |       - |     - |     - |         - |
|                         |      |                   |           |              |            |            |       |         |         |       |       |           |
|    IndexOfFirstMismatch |  100 |           Ordinal |         A |  1,450.21 ns |  27.053 ns |  25.305 ns |  1.00 |    0.00 |  1.5297 |     - |     - |    4800 B |
| IndexOfFirstMismatchNew |  100 |           Ordinal |         A |    220.87 ns |   4.387 ns |   4.103 ns |  0.15 |    0.00 |       - |     - |     - |         - |
|                         |      |                   |           |              |            |            |       |         |         |       |       |           |
|    IndexOfFirstMismatch |  100 |           Ordinal |         a |  1,494.67 ns |  25.202 ns |  22.341 ns |  1.00 |    0.00 |  1.5297 |     - |     - |    4800 B |
| IndexOfFirstMismatchNew |  100 |           Ordinal |         a |    221.16 ns |   4.237 ns |   3.963 ns |  0.15 |    0.00 |       - |     - |     - |         - |
|                         |      |                   |           |              |            |            |       |         |         |       |       |           |
|    IndexOfFirstMismatch |  100 | OrdinalIgnoreCase |         A |  1,451.73 ns |  23.029 ns |  21.541 ns |  1.00 |    0.00 |  1.5297 |     - |     - |    4800 B |
| IndexOfFirstMismatchNew |  100 | OrdinalIgnoreCase |         A |  1,200.20 ns |  22.824 ns |  19.059 ns |  0.83 |    0.02 |       - |     - |     - |         - |
|                         |      |                   |           |              |            |            |       |         |         |       |       |           |
|    IndexOfFirstMismatch |  100 | OrdinalIgnoreCase |         a |  1,471.89 ns |  28.826 ns |  25.554 ns |  1.00 |    0.00 |  1.5297 |     - |     - |    4800 B |
| IndexOfFirstMismatchNew |  100 | OrdinalIgnoreCase |         a |  1,251.52 ns |  22.909 ns |  21.429 ns |  0.85 |    0.02 |       - |     - |     - |         - |
|                         |      |                   |           |              |            |            |       |         |         |       |       |           |
|    IndexOfFirstMismatch | 1000 |           Ordinal |         A | 14,763.79 ns | 211.786 ns | 198.105 ns |  1.00 |    0.00 | 15.2893 |     - |     - |   48000 B |
| IndexOfFirstMismatchNew | 1000 |           Ordinal |         A |  2,107.93 ns |  41.638 ns |  40.894 ns |  0.14 |    0.00 |       - |     - |     - |         - |
|                         |      |                   |           |              |            |            |       |         |         |       |       |           |
|    IndexOfFirstMismatch | 1000 |           Ordinal |         a | 14,915.25 ns | 259.354 ns | 229.910 ns |  1.00 |    0.00 | 15.2893 |     - |     - |   48000 B |
| IndexOfFirstMismatchNew | 1000 |           Ordinal |         a |  2,128.56 ns |  36.094 ns |  33.762 ns |  0.14 |    0.00 |       - |     - |     - |         - |
|                         |      |                   |           |              |            |            |       |         |         |       |       |           |
|    IndexOfFirstMismatch | 1000 | OrdinalIgnoreCase |         A | 14,392.58 ns | 248.211 ns | 232.176 ns |  1.00 |    0.00 | 15.2893 |     - |     - |   48000 B |
| IndexOfFirstMismatchNew | 1000 | OrdinalIgnoreCase |         A | 11,496.83 ns | 166.617 ns | 155.853 ns |  0.80 |    0.02 |       - |     - |     - |         - |
|                         |      |                   |           |              |            |            |       |         |         |       |       |           |
|    IndexOfFirstMismatch | 1000 | OrdinalIgnoreCase |         a | 14,470.07 ns | 195.623 ns | 240.242 ns |  1.00 |    0.00 | 15.2893 |     - |     - |   48000 B |
| IndexOfFirstMismatchNew | 1000 | OrdinalIgnoreCase |         a | 12,458.73 ns | 207.025 ns | 193.652 ns |  0.86 |    0.03 |       - |     - |     - |         - |
```

The savings in memory allocations corresponds *exactly* to not heap
allocating the two `char`s per iteration.
`1000 chars x 2 x 24 B = 48000 B`.

`str.Should().BeEquivalentTo()` will be allocation free and 16-25%
faster.
`str.Should().Be()` will be allocation free as well and 6-7x faster.