### PR TITLE
Add AllBe for string collections

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -590,24 +590,5 @@ namespace FluentAssertions.Collections
 
             return BeEquivalentTo(repeatedExpectation, forceStringOrderingConfig, because, becauseArgs);
         }
-
-        private static IEnumerable<TExpectation> RepeatAsManyAs<TExpectation>(TExpectation value, IEnumerable<T> enumerable)
-        {
-            if (enumerable is null)
-            {
-                return Enumerable.Empty<TExpectation>();
-            }
-
-            return RepeatAsManyAsIterator(value, enumerable);
-        }
-
-        private static IEnumerable<TExpectation> RepeatAsManyAsIterator<TExpectation>(TExpectation value, IEnumerable<T> enumerable)
-        {
-            using IEnumerator<T> enumerator = enumerable.GetEnumerator();
-            while (enumerator.MoveNext())
-            {
-                yield return value;
-            }
-        }
     }
 }

--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -789,5 +789,24 @@ namespace FluentAssertions.Collections
 
             return collectionFailures;
         }
+
+        protected static IEnumerable<TExpectation> RepeatAsManyAs<TExpectation>(TExpectation value, IEnumerable<T> enumerable)
+        {
+            if (enumerable is null)
+            {
+                return Enumerable.Empty<TExpectation>();
+            }
+
+            return RepeatAsManyAsIterator(value, enumerable);
+        }
+
+        private static IEnumerable<TExpectation> RepeatAsManyAsIterator<TExpectation>(TExpectation value, IEnumerable<T> enumerable)
+        {
+            using IEnumerator<T> enumerator = enumerable.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                yield return value;
+            }
+        }
     }
 }

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -145,6 +145,67 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
+        /// Asserts that all elements in a collection of objects are equivalent to a given object.
+        /// </summary>
+        /// <remarks>
+        /// The two collections are equivalent when they both contain the same strings in any order.
+        /// </remarks>
+        /// <param name="expectation">An expected <see cref="string"/> element.</param>
+        /// <param name="because">
+        /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the
+        /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> AllBeEquivalentTo(string expectation,
+            string because = "", params object[] becauseArgs)
+        {
+            return AllBeEquivalentTo(expectation, options => options, because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts that all elements in a collection of objects are equivalent to a given object.
+        /// </summary>
+        /// <remarks>
+        /// The two collections are equivalent when they both contain the same strings in any order.
+        /// </remarks>
+        /// <param name="expectation">An expected <see cref="string"/> element.</param>
+        /// <param name="config">
+        /// A reference to the <see cref="EquivalencyAssertionOptions{String}"/> configuration object that can be used
+        /// to influence the way the object graphs are compared. You can also provide an alternative instance of the
+        /// <see cref="EquivalencyAssertionOptions{String}"/> class. The global defaults are determined by the
+        /// <see cref="AssertionOptions"/> class.
+        /// </param>
+        /// <param name="because">
+        /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the
+        /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> AllBeEquivalentTo(string expectation,
+            Func<EquivalencyAssertionOptions<string>, EquivalencyAssertionOptions<string>> config,
+            string because = "",
+            params object[] becauseArgs)
+        {
+            Guard.ThrowIfArgumentIsNull(config, nameof(config));
+
+            string[] repeatedExpectation = RepeatAsManyAs(expectation, Subject).ToArray();
+
+            // Because we have just manually created the collection based on single element
+            // we are sure that we can force strict ordering, because ordering does not matter in terms
+            // of correctness. On the other hand we do not want to change ordering rules for nested objects
+            // in case user needs to use them. Strict ordering improves algorithmic complexity
+            // from O(n^2) to O(n). For bigger tables it is necessary in order to achieve acceptable
+            // execution times.
+            Func<EquivalencyAssertionOptions<string>, EquivalencyAssertionOptions<string>> forceStringOrderingConfig =
+                x => config(x).WithStrictOrderingFor(s => string.IsNullOrEmpty(s.SelectedMemberPath));
+
+            return BeEquivalentTo(repeatedExpectation, forceStringOrderingConfig, because, becauseArgs);
+        }
+
+        /// <summary>
         /// Expects the current collection to contain the specified elements in the exact same order. Elements are compared
         /// using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -145,11 +145,8 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
-        /// Asserts that all elements in a collection of objects are equivalent to a given object.
+        /// Asserts that all elements in a collection of objects are equal to a given object.
         /// </summary>
-        /// <remarks>
-        /// The two collections are equivalent when they both contain the same strings in any order.
-        /// </remarks>
         /// <param name="expectation">An expected <see cref="string"/> element.</param>
         /// <param name="because">
         /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the
@@ -158,18 +155,15 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> AllBeEquivalentTo(string expectation,
+        public AndConstraint<TAssertions> AllBe(string expectation,
             string because = "", params object[] becauseArgs)
         {
-            return AllBeEquivalentTo(expectation, options => options, because, becauseArgs);
+            return AllBe(expectation, options => options, because, becauseArgs);
         }
 
         /// <summary>
-        /// Asserts that all elements in a collection of objects are equivalent to a given object.
+        /// Asserts that all elements in a collection of objects are equal to a given object.
         /// </summary>
-        /// <remarks>
-        /// The two collections are equivalent when they both contain the same strings in any order.
-        /// </remarks>
         /// <param name="expectation">An expected <see cref="string"/> element.</param>
         /// <param name="config">
         /// A reference to the <see cref="EquivalencyAssertionOptions{String}"/> configuration object that can be used
@@ -184,7 +178,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> AllBeEquivalentTo(string expectation,
+        public AndConstraint<TAssertions> AllBe(string expectation,
             Func<EquivalencyAssertionOptions<string>, EquivalencyAssertionOptions<string>> config,
             string because = "",
             params object[] becauseArgs)

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -145,9 +145,9 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
-        /// Asserts that all elements in a collection of objects are equal to a given object.
+        /// Asserts that all strings in a collection of strings are equal to the given string.
         /// </summary>
-        /// <param name="expectation">An expected <see cref="string"/> element.</param>
+        /// <param name="expectation">An expected <see cref="string"/>.</param>
         /// <param name="because">
         /// An optional formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the
         /// assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -162,9 +162,9 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
-        /// Asserts that all elements in a collection of objects are equal to a given object.
+        /// Asserts that all strings in a collection of strings are equal to the given string.
         /// </summary>
-        /// <param name="expectation">An expected <see cref="string"/> element.</param>
+        /// <param name="expectation">An expected <see cref="string"/>.</param>
         /// <param name="config">
         /// A reference to the <see cref="EquivalencyAssertionOptions{String}"/> configuration object that can be used
         /// to influence the way the object graphs are compared. You can also provide an alternative instance of the

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -449,6 +449,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(System.Collections.Generic.IEnumerable<System.Action<T>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected static System.Collections.Generic.IEnumerable<TExpectation> RepeatAsManyAs<TExpectation>(TExpectation value, System.Collections.Generic.IEnumerable<T> enumerable) { }
     }
     public class StringCollectionAssertions : FluentAssertions.Collections.StringCollectionAssertions<System.Collections.Generic.IEnumerable<string>>
     {
@@ -464,6 +465,8 @@ namespace FluentAssertions.Collections
         where TAssertions : FluentAssertions.Collections.StringCollectionAssertions<TCollection, TAssertions>
     {
         public StringCollectionAssertions(TCollection actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params string[] expectation) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -449,6 +449,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(System.Collections.Generic.IEnumerable<System.Action<T>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected static System.Collections.Generic.IEnumerable<TExpectation> RepeatAsManyAs<TExpectation>(TExpectation value, System.Collections.Generic.IEnumerable<T> enumerable) { }
     }
     public class StringCollectionAssertions : FluentAssertions.Collections.StringCollectionAssertions<System.Collections.Generic.IEnumerable<string>>
     {
@@ -464,6 +465,8 @@ namespace FluentAssertions.Collections
         where TAssertions : FluentAssertions.Collections.StringCollectionAssertions<TCollection, TAssertions>
     {
         public StringCollectionAssertions(TCollection actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params string[] expectation) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -449,6 +449,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(System.Collections.Generic.IEnumerable<System.Action<T>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected static System.Collections.Generic.IEnumerable<TExpectation> RepeatAsManyAs<TExpectation>(TExpectation value, System.Collections.Generic.IEnumerable<T> enumerable) { }
     }
     public class StringCollectionAssertions : FluentAssertions.Collections.StringCollectionAssertions<System.Collections.Generic.IEnumerable<string>>
     {
@@ -464,6 +465,8 @@ namespace FluentAssertions.Collections
         where TAssertions : FluentAssertions.Collections.StringCollectionAssertions<TCollection, TAssertions>
     {
         public StringCollectionAssertions(TCollection actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params string[] expectation) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -442,6 +442,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(System.Collections.Generic.IEnumerable<System.Action<T>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected static System.Collections.Generic.IEnumerable<TExpectation> RepeatAsManyAs<TExpectation>(TExpectation value, System.Collections.Generic.IEnumerable<T> enumerable) { }
     }
     public class StringCollectionAssertions : FluentAssertions.Collections.StringCollectionAssertions<System.Collections.Generic.IEnumerable<string>>
     {
@@ -457,6 +458,8 @@ namespace FluentAssertions.Collections
         where TAssertions : FluentAssertions.Collections.StringCollectionAssertions<TCollection, TAssertions>
     {
         public StringCollectionAssertions(TCollection actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params string[] expectation) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -449,6 +449,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> SatisfyRespectively(System.Collections.Generic.IEnumerable<System.Action<T>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith(System.Collections.Generic.IEnumerable<T> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith<TExpected>(System.Collections.Generic.IEnumerable<TExpected> expectation, System.Func<T, TExpected, bool> equalityComparison, string because = "", params object[] becauseArgs) { }
+        protected static System.Collections.Generic.IEnumerable<TExpectation> RepeatAsManyAs<TExpectation>(TExpectation value, System.Collections.Generic.IEnumerable<T> enumerable) { }
     }
     public class StringCollectionAssertions : FluentAssertions.Collections.StringCollectionAssertions<System.Collections.Generic.IEnumerable<string>>
     {
@@ -464,6 +465,8 @@ namespace FluentAssertions.Collections
         where TAssertions : FluentAssertions.Collections.StringCollectionAssertions<TCollection, TAssertions>
     {
         public StringCollectionAssertions(TCollection actualValue) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> AllBe(string expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(params string[] expectation) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }

--- a/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
@@ -828,7 +828,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_all_string_subject_items_are_equal_to_expectation_object_it_should_succeed()
+        public void When_all_strings_in_the_collection_are_equal_to_the_expected_string_it_should_succeed()
         {
             // Arrange
             var subject = new List<string> { "one", "one", "one" };
@@ -841,7 +841,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_all_string_subject_items_are_equal_to_expectation_object_it_should_allow_chaining()
+        public void When_all_strings_in_the_collection_are_equal_to_the_expected_string_it_should_allow_chaining()
         {
             // Arrange
             var subject = new List<string> { "one", "one", "one" };
@@ -854,7 +854,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_some_string_subject_items_are_not_equal_to_expectation_object_it_should_throw()
+        public void When_some_string_in_the_collection_is_not_equal_to_the_expected_string_it_should_throw()
         {
             // Arrange
             var subject = new[] { "one", "two", "six" };
@@ -869,7 +869,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_some_string_subject_items_are_in_different_case_than_expectation_object_it_should_throw()
+        public void When_some_string_in_the_collection_is_in_different_case_than_expected_string_it_should_throw()
         {
             // Arrange
             var subject = new[] { "one", "One", "ONE" };
@@ -884,7 +884,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_more_than_10_string_subjects_items_are_not_equal_to_expectation_only_10_are_reported()
+        public void When_more_than_10_strings_in_the_collection_are_not_equal_to_expected_string_only_10_are_reported()
         {
             // Arrange
             var subject = Enumerable.Repeat("two", 11);
@@ -899,7 +899,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_some_string_subject_items_are_not_equal_to_expectation_for_huge_table_execution_time_should_still_be_short()
+        public void When_some_strings_in_the_collection_are_not_equal_to_expected_string_for_huge_table_execution_time_should_still_be_short()
         {
             // Arrange
             const int N = 100000;

--- a/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
@@ -851,6 +851,19 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_all_string_subject_items_are_equivalent_to_expectation_object_it_should_succeed()
+        {
+            // Arrange
+            var subject = new List<string> { "one", "one", "one" };
+
+            // Act
+            Action action = () => subject.Should().AllBeEquivalentTo("one");
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
         public void When_all_subject_items_are_equivalent_to_expectation_object_it_should_allow_chaining()
         {
             // Arrange
@@ -875,6 +888,19 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_all_string_subject_items_are_equivalent_to_expectation_object_it_should_allow_chaining()
+        {
+            // Arrange
+            var subject = new List<string> { "one", "one", "one" };
+
+            // Act
+            Action action = () => subject.Should().AllBeEquivalentTo("one").And.HaveCount(3);
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
         public void When_some_subject_items_are_not_equivalent_to_expectation_object_it_should_throw()
         {
             // Arrange
@@ -889,6 +915,21 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_some_string_subject_items_are_not_equivalent_to_expectation_object_it_should_throw()
+        {
+            // Arrange
+            var subject = new[] { "one", "two", "six" };
+
+            // Act
+            Action action = () => subject.Should().AllBeEquivalentTo("one");
+
+            // Assert
+            action.Should().Throw<XunitException>().WithMessage(
+                "Expected item[1] to be \"one\", but \"two\" differs near \"two\" (index 0).*" +
+                "Expected item[2] to be \"one\", but \"six\" differs near \"six\" (index 0).*");
+        }
+
+        [Fact]
         public void When_more_than_10_subjects_items_are_not_equivalent_to_expectation_only_10_are_reported()
         {
             // Arrange
@@ -900,6 +941,21 @@ namespace FluentAssertions.Specs
             // Assert
             action.Should().Throw<XunitException>().Which
                 .Message.Should().Contain("item[9] to be 1, but found 2")
+                .And.NotContain("item[10]");
+        }
+
+        [Fact]
+        public void When_more_than_10_string_subjects_items_are_not_equivalent_to_expectation_only_10_are_reported()
+        {
+            // Arrange
+            var subject = Enumerable.Repeat("two", 11);
+
+            // Act
+            Action action = () => subject.Should().AllBeEquivalentTo("one");
+
+            // Assert
+            action.Should().Throw<XunitException>().Which
+                .Message.Should().Contain("item[9] to be \"one\", but \"two\" differs near \"two\" (index 0)")
                 .And.NotContain("item[10]");
         }
 
@@ -920,6 +976,34 @@ namespace FluentAssertions.Specs
                 try
                 {
                     subject.Should().AllBeEquivalentTo(1);
+                }
+                catch
+                {
+                    // ignored, we only care about execution time
+                }
+            };
+
+            // Assert
+            action.ExecutionTime().Should().BeLessThan(1.Seconds());
+        }
+
+        [Fact]
+        public void When_some_string_subject_items_are_not_equivalent_to_expectation_for_huge_table_execution_time_should_still_be_short()
+        {
+            // Arrange
+            const int N = 100000;
+            var subject = new List<string>(N) { "one" };
+            for (int i = 1; i < N; i++)
+            {
+                subject.Add("two");
+            }
+
+            // Act
+            Action action = () =>
+            {
+                try
+                {
+                    subject.Should().AllBeEquivalentTo("one");
                 }
                 catch
                 {
@@ -1555,6 +1639,19 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_string_collection_subject_is_empty_and_expectation_is_object_succeed()
+        {
+            // Arrange
+            var subject = new List<string>();
+
+            // Act
+            Action action = () => subject.Should().AllBeEquivalentTo("one");
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
         public void When_injecting_a_null_config_to_AllBeEquivalentTo_it_should_throw()
         {
             // Arrange
@@ -1562,6 +1659,20 @@ namespace FluentAssertions.Specs
 
             // Act
             Action action = () => subject.Should().AllBeEquivalentTo('g', config: null);
+
+            // Assert
+            action.Should().ThrowExactly<ArgumentNullException>()
+                .Which.ParamName.Should().Be("config");
+        }
+
+        [Fact]
+        public void When_injecting_a_null_config_to_AllBeEquivalentTo_for_string_collection_it_should_throw()
+        {
+            // Arrange
+            var subject = new List<string>();
+
+            // Act
+            Action action = () => subject.Should().AllBeEquivalentTo("one", config: null);
 
             // Assert
             action.Should().ThrowExactly<ArgumentNullException>()
@@ -1582,6 +1693,19 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_all_string_subject_items_are_equivalent_to_expectation_object_with_a_config_it_should_succeed()
+        {
+            // Arrange
+            var subject = new List<string> { "one", "one" };
+
+            // Act
+            Action action = () => subject.Should().AllBeEquivalentTo("one", opt => opt);
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
         public void When_not_all_subject_items_are_equivalent_to_expectation_object_with_a_config_it_should_fail()
         {
             // Arrange
@@ -1596,6 +1720,20 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_not_all_string_subject_items_are_equivalent_to_expectation_object_with_a_config_it_should_fail()
+        {
+            // Arrange
+            var subject = new List<string> { "one", "two" };
+
+            // Act
+            Action action = () => subject.Should().AllBeEquivalentTo("one", opt => opt, "we want to test the failure {0}", "message");
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("*we want to test the failure message*");
+        }
+
+        [Fact]
         public void When_all_subject_items_are_equivalent_to_expectation_object_with_a_config_it_should_allow_chaining()
         {
             // Arrange
@@ -1603,6 +1741,20 @@ namespace FluentAssertions.Specs
 
             // Act
             Action action = () => subject.Should().AllBeEquivalentTo('g', opt => opt)
+                .And.HaveCount(2);
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_all_string_subject_items_are_equivalent_to_expectation_object_with_a_config_it_should_allow_chaining()
+        {
+            // Arrange
+            var subject = new List<string> { "one", "one" };
+
+            // Act
+            Action action = () => subject.Should().AllBeEquivalentTo("one", opt => opt)
                 .And.HaveCount(2);
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
@@ -930,6 +930,21 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_some_string_subject_items_are_in_different_case_than_expectation_object_it_should_throw()
+        {
+            // Arrange
+            var subject = new[] { "one", "One", "ONE" };
+
+            // Act
+            Action action = () => subject.Should().AllBeEquivalentTo("one");
+
+            // Assert
+            action.Should().Throw<XunitException>().WithMessage(
+                "Expected item[1] to be \"one\", but \"One\" differs near \"One\" (index 0).*" +
+                "Expected item[2] to be \"one\", but \"ONE\" differs near \"ONE\" (index 0).*");
+        }
+
+        [Fact]
         public void When_more_than_10_subjects_items_are_not_equivalent_to_expectation_only_10_are_reported()
         {
             // Arrange

--- a/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
@@ -828,6 +828,105 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_all_string_subject_items_are_equal_to_expectation_object_it_should_succeed()
+        {
+            // Arrange
+            var subject = new List<string> { "one", "one", "one" };
+
+            // Act
+            Action action = () => subject.Should().AllBe("one");
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_all_string_subject_items_are_equal_to_expectation_object_it_should_allow_chaining()
+        {
+            // Arrange
+            var subject = new List<string> { "one", "one", "one" };
+
+            // Act
+            Action action = () => subject.Should().AllBe("one").And.HaveCount(3);
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_some_string_subject_items_are_not_equal_to_expectation_object_it_should_throw()
+        {
+            // Arrange
+            var subject = new[] { "one", "two", "six" };
+
+            // Act
+            Action action = () => subject.Should().AllBe("one");
+
+            // Assert
+            action.Should().Throw<XunitException>().WithMessage(
+                "Expected item[1] to be \"one\", but \"two\" differs near \"two\" (index 0).*" +
+                "Expected item[2] to be \"one\", but \"six\" differs near \"six\" (index 0).*");
+        }
+
+        [Fact]
+        public void When_some_string_subject_items_are_in_different_case_than_expectation_object_it_should_throw()
+        {
+            // Arrange
+            var subject = new[] { "one", "One", "ONE" };
+
+            // Act
+            Action action = () => subject.Should().AllBe("one");
+
+            // Assert
+            action.Should().Throw<XunitException>().WithMessage(
+                "Expected item[1] to be \"one\", but \"One\" differs near \"One\" (index 0).*" +
+                "Expected item[2] to be \"one\", but \"ONE\" differs near \"ONE\" (index 0).*");
+        }
+
+        [Fact]
+        public void When_more_than_10_string_subjects_items_are_not_equal_to_expectation_only_10_are_reported()
+        {
+            // Arrange
+            var subject = Enumerable.Repeat("two", 11);
+
+            // Act
+            Action action = () => subject.Should().AllBe("one");
+
+            // Assert
+            action.Should().Throw<XunitException>().Which
+                .Message.Should().Contain("item[9] to be \"one\", but \"two\" differs near \"two\" (index 0)")
+                .And.NotContain("item[10]");
+        }
+
+        [Fact]
+        public void When_some_string_subject_items_are_not_equal_to_expectation_for_huge_table_execution_time_should_still_be_short()
+        {
+            // Arrange
+            const int N = 100000;
+            var subject = new List<string>(N) { "one" };
+            for (int i = 1; i < N; i++)
+            {
+                subject.Add("two");
+            }
+
+            // Act
+            Action action = () =>
+            {
+                try
+                {
+                    subject.Should().AllBe("one");
+                }
+                catch
+                {
+                    // ignored, we only care about execution time
+                }
+            };
+
+            // Assert
+            action.ExecutionTime().Should().BeLessThan(1.Seconds());
+        }
+
+        [Fact]
         public void When_all_subject_items_are_equivalent_to_expectation_object_it_should_succeed()
         {
             // Arrange
@@ -845,19 +944,6 @@ namespace FluentAssertions.Specs
                 Age = 1,
                 Birthdate = default(DateTime)
             });
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_all_string_subject_items_are_equivalent_to_expectation_object_it_should_succeed()
-        {
-            // Arrange
-            var subject = new List<string> { "one", "one", "one" };
-
-            // Act
-            Action action = () => subject.Should().AllBeEquivalentTo("one");
 
             // Assert
             action.Should().NotThrow();
@@ -888,19 +974,6 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_all_string_subject_items_are_equivalent_to_expectation_object_it_should_allow_chaining()
-        {
-            // Arrange
-            var subject = new List<string> { "one", "one", "one" };
-
-            // Act
-            Action action = () => subject.Should().AllBeEquivalentTo("one").And.HaveCount(3);
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
         public void When_some_subject_items_are_not_equivalent_to_expectation_object_it_should_throw()
         {
             // Arrange
@@ -915,36 +988,6 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_some_string_subject_items_are_not_equivalent_to_expectation_object_it_should_throw()
-        {
-            // Arrange
-            var subject = new[] { "one", "two", "six" };
-
-            // Act
-            Action action = () => subject.Should().AllBeEquivalentTo("one");
-
-            // Assert
-            action.Should().Throw<XunitException>().WithMessage(
-                "Expected item[1] to be \"one\", but \"two\" differs near \"two\" (index 0).*" +
-                "Expected item[2] to be \"one\", but \"six\" differs near \"six\" (index 0).*");
-        }
-
-        [Fact]
-        public void When_some_string_subject_items_are_in_different_case_than_expectation_object_it_should_throw()
-        {
-            // Arrange
-            var subject = new[] { "one", "One", "ONE" };
-
-            // Act
-            Action action = () => subject.Should().AllBeEquivalentTo("one");
-
-            // Assert
-            action.Should().Throw<XunitException>().WithMessage(
-                "Expected item[1] to be \"one\", but \"One\" differs near \"One\" (index 0).*" +
-                "Expected item[2] to be \"one\", but \"ONE\" differs near \"ONE\" (index 0).*");
-        }
-
-        [Fact]
         public void When_more_than_10_subjects_items_are_not_equivalent_to_expectation_only_10_are_reported()
         {
             // Arrange
@@ -956,21 +999,6 @@ namespace FluentAssertions.Specs
             // Assert
             action.Should().Throw<XunitException>().Which
                 .Message.Should().Contain("item[9] to be 1, but found 2")
-                .And.NotContain("item[10]");
-        }
-
-        [Fact]
-        public void When_more_than_10_string_subjects_items_are_not_equivalent_to_expectation_only_10_are_reported()
-        {
-            // Arrange
-            var subject = Enumerable.Repeat("two", 11);
-
-            // Act
-            Action action = () => subject.Should().AllBeEquivalentTo("one");
-
-            // Assert
-            action.Should().Throw<XunitException>().Which
-                .Message.Should().Contain("item[9] to be \"one\", but \"two\" differs near \"two\" (index 0)")
                 .And.NotContain("item[10]");
         }
 
@@ -991,34 +1019,6 @@ namespace FluentAssertions.Specs
                 try
                 {
                     subject.Should().AllBeEquivalentTo(1);
-                }
-                catch
-                {
-                    // ignored, we only care about execution time
-                }
-            };
-
-            // Assert
-            action.ExecutionTime().Should().BeLessThan(1.Seconds());
-        }
-
-        [Fact]
-        public void When_some_string_subject_items_are_not_equivalent_to_expectation_for_huge_table_execution_time_should_still_be_short()
-        {
-            // Arrange
-            const int N = 100000;
-            var subject = new List<string>(N) { "one" };
-            for (int i = 1; i < N; i++)
-            {
-                subject.Add("two");
-            }
-
-            // Act
-            Action action = () =>
-            {
-                try
-                {
-                    subject.Should().AllBeEquivalentTo("one");
                 }
                 catch
                 {
@@ -1641,6 +1641,74 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_string_collection_subject_is_empty_and_expectation_is_object_succeed()
+        {
+            // Arrange
+            var subject = new List<string>();
+
+            // Act
+            Action action = () => subject.Should().AllBe("one");
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_injecting_a_null_config_to_AllBe_for_string_collection_it_should_throw()
+        {
+            // Arrange
+            var subject = new List<string>();
+
+            // Act
+            Action action = () => subject.Should().AllBe("one", config: null);
+
+            // Assert
+            action.Should().ThrowExactly<ArgumentNullException>()
+                .Which.ParamName.Should().Be("config");
+        }
+
+        [Fact]
+        public void When_all_string_subject_items_are_equal_to_expectation_object_with_a_config_it_should_succeed()
+        {
+            // Arrange
+            var subject = new List<string> { "one", "one" };
+
+            // Act
+            Action action = () => subject.Should().AllBe("one", opt => opt);
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_not_all_string_subject_items_are_equal_to_expectation_object_with_a_config_it_should_fail()
+        {
+            // Arrange
+            var subject = new List<string> { "one", "two" };
+
+            // Act
+            Action action = () => subject.Should().AllBe("one", opt => opt, "we want to test the failure {0}", "message");
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("*we want to test the failure message*");
+        }
+
+        [Fact]
+        public void When_all_string_subject_items_are_equal_to_expectation_object_with_a_config_it_should_allow_chaining()
+        {
+            // Arrange
+            var subject = new List<string> { "one", "one" };
+
+            // Act
+            Action action = () => subject.Should().AllBe("one", opt => opt)
+                .And.HaveCount(2);
+
+            // Assert
+            action.Should().NotThrow();
+        }
+
+        [Fact]
         public void When_subject_is_empty_and_expectation_is_object_succeed()
         {
             // Arrange
@@ -1648,19 +1716,6 @@ namespace FluentAssertions.Specs
 
             // Act
             Action action = () => subject.Should().AllBeEquivalentTo('g');
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_string_collection_subject_is_empty_and_expectation_is_object_succeed()
-        {
-            // Arrange
-            var subject = new List<string>();
-
-            // Act
-            Action action = () => subject.Should().AllBeEquivalentTo("one");
 
             // Assert
             action.Should().NotThrow();
@@ -1681,20 +1736,6 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_injecting_a_null_config_to_AllBeEquivalentTo_for_string_collection_it_should_throw()
-        {
-            // Arrange
-            var subject = new List<string>();
-
-            // Act
-            Action action = () => subject.Should().AllBeEquivalentTo("one", config: null);
-
-            // Assert
-            action.Should().ThrowExactly<ArgumentNullException>()
-                .Which.ParamName.Should().Be("config");
-        }
-
-        [Fact]
         public void When_all_subject_items_are_equivalent_to_expectation_object_with_a_config_it_should_succeed()
         {
             // Arrange
@@ -1702,19 +1743,6 @@ namespace FluentAssertions.Specs
 
             // Act
             Action action = () => subject.Should().AllBeEquivalentTo('g', opt => opt);
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_all_string_subject_items_are_equivalent_to_expectation_object_with_a_config_it_should_succeed()
-        {
-            // Arrange
-            var subject = new List<string> { "one", "one" };
-
-            // Act
-            Action action = () => subject.Should().AllBeEquivalentTo("one", opt => opt);
 
             // Assert
             action.Should().NotThrow();
@@ -1735,20 +1763,6 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_not_all_string_subject_items_are_equivalent_to_expectation_object_with_a_config_it_should_fail()
-        {
-            // Arrange
-            var subject = new List<string> { "one", "two" };
-
-            // Act
-            Action action = () => subject.Should().AllBeEquivalentTo("one", opt => opt, "we want to test the failure {0}", "message");
-
-            // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("*we want to test the failure message*");
-        }
-
-        [Fact]
         public void When_all_subject_items_are_equivalent_to_expectation_object_with_a_config_it_should_allow_chaining()
         {
             // Arrange
@@ -1756,20 +1770,6 @@ namespace FluentAssertions.Specs
 
             // Act
             Action action = () => subject.Should().AllBeEquivalentTo('g', opt => opt)
-                .And.HaveCount(2);
-
-            // Assert
-            action.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_all_string_subject_items_are_equivalent_to_expectation_object_with_a_config_it_should_allow_chaining()
-        {
-            // Arrange
-            var subject = new List<string> { "one", "one" };
-
-            // Act
-            Action action = () => subject.Should().AllBeEquivalentTo("one", opt => opt)
                 .And.HaveCount(2);
 
             // Assert

--- a/docs/_pages/collections.md
+++ b/docs/_pages/collections.md
@@ -85,8 +85,9 @@ collection.Should().BeInDescendingOrder();
 collection.Should().NotBeInAscendingOrder();
 collection.Should().NotBeInDescendingOrder();
 
-IEnumerable<string> stringCollection = new[] { "build succeded", "test failed" };
+IEnumerable<string> stringCollection = new[] { "build succeeded", "test failed" };
 stringCollection.Should().ContainMatch("* failed");
+stringCollection.Should().AllBe("build succeeded");
 ```
 
 In order to assert presence of an equivalent item in a collection applying [Object graph comparison](/objectgraphs) rules, use this:

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -30,6 +30,7 @@ sidebar:
 * Added `[Not]BeSealed` to `TypeSelectorAssertions`
 * Added `collection.Should().NotContainEquivalentTo` to use object graph comparison rules to assert absence of an element in the collection - [#1318](https://github.com/fluentassertions/fluentassertions/pull/1318).
 * Added `[Not]BeInNamespace` and `[NotBeUnderNamespace]` to `TypeSelectorAssertions` - [#1329](https://github.com/fluentassertions/fluentassertions/pull/1329).
+* Added `AllBe` to `StringCollectionAssertions` to be able to assert that all strings in collection are equal to the specified string - [#1332](https://github.com/fluentassertions/fluentassertions/pull/1332).
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).


### PR DESCRIPTION
Implements feature #1263.

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/master/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com).
