### PR TITLE
Event constraining extensions WithArgs and WithSender will return matching events

### DIFF
--- a/Src/FluentAssertions/EventRaisingExtensions.cs
+++ b/Src/FluentAssertions/EventRaisingExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions.Common;
@@ -13,84 +14,139 @@ namespace FluentAssertions
     public static class EventRaisingExtensions
     {
         /// <summary>
-        /// Asserts that all occurrences of the event originated from the <param name="expectedSender"/>.
+        /// Asserts that all occurrences of the event originated from the <param name="expectedSender"/> and
+        /// returns only the events that came from that sender.
         /// </summary>
-        public static IEventRecorder WithSender(this IEventRecorder eventRecorder, object expectedSender)
+        public static IEventRecording WithSender(this IEventRecording eventRecording, object expectedSender)
         {
-            foreach (RecordedEvent recordedEvent in eventRecorder)
-            {
-                if (!recordedEvent.Parameters.Any())
-                {
-                    throw new ArgumentException(string.Format(
-                        "Expected event from sender <{0}>, but event {1} does not include any arguments",
-                        expectedSender, eventRecorder.EventName));
-                }
+            var eventsForSender = new List<OccurredEvent>();
+            var otherSenders = new List<object>();
 
-                object actualSender = recordedEvent.Parameters.First();
-                Execute.Assertion
-                    .ForCondition(ReferenceEquals(actualSender, expectedSender))
-                    .FailWith("Expected sender {0}, but found {1}.", expectedSender, actualSender);
+            foreach (OccurredEvent @event in eventRecording)
+            {
+                bool hasSender = Execute.Assertion
+                    .ForCondition(@event.Parameters.Any())
+                    .FailWith("Expected event from sender {0}, " +
+                              $"but event {eventRecording.EventName} does not have any parameters", expectedSender);
+
+                if (hasSender)
+                {
+                    object sender = @event.Parameters.First();
+                    if (ReferenceEquals(sender, expectedSender))
+                    {
+                        eventsForSender.Add(@event);
+                    }
+                    else
+                    {
+                        otherSenders.Add(sender);
+                    }
+                }
             }
 
-            return eventRecorder;
+            Execute.Assertion
+                .ForCondition(eventsForSender.Any())
+                .FailWith("Expected sender {0}, but found {1}.",
+                    () => expectedSender,
+                    () => otherSenders.Distinct());
+
+            return new FilteredEventRecording(eventRecording, eventsForSender);
         }
 
         /// <summary>
-        /// Asserts that at least one occurrence of the event had at least one of the arguments matching a predicate.
+        /// Asserts that at least one occurrence of the events had at least one of the arguments matching a predicate. Returns
+        /// only the events that matched that predicate.
         /// </summary>
-        public static IEventRecorder WithArgs<T>(this IEventRecorder eventRecorder, Expression<Func<T, bool>> predicate)
+        public static IEventRecording WithArgs<T>(this IEventRecording eventRecording, Expression<Func<T, bool>> predicate)
         {
             Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
 
             Func<T, bool> compiledPredicate = predicate.Compile();
 
-            if (!eventRecorder.First().Parameters.OfType<T>().Any())
+            bool hasArgumentOfRightType = false;
+            var eventsMatchingPredicate = new List<OccurredEvent>();
+
+            foreach (OccurredEvent @event in eventRecording)
             {
-                throw new ArgumentException("No argument of event " + eventRecorder.EventName + " is of type <" + typeof(T) + ">.");
+                var typedParameters = @event.Parameters.OfType<T>().ToArray();
+                if (typedParameters.Any())
+                {
+                    hasArgumentOfRightType = true;
+                }
+
+                if (typedParameters.Any(parameter => compiledPredicate(parameter)))
+                {
+                    eventsMatchingPredicate.Add(@event);
+                }
             }
 
-            if (eventRecorder.All(recordedEvent => !recordedEvent.Parameters.OfType<T>().Any(parameter => compiledPredicate(parameter))))
+            if (!hasArgumentOfRightType)
+            {
+                throw new ArgumentException("No argument of event " + eventRecording.EventName + " is of type <" + typeof(T) + ">.");
+            }
+
+            if (!eventsMatchingPredicate.Any())
             {
                 Execute.Assertion
                     .FailWith("Expected at least one event with arguments matching {0}, but found none.", predicate.Body);
             }
 
-            return eventRecorder;
+            return new FilteredEventRecording(eventRecording, eventsMatchingPredicate);
         }
 
         /// <summary>
-        /// Asserts that at least one occurrence of the event had arguments matching all predicates.
+        /// Asserts that at least one of the occurred events has arguments the match the predicates in the same order. Returns
+        /// only the events that matched those predicates.
         /// </summary>
-        public static IEventRecorder WithArgs<T>(this IEventRecorder eventRecorder, params Expression<Func<T, bool>>[] predicates)
+        /// <remarks>
+        /// If a <c>null</c> is provided as predicate argument, the corresponding event parameter value is ignored.
+        /// </remarks>
+        public static IEventRecording WithArgs<T>(this IEventRecording eventRecording, params Expression<Func<T, bool>>[] predicates)
         {
             Func<T, bool>[] compiledPredicates = predicates.Select(p => p?.Compile()).ToArray();
 
-            if (!eventRecorder.First().Parameters.OfType<T>().Any())
-            {
-                throw new ArgumentException("No argument of event " + eventRecorder.EventName + " is of type <" + typeof(T) + ">.");
-            }
+            bool hasArgumentOfRightType = false;
+            var eventsMatchingPredicate = new List<OccurredEvent>();
 
-            bool expected = eventRecorder.Any(recordedEvent =>
+            foreach (OccurredEvent @event in eventRecording)
             {
-                T[] parameters = recordedEvent.Parameters.OfType<T>().ToArray();
-                int parametersToCheck = Math.Min(parameters.Length, predicates.Length);
-
-                bool isMatch = true;
-                for (int i = 0; i < parametersToCheck && isMatch; i++)
+                var typedParameters = @event.Parameters.OfType<T>().ToArray();
+                if (typedParameters.Any())
                 {
-                    isMatch = compiledPredicates[i]?.Invoke(parameters[i]) ?? true;
+                    hasArgumentOfRightType = true;
                 }
 
-                return isMatch;
-            });
+                if (predicates.Length > typedParameters.Length)
+                {
+                    throw new ArgumentException(
+                        $"Expected the event to have at least {predicates.Length} parameters of type {typeof(T)}, but only found {typedParameters.Length}.");
+                }
 
-            if (!expected)
-            {
-                Execute.Assertion
-                    .FailWith("Expected at least one event with arguments matching {0}, but found none.", string.Join(" | ", predicates.Where(p => p != null).Select(p => p.Body.ToString())));
+                bool isMatch = true;
+                for (int index = 0; index < predicates.Length && isMatch; index++)
+                {
+                    isMatch = compiledPredicates[index]?.Invoke(typedParameters[index]) ?? true;
+                }
+
+                if (isMatch)
+                {
+                    eventsMatchingPredicate.Add(@event);
+                }
             }
 
-            return eventRecorder;
+            if (!hasArgumentOfRightType)
+            {
+                throw new ArgumentException("No argument of event " + eventRecording.EventName + " is of type <" + typeof(T) + ">.");
+            }
+
+            if (!eventsMatchingPredicate.Any())
+            {
+                Execute
+                    .Assertion
+                    .FailWith("Expected at least one event with arguments matching {0}, but found none.",
+                    string.Join(" | ", predicates.Where(p => p != null).Select(p => p.Body.ToString())));
+            }
+
+            return new FilteredEventRecording(eventRecording, eventsMatchingPredicate);
         }
     }
 }

