### PR TITLE
date time range assertions - asserting difference is not negative

### DIFF
--- a/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
@@ -74,14 +74,21 @@ namespace FluentAssertions.Primitives
             {
                 TimeSpan actual = target - subject.Value;
 
-                if (!predicate.IsMatchedBy(actual, timeSpan))
-                {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith(
-                            "Expected {context:the date and time} to be " + predicate.DisplayText +
-                            " {1} before {2}{reason}, but {0} differs {3}.", subject, timeSpan, target, actual);
-                }
+                Execute.Assertion
+                    .ForCondition(actual >= TimeSpan.Zero)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected {context:the date and time} {0} to be " + predicate.DisplayText +
+                        " {1} before {2}{reason}, but it is after by {3}.",
+                        subject, timeSpan, target, actual.Duration());
+
+                Execute.Assertion
+                    .ForCondition(predicate.IsMatchedBy(actual, timeSpan))
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected {context:the date and time} to be " + predicate.DisplayText +
+                        " {1} before {2}{reason}, but {0} differs {3}.", subject, timeSpan, target, actual);
+
             }
 
             return new AndConstraint<TAssertions>(parentAssertions);
@@ -112,15 +119,22 @@ namespace FluentAssertions.Primitives
             {
                 TimeSpan actual = subject.Value - target;
 
-                if (!predicate.IsMatchedBy(actual, timeSpan))
-                {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith(
-                            "Expected {context:the date and time} to be " + predicate.DisplayText +
-                            " {0} after {1}{reason}, but {2} differs {3}.",
-                            timeSpan, target, subject, actual);
-                }
+                Execute.Assertion
+                    .ForCondition(actual >= TimeSpan.Zero)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected {context:the date and time} {0} to be " + predicate.DisplayText +
+                        " {1} after {2}{reason}, but it is before by {3}.",
+                        subject, timeSpan, target, actual.Duration());
+
+                Execute.Assertion
+                    .ForCondition(predicate.IsMatchedBy(actual, timeSpan))
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected {context:the date and time} to be " + predicate.DisplayText +
+                        " {0} after {1}{reason}, but {2} differs {3}.",
+                        timeSpan, target, subject, actual);
+                
             }
 
             return new AndConstraint<TAssertions>(parentAssertions);

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetRangeAssertions.cs
@@ -75,20 +75,12 @@ namespace FluentAssertions.Primitives
                 TimeSpan actual = target - subject.Value;
 
                 Execute.Assertion
-                    .ForCondition(actual >= TimeSpan.Zero)
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith(
-                        "Expected {context:the date and time} {0} to be " + predicate.DisplayText +
-                        " {1} before {2}{reason}, but it is after by {3}.",
-                        subject, timeSpan, target, actual.Duration());
-
-                Execute.Assertion
                     .ForCondition(predicate.IsMatchedBy(actual, timeSpan))
                     .BecauseOf(because, becauseArgs)
                     .FailWith(
-                        "Expected {context:the date and time} to be " + predicate.DisplayText +
-                        " {1} before {2}{reason}, but {0} differs {3}.", subject, timeSpan, target, actual);
-
+                        "Expected {context:the date and time} {0} to be " + predicate.DisplayText +
+                        " {1} before {2}{reason}, but it is " + PositionRelativeToTarget(subject.Value, target) + " by {3}.",
+                        subject, timeSpan, target, actual.Duration());
             }
 
             return new AndConstraint<TAssertions>(parentAssertions);
@@ -120,24 +112,20 @@ namespace FluentAssertions.Primitives
                 TimeSpan actual = subject.Value - target;
 
                 Execute.Assertion
-                    .ForCondition(actual >= TimeSpan.Zero)
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith(
-                        "Expected {context:the date and time} {0} to be " + predicate.DisplayText +
-                        " {1} after {2}{reason}, but it is before by {3}.",
-                        subject, timeSpan, target, actual.Duration());
-
-                Execute.Assertion
                     .ForCondition(predicate.IsMatchedBy(actual, timeSpan))
                     .BecauseOf(because, becauseArgs)
                     .FailWith(
-                        "Expected {context:the date and time} to be " + predicate.DisplayText +
-                        " {0} after {1}{reason}, but {2} differs {3}.",
-                        timeSpan, target, subject, actual);
-                
+                        "Expected {context:the date and time} {0} to be " + predicate.DisplayText +
+                        " {1} after {2}{reason}, but it is " + PositionRelativeToTarget(subject.Value, target) + " by {3}.",
+                        subject, timeSpan, target, actual.Duration());
             }
 
             return new AndConstraint<TAssertions>(parentAssertions);
+        }
+
+        private static string PositionRelativeToTarget(DateTimeOffset actual, DateTimeOffset target)
+        {
+            return actual - target >= TimeSpan.Zero ? "ahead" : "behind";
         }
     }
 }

--- a/Src/FluentAssertions/Primitives/DateTimeRangeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeRangeAssertions.cs
@@ -75,15 +75,22 @@ namespace FluentAssertions.Primitives
             {
                 TimeSpan actual = target - subject.Value;
 
-                if (!predicate.IsMatchedBy(actual, timeSpan))
-                {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith(
-                            "Expected date and/or time {0} to be " + predicate.DisplayText +
-                            " {1} before {2}{reason}, but it differs {3}.",
-                            subject, timeSpan, target, actual);
-                }
+                Execute.Assertion
+                    .ForCondition(actual >= TimeSpan.Zero)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected {context:the date and time} {0} to be " + predicate.DisplayText +
+                        " {1} before {2}{reason}, but it is after by {3}.",
+                        subject, timeSpan, target, actual.Duration());
+
+                Execute.Assertion
+                    .ForCondition(predicate.IsMatchedBy(actual, timeSpan))
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected date and/or time {0} to be " + predicate.DisplayText +
+                        " {1} before {2}{reason}, but it differs {3}.",
+                        subject, timeSpan, target, actual);
+                
             }
 
             return new AndConstraint<TAssertions>(parentAssertions);
