### PR TITLE
Ensure that chained assertion calls are ignored when the preceding one fails

### DIFF
--- a/Src/FluentAssertions/Equivalency/EqualityComparerEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/EqualityComparerEquivalencyStep.cs
@@ -25,7 +25,8 @@ namespace FluentAssertions.Equivalency
                 .ForCondition(context.Subject is T)
                 .FailWith("Expected {context:object} to be of type {0}{because}, but found {1}", typeof(T), context.Subject)
                 .Then
-                .ForCondition(comparer.Equals((T)context.Subject, (T)context.Expectation))
+                .Given(() => comparer.Equals((T)context.Subject, (T)context.Expectation))
+                .ForCondition(isEqual => isEqual)
                 .FailWith("Expected {context:object} to be equal to {1} according to {0}{because}, but {2} was not.",
                     comparer.ToString(), context.Expectation, context.Subject);
 

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -167,12 +167,13 @@ namespace FluentAssertions.Execution
         {
             expectation = null;
 
-            return new Continuation(this, !succeeded.HasValue || succeeded.Value);
+            // SMELL: Isn't this always going to return null? Or this method also called without FailWidth (which sets the success state to null)
+            return new Continuation(this, Succeeded);
         }
 
         public GivenSelector<T> Given<T>(Func<T> selector)
         {
-            return new GivenSelector<T>(selector, !succeeded.HasValue || succeeded.Value, this);
+            return new GivenSelector<T>(selector, this, continueAsserting: !succeeded.HasValue || succeeded.Value);
         }
 
         public AssertionScope ForCondition(bool condition)
@@ -202,7 +203,8 @@ namespace FluentAssertions.Execution
         {
             try
             {
-                if (!succeeded.HasValue || !succeeded.Value)
+                bool failed = !succeeded.HasValue || !succeeded.Value;
+                if (failed)
                 {
                     string result = failReasonFunc();
 
@@ -216,7 +218,7 @@ namespace FluentAssertions.Execution
                     succeeded = false;
                 }
 
-                return new Continuation(this, succeeded.Value);
+                return new Continuation(this, continueAsserting: !failed);
             }
             finally
             {

--- a/Src/FluentAssertions/Execution/Continuation.cs
+++ b/Src/FluentAssertions/Execution/Continuation.cs
@@ -6,26 +6,31 @@ namespace FluentAssertions.Execution
     public class Continuation
     {
         private readonly AssertionScope sourceScope;
+        private readonly bool continueAsserting;
 
-        public Continuation(AssertionScope sourceScope, bool sourceSucceeded)
+        internal Continuation(AssertionScope sourceScope, bool continueAsserting)
         {
             this.sourceScope = sourceScope;
-            SourceSucceeded = sourceSucceeded;
+            this.continueAsserting = continueAsserting;
         }
 
         /// <summary>
         /// Continuous the assertion chain if the previous assertion was successful.
         /// </summary>
-        public IAssertionScope Then => new ContinuedAssertionScope(sourceScope, SourceSucceeded);
-
-        public bool SourceSucceeded { get; }
+        public IAssertionScope Then
+        {
+            get
+            {
+                return new ContinuedAssertionScope(sourceScope, continueAsserting);
+            }
+        }
 
         /// <summary>
         /// Provides back-wards compatibility for code that expects <see cref="AssertionScope.FailWith(string, object[])"/> to return a boolean.
         /// </summary>
         public static implicit operator bool(Continuation continuation)
         {
-            return continuation.SourceSucceeded;
+            return continuation.continueAsserting;
         }
     }
 }

--- a/Src/FluentAssertions/Execution/ContinuationOfGiven.cs
+++ b/Src/FluentAssertions/Execution/ContinuationOfGiven.cs
@@ -5,22 +5,19 @@ namespace FluentAssertions.Execution
     /// </summary>
     public class ContinuationOfGiven<TSubject>
     {
-        #region Private Definitions
-
+        private readonly GivenSelector<TSubject> parent;
         private readonly bool succeeded;
 
-        #endregion
-
-        public ContinuationOfGiven(GivenSelector<TSubject> parent, bool succeeded)
+        internal ContinuationOfGiven(GivenSelector<TSubject> parent, bool succeeded)
         {
-            Then = parent;
             this.succeeded = succeeded;
+            this.parent = parent;
         }
 
         /// <summary>
         /// Continuous the assertion chain if the previous assertion was successful.
         /// </summary>
-        public GivenSelector<TSubject> Then { get; }
+        public GivenSelector<TSubject> Then => parent;
 
         /// <summary>
         /// Provides back-wards compatibility for code that expects <see cref="AssertionScope.FailWith(string, object[])"/> to return a boolean.

--- a/Src/FluentAssertions/Execution/IAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/IAssertionScope.cs
@@ -99,11 +99,6 @@ namespace FluentAssertions.Execution
         IAssertionScope UsingLineBreaks { get; }
 
         /// <summary>
-        /// Gets a value indicating whether or not the last assertion executed through this scope succeeded.
-        /// </summary>
-        bool Succeeded { get; }
-
-        /// <summary>
         /// Discards and returns the failures that happened up to now.
         /// </summary>
         string[] Discard();

--- a/Src/FluentAssertions/Primitives/StringEqualityValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringEqualityValidator.cs
@@ -22,8 +22,7 @@ namespace FluentAssertions.Primitives
                 .FailWith(ExpectationDescription + "{0}{reason}, but it misses some extra whitespace at the end.", Expected)
                 .Then
                 .ForCondition(!((Subject.Length > Expected.Length) && Subject.TrimEnd().Equals(Expected, comparisonMode)))
-                .FailWith(ExpectationDescription + "{0}{reason}, but it has unexpected whitespace at the end.", Expected)
-                .SourceSucceeded;
+                .FailWith(ExpectationDescription + "{0}{reason}, but it has unexpected whitespace at the end.", Expected);
         }
 
         protected override bool ValidateAgainstLengthDifferences()
@@ -38,8 +37,7 @@ namespace FluentAssertions.Primitives
                                         "{0} with a length of {1}{reason}, but {2} has a length of {3}, differs near " + mismatchSegment + ".";
 
                     return new FailReason(message, Expected, Expected.Length, Subject, Subject.Length);
-                })
-                .SourceSucceeded;
+                });
         }
 
         private string GetMismatchSegmentForStringsOfDifferentLengths()