--- a/Src/FluentAssertions/Events/EventAssertions.cs
+++ b/Src/FluentAssertions/Events/EventAssertions.cs
@@ -37,22 +37,17 @@ namespace FluentAssertions.Events
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        /// <remarks>
-        /// You must call <see cref="AssertionExtensions.Monitor"/> on the same object prior to this call so that Fluent Assertions can
-        /// subscribe for the events of the object.
-        /// </remarks>
-        public IEventRecorder Raise(string eventName, string because = "", params object[] becauseArgs)
+        public IEventRecording Raise(string eventName, string because = "", params object[] becauseArgs)
         {
-            IEventRecorder eventRecorder = monitor.GetEventRecorder(eventName);
-
-            if (!eventRecorder.Any())
+            IEventRecording recording = monitor.GetRecordingFor(eventName);
+            if (!recording.Any())
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
                     .FailWith("Expected object {0} to raise event {1}{reason}, but it did not.", monitor.Subject, eventName);
             }
 
-            return eventRecorder;
+            return recording;
         }
 
         /// <summary>
@@ -68,14 +63,10 @@ namespace FluentAssertions.Events
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        /// <remarks>
-        /// You must call <see cref="AssertionExtensions.Monitor"/> on the same object prior to this call so that Fluent Assertions can
-        /// subscribe for the events of the object.
-        /// </remarks>
         public void NotRaise(string eventName, string because = "", params object[] becauseArgs)
         {
-            IEventRecorder eventRecorder = monitor.GetEventRecorder(eventName);
-            if (eventRecorder.Any())
+            IEventRecording events = monitor.GetRecordingFor(eventName);
+            if (events.Any())
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -97,17 +88,13 @@ namespace FluentAssertions.Events
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        /// <remarks>
-        /// You must call <see cref="AssertionExtensions.Monitor"/> on the same object prior to this call so that Fluent Assertions can
-        /// subscribe for the events of the object.
-        /// </remarks>
-        public IEventRecorder RaisePropertyChangeFor(Expression<Func<T, object>> propertyExpression,
+        public IEventRecording RaisePropertyChangeFor(Expression<Func<T, object>> propertyExpression,
             string because = "", params object[] becauseArgs)
         {
-            IEventRecorder eventRecorder = monitor.GetEventRecorder(PropertyChangedEventName);
+            IEventRecording recording = monitor.GetRecordingFor(PropertyChangedEventName);
             string propertyName = propertyExpression?.GetPropertyInfo().Name;
 
-            if (!eventRecorder.Any())
+            if (!recording.Any())
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -115,7 +102,7 @@ namespace FluentAssertions.Events
                         monitor.Subject, PropertyChangedEventName, propertyName);
             }
 
-            return eventRecorder.WithArgs<PropertyChangedEventArgs>(args => args.PropertyName == propertyName);
+            return recording.WithArgs<PropertyChangedEventArgs>(args => args.PropertyName == propertyName);
         }
 
         /// <summary>