@@ -116,15 +123,21 @@ namespace FluentAssertions.Primitives
             {
                 TimeSpan actual = subject.Value - target;
 
-                if (!predicate.IsMatchedBy(actual, timeSpan))
-                {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith(
-                            "Expected date and/or time {0} to be " + predicate.DisplayText +
-                            " {1} after {2}{reason}, but it differs {3}.",
-                            subject, timeSpan, target, actual);
-                }
+                Execute.Assertion
+                    .ForCondition(actual >= TimeSpan.Zero)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected {context:the date and time} {0} to be " + predicate.DisplayText +
+                        " {1} after {2}{reason}, but it is before by {3}.",
+                        subject, timeSpan, target, actual.Duration());
+
+                Execute.Assertion
+                    .ForCondition(predicate.IsMatchedBy(actual, timeSpan))
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected date and/or time {0} to be " + predicate.DisplayText +
+                        " {1} after {2}{reason}, but it differs {3}.",
+                        subject, timeSpan, target, actual);
             }
 
             return new AndConstraint<TAssertions>(parentAssertions);

--- a/Src/FluentAssertions/Primitives/DateTimeRangeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeRangeAssertions.cs
@@ -126,7 +126,7 @@ namespace FluentAssertions.Primitives
             return new AndConstraint<TAssertions>(parentAssertions);
         }
 
-        private static string PositionRelativeToTarget(DateTimeOffset actual, DateTimeOffset target)
+        private static string PositionRelativeToTarget(DateTime actual, DateTime target)
         {
             return actual - target >= TimeSpan.Zero ? "ahead" : "behind";
         }

--- a/Src/FluentAssertions/Primitives/DateTimeRangeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeRangeAssertions.cs
@@ -76,21 +76,12 @@ namespace FluentAssertions.Primitives
                 TimeSpan actual = target - subject.Value;
 
                 Execute.Assertion
-                    .ForCondition(actual >= TimeSpan.Zero)
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith(
-                        "Expected {context:the date and time} {0} to be " + predicate.DisplayText +
-                        " {1} before {2}{reason}, but it is after by {3}.",
-                        subject, timeSpan, target, actual.Duration());
-
-                Execute.Assertion
                     .ForCondition(predicate.IsMatchedBy(actual, timeSpan))
                     .BecauseOf(because, becauseArgs)
                     .FailWith(
-                        "Expected date and/or time {0} to be " + predicate.DisplayText +
-                        " {1} before {2}{reason}, but it differs {3}.",
-                        subject, timeSpan, target, actual);
-                
+                        "Expected {context:the date and time} {0} to be " + predicate.DisplayText +
+                        " {1} before {2}{reason}, but it is " + PositionRelativeToTarget(subject.Value, target) + " by {3}.",
+                        subject, timeSpan, target, actual.Duration());
             }
 
             return new AndConstraint<TAssertions>(parentAssertions);
@@ -124,23 +115,20 @@ namespace FluentAssertions.Primitives
                 TimeSpan actual = subject.Value - target;
 
                 Execute.Assertion
-                    .ForCondition(actual >= TimeSpan.Zero)
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith(
-                        "Expected {context:the date and time} {0} to be " + predicate.DisplayText +
-                        " {1} after {2}{reason}, but it is before by {3}.",
-                        subject, timeSpan, target, actual.Duration());
-
-                Execute.Assertion
                     .ForCondition(predicate.IsMatchedBy(actual, timeSpan))
                     .BecauseOf(because, becauseArgs)
                     .FailWith(
-                        "Expected date and/or time {0} to be " + predicate.DisplayText +
-                        " {1} after {2}{reason}, but it differs {3}.",
-                        subject, timeSpan, target, actual);
+                        "Expected {context:the date and time} {0} to be " + predicate.DisplayText +
+                        " {1} after {2}{reason}, but it is " + PositionRelativeToTarget(subject.Value, target) + " by {3}.",
+                        subject, timeSpan, target, actual.Duration());
             }
 
             return new AndConstraint<TAssertions>(parentAssertions);
+        }
+
+        private static string PositionRelativeToTarget(DateTimeOffset actual, DateTimeOffset target)
+        {
+            return actual - target >= TimeSpan.Zero ? "ahead" : "behind";
         }
     }
 }

--- a/Src/FluentAssertions/Primitives/TimeSpanPredicate.cs
+++ b/Src/FluentAssertions/Primitives/TimeSpanPredicate.cs
@@ -20,7 +20,7 @@ namespace FluentAssertions.Primitives
 
         public bool IsMatchedBy(TimeSpan actual, TimeSpan expected)
         {
-            return lambda(actual, expected);
+            return lambda(actual, expected) && actual >= TimeSpan.Zero;
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
@@ -1902,6 +1902,144 @@ namespace FluentAssertions.Specs
             subject.Should().BeLessThan(TimeSpan.FromSeconds(30)).After(target);
         }
 
