### PR TITLE
Improve identification of callers containing Should

### DIFF
--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -85,10 +85,10 @@ namespace FluentAssertions
 
                 logger(statement);
 
-                int indexOfShould = statement.IndexOf("Should", StringComparison.Ordinal);
+                int indexOfShould = statement.IndexOf(".Should", StringComparison.Ordinal);
                 if (indexOfShould != -1)
                 {
-                    string candidate = statement.Substring(0, indexOfShould - 1);
+                    string candidate = statement.Substring(0, indexOfShould);
 
                     logger(candidate);
 

--- a/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
@@ -36,6 +36,20 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>().WithMessage("Expected actualCaller to be*");
         }
+
+        [Fact]
+        public void When_variable_name_contains_Should_it_should_identify_the_entire_variable_name_as_the_caller()
+        {
+            // Arrange
+            string fooShould = "bar";
+
+            // Act
+            Action act = () => fooShould.Should().BeNull();
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*Expected fooShould to be <null>*");
+        }
     }
 }
 


### PR DESCRIPTION
We can improve the caller identification a tiny bit without adding complexity.

This fixes #1330