@@ -131,18 +118,14 @@ namespace FluentAssertions.Events
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
         /// </param>
-        /// <remarks>
-        /// You must call <see cref="AssertionExtensions.Monitor"/> on the same object prior to this call so that Fluent Assertions can
-        /// subscribe for the events of the object.
-        /// </remarks>
         public void NotRaisePropertyChangeFor(Expression<Func<T, object>> propertyExpression,
             string because = "", params object[] becauseArgs)
         {
-            IEventRecorder eventRecorder = monitor.GetEventRecorder(PropertyChangedEventName);
+            IEventRecording recording = monitor.GetRecordingFor(PropertyChangedEventName);
 
             string propertyName = propertyExpression.GetPropertyInfo().Name;
 
-            if (eventRecorder.Any(@event => GetAffectedPropertyName(@event) == propertyName))
+            if (recording.Any(@event => GetAffectedPropertyName(@event) == propertyName))
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -151,7 +134,7 @@ namespace FluentAssertions.Events
             }
         }
 
-        private static string GetAffectedPropertyName(RecordedEvent @event)
+        private static string GetAffectedPropertyName(OccurredEvent @event)
         {
             return @event.Parameters.OfType<PropertyChangedEventArgs>().Single().PropertyName;
         }

--- a/Src/FluentAssertions/Events/EventHandlerFactory.cs
+++ b/Src/FluentAssertions/Events/EventHandlerFactory.cs
@@ -13,7 +13,7 @@ namespace FluentAssertions.Events
         /// Generates an eventhandler for an event of type eventSignature that calls RegisterEvent on recorder
         /// when invoked.
         /// </summary>
-        public static Delegate GenerateHandler(Type eventSignature, IEventRecorder recorder)
+        public static Delegate GenerateHandler(Type eventSignature, EventRecorder recorder)
         {
             Type returnType = GetDelegateReturnType(eventSignature);
             Type[] parameters = GetDelegateParameterTypes(eventSignature);
@@ -27,7 +27,7 @@ namespace FluentAssertions.Events
                 AppendParameterListThisReference(parameters),
                 module);
 