+        [Fact]
+        public void When_asserting_subject_be_morethan_10_seconds_after_target_but_subject_is_before_target_should_throw()
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, 30);
+            var subject = 1.January(0001).At(0, 0, 15);
+
+            // Act / Assert
+            Action action = () => subject.Should().BeMoreThan(10.Seconds()).After(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected subject <00:00:15> to be more than 10s after <00:00:30>, but it is before by 15s.");
+        }
+
+        [Theory]
+        [InlineData(30, 20)] // edge case
+        [InlineData(30, 15)]
+        public void When_asserting_subject_be_atleast_10_seconds_after_target_but_subject_is_before_target_should_throw(int targetSeconds, int subjectSeconds)
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, targetSeconds);
+            var subject = 1.January(0001).At(0, 0, subjectSeconds);
+
+            // Act / Assert
+            Action action = () => subject.Should().BeAtLeast(10.Seconds()).After(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s after <00:00:30>, but it is before by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+        }
+
+        [Fact]
+        public void When_asserting_subject_be_exactly_10_seconds_after_target_but_subject_is_before_target_should_throw()
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, 30);
+            var subject = 1.January(0001).At(0, 0, 20);
+
+            // Act / Assert
+            Action action = () => subject.Should().BeExactly(10.Seconds()).After(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected subject <00:00:20> to be exactly 10s after <00:00:30>, but it is before by 10s.");
+        }
+
+        [Theory]
+        [InlineData(30, 20)] // edge case
+        [InlineData(30, 25)]
+        public void When_asserting_subject_be_within_10_seconds_after_target_but_subject_is_before_target_should_throw(int targetSeconds, int subjectSeconds)
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, targetSeconds);
+            var subject = 1.January(0001).At(0, 0, subjectSeconds);
+
+            // Act / Assert
+            Action action = () => subject.Should().BeWithin(10.Seconds()).After(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s after <00:00:30>, but it is before by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+        }
+
+        [Fact]
+        public void When_asserting_subject_be_lessthan_10_seconds_after_target_but_subject_is_before_target_should_throw()
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, 30);
+            var subject = 1.January(0001).At(0, 0, 25);
+
+            // Act / Assert
+            Action action = () => subject.Should().BeLessThan(10.Seconds()).After(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected subject <00:00:25> to be less than 10s after <00:00:30>, but it is before by 5s.");
+        }
+
+        [Fact]
+        public void When_asserting_subject_be_morethan_10_seconds_before_target_but_subject_is_after_target_should_throw()
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, 30);
+            var subject = 1.January(0001).At(0, 0, 45);
+
+            // Act / Assert
+            Action action = () => subject.Should().BeMoreThan(10.Seconds()).Before(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected subject <00:00:45> to be more than 10s before <00:00:30>, but it is after by 15s.");
+        }
+
+        [Theory]
+        [InlineData(30, 40)] // edge case
+        [InlineData(30, 45)]
+        public void When_asserting_subject_be_atleast_10_seconds_before_target_but_subject_is_after_target_should_throw(int targetSeconds, int subjectSeconds)
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, targetSeconds);
+            var subject = 1.January(0001).At(0, 0, subjectSeconds);
+
+            // Act / Assert
+            Action action = () => subject.Should().BeAtLeast(10.Seconds()).Before(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s before <00:00:30>, but it is after by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+        }
+
+        [Fact]
+        public void When_asserting_subject_be_exactly_10_seconds_before_target_but_subject_is_after_target_should_throw()
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, 30);
+            var subject = 1.January(0001).At(0, 0, 40);
+
+            // Act / Assert
+            Action action = () => subject.Should().BeExactly(10.Seconds()).Before(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected subject <00:00:40> to be exactly 10s before <00:00:30>, but it is after by 10s.");
+        }
+
+        [Theory]
+        [InlineData(30, 40)] // edge case
+        [InlineData(30, 35)]
+        public void When_asserting_subject_be_within_10_seconds_before_target_but_subject_is_after_target_should_throw(int targetSeconds, int subjectSeconds)
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, targetSeconds);
+            var subject = 1.January(0001).At(0, 0, subjectSeconds);
+
+            // Act / Assert
+            Action action = () => subject.Should().BeWithin(10.Seconds()).Before(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s before <00:00:30>, but it is after by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+        }
+
+        [Fact]
+        public void When_asserting_subject_be_lessthan_10_seconds_before_target_but_subject_is_after_target_should_throw()
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, 30);
+            var subject = 1.January(0001).At(0, 0, 45);
+
+            // Act / Assert
+            Action action = () => subject.Should().BeLessThan(10.Seconds()).Before(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected subject <00:00:45> to be less than 10s before <00:00:30>, but it is after by 15s.");
+        }
+
         #endregion
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
@@ -1903,14 +1903,16 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_asserting_subject_be_morethan_10_seconds_after_target_but_subject_is_before_target_should_throw()
+        public void When_asserting_subject_be_more_than_10_seconds_after_target_but_subject_is_before_target_it_should_throw()
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, 30);
+            var expectation = 1.January(0001).At(0, 0, 30);
             var subject = 1.January(0001).At(0, 0, 15);
 
-            // Act / Assert
-            Action action = () => subject.Should().BeMoreThan(10.Seconds()).After(target);
+            // Act
+            Action action = () => subject.Should().BeMoreThan(10.Seconds()).After(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected subject <00:00:15> to be more than 10s after <00:00:30>, but it is behind by 15s.");
         }
@@ -1918,27 +1920,31 @@ namespace FluentAssertions.Specs
         [Theory]
         [InlineData(30, 20)] // edge case
         [InlineData(30, 15)]
-        public void When_asserting_subject_be_atleast_10_seconds_after_target_but_subject_is_before_target_should_throw(int targetSeconds, int subjectSeconds)
+        public void When_asserting_subject_be_at_least_10_seconds_after_target_but_subject_is_before_target_it_should_throw(int targetSeconds, int subjectSeconds)
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, targetSeconds);
+            var expectation = 1.January(0001).At(0, 0, targetSeconds);
             var subject = 1.January(0001).At(0, 0, subjectSeconds);
 