--- a/Src/FluentAssertions/Primitives/StringStartValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringStartValidator.cs
@@ -35,8 +35,7 @@ namespace FluentAssertions.Primitives
         {
             return Assertion
                 .ForCondition(Subject.Length >= Expected.Length)
-                .FailWith(ExpectationDescription + "{0}{reason}, but {1} is too short.", Expected, Subject)
-                .SourceSucceeded;
+                .FailWith(ExpectationDescription + "{0}{reason}, but {1} is too short.", Expected, Subject);
         }
 
         protected override void ValidateAgainstMismatch()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -999,21 +999,16 @@ namespace FluentAssertions.Execution
     }
     public class Continuation
     {
-        public Continuation(FluentAssertions.Execution.AssertionScope sourceScope, bool sourceSucceeded) { }
-        public bool SourceSucceeded { get; }
         public FluentAssertions.Execution.IAssertionScope Then { get; }
         public static bool op_Implicit(FluentAssertions.Execution.Continuation continuation) { }
     }
     public class ContinuationOfGiven<TSubject>
     {
-        public ContinuationOfGiven(FluentAssertions.Execution.GivenSelector<TSubject> parent, bool succeeded) { }
         public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
         public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
     }
     public sealed class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
     {
-        public ContinuedAssertionScope(FluentAssertions.Execution.AssertionScope predecessor, bool predecessorSucceeded) { }
-        public bool Succeeded { get; }
         public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
         public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
         public FluentAssertions.Execution.Continuation ClearExpectation() { }
@@ -1038,7 +1033,6 @@ namespace FluentAssertions.Execution
     }
     public class GivenSelector<T>
     {
-        public GivenSelector(System.Func<T> selector, bool predecessorSucceeded, FluentAssertions.Execution.AssertionScope predecessor) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> ClearExpectation() { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<, >[] args) { }
@@ -1048,7 +1042,6 @@ namespace FluentAssertions.Execution
     }
     public interface IAssertionScope : System.IDisposable
     {
-        bool Succeeded { get; }
         FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
         FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
         FluentAssertions.Execution.Continuation ClearExpectation();

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -999,21 +999,16 @@ namespace FluentAssertions.Execution
     }
     public class Continuation
     {
-        public Continuation(FluentAssertions.Execution.AssertionScope sourceScope, bool sourceSucceeded) { }
-        public bool SourceSucceeded { get; }
         public FluentAssertions.Execution.IAssertionScope Then { get; }
         public static bool op_Implicit(FluentAssertions.Execution.Continuation continuation) { }
     }
     public class ContinuationOfGiven<TSubject>
     {
-        public ContinuationOfGiven(FluentAssertions.Execution.GivenSelector<TSubject> parent, bool succeeded) { }
         public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
         public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
     }
     public sealed class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
     {
-        public ContinuedAssertionScope(FluentAssertions.Execution.AssertionScope predecessor, bool predecessorSucceeded) { }
-        public bool Succeeded { get; }
         public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
         public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
         public FluentAssertions.Execution.Continuation ClearExpectation() { }
@@ -1038,7 +1033,6 @@ namespace FluentAssertions.Execution
     }
     public class GivenSelector<T>
     {
-        public GivenSelector(System.Func<T> selector, bool predecessorSucceeded, FluentAssertions.Execution.AssertionScope predecessor) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> ClearExpectation() { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<, >[] args) { }
@@ -1048,7 +1042,6 @@ namespace FluentAssertions.Execution
     }
     public interface IAssertionScope : System.IDisposable
     {
-        bool Succeeded { get; }
         FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
         FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
         FluentAssertions.Execution.Continuation ClearExpectation();

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -999,21 +999,16 @@ namespace FluentAssertions.Execution
     }
     public class Continuation
     {
-        public Continuation(FluentAssertions.Execution.AssertionScope sourceScope, bool sourceSucceeded) { }
-        public bool SourceSucceeded { get; }
         public FluentAssertions.Execution.IAssertionScope Then { get; }
         public static bool op_Implicit(FluentAssertions.Execution.Continuation continuation) { }
     }
     public class ContinuationOfGiven<TSubject>
     {
-        public ContinuationOfGiven(FluentAssertions.Execution.GivenSelector<TSubject> parent, bool succeeded) { }
         public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
         public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
     }
     public sealed class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
     {
-        public ContinuedAssertionScope(FluentAssertions.Execution.AssertionScope predecessor, bool predecessorSucceeded) { }
-        public bool Succeeded { get; }
         public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
         public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
         public FluentAssertions.Execution.Continuation ClearExpectation() { }
@@ -1038,7 +1033,6 @@ namespace FluentAssertions.Execution
     }
     public class GivenSelector<T>
     {
-        public GivenSelector(System.Func<T> selector, bool predecessorSucceeded, FluentAssertions.Execution.AssertionScope predecessor) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> ClearExpectation() { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<, >[] args) { }
@@ -1048,7 +1042,6 @@ namespace FluentAssertions.Execution
     }
     public interface IAssertionScope : System.IDisposable
     {
-        bool Succeeded { get; }
         FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
         FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
         FluentAssertions.Execution.Continuation ClearExpectation();

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -952,21 +952,16 @@ namespace FluentAssertions.Execution
     }
     public class Continuation
     {
-        public Continuation(FluentAssertions.Execution.AssertionScope sourceScope, bool sourceSucceeded) { }
-        public bool SourceSucceeded { get; }
         public FluentAssertions.Execution.IAssertionScope Then { get; }
         public static bool op_Implicit(FluentAssertions.Execution.Continuation continuation) { }
     }
     public class ContinuationOfGiven<TSubject>
     {
-        public ContinuationOfGiven(FluentAssertions.Execution.GivenSelector<TSubject> parent, bool succeeded) { }
         public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
         public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
     }
     public sealed class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
     {
-        public ContinuedAssertionScope(FluentAssertions.Execution.AssertionScope predecessor, bool predecessorSucceeded) { }
-        public bool Succeeded { get; }
         public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
         public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
         public FluentAssertions.Execution.Continuation ClearExpectation() { }
@@ -991,7 +986,6 @@ namespace FluentAssertions.Execution
     }
     public class GivenSelector<T>
     {
-        public GivenSelector(System.Func<T> selector, bool predecessorSucceeded, FluentAssertions.Execution.AssertionScope predecessor) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> ClearExpectation() { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<, >[] args) { }
@@ -1001,7 +995,6 @@ namespace FluentAssertions.Execution
     }
     public interface IAssertionScope : System.IDisposable
     {
-        bool Succeeded { get; }
         FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
         FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
         FluentAssertions.Execution.Continuation ClearExpectation();

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -999,21 +999,16 @@ namespace FluentAssertions.Execution
     }
     public class Continuation
     {
-        public Continuation(FluentAssertions.Execution.AssertionScope sourceScope, bool sourceSucceeded) { }
-        public bool SourceSucceeded { get; }
         public FluentAssertions.Execution.IAssertionScope Then { get; }
         public static bool op_Implicit(FluentAssertions.Execution.Continuation continuation) { }
     }
     public class ContinuationOfGiven<TSubject>
     {
-        public ContinuationOfGiven(FluentAssertions.Execution.GivenSelector<TSubject> parent, bool succeeded) { }
         public FluentAssertions.Execution.GivenSelector<TSubject> Then { get; }
         public static bool op_Implicit(FluentAssertions.Execution.ContinuationOfGiven<TSubject> continuationOfGiven) { }
     }
     public sealed class ContinuedAssertionScope : FluentAssertions.Execution.IAssertionScope, System.IDisposable
     {
-        public ContinuedAssertionScope(FluentAssertions.Execution.AssertionScope predecessor, bool predecessorSucceeded) { }
-        public bool Succeeded { get; }
         public FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
         public FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs) { }
         public FluentAssertions.Execution.Continuation ClearExpectation() { }