-            MethodInfo methodToCall = typeof(IEventRecorder).GetMethod("RecordEvent",
+            MethodInfo methodToCall = typeof(EventRecorder).GetMethod(nameof(EventRecorder.RecordEvent),
                 BindingFlags.Instance | BindingFlags.Public);
 
             ILGenerator ilGen = eventHandler.GetILGenerator();
@@ -108,8 +108,7 @@ namespace FluentAssertions.Events
         private static Type[] AppendParameterListThisReference(Type[] parameters)
         {
             var newList = new Type[parameters.Length + 1];
-
-            newList[0] = typeof(IEventRecorder);
+            newList[0] = typeof(EventRecorder);
 
             for (var index = 0; index < parameters.Length; index++)
             {

--- a/Src/FluentAssertions/Events/FilteredEventRecording.cs
+++ b/Src/FluentAssertions/Events/FilteredEventRecording.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FluentAssertions.Events
+{
+    internal class FilteredEventRecording : IEventRecording
+    {
+        private readonly OccurredEvent[] occurredEvents;
+
+        public FilteredEventRecording(IEventRecording eventRecorder, IEnumerable<OccurredEvent> events)
+        {
+            EventObject = eventRecorder.EventObject;
+            EventName = eventRecorder.EventName;
+            EventHandlerType = eventRecorder.EventHandlerType;
+
+            occurredEvents = events.ToArray();
+        }
+
+        public object EventObject { get; }
+
+        public string EventName { get; }
+
+        public Type EventHandlerType { get; }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public IEnumerator<OccurredEvent> GetEnumerator()
+        {
+            foreach (var occurredEvent in occurredEvents)
+            {
+                yield return new OccurredEvent
+                {
+                    EventName = EventName,
+                    Parameters = occurredEvent.Parameters,
+                    TimestampUtc = occurredEvent.TimestampUtc
+                };
+            }
+        }
+    }
+}

--- a/Src/FluentAssertions/Events/IEventRecording.cs
+++ b/Src/FluentAssertions/Events/IEventRecording.cs
@@ -4,21 +4,10 @@ using System.Collections.Generic;
 namespace FluentAssertions.Events
 {
     /// <summary>
-    /// Records raised events for one event on one object
+    /// Represents an (active) recording of all events that happen(ed) while monitoring an object.
     /// </summary>
-    public interface IEventRecorder : IEnumerable<RecordedEvent>, IDisposable
+    public interface IEventRecording : IEnumerable<OccurredEvent>
     {
-        /// <summary>
-        /// Store information about a raised event
-        /// </summary>
-        /// <param name="parameters">Parameters the event was raised with</param>
-        void RecordEvent(params object[] parameters);
-
-        /// <summary>
-        /// Resets the event recorder, removing any events recorded thus far.
-        /// </summary>
-        void Reset();
-
         /// <summary>
         /// The object events are recorded from
         /// </summary>

--- a/Src/FluentAssertions/Events/IMonitor.cs
+++ b/Src/FluentAssertions/Events/IMonitor.cs
@@ -22,10 +22,7 @@ namespace FluentAssertions.Events
         /// </summary>
         EventAssertions<T> Should();
 
-        /// <summary>
-        /// Gets an object that tracks the occurrences of a particular <paramref name="eventName"/>.
-        /// </summary>
-        IEventRecorder GetEventRecorder(string eventName);
+        IEventRecording GetRecordingFor(string eventName);
 
         /// <summary>
         /// Gets the metadata of all the events that are currently being monitored.

--- a/Src/FluentAssertions/Events/RecordedEvent.cs
+++ b/Src/FluentAssertions/Events/RecordedEvent.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 
 namespace FluentAssertions.Events
 {
@@ -9,39 +7,25 @@ namespace FluentAssertions.Events
     /// This class is used to store data about an intercepted event
     /// </summary>
     [DebuggerNonUserCode]
-    public class RecordedEvent
+    internal class RecordedEvent
     {
-        private object[] parameters;
-
         /// <summary>
         /// Default constructor stores the parameters the event was raised with
         /// </summary>
-        public RecordedEvent(DateTime utcNow, object monitoredObject, params object[] parameters)
+        public RecordedEvent(DateTime utcNow, params object[] parameters)
         {
-            Parameters = parameters.Select(p => (p == monitoredObject) ? new WeakReference(p) : p);
+            Parameters = parameters;
             TimestampUtc = utcNow;
         }
 
         /// <summary>
         /// The exact data and time in UTC format at which the event occurred.
         /// </summary>
-        public DateTime TimestampUtc { get; set; }
+        public DateTime TimestampUtc { get; }
 
         /// <summary>
         /// Parameters for the event
         /// </summary>
-        public IEnumerable<object> Parameters
-        {
-            get
-            {
-                return parameters.Select(parameter =>
-                    (parameter is WeakReference weakReference) ? weakReference.Target : parameter).ToArray();
-            }
-
-            private set
-            {
-                parameters = value.ToArray();
-            }
-        }
+        public object[] Parameters { get; }
     }
 }

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -224,9 +224,29 @@ namespace FluentAssertions.Execution
             }
         }
 
+        /// <summary>
+        /// Registers a failure message that does not contain any formatting placeholders.
+        /// </summary>
+        public Continuation FailWith(string message)
+        {
+            return FailWith(() => new FailReason(message, new object[0]));
+        }
+
+        /// <summary>
+        /// Registers a failure message with optional formatting arguments.
+        /// </summary>
         public Continuation FailWith(string message, params object[] args)
         {
             return FailWith(() => new FailReason(message, args));
+        }
+
+        /// <summary>
+        /// Registers a failure message, but postpones evaluation of the formatting arguments until the assertion really fails.
+        /// </summary>
+        public Continuation FailWith(string message, params Func<object>[] argProviders)
+        {
+            return FailWith(() => new FailReason(message,
+                argProviders.Select(a => a()).ToArray()));
         }
 
         private string GetIdentifier()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -145,9 +145,9 @@ namespace FluentAssertions
     }
     public static class EventRaisingExtensions
     {
-        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, params System.Linq.Expressions.Expression<>[] predicates) { }
-        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
-        public static FluentAssertions.Events.IEventRecorder WithSender(this FluentAssertions.Events.IEventRecorder eventRecorder, object expectedSender) { }
+        public static FluentAssertions.Events.IEventRecording WithArgs<T>(this FluentAssertions.Events.IEventRecording eventRecording, params System.Linq.Expressions.Expression<>[] predicates) { }
+        public static FluentAssertions.Events.IEventRecording WithArgs<T>(this FluentAssertions.Events.IEventRecording eventRecording, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
+        public static FluentAssertions.Events.IEventRecording WithSender(this FluentAssertions.Events.IEventRecording eventRecording, object expectedSender) { }
     }
     public static class Exactly
     {
@@ -931,8 +931,8 @@ namespace FluentAssertions.Events
         protected override string Identifier { get; }
         public void NotRaise(string eventName, string because = "", params object[] becauseArgs) { }
         public void NotRaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Events.IEventRecorder Raise(string eventName, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Events.IEventRecorder RaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecording Raise(string eventName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecording RaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
     }
     public class EventMetadata
     {
@@ -940,25 +940,11 @@ namespace FluentAssertions.Events
         public string EventName { get; }
         public System.Type HandlerType { get; }
     }
-    public sealed class EventRecorder : FluentAssertions.Events.IEventRecorder, System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
-    {
-        public EventRecorder(object eventRaiser, string eventName, System.Func<System.DateTime> utcNow) { }
-        public System.Type EventHandlerType { get; }
-        public string EventName { get; }
-        public object EventObject { get; }
-        public void Attach(System.WeakReference subject, System.Reflection.EventInfo eventInfo) { }
-        public void Dispose() { }
-        public System.Collections.Generic.IEnumerator<FluentAssertions.Events.RecordedEvent> GetEnumerator() { }
-        public void RecordEvent(params object[] parameters) { }
-        public void Reset() { }
-    }
-    public interface IEventRecorder : System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
+    public interface IEventRecording : System.Collections.Generic.IEnumerable<FluentAssertions.Events.OccurredEvent>, System.Collections.IEnumerable
     {
         System.Type EventHandlerType { get; }
         string EventName { get; }
         object EventObject { get; }
-        void RecordEvent(params object[] parameters);
-        void Reset();
     }
     public interface IMonitor<T> : System.IDisposable
     {
@@ -966,7 +952,7 @@ namespace FluentAssertions.Events
         FluentAssertions.Events.OccurredEvent[] OccurredEvents { get; }
         T Subject { get; }
         void Clear();
-        FluentAssertions.Events.IEventRecorder GetEventRecorder(string eventName);
+        FluentAssertions.Events.IEventRecording GetRecordingFor(string eventName);
         FluentAssertions.Events.EventAssertions<T> Should();
     }
     public class OccurredEvent
@@ -974,12 +960,6 @@ namespace FluentAssertions.Events
         public OccurredEvent() { }
         public string EventName { get; set; }
         public object[] Parameters { get; set; }
-        public System.DateTime TimestampUtc { get; set; }
-    }
-    public class RecordedEvent
-    {
-        public RecordedEvent(System.DateTime utcNow, object monitoredObject, params object[] parameters) { }
-        public System.Collections.Generic.IEnumerable<object> Parameters { get; }
         public System.DateTime TimestampUtc { get; set; }
     }
 }
@@ -1007,6 +987,8 @@ namespace FluentAssertions.Execution
         public string[] Discard() { }
         public void Dispose() { }
         public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
         public T Get<T>(string key) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -145,9 +145,9 @@ namespace FluentAssertions
     }
     public static class EventRaisingExtensions
     {
-        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, params System.Linq.Expressions.Expression<>[] predicates) { }
-        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
-        public static FluentAssertions.Events.IEventRecorder WithSender(this FluentAssertions.Events.IEventRecorder eventRecorder, object expectedSender) { }
+        public static FluentAssertions.Events.IEventRecording WithArgs<T>(this FluentAssertions.Events.IEventRecording eventRecording, params System.Linq.Expressions.Expression<>[] predicates) { }
+        public static FluentAssertions.Events.IEventRecording WithArgs<T>(this FluentAssertions.Events.IEventRecording eventRecording, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
+        public static FluentAssertions.Events.IEventRecording WithSender(this FluentAssertions.Events.IEventRecording eventRecording, object expectedSender) { }
     }
     public static class Exactly
     {
@@ -931,8 +931,8 @@ namespace FluentAssertions.Events
         protected override string Identifier { get; }
         public void NotRaise(string eventName, string because = "", params object[] becauseArgs) { }
         public void NotRaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Events.IEventRecorder Raise(string eventName, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Events.IEventRecorder RaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecording Raise(string eventName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecording RaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
     }
     public class EventMetadata
     {
@@ -940,25 +940,11 @@ namespace FluentAssertions.Events
         public string EventName { get; }
         public System.Type HandlerType { get; }
     }
-    public sealed class EventRecorder : FluentAssertions.Events.IEventRecorder, System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
-    {
-        public EventRecorder(object eventRaiser, string eventName, System.Func<System.DateTime> utcNow) { }
-        public System.Type EventHandlerType { get; }
-        public string EventName { get; }
-        public object EventObject { get; }
-        public void Attach(System.WeakReference subject, System.Reflection.EventInfo eventInfo) { }
-        public void Dispose() { }
-        public System.Collections.Generic.IEnumerator<FluentAssertions.Events.RecordedEvent> GetEnumerator() { }
-        public void RecordEvent(params object[] parameters) { }
-        public void Reset() { }
-    }
-    public interface IEventRecorder : System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
+    public interface IEventRecording : System.Collections.Generic.IEnumerable<FluentAssertions.Events.OccurredEvent>, System.Collections.IEnumerable
     {
         System.Type EventHandlerType { get; }
         string EventName { get; }
         object EventObject { get; }
-        void RecordEvent(params object[] parameters);
-        void Reset();
     }
     public interface IMonitor<T> : System.IDisposable
     {
@@ -966,7 +952,7 @@ namespace FluentAssertions.Events
         FluentAssertions.Events.OccurredEvent[] OccurredEvents { get; }
         T Subject { get; }
         void Clear();
-        FluentAssertions.Events.IEventRecorder GetEventRecorder(string eventName);
+        FluentAssertions.Events.IEventRecording GetRecordingFor(string eventName);
         FluentAssertions.Events.EventAssertions<T> Should();
     }
     public class OccurredEvent
@@ -974,12 +960,6 @@ namespace FluentAssertions.Events
         public OccurredEvent() { }
         public string EventName { get; set; }
         public object[] Parameters { get; set; }
-        public System.DateTime TimestampUtc { get; set; }
-    }
-    public class RecordedEvent
-    {
-        public RecordedEvent(System.DateTime utcNow, object monitoredObject, params object[] parameters) { }
-        public System.Collections.Generic.IEnumerable<object> Parameters { get; }
         public System.DateTime TimestampUtc { get; set; }
     }
 }
@@ -1007,6 +987,8 @@ namespace FluentAssertions.Execution
         public string[] Discard() { }
         public void Dispose() { }
         public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
         public T Get<T>(string key) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -145,9 +145,9 @@ namespace FluentAssertions
     }
     public static class EventRaisingExtensions
     {
-        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, params System.Linq.Expressions.Expression<>[] predicates) { }
-        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
-        public static FluentAssertions.Events.IEventRecorder WithSender(this FluentAssertions.Events.IEventRecorder eventRecorder, object expectedSender) { }
+        public static FluentAssertions.Events.IEventRecording WithArgs<T>(this FluentAssertions.Events.IEventRecording eventRecording, params System.Linq.Expressions.Expression<>[] predicates) { }
+        public static FluentAssertions.Events.IEventRecording WithArgs<T>(this FluentAssertions.Events.IEventRecording eventRecording, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
+        public static FluentAssertions.Events.IEventRecording WithSender(this FluentAssertions.Events.IEventRecording eventRecording, object expectedSender) { }
     }
     public static class Exactly
     {
@@ -931,8 +931,8 @@ namespace FluentAssertions.Events
         protected override string Identifier { get; }
         public void NotRaise(string eventName, string because = "", params object[] becauseArgs) { }
         public void NotRaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Events.IEventRecorder Raise(string eventName, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Events.IEventRecorder RaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecording Raise(string eventName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecording RaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
     }
     public class EventMetadata
     {
@@ -940,25 +940,11 @@ namespace FluentAssertions.Events
         public string EventName { get; }
         public System.Type HandlerType { get; }
     }
-    public sealed class EventRecorder : FluentAssertions.Events.IEventRecorder, System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
-    {
-        public EventRecorder(object eventRaiser, string eventName, System.Func<System.DateTime> utcNow) { }
-        public System.Type EventHandlerType { get; }
-        public string EventName { get; }
-        public object EventObject { get; }
-        public void Attach(System.WeakReference subject, System.Reflection.EventInfo eventInfo) { }
-        public void Dispose() { }
-        public System.Collections.Generic.IEnumerator<FluentAssertions.Events.RecordedEvent> GetEnumerator() { }
-        public void RecordEvent(params object[] parameters) { }
-        public void Reset() { }
-    }
-    public interface IEventRecorder : System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
+    public interface IEventRecording : System.Collections.Generic.IEnumerable<FluentAssertions.Events.OccurredEvent>, System.Collections.IEnumerable
     {
         System.Type EventHandlerType { get; }
         string EventName { get; }
         object EventObject { get; }
-        void RecordEvent(params object[] parameters);
-        void Reset();
     }
     public interface IMonitor<T> : System.IDisposable
     {
@@ -966,7 +952,7 @@ namespace FluentAssertions.Events
         FluentAssertions.Events.OccurredEvent[] OccurredEvents { get; }
         T Subject { get; }
         void Clear();
-        FluentAssertions.Events.IEventRecorder GetEventRecorder(string eventName);
+        FluentAssertions.Events.IEventRecording GetRecordingFor(string eventName);
         FluentAssertions.Events.EventAssertions<T> Should();
     }
     public class OccurredEvent
@@ -974,12 +960,6 @@ namespace FluentAssertions.Events
         public OccurredEvent() { }
         public string EventName { get; set; }
         public object[] Parameters { get; set; }
-        public System.DateTime TimestampUtc { get; set; }
-    }
-    public class RecordedEvent
-    {
-        public RecordedEvent(System.DateTime utcNow, object monitoredObject, params object[] parameters) { }
-        public System.Collections.Generic.IEnumerable<object> Parameters { get; }
         public System.DateTime TimestampUtc { get; set; }
     }
 }