-            // Act / Assert
-            Action action = () => subject.Should().BeAtLeast(10.Seconds()).After(target);
+            // Act
+            Action action = () => subject.Should().BeAtLeast(10.Seconds()).After(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s after <00:00:30>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
-        public void When_asserting_subject_be_exactly_10_seconds_after_target_but_subject_is_before_target_should_throw()
+        public void When_asserting_subject_be_exactly_10_seconds_after_target_but_subject_is_before_target_it_should_throw()
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, 30);
+            var expectation = 1.January(0001).At(0, 0, 30);
             var subject = 1.January(0001).At(0, 0, 20);
 
-            // Act / Assert
-            Action action = () => subject.Should().BeExactly(10.Seconds()).After(target);
+            // Ac
+            Action action = () => subject.Should().BeExactly(10.Seconds()).After(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected subject <00:00:20> to be exactly 10s after <00:00:30>, but it is behind by 10s.");
         }
@@ -1946,40 +1952,46 @@ namespace FluentAssertions.Specs
         [Theory]
         [InlineData(30, 20)] // edge case
         [InlineData(30, 25)]
-        public void When_asserting_subject_be_within_10_seconds_after_target_but_subject_is_before_target_should_throw(int targetSeconds, int subjectSeconds)
+        public void When_asserting_subject_be_within_10_seconds_after_target_but_subject_is_before_target_it_should_throw(int targetSeconds, int subjectSeconds)
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, targetSeconds);
+            var expectation = 1.January(0001).At(0, 0, targetSeconds);
             var subject = 1.January(0001).At(0, 0, subjectSeconds);
 
-            // Act / Assert
-            Action action = () => subject.Should().BeWithin(10.Seconds()).After(target);
+            // Act
+            Action action = () => subject.Should().BeWithin(10.Seconds()).After(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s after <00:00:30>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
-        public void When_asserting_subject_be_lessthan_10_seconds_after_target_but_subject_is_before_target_should_throw()
+        public void When_asserting_subject_be_less_than_10_seconds_after_target_but_subject_is_before_target_it_should_throw()
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, 30);
+            var expectation = 1.January(0001).At(0, 0, 30);
             var subject = 1.January(0001).At(0, 0, 25);
 
-            // Act / Assert
-            Action action = () => subject.Should().BeLessThan(10.Seconds()).After(target);
+            // Act
+            Action action = () => subject.Should().BeLessThan(10.Seconds()).After(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected subject <00:00:25> to be less than 10s after <00:00:30>, but it is behind by 5s.");
         }
 
         [Fact]
-        public void When_asserting_subject_be_morethan_10_seconds_before_target_but_subject_is_after_target_should_throw()
+        public void When_asserting_subject_be_more_than_10_seconds_before_target_but_subject_is_after_target_it_should_throw()
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, 30);
+            var expectation = 1.January(0001).At(0, 0, 30);
             var subject = 1.January(0001).At(0, 0, 45);
 
-            // Act / Assert
-            Action action = () => subject.Should().BeMoreThan(10.Seconds()).Before(target);
+            // Act
+            Action action = () => subject.Should().BeMoreThan(10.Seconds()).Before(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected subject <00:00:45> to be more than 10s before <00:00:30>, but it is ahead by 15s.");
         }
@@ -1987,27 +1999,31 @@ namespace FluentAssertions.Specs
         [Theory]
         [InlineData(30, 40)] // edge case
         [InlineData(30, 45)]
-        public void When_asserting_subject_be_atleast_10_seconds_before_target_but_subject_is_after_target_should_throw(int targetSeconds, int subjectSeconds)
+        public void When_asserting_subject_be_at_least_10_seconds_before_target_but_subject_is_after_target_it_should_throw(int targetSeconds, int subjectSeconds)
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, targetSeconds);
+            var expectation = 1.January(0001).At(0, 0, targetSeconds);
             var subject = 1.January(0001).At(0, 0, subjectSeconds);
 
-            // Act / Assert
-            Action action = () => subject.Should().BeAtLeast(10.Seconds()).Before(target);
+            // Act
+            Action action = () => subject.Should().BeAtLeast(10.Seconds()).Before(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s before <00:00:30>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
-        public void When_asserting_subject_be_exactly_10_seconds_before_target_but_subject_is_after_target_should_throw()
+        public void When_asserting_subject_be_exactly_10_seconds_before_target_but_subject_is_after_target_it_should_throw()
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, 30);
+            var expectation = 1.January(0001).At(0, 0, 30);
             var subject = 1.January(0001).At(0, 0, 40);
 
-            // Act / Assert
-            Action action = () => subject.Should().BeExactly(10.Seconds()).Before(target);
+            // Act
+            Action action = () => subject.Should().BeExactly(10.Seconds()).Before(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected subject <00:00:40> to be exactly 10s before <00:00:30>, but it is ahead by 10s.");
         }
@@ -2015,27 +2031,31 @@ namespace FluentAssertions.Specs
         [Theory]
         [InlineData(30, 40)] // edge case
         [InlineData(30, 35)]
-        public void When_asserting_subject_be_within_10_seconds_before_target_but_subject_is_after_target_should_throw(int targetSeconds, int subjectSeconds)
+        public void When_asserting_subject_be_within_10_seconds_before_target_but_subject_is_after_target_it_should_throw(int targetSeconds, int subjectSeconds)
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, targetSeconds);
+            var expectation = 1.January(0001).At(0, 0, targetSeconds);
             var subject = 1.January(0001).At(0, 0, subjectSeconds);
 
-            // Act / Assert
-            Action action = () => subject.Should().BeWithin(10.Seconds()).Before(target);
+            // Act
+            Action action = () => subject.Should().BeWithin(10.Seconds()).Before(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s before <00:00:30>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
-        public void When_asserting_subject_be_lessthan_10_seconds_before_target_but_subject_is_after_target_should_throw()
+        public void When_asserting_subject_be_less_than_10_seconds_before_target_but_subject_is_after_target_it_should_throw()
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, 30);
+            var expectation = 1.January(0001).At(0, 0, 30);
             var subject = 1.January(0001).At(0, 0, 45);
 
