### PR TITLE
Guard against NullReferenceExceptions

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -1671,6 +1671,8 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> AllBeAssignableTo(Type expectedType, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(expectedType, nameof(expectedType));
+
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected type to be {0}{reason}, ", expectedType.FullName)
@@ -1727,6 +1729,8 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> AllBeOfType(Type expectedType, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(expectedType, nameof(expectedType));
+
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected type to be {0}{reason}, ", expectedType.FullName)

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -370,10 +370,12 @@ namespace FluentAssertions.Numeric
         /// </param>
         public AndConstraint<TAssertions> BeOfType(Type expectedType, string because = "", params object[] becauseArgs)
         {
-            Type subjectType = SubjectInternal.GetType();
-            if (expectedType.IsGenericTypeDefinition && subjectType.IsGenericType)
+            Guard.ThrowIfArgumentIsNull(expectedType, nameof(expectedType));
+
+            Type subjectType = SubjectInternal?.GetType();
+            if (expectedType.IsGenericTypeDefinition && subjectType?.IsGenericType == true)
             {
-                subjectType.GetGenericTypeDefinition().Should().Be(expectedType, because, becauseArgs);
+                (subjectType?.GetGenericTypeDefinition()).Should().Be(expectedType, because, becauseArgs);
             }
             else
             {
@@ -398,6 +400,13 @@ namespace FluentAssertions.Numeric
         /// </param>
         public AndConstraint<TAssertions> NotBeOfType(Type unexpectedType, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(unexpectedType, nameof(unexpectedType));
+
+            Execute.Assertion
+                .ForCondition(SubjectInternal.HasValue)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected type not to be " + unexpectedType + "{reason}, but found <null>.");
+
             SubjectInternal.GetType().Should().NotBe(unexpectedType, because, becauseArgs);
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -149,6 +149,8 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<TAssertions> BeOfType(Type expectedType, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(expectedType, nameof(expectedType));
+
             Execute.Assertion
                 .ForCondition(!ReferenceEquals(Subject, null))
                 .BecauseOf(because, becauseArgs)
@@ -201,6 +203,8 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<TAssertions> NotBeOfType(Type unexpectedType, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(unexpectedType, nameof(unexpectedType));
+
             Execute.Assertion
                 .ForCondition(!ReferenceEquals(Subject, null))
                 .BecauseOf(because, becauseArgs)
@@ -253,6 +257,8 @@ namespace FluentAssertions.Primitives
         /// <returns>An <see cref="AndConstraint{TAssertions}"/> which can be used to chain assertions.</returns>
         public AndConstraint<TAssertions> BeAssignableTo(Type type, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(type, nameof(type));
+
             Execute.Assertion
                 .ForCondition(!ReferenceEquals(Subject, null))
                 .BecauseOf(because, becauseArgs)
@@ -301,6 +307,8 @@ namespace FluentAssertions.Primitives
         /// <returns>An <see cref="AndConstraint{TAssertions}"/> which can be used to chain assertions.</returns>
         public AndConstraint<TAssertions> NotBeAssignableTo(Type type, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(type, nameof(type));
+
             Execute.Assertion
                 .ForCondition(!ReferenceEquals(Subject, null))
                 .BecauseOf(because, becauseArgs)

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -1001,7 +1001,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.Length > 0)
+                .ForCondition(Subject is null || Subject.Length > 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:string} to be empty{reason}.");
 
@@ -1022,8 +1022,11 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.Length == expected)
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is object)
+                .FailWith("Expected {context:string} with length {0}{reason}, but found <null>", expected)
+                .Then
+                .ForCondition(Subject.Length == expected)
                 .FailWith("Expected {context:string} with length {0}{reason}, but found string {1} with length {2}.",
                     expected, Subject, Subject.Length);
 

--- a/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Specialized
         /// <param name="executionTime">The execution on which time must be asserted.</param>
         public ExecutionTimeAssertions(ExecutionTime executionTime)
         {
-            execution = executionTime;
+            execution = executionTime ?? throw new ArgumentNullException(nameof(executionTime));
         }
 
         /// <summary>

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -3667,6 +3667,20 @@ namespace FluentAssertions.Specs
         #region ShouldAllBeAssignableTo
 
         [Fact]
+        public void When_the_types_in_a_collection_is_matched_against_a_null_type_it_should_throw()
+        {
+            // Arrange
+            IEnumerable collection = new int[0];
+
+            // Act
+            Action act = () => collection.Should().AllBeAssignableTo(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>()
+                .Which.ParamName.Should().Be("expectedType");
+        }
+
+        [Fact]
         public void When_all_of_the_types_in_a_collection_match_expected_type_it_should_succeed()
         {
             // Arrange
@@ -3772,6 +3786,20 @@ namespace FluentAssertions.Specs
         #endregion
 
         #region ShouldAllBeOfType
+
+        [Fact]
+        public void When_the_types_in_a_collection_is_matched_against_a_null_type_exactly_it_should_throw()
+        {
+            // Arrange
+            IEnumerable collection = new int[0];
+
+            // Act
+            Action act = () => collection.Should().AllBeOfType(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>()
+                .Which.ParamName.Should().Be("expectedType");
+        }
 
         [Fact]
         public void When_all_of_the_types_in_a_collection_match_expected_type_exactly_it_should_succeed()

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -213,6 +213,34 @@ namespace FluentAssertions.Specs
         #region BeOfType / NotBeOfType
 
         [Fact]
+        public void When_object_type_is_matched_against_null_type_exactly_it_should_throw()
+        {
+            // Arrange
+            var someObject = new object();
+
+            // Act
+            Action act = () => someObject.Should().BeOfType(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>()
+                .Which.ParamName.Should().Be("expectedType");
+        }
+
+        [Fact]
+        public void When_object_type_is_matched_negatively_against_null_type_exactly_it_should_throw()
+        {
+            // Arrange
+            var someObject = new object();
+
+            // Act
+            Action act = () => someObject.Should().NotBeOfType(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>()
+                .Which.ParamName.Should().Be("unexpectedType");
+        }
+
+        [Fact]
         public void When_object_type_is_exactly_equal_to_the_specified_type_it_should_not_fail()
         {
             // Arrange
@@ -239,6 +267,48 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_object_is_matched_against_a_null_type_it_should_throw()
+        {
+            // Arrange
+            int valueTypeObject = 42;
+
+            // Act
+            Action act = () => valueTypeObject.Should().BeOfType(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>()
+                .Which.ParamName.Should().Be("expectedType");
+        }
+
+        [Fact]
+        public void When_null_object_is_matched_against_a_type_it_should_throw()
+        {
+            // Arrange
+            int? valueTypeObject = null;
+
+            // Act
+            Action act = () => valueTypeObject.Should().BeOfType(typeof(int), "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*type to be System.Int32*because we want to test the failure message*");
+        }
+
+        [Fact]
+        public void When_object_is_matched_negatively_against_a_null_type_it_should_throw()
+        {
+            // Arrange
+            int valueTypeObject = 42;
+
+            // Act
+            Action act = () => valueTypeObject.Should().NotBeOfType(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>()
+                .Which.ParamName.Should().Be("unexpectedType");
+        }
+
+        [Fact]
         public void When_object_type_is_value_type_and_doesnt_match_received_type_as_expected_should_not_fail_and_assert_correctly()
         {
             // Arrange
@@ -249,6 +319,20 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_null_object_is_matched_negatively_against_a_type_it_should_throw()
+        {
+            // Arrange
+            int? valueTypeObject = null;
+
+            // Act
+            Action act = () => valueTypeObject.Should().NotBeOfType(typeof(int), "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*type not to be System.Int32*because we want to test the failure message*");
         }
 
         [Fact]
@@ -360,6 +444,20 @@ namespace FluentAssertions.Specs
         #endregion
 
         #region BeAssignableTo
+
+        [Fact]
+        public void When_object_type_is_matched_against_null_type_it_should_throw()
+        {
+            // Arrange
+            var someObject = new object();
+
+            // Act
+            Action act = () => someObject.Should().BeAssignableTo(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>()
+                .Which.ParamName.Should().Be("type");
+        }
 
         [Fact]
         public void When_its_own_type_it_should_succeed()
@@ -495,6 +593,20 @@ namespace FluentAssertions.Specs
         #endregion
 
         #region NotBeAssignableTo
+
+        [Fact]
+        public void When_object_type_is_matched_negatively_against_null_type_it_should_throw()
+        {
+            // Arrange
+            var someObject = new object();
+
+            // Act
+            Action act = () => someObject.Should().NotBeAssignableTo(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>()
+                .Which.ParamName.Should().Be("type");
+        }
 
         [Fact]
         public void When_its_own_type_and_asserting_not_assignable_it_should_fail_with_a_useful_message()

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
@@ -2981,6 +2981,16 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_asserting_null_string_to_not_be_empty_it_should_succeed()
+        {
+            // Arrange
+            string actual = null;
+
+            // Act / Assert
+            actual.Should().NotBeEmpty();
+        }
+
+        [Fact]
         public void Should_fail_when_asserting_empty_string_to_be_filled()
         {
             // Arrange
@@ -3019,6 +3029,19 @@ namespace FluentAssertions.Specs
 
             // Act / Assert
             actual.Should().HaveLength(3);
+        }
+
+        [Fact]
+        public void When_asserting_string_length_on_null_string_it_should_fail()
+        {
+            // Arrange
+            string actual = null;
+
+            // Act
+            Action act = () => actual.Should().HaveLength(0);
+
+            // Assert
+            act.Should().Throw<XunitException>();
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions.Extensions;
+using FluentAssertions.Specialized;
 using Xunit;
 using Xunit.Sdk;
 
@@ -441,13 +442,27 @@ namespace FluentAssertions.Specs
             {
                 // I know it's not meant to be used like this,
                 // but since you can, it should still give consistent results
-                Specialized.ExecutionTime time = someAction.ExecutionTime();
+                ExecutionTime time = someAction.ExecutionTime();
                 time.Should().BeGreaterThan(100.Milliseconds());
                 time.Should().BeGreaterThan(200.Milliseconds());
             };
 
             // Assert
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_on_null_execution_it_should_throw()
+        {
+            // Arrange
+            ExecutionTime executionTime = null;
+
+            // Act
+            Action act = () => new ExecutionTimeAssertions(executionTime);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>()
+                .Which.ParamName.Should().Be("executionTime");
         }
         #endregion
 


### PR DESCRIPTION
I re-ran my [program](https://github.com/jnyrup/fluentassertions/tree/nullReflection) to find `NullReferenceException`s when entering our library using `Should()`.

So I fixed a few more.

The remaining 76 are here:
[NullReferenceExceptions2.txt](https://github.com/fluentassertions/fluentassertions/files/4499738/NullReferenceExceptions2.txt)

We now have over 4000 tests 🎉 