@@ -1007,6 +987,8 @@ namespace FluentAssertions.Execution
         public string[] Discard() { }
         public void Dispose() { }
         public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
         public T Get<T>(string key) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -940,6 +940,8 @@ namespace FluentAssertions.Execution
         public string[] Discard() { }
         public void Dispose() { }
         public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
         public T Get<T>(string key) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -145,9 +145,9 @@ namespace FluentAssertions
     }
     public static class EventRaisingExtensions
     {
-        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, params System.Linq.Expressions.Expression<>[] predicates) { }
-        public static FluentAssertions.Events.IEventRecorder WithArgs<T>(this FluentAssertions.Events.IEventRecorder eventRecorder, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
-        public static FluentAssertions.Events.IEventRecorder WithSender(this FluentAssertions.Events.IEventRecorder eventRecorder, object expectedSender) { }
+        public static FluentAssertions.Events.IEventRecording WithArgs<T>(this FluentAssertions.Events.IEventRecording eventRecording, params System.Linq.Expressions.Expression<>[] predicates) { }
+        public static FluentAssertions.Events.IEventRecording WithArgs<T>(this FluentAssertions.Events.IEventRecording eventRecording, System.Linq.Expressions.Expression<System.Func<T, bool>> predicate) { }
+        public static FluentAssertions.Events.IEventRecording WithSender(this FluentAssertions.Events.IEventRecording eventRecording, object expectedSender) { }
     }
     public static class Exactly
     {
@@ -931,8 +931,8 @@ namespace FluentAssertions.Events
         protected override string Identifier { get; }
         public void NotRaise(string eventName, string because = "", params object[] becauseArgs) { }
         public void NotRaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Events.IEventRecorder Raise(string eventName, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Events.IEventRecorder RaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecording Raise(string eventName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Events.IEventRecording RaisePropertyChangeFor(System.Linq.Expressions.Expression<System.Func<T, object>> propertyExpression, string because = "", params object[] becauseArgs) { }
     }
     public class EventMetadata
     {
@@ -940,25 +940,11 @@ namespace FluentAssertions.Events
         public string EventName { get; }
         public System.Type HandlerType { get; }
     }
-    public sealed class EventRecorder : FluentAssertions.Events.IEventRecorder, System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
-    {
-        public EventRecorder(object eventRaiser, string eventName, System.Func<System.DateTime> utcNow) { }
-        public System.Type EventHandlerType { get; }
-        public string EventName { get; }
-        public object EventObject { get; }
-        public void Attach(System.WeakReference subject, System.Reflection.EventInfo eventInfo) { }
-        public void Dispose() { }
-        public System.Collections.Generic.IEnumerator<FluentAssertions.Events.RecordedEvent> GetEnumerator() { }
-        public void RecordEvent(params object[] parameters) { }
-        public void Reset() { }
-    }
-    public interface IEventRecorder : System.Collections.Generic.IEnumerable<FluentAssertions.Events.RecordedEvent>, System.Collections.IEnumerable, System.IDisposable
+    public interface IEventRecording : System.Collections.Generic.IEnumerable<FluentAssertions.Events.OccurredEvent>, System.Collections.IEnumerable
     {
         System.Type EventHandlerType { get; }
         string EventName { get; }
         object EventObject { get; }
-        void RecordEvent(params object[] parameters);
-        void Reset();
     }
     public interface IMonitor<T> : System.IDisposable
     {
@@ -966,7 +952,7 @@ namespace FluentAssertions.Events
         FluentAssertions.Events.OccurredEvent[] OccurredEvents { get; }
         T Subject { get; }
         void Clear();
-        FluentAssertions.Events.IEventRecorder GetEventRecorder(string eventName);
+        FluentAssertions.Events.IEventRecording GetRecordingFor(string eventName);
         FluentAssertions.Events.EventAssertions<T> Should();
     }
     public class OccurredEvent
@@ -974,12 +960,6 @@ namespace FluentAssertions.Events
         public OccurredEvent() { }
         public string EventName { get; set; }
         public object[] Parameters { get; set; }
-        public System.DateTime TimestampUtc { get; set; }
-    }
-    public class RecordedEvent
-    {
-        public RecordedEvent(System.DateTime utcNow, object monitoredObject, params object[] parameters) { }
-        public System.Collections.Generic.IEnumerable<object> Parameters { get; }
         public System.DateTime TimestampUtc { get; set; }
     }
 }