-            // Act / Assert
-            Action action = () => subject.Should().BeLessThan(10.Seconds()).Before(target);
+            // Act
+            Action action = () => subject.Should().BeLessThan(10.Seconds()).Before(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected subject <00:00:45> to be less than 10s before <00:00:30>, but it is ahead by 15s.");
         }

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
@@ -1750,7 +1750,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected date and/or time <2009-10-01> to be more than 1d before <2009-10-02> because we like that, but it differs 1d.");
+                "Expected subject <2009-10-01> to be more than 1d before <2009-10-02> because we like that, but it is behind by 1d.");
         }
 
         [Fact]
@@ -1776,7 +1776,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected date and/or time <2009-10-01 01:00:00> to be at least 1d before <2009-10-02> because we like that, but it differs 23h.");
+                "Expected subject <2009-10-01 01:00:00> to be at least 1d before <2009-10-02> because we like that, but it is behind by 23h.");
         }
 
         [Fact]
@@ -1803,7 +1803,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected date and/or time <12:36:00> to be exactly 20m before <12:55:00> because 20 minutes is enough, but it differs 19m.");
+                "Expected subject <12:36:00> to be exactly 20m before <12:55:00> because 20 minutes is enough, but it is behind by 19m.");
         }
 
         [Fact]
@@ -1830,7 +1830,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected date and/or time <2010-04-08 09:59:59> to be within 2d and 2h before <2010-04-10 12:00:00> because 50 hours is enough, but it differs 2d, 2h and 1s.");
+                "Expected subject <2010-04-08 09:59:59> to be within 2d and 2h before <2010-04-10 12:00:00> because 50 hours is enough, but it is behind by 2d, 2h and 1s.");
         }
 
         [Fact]
@@ -1888,7 +1888,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected date and/or time <12:01:00> to be less than 30s after <12:00:30> because 30s is the max, but it differs 30s.");
+                "Expected subject <12:01:00> to be less than 30s after <12:00:30> because 30s is the max, but it is ahead by 30s.");
         }
 
         [Fact]
@@ -1912,7 +1912,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeMoreThan(10.Seconds()).After(target);
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:15> to be more than 10s after <00:00:30>, but it is before by 15s.");
+                .WithMessage("Expected subject <00:00:15> to be more than 10s after <00:00:30>, but it is behind by 15s.");
         }
 
         [Theory]
@@ -1927,7 +1927,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeAtLeast(10.Seconds()).After(target);
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s after <00:00:30>, but it is before by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s after <00:00:30>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -1940,7 +1940,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeExactly(10.Seconds()).After(target);
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:20> to be exactly 10s after <00:00:30>, but it is before by 10s.");
+                .WithMessage("Expected subject <00:00:20> to be exactly 10s after <00:00:30>, but it is behind by 10s.");
         }
 
         [Theory]
@@ -1955,7 +1955,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeWithin(10.Seconds()).After(target);
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s after <00:00:30>, but it is before by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s after <00:00:30>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -1968,7 +1968,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeLessThan(10.Seconds()).After(target);
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:25> to be less than 10s after <00:00:30>, but it is before by 5s.");
+                .WithMessage("Expected subject <00:00:25> to be less than 10s after <00:00:30>, but it is behind by 5s.");
         }
 
         [Fact]
@@ -1981,7 +1981,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeMoreThan(10.Seconds()).Before(target);
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:45> to be more than 10s before <00:00:30>, but it is after by 15s.");
+                .WithMessage("Expected subject <00:00:45> to be more than 10s before <00:00:30>, but it is ahead by 15s.");
         }
 
         [Theory]
@@ -1996,7 +1996,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeAtLeast(10.Seconds()).Before(target);
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s before <00:00:30>, but it is after by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s before <00:00:30>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -2009,7 +2009,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeExactly(10.Seconds()).Before(target);
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:40> to be exactly 10s before <00:00:30>, but it is after by 10s.");
+                .WithMessage("Expected subject <00:00:40> to be exactly 10s before <00:00:30>, but it is ahead by 10s.");
         }
 
         [Theory]
@@ -2024,7 +2024,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeWithin(10.Seconds()).Before(target);
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s before <00:00:30>, but it is after by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s before <00:00:30>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -2037,7 +2037,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeLessThan(10.Seconds()).Before(target);
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:45> to be less than 10s before <00:00:30>, but it is after by 15s.");
+                .WithMessage("Expected subject <00:00:45> to be less than 10s before <00:00:30>, but it is ahead by 15s.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
@@ -1957,14 +1957,16 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_asserting_subject_be_morethan_10_seconds_after_target_but_subject_is_before_target_should_throw()
+        public void When_asserting_subject_be_more_than_10_seconds_after_target_but_subject_is_before_target_it_should_throw()
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
+            var expectation = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
             var subject = 1.January(0001).At(0, 0, 15).WithOffset(0.Hours());
 
-            // Act / Assert
-            Action action = () => subject.Should().BeMoreThan(10.Seconds()).After(target);
+            // Act
+            Action action = () => subject.Should().BeMoreThan(10.Seconds()).After(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected subject <00:00:15> to be more than 10s after <00:00:30>, but it is behind by 15s.");
         }
@@ -1972,27 +1974,31 @@ namespace FluentAssertions.Specs
         [Theory]
         [InlineData(30, 20)] // edge case
         [InlineData(30, 15)]
-        public void When_asserting_subject_be_atleast_10_seconds_after_target_but_subject_is_before_target_should_throw(int targetSeconds, int subjectSeconds)
+        public void When_asserting_subject_be_at_least_10_seconds_after_target_but_subject_is_before_target_it_should_throw(int targetSeconds, int subjectSeconds)
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, targetSeconds).WithOffset(0.Hours());
+            var expectation = 1.January(0001).At(0, 0, targetSeconds).WithOffset(0.Hours());
             var subject = 1.January(0001).At(0, 0, subjectSeconds).WithOffset(0.Hours());
 
