### PR TITLE
Document using global AssertionsOptions for xUnit.net

### DIFF
--- a/docs/_pages/tips.md
+++ b/docs/_pages/tips.md
@@ -38,3 +38,36 @@ If you see something missing, please consider submitting a pull request.
 {% include assertion-comparison.html header1="MSTest" header2="Fluent Assertions" idPrefix="mstest-" caption="CollectionAssert"  examples=site.data.mstest-migration.collectionAssert %}
 {% include assertion-comparison.html header1="MSTest" header2="Fluent Assertions" idPrefix="mstest-" caption="StringAssert"      examples=site.data.mstest-migration.stringAssert %}
 {% include assertion-comparison.html header1="MSTest" header2="Fluent Assertions" idPrefix="mstest-" caption="Exceptions"        examples=site.data.mstest-migration.exceptions %}
+
+## Using global AssertionOptions
+The `AssertionOptions` class allows you to globally configure how `Should().BeEquivalentTo()` works, see also [Object graph comparison](/objectgraphs). Setting up the global configuration multiple times can lead to multi-threading issues when tests are run in parallel.
+
+In order to ensure the global AssertionOptions are configured exactly once, a test framework specific solution is required.
+
+### xUnit.net
+Create a custom [xUnit.net test framework](https://xunit.net/docs/running-tests-in-parallel#runners-and-test-frameworks) where you configure equivalency assertions. This class can be shared between multiple test projects using assembly references.
+```csharp
+namespace MyNamespace
+{
+    using Xunit.Abstractions;
+    using Xunit.Sdk;
+
+    public class MyFramework: XunitTestFramework
+    {
+        public MyFramework(IMessageSink messageSink)
+            : base(messageSink)
+        {
+            AssertionOptions.AssertEquivalencyUsing(
+                options => { <configure here> });
+        }
+    }
+}
+```
+
+Add the assembly level attribute so that xUnit.net picks up your custom test framework. This is required for *every* test assembly that should use your custom test framework.
+```csharp
+[assembly: Xunit.TestFramework("MyNamespace.MyFramework", "MyAssembly.Facts")]
+```
+Note:
+* The `nameof` operator cannot be used to reference the `MyFramework` class. If your global configuration doesn't work, ensure there is no typo in the assembly level attribute declaration and that the assembly containing the `MyFramework` class is referenced by the test assembly and gets copied to the output folder.
+* Because you have to add the assembly level attribute per assembly you can define different `AssertionOptions` per test assembly if required.


### PR DESCRIPTION
Added `tips` on how to globally configure `AssertionOptions` for xUnit.net. As discussed in #1323.

The syntax highlighting for the `assembly` part doesn't look really nice since it's untypical C# code. I guess this is the template's limitation?
## IMPORTANT 

* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/master/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com).