@@ -1007,6 +987,8 @@ namespace FluentAssertions.Execution
         public string[] Discard() { }
         public void Dispose() { }
         public FluentAssertions.Execution.Continuation FailWith(System.Func<FluentAssertions.Execution.FailReason> failReasonFunc) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message) { }
+        public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
         public T Get<T>(string key) { }

--- a/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
@@ -558,9 +558,9 @@ namespace FluentAssertions.Specs
             public string Description { get; set; }
 
             public string Field;
-#pragma warning disable 169, IDE0044, CA1823
+#pragma warning disable 169, CA1823, IDE0044
             private string privateField;
-#pragma warning restore CA1823, IDE0044, 169
+#pragma warning restore 169, CA1823, IDE0044
         }
 
         public class Stuff<TChild> : BaseStuff

--- a/docs/_pages/eventmonitoring.md
+++ b/docs/_pages/eventmonitoring.md
@@ -12,11 +12,11 @@ Before you can invoke the assertion extensions, you must first tell Fluent Asser
 
 ```csharp
 var subject = new EditCustomerViewModel();
-using (var monitoredSubject = subject.Monitor())
-{
-    subject.Foo();
-    monitoredSubject.Should().Raise("NameChangedEvent");
-}
+using var monitoredSubject = subject.Monitor();
+
+subject.Foo();
+monitoredSubject.Should().Raise("NameChangedEvent");
+
 ```
 
 Notice that Fluent Assertions will keep monitoring the `subject` for as long as the `using` block lasts.