-            // Act / Assert
-            Action action = () => subject.Should().BeAtLeast(10.Seconds()).After(target);
+            // Act
+            Action action = () => subject.Should().BeAtLeast(10.Seconds()).After(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s after <00:00:30>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
-        public void When_asserting_subject_be_exactly_10_seconds_after_target_but_subject_is_before_target_should_throw()
+        public void When_asserting_subject_be_exactly_10_seconds_after_target_but_subject_is_before_target_it_should_throw()
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
+            var expectation = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
             var subject = 1.January(0001).At(0, 0, 20).WithOffset(0.Hours());
 
-            // Act / Assert
-            Action action = () => subject.Should().BeExactly(10.Seconds()).After(target);
+            // Act
+            Action action = () => subject.Should().BeExactly(10.Seconds()).After(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected subject <00:00:20> to be exactly 10s after <00:00:30>, but it is behind by 10s.");
         }
@@ -2000,40 +2006,46 @@ namespace FluentAssertions.Specs
         [Theory]
         [InlineData(30, 20)] // edge case
         [InlineData(30, 25)]
-        public void When_asserting_subject_be_within_10_seconds_after_target_but_subject_is_before_target_should_throw(int targetSeconds, int subjectSeconds)
+        public void When_asserting_subject_be_within_10_seconds_after_target_but_subject_is_before_target_it_should_throw(int targetSeconds, int subjectSeconds)
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, targetSeconds).WithOffset(0.Hours());
+            var expectation = 1.January(0001).At(0, 0, targetSeconds).WithOffset(0.Hours());
             var subject = 1.January(0001).At(0, 0, subjectSeconds).WithOffset(0.Hours());
 
-            // Act / Assert
-            Action action = () => subject.Should().BeWithin(10.Seconds()).After(target);
+            // Act
+            Action action = () => subject.Should().BeWithin(10.Seconds()).After(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s after <00:00:30>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
-        public void When_asserting_subject_be_lessthan_10_seconds_after_target_but_subject_is_before_target_should_throw()
+        public void When_asserting_subject_be_less_than_10_seconds_after_target_but_subject_is_before_target_it_should_throw()
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
+            var expectation = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
             var subject = 1.January(0001).At(0, 0, 25).WithOffset(0.Hours());
 
-            // Act / Assert
-            Action action = () => subject.Should().BeLessThan(10.Seconds()).After(target);
+            // Act
+            Action action = () => subject.Should().BeLessThan(10.Seconds()).After(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected subject <00:00:25> to be less than 10s after <00:00:30>, but it is behind by 5s.");
         }
 
         [Fact]
-        public void When_asserting_subject_be_morethan_10_seconds_before_target_but_subject_is_after_target_should_throw()
+        public void When_asserting_subject_be_more_than_10_seconds_before_target_but_subject_is_after_target_it_should_throw()
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
+            var expectation = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
             var subject = 1.January(0001).At(0, 0, 45).WithOffset(0.Hours());
 
-            // Act / Assert
-            Action action = () => subject.Should().BeMoreThan(10.Seconds()).Before(target);
+            // Act
+            Action action = () => subject.Should().BeMoreThan(10.Seconds()).Before(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected subject <00:00:45> to be more than 10s before <00:00:30>, but it is ahead by 15s.");
         }
@@ -2041,27 +2053,31 @@ namespace FluentAssertions.Specs
         [Theory]
         [InlineData(30, 40)] // edge case
         [InlineData(30, 45)]
-        public void When_asserting_subject_be_atleast_10_seconds_before_target_but_subject_is_after_target_should_throw(int targetSeconds, int subjectSeconds)
+        public void When_asserting_subject_be_at_least_10_seconds_before_target_but_subject_is_after_target_it_should_throw(int targetSeconds, int subjectSeconds)
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, targetSeconds).WithOffset(0.Hours());
+            var expectation = 1.January(0001).At(0, 0, targetSeconds).WithOffset(0.Hours());
             var subject = 1.January(0001).At(0, 0, subjectSeconds).WithOffset(0.Hours());
 
-            // Act / Assert
-            Action action = () => subject.Should().BeAtLeast(10.Seconds()).Before(target);
+            // Act
+            Action action = () => subject.Should().BeAtLeast(10.Seconds()).Before(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s before <00:00:30>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
-        public void When_asserting_subject_be_exactly_10_seconds_before_target_but_subject_is_after_target_should_throw()
+        public void When_asserting_subject_be_exactly_10_seconds_before_target_but_subject_is_after_target_it_should_throw()
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
+            var expectation = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
             var subject = 1.January(0001).At(0, 0, 40).WithOffset(0.Hours());
 
-            // Act / Assert
-            Action action = () => subject.Should().BeExactly(10.Seconds()).Before(target);
+            // Act
+            Action action = () => subject.Should().BeExactly(10.Seconds()).Before(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected subject <00:00:40> to be exactly 10s before <00:00:30>, but it is ahead by 10s.");
         }
@@ -2069,27 +2085,31 @@ namespace FluentAssertions.Specs
         [Theory]
         [InlineData(30, 40)] // edge case
         [InlineData(30, 35)]
-        public void When_asserting_subject_be_within_10_seconds_before_target_but_subject_is_after_target_should_throw(int targetSeconds, int subjectSeconds)
+        public void When_asserting_subject_be_within_10_seconds_before_target_but_subject_is_after_target_it_should_throw(int targetSeconds, int subjectSeconds)
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, targetSeconds).WithOffset(0.Hours());
+            var expectation = 1.January(0001).At(0, 0, targetSeconds).WithOffset(0.Hours());
             var subject = 1.January(0001).At(0, 0, subjectSeconds).WithOffset(0.Hours());
 
