### PR TITLE
Update README.md to navigate to docs directory

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ The Fluent Assertions [landing page](https://fluentassertions.com) is using Jeky
 ### Building
 
 * Clone this repository
-* `cd` into the root of the repository
+* `cd` into the `root/docs` directory of the repository
 * Install the Ruby Devkit using `ridk install` followed by option 3.
 * Run `bundle install`. 
 * Run `bundle exec jekyll serve`. To have it monitor your working directory for changes, add the `--incremental` option. 


### PR DESCRIPTION
When I was to try out my changes from #1334 I figured out I need to navigate to the `docs` subfolder to run `bundle install`