@@ -30,9 +30,10 @@ monitoredSubject
   .WithArgs<PropertyChangedEventArgs>(args => args.PropertyName == "SomeProperty");
 ```
 
-Notice that `WithSender()` verifies that all occurrences had its sender argument set to the specified object.
-`WithArgs()` just verifies that at least one occurrence had a matching `EventArgs` object.
-In other words, event monitoring only works for events that comply with the standard two-argument sender/args .NET pattern.
+`WithSender()` will verify that all occurrences of the event had their `sender` argument set to the specified object.
+`WithArgs()` just verifies that at least one occurrence had a matching `EventArgs` object. Both will return an `IEventRecording` representing only the events that match the constraint.
+
+This means that event monitoring only works for events that comply with the standard two-argument `sender`/`args` .NET pattern. 
 
 Since verifying for `PropertyChanged` events is so common, we've included a specialized shortcut to the example above:
 
@@ -52,47 +53,40 @@ Or...
 subject.Should().NotRaise("SomeOtherEvent");
 ```
 
-There's also a generic version of `Monitor()`.
-It is used to limit which events you want to listen to.
-You do that by providing a type which defines the events.
+`Monitor()` is a generic method, but you will usually have the compiler infer the type. You _can_ specify an explicit type to limit which events you want to listen to:
 
 ```csharp
 var subject = new ClassWithManyEvents();
-using (var monitor = subject.Monitor<IInterfaceWithFewEvents>();
-{
-    
-}
+using var monitor = subject.Monitor<IInterfaceWithFewEvents>();
 ```
 