-            // Act / Assert
-            Action action = () => subject.Should().BeWithin(10.Seconds()).Before(target);
+            // Act
+            Action action = () => subject.Should().BeWithin(10.Seconds()).Before(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s before <00:00:30>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
-        public void When_asserting_subject_be_lessthan_10_seconds_before_target_but_subject_is_after_target_should_throw()
+        public void When_asserting_subject_be_less_than_10_seconds_before_target_but_subject_is_after_target_it_should_throw()
         {
             // Arrange
-            var target = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
+            var expectation = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
             var subject = 1.January(0001).At(0, 0, 45).WithOffset(0.Hours());
 
-            // Act / Assert
-            Action action = () => subject.Should().BeLessThan(10.Seconds()).Before(target);
+            // Act
+            Action action = () => subject.Should().BeLessThan(10.Seconds()).Before(expectation);
+
+            // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected subject <00:00:45> to be less than 10s before <00:00:30>, but it is ahead by 15s.");
         }

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
@@ -1956,6 +1956,144 @@ namespace FluentAssertions.Specs
             subject.Should().BeLessThan(TimeSpan.FromSeconds(30)).After(target);
         }
 
+        [Fact]
+        public void When_asserting_subject_be_morethan_10_seconds_after_target_but_subject_is_before_target_should_throw()
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
+            var subject = 1.January(0001).At(0, 0, 15).WithOffset(0.Hours());
+
+            // Act / Assert
+            Action action = () => subject.Should().BeMoreThan(10.Seconds()).After(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected subject <00:00:15> to be more than 10s after <00:00:30>, but it is before by 15s.");
+        }
+
+        [Theory]
+        [InlineData(30, 20)] // edge case
+        [InlineData(30, 15)]
+        public void When_asserting_subject_be_atleast_10_seconds_after_target_but_subject_is_before_target_should_throw(int targetSeconds, int subjectSeconds)
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, targetSeconds).WithOffset(0.Hours());
+            var subject = 1.January(0001).At(0, 0, subjectSeconds).WithOffset(0.Hours());
+
+            // Act / Assert
+            Action action = () => subject.Should().BeAtLeast(10.Seconds()).After(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s after <00:00:30>, but it is before by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+        }
+
+        [Fact]
+        public void When_asserting_subject_be_exactly_10_seconds_after_target_but_subject_is_before_target_should_throw()
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
+            var subject = 1.January(0001).At(0, 0, 20).WithOffset(0.Hours());
+
+            // Act / Assert
+            Action action = () => subject.Should().BeExactly(10.Seconds()).After(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected subject <00:00:20> to be exactly 10s after <00:00:30>, but it is before by 10s.");
+        }
+
+        [Theory]
+        [InlineData(30, 20)] // edge case
+        [InlineData(30, 25)]
+        public void When_asserting_subject_be_within_10_seconds_after_target_but_subject_is_before_target_should_throw(int targetSeconds, int subjectSeconds)
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, targetSeconds).WithOffset(0.Hours());
+            var subject = 1.January(0001).At(0, 0, subjectSeconds).WithOffset(0.Hours());
+
+            // Act / Assert
+            Action action = () => subject.Should().BeWithin(10.Seconds()).After(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s after <00:00:30>, but it is before by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+        }
+
+        [Fact]
+        public void When_asserting_subject_be_lessthan_10_seconds_after_target_but_subject_is_before_target_should_throw()
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
+            var subject = 1.January(0001).At(0, 0, 25).WithOffset(0.Hours());
+
+            // Act / Assert
+            Action action = () => subject.Should().BeLessThan(10.Seconds()).After(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected subject <00:00:25> to be less than 10s after <00:00:30>, but it is before by 5s.");
+        }
+
+        [Fact]
+        public void When_asserting_subject_be_morethan_10_seconds_before_target_but_subject_is_after_target_should_throw()
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
+            var subject = 1.January(0001).At(0, 0, 45).WithOffset(0.Hours());
+
+            // Act / Assert
+            Action action = () => subject.Should().BeMoreThan(10.Seconds()).Before(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected subject <00:00:45> to be more than 10s before <00:00:30>, but it is after by 15s.");
+        }
+
+        [Theory]
+        [InlineData(30, 40)] // edge case
+        [InlineData(30, 45)]
+        public void When_asserting_subject_be_atleast_10_seconds_before_target_but_subject_is_after_target_should_throw(int targetSeconds, int subjectSeconds)
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, targetSeconds).WithOffset(0.Hours());
+            var subject = 1.January(0001).At(0, 0, subjectSeconds).WithOffset(0.Hours());
+
+            // Act / Assert
+            Action action = () => subject.Should().BeAtLeast(10.Seconds()).Before(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s before <00:00:30>, but it is after by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+        }
+
+        [Fact]
+        public void When_asserting_subject_be_exactly_10_seconds_before_target_but_subject_is_after_target_should_throw()
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
+            var subject = 1.January(0001).At(0, 0, 40).WithOffset(0.Hours());
+
+            // Act / Assert
+            Action action = () => subject.Should().BeExactly(10.Seconds()).Before(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected subject <00:00:40> to be exactly 10s before <00:00:30>, but it is after by 10s.");
+        }
+
+        [Theory]
+        [InlineData(30, 40)] // edge case
+        [InlineData(30, 35)]
+        public void When_asserting_subject_be_within_10_seconds_before_target_but_subject_is_after_target_should_throw(int targetSeconds, int subjectSeconds)
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, targetSeconds).WithOffset(0.Hours());
+            var subject = 1.January(0001).At(0, 0, subjectSeconds).WithOffset(0.Hours());
+
+            // Act / Assert
+            Action action = () => subject.Should().BeWithin(10.Seconds()).Before(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s before <00:00:30>, but it is after by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+        }
+
+        [Fact]
+        public void When_asserting_subject_be_lessthan_10_seconds_before_target_but_subject_is_after_target_should_throw()
+        {
+            // Arrange
+            var target = 1.January(0001).At(0, 0, 30).WithOffset(0.Hours());
+            var subject = 1.January(0001).At(0, 0, 45).WithOffset(0.Hours());
+
+            // Act / Assert
+            Action action = () => subject.Should().BeLessThan(10.Seconds()).Before(target);
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected subject <00:00:45> to be less than 10s before <00:00:30>, but it is after by 15s.");
+        }
+
         #endregion
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
@@ -1804,7 +1804,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject to be more than 1d before <2009-10-02> because we like that, but <2009-10-01> differs 1d.");
+                "Expected subject <2009-10-01> to be more than 1d before <2009-10-02> because we like that, but it is behind by 1d.");
         }
 
         [Fact]