@@ -1038,7 +1033,6 @@ namespace FluentAssertions.Execution
     }
     public class GivenSelector<T>
     {
-        public GivenSelector(System.Func<T> selector, bool predecessorSucceeded, FluentAssertions.Execution.AssertionScope predecessor) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> ClearExpectation() { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message) { }
         public FluentAssertions.Execution.ContinuationOfGiven<T> FailWith(string message, params System.Func<, >[] args) { }
@@ -1048,7 +1042,6 @@ namespace FluentAssertions.Execution
     }
     public interface IAssertionScope : System.IDisposable
     {
-        bool Succeeded { get; }
         FluentAssertions.Execution.IAssertionScope UsingLineBreaks { get; }
         FluentAssertions.Execution.IAssertionScope BecauseOf(string because, params object[] becauseArgs);
         FluentAssertions.Execution.Continuation ClearExpectation();

--- a/Tests/FluentAssertions.Specs/.editorconfig
+++ b/Tests/FluentAssertions.Specs/.editorconfig
@@ -107,3 +107,6 @@ dotnet_diagnostic.SA1602.severity = none
 dotnet_diagnostic.SA1611.severity = none
 # SA1615: Element return value should be documented
 dotnet_diagnostic.SA1615.severity = none
+
+# SA1005: Single line comments should begin with single space
+dotnet_diagnostic.SA1005.severity = suggestion

--- a/Tests/FluentAssertions.Specs/Execution/IgnoringFailuresAssertionStrategy.cs
+++ b/Tests/FluentAssertions.Specs/Execution/IgnoringFailuresAssertionStrategy.cs
@@ -1,0 +1,20 @@
+namespace FluentAssertions.Specs.Execution
+{
+    using System.Collections.Generic;
+    using FluentAssertions.Execution;
+
+    internal class IgnoringFailuresAssertionStrategy : IAssertionStrategy
+    {
+        public IEnumerable<string> FailureMessages => new string[0];
+
+        public void HandleFailure(string message)
+        {
+        }
+
+        public IEnumerable<string> DiscardFailures() => new string[0];
+
+        public void ThrowIfAny(IDictionary<string, object> context)
+        {
+        }
+    }
+}

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -35,6 +35,8 @@ sidebar:
 * Changed dictionary assertion `NotContainKeys` to honour the key comparer if applicable - [#1233](https://github.com/fluentassertions/fluentassertions/pull/1233).
 * Ensures that date time assertions like "a is less than an hour after b" don't succeed when `a - b == -30.Minutes()` [#1313](https://github.com/fluentassertions/fluentassertions/pull/1313).
 * Event raising assertions like `WithSender` and `WithArgs` will only return the events that match the constraints - [#1321](https://github.com/fluentassertions/fluentassertions/pull/1321)
+* Fixed an `InvalidCastException` that `BeEquivalentTo` could throw while debugging - [#1325](https://github.com/fluentassertions/fluentassertions/pull/1325)
+* Ensured that `Given` will no longer evaluate its predicate if the preceding `FailWith` raised an assertion failure - [#1325](https://github.com/fluentassertions/fluentassertions/pull/1325)
 
 **Breaking Changes**
 * Dropped support for .NET Framework 4.5, .NET Standard 1.3 and 1.6 - [#1227](https://github.com/fluentassertions/fluentassertions/pull/1227).
@@ -64,7 +66,7 @@ sidebar:
 * Several event raising assertion APIs will return an `IEventRecording` instead of `IEventRecorder` - [#1321](https://github.com/fluentassertions/fluentassertions/pull/1321)
 * The classes `EventMonitor` and `RecordedEvent` are now treated as `internal` code - [#1321](https://github.com/fluentassertions/fluentassertions/pull/1321)
 * Renamed method `GetEventRecorder` of interface `IMonitor` to `GetRecordingFor` and will return `IEventRecording` - [#1321](https://github.com/fluentassertions/fluentassertions/pull/1321)
-
+* Removed `Succeeded` and `SourceSucceeded` from `Continuation` and `IAssertionScope` - [#1325](https://github.com/fluentassertions/fluentassertions/pull/1325)
 
 ## 5.10.3
 **Fixes**


### PR DESCRIPTION
When the initial assertion run through the AssertionScope failed, the chaining API would not ignore any following calls to Given, FailWith, etc. 

Fixes #1302

* [x] Add release notes