-This generic version of `Monitor()` is also very useful if you wish to monitor events of a dynamically generated class using `System.Reflection.Emit`.
-Since events are dynamically generated and are not present in parent class non-generic version of `Monitor()` will not find the events.
-This way you can tell the event monitor which interface was implemented in the generated class.
+This generic version of `Monitor()` is also very useful if you wish to monitor events of a dynamically generated class using `System.Reflection.Emit`. Since events are dynamically generated and are not present in parent class non-generic version of `Monitor()` will not find the events. This way you can tell the event monitor which interface was implemented in the generated class.
 
 ```csharp
 POCOClass subject = EmitViewModelFromPOCOClass();
 
-using (var monitor = subject.Monitor<ISomeInterface>())
-{
-    // POCO class doesn't have INotifyPropertyChanged implemented
-    monitor.Should().Raise("SomeEvent");
-}
+using var monitor = subject.Monitor<ISomeInterface>();
+
+// POCO class doesn't have INotifyPropertyChanged implemented
+monitor.Should().Raise("SomeEvent");
+
 ```
 
-The object returned by `Monitor` exposes a method named `GetEventRecorder` as well as the properties `MonitoredEvents` and `OccurredEvents` that you can use to directly interact with the monitor, e.g. to create your own extensions. For example:
+The `IMonitor` interface returned by `Monitor()` exposes a method named `GetRecordingFor` as well as the properties `MonitoredEvents` and `OccurredEvents` that you can use to directly interact with the monitor, e.g. to create your own extensions. For example:
 
 ```csharp
     var eventSource = new ClassThatRaisesEventsItself();
-    using (var monitor = eventSource.Monitor<IEventRaisingInterface>())
-    {
-        EventMetadata[] metadata = monitor.MonitoredEvents;
 
-        metadata.Should().BeEquivalentTo(new[]
+    using IMonitor monitor = eventSource.Monitor<IEventRaisingInterface>();
+
+    EventMetadata[] metadata = monitor.MonitoredEvents;
+
+    metadata.Should().BeEquivalentTo(new[]
+    {
+        new
         {
-            new
-            {
-                EventName = nameof(IEventRaisingInterface.InterfaceEvent),
-                HandlerType = typeof(EventHandler)
-            }
-        });
-    }
+            EventName = nameof(IEventRaisingInterface.InterfaceEvent),
+            HandlerType = typeof(EventHandler)
+        }
+    });
 ```

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -34,6 +34,7 @@ sidebar:
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).
 * Changed dictionary assertion `NotContainKeys` to honour the key comparer if applicable - [#1233](https://github.com/fluentassertions/fluentassertions/pull/1233).
 * Ensures that date time assertions like "a is less than an hour after b" don't succeed when `a - b == -30.Minutes()` [#1313](https://github.com/fluentassertions/fluentassertions/pull/1313).
+* Event raising assertions like `WithSender` and `WithArgs` will only return the events that match the constraints - [#1321](https://github.com/fluentassertions/fluentassertions/pull/1321)
 
 **Breaking Changes**
 * Dropped support for .NET Framework 4.5, .NET Standard 1.3 and 1.6 - [#1227](https://github.com/fluentassertions/fluentassertions/pull/1227).
@@ -60,6 +61,10 @@ sidebar:
 * Aligned strings to be compared using `Ordinal[Ignorecase]` - [#1283](https://github.com/fluentassertions/fluentassertions/pull/1283).
 * Changed `AutoConversion` to convert using `CultureInfo.InvariantCulture` instead of `CultureInfo.CurrentCulture` - [#1283](https://github.com/fluentassertions/fluentassertions/pull/1283).
 * Renamed `StartWithEquivalent` and `EndWithEquivalent` to `StartWithEquivalentOf` and `EndWithEquivalentOf` to make the API for Equivalent methods consistent - [#1292](https://github.com/fluentassertions/fluentassertions/pull/1292).
+* Several event raising assertion APIs will return an `IEventRecording` instead of `IEventRecorder` - [#1321](https://github.com/fluentassertions/fluentassertions/pull/1321)
+* The classes `EventMonitor` and `RecordedEvent` are now treated as `internal` code - [#1321](https://github.com/fluentassertions/fluentassertions/pull/1321)
+* Renamed method `GetEventRecorder` of interface `IMonitor` to `GetRecordingFor` and will return `IEventRecording` - [#1321](https://github.com/fluentassertions/fluentassertions/pull/1321)
+
 
 ## 5.10.3
 **Fixes**


### PR DESCRIPTION
* Event constraining extensions `WithArgs` and `WithSender` will return only the events that match the constraints
* Several event raising assertion APIs will return an `IEventRecording` instead of `IEventRecorder` 
* The classes `EventMonitor` and `RecordedEvent` are now treated as `internal` code 
* Renamed method `GetEventRecorder` of interface `IMonitor` to `GetRecordingFor` and will return `IEventRecording`

Fixes #337