@@ -1830,7 +1830,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject to be at least 1d before <2009-10-02> because we like that, but <2009-10-01 01:00:00> differs 23h.");
+                "Expected subject <2009-10-01 01:00:00> to be at least 1d before <2009-10-02> because we like that, but it is behind by 23h.");
         }
 
         [Fact]
@@ -1857,7 +1857,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject to be exactly 20m before <12:55:00> because 20 minutes is enough, but <12:36:00> differs 19m.");
+                "Expected subject <12:36:00> to be exactly 20m before <12:55:00> because 20 minutes is enough, but it is behind by 19m.");
         }
 
         [Fact]
@@ -1884,7 +1884,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject to be within 2d and 2h before <2010-04-10 12:00:00> because 50 hours is enough, but <2010-04-08 09:59:59> differs 2d, 2h and 1s.");
+                "Expected subject <2010-04-08 09:59:59> to be within 2d and 2h before <2010-04-10 12:00:00> because 50 hours is enough, but it is behind by 2d, 2h and 1s.");
         }
 
         [Fact]
@@ -1942,7 +1942,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject to be less than 30s after <12:00:30 +1h> because 30s is the max, but <12:01:00 +1h> differs 30s.");
+                "Expected subject <12:01:00 +1h> to be less than 30s after <12:00:30 +1h> because 30s is the max, but it is ahead by 30s.");
         }
 
         [Fact]
@@ -1966,7 +1966,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeMoreThan(10.Seconds()).After(target);
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:15> to be more than 10s after <00:00:30>, but it is before by 15s.");
+                .WithMessage("Expected subject <00:00:15> to be more than 10s after <00:00:30>, but it is behind by 15s.");
         }
 
         [Theory]
@@ -1981,7 +1981,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeAtLeast(10.Seconds()).After(target);
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s after <00:00:30>, but it is before by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s after <00:00:30>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -1994,7 +1994,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeExactly(10.Seconds()).After(target);
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:20> to be exactly 10s after <00:00:30>, but it is before by 10s.");
+                .WithMessage("Expected subject <00:00:20> to be exactly 10s after <00:00:30>, but it is behind by 10s.");
         }
 
         [Theory]
@@ -2009,7 +2009,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeWithin(10.Seconds()).After(target);
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s after <00:00:30>, but it is before by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s after <00:00:30>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -2022,7 +2022,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeLessThan(10.Seconds()).After(target);
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:25> to be less than 10s after <00:00:30>, but it is before by 5s.");
+                .WithMessage("Expected subject <00:00:25> to be less than 10s after <00:00:30>, but it is behind by 5s.");
         }
 
         [Fact]
@@ -2035,7 +2035,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeMoreThan(10.Seconds()).Before(target);
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:45> to be more than 10s before <00:00:30>, but it is after by 15s.");
+                .WithMessage("Expected subject <00:00:45> to be more than 10s before <00:00:30>, but it is ahead by 15s.");
         }
 
         [Theory]
@@ -2050,7 +2050,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeAtLeast(10.Seconds()).Before(target);
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s before <00:00:30>, but it is after by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s before <00:00:30>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -2063,7 +2063,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeExactly(10.Seconds()).Before(target);
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:40> to be exactly 10s before <00:00:30>, but it is after by 10s.");
+                .WithMessage("Expected subject <00:00:40> to be exactly 10s before <00:00:30>, but it is ahead by 10s.");
         }
 
         [Theory]
@@ -2078,7 +2078,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeWithin(10.Seconds()).Before(target);
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s before <00:00:30>, but it is after by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s before <00:00:30>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -2091,7 +2091,7 @@ namespace FluentAssertions.Specs
             // Act / Assert
             Action action = () => subject.Should().BeLessThan(10.Seconds()).Before(target);
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:45> to be less than 10s before <00:00:30>, but it is after by 15s.");
+                .WithMessage("Expected subject <00:00:45> to be less than 10s before <00:00:30>, but it is ahead by 15s.");
         }
 
         #endregion

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -25,6 +25,7 @@ sidebar:
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).
 * Changed dictionary assertion `NotContainKeys` to honour the key comparer if applicable - [#1233](https://github.com/fluentassertions/fluentassertions/pull/1233).
+* Ensures that date time assertions like "a is less than an hour after b" don't succeed when `a - b == -30.Minutes()` [#1313](https://github.com/fluentassertions/fluentassertions/pull/1313).
 
 **Breaking Changes**
 * Dropped support for .NET Framework 4.5, .NET Standard 1.3 and 1.6 - [#1227](https://github.com/fluentassertions/fluentassertions/pull/1227).


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/master/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com).

Fixing issue where assertion on `DateTimeRange` will fail on `BeLessThan` or `BeWithin` when the subject and target has a negative delta.

Reported in #1165