### PR TITLE
Allow using custom IOrderingRule

### DIFF
--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -417,6 +417,14 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
+        /// Adds an ordering rule to the ones already added by default, and which is evaluated after all existing rules.
+        /// </summary>
+        public TSelf Using(IOrderingRule orderingRule)
+        {
+            return AddOrderingRule(orderingRule);
+        }
+
+        /// <summary>
         /// Adds an equivalency step rule to the ones already added by default, and which is evaluated before previous
         /// user-registered steps
         /// </summary>
@@ -705,6 +713,12 @@ namespace FluentAssertions.Equivalency
         private TSelf AddMatchingRule(IMemberMatchingRule matchingRule)
         {
             matchingRules.Insert(0, matchingRule);
+            return (TSelf)this;
+        }
+
+        private TSelf AddOrderingRule(IOrderingRule orderingRule)
+        {
+            orderingRules.Add(orderingRule);
             return (TSelf)this;
         }
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -863,6 +863,7 @@ namespace FluentAssertions.Equivalency
         public TSelf Using(FluentAssertions.Equivalency.IEquivalencyStep equivalencyStep) { }
         public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IOrderingRule orderingRule) { }
         public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
         public TSelf Using<T>(System.Collections.Generic.IEqualityComparer<T> comparer) { }
         public TSelf Using<T, TEqualityComparer>()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -863,6 +863,7 @@ namespace FluentAssertions.Equivalency
         public TSelf Using(FluentAssertions.Equivalency.IEquivalencyStep equivalencyStep) { }
         public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IOrderingRule orderingRule) { }
         public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
         public TSelf Using<T>(System.Collections.Generic.IEqualityComparer<T> comparer) { }
         public TSelf Using<T, TEqualityComparer>()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -863,6 +863,7 @@ namespace FluentAssertions.Equivalency
         public TSelf Using(FluentAssertions.Equivalency.IEquivalencyStep equivalencyStep) { }
         public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IOrderingRule orderingRule) { }
         public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
         public TSelf Using<T>(System.Collections.Generic.IEqualityComparer<T> comparer) { }
         public TSelf Using<T, TEqualityComparer>()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -856,6 +856,7 @@ namespace FluentAssertions.Equivalency
         public TSelf Using(FluentAssertions.Equivalency.IEquivalencyStep equivalencyStep) { }
         public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IOrderingRule orderingRule) { }
         public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
         public TSelf Using<T>(System.Collections.Generic.IEqualityComparer<T> comparer) { }
         public TSelf Using<T, TEqualityComparer>()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -863,6 +863,7 @@ namespace FluentAssertions.Equivalency
         public TSelf Using(FluentAssertions.Equivalency.IEquivalencyStep equivalencyStep) { }
         public TSelf Using(FluentAssertions.Equivalency.IMemberMatchingRule matchingRule) { }
         public TSelf Using(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
+        public TSelf Using(FluentAssertions.Equivalency.IOrderingRule orderingRule) { }
         public FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>.Restriction<TProperty> Using<TProperty>(System.Action<FluentAssertions.Equivalency.IAssertionContext<TProperty>> action) { }
         public TSelf Using<T>(System.Collections.Generic.IEqualityComparer<T> comparer) { }
         public TSelf Using<T, TEqualityComparer>()

--- a/Tests/FluentAssertions.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
@@ -154,6 +154,50 @@ namespace FluentAssertions.Specs
 
         #endregion
 
+        #region Ordering Rules
+
+        [Fact]
+        public void When_an_ordering_rule_is_added_it_should_be_evaluated_after_all_existing_rules()
+        {
+            // Arrange
+            var subject = new[] { "First", "Second" };
+            var expected = new[] { "First", "Second" };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(
+                expected,
+                options => options.Using(new StrictOrderingRule()));
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_an_ordering_rule_is_added_it_should_appear_in_the_exception_message()
+        {
+            // Arrange
+            var subject = new[] { "First", "Second" };
+            var expected = new[] { "Second", "First" };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(
+                expected,
+                options => options.Using(new StrictOrderingRule()));
+
+            act.Should().Throw<XunitException>()
+                .WithMessage(string.Format("*{0}*", typeof(StrictOrderingRule).Name));
+        }
+
+        internal class StrictOrderingRule : IOrderingRule
+        {
+            public OrderStrictness Evaluate(IMemberInfo memberInfo)
+            {
+                return OrderStrictness.Strict;
+            }
+        }
+
+        #endregion
+
         #region Assertion Rules
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
@@ -62,7 +62,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(string.Format("*{0}*", typeof(ExcludeForeignKeysSelectionRule).Name));
+                .WithMessage($"*{nameof(ExcludeForeignKeysSelectionRule)}*");
         }
 
         internal class ExcludeForeignKeysSelectionRule : IMemberSelectionRule
@@ -135,7 +135,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(string.Format("*{0}*", typeof(ForeignKeyMatchingRule).Name));
+                .WithMessage($"*{nameof(ForeignKeyMatchingRule)}*");
         }
 
         internal class ForeignKeyMatchingRule : IMemberMatchingRule
@@ -185,7 +185,7 @@ namespace FluentAssertions.Specs
                 options => options.Using(new StrictOrderingRule()));
 
             act.Should().Throw<XunitException>()
-                .WithMessage(string.Format("*{0}*", typeof(StrictOrderingRule).Name));
+                .WithMessage($"*{nameof(StrictOrderingRule)}*");
         }
 
         internal class StrictOrderingRule : IOrderingRule
@@ -500,7 +500,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*{typeof(RelaxingDateTimeEquivalencyStep).Name}*");
+                .WithMessage($"*{nameof(RelaxingDateTimeEquivalencyStep)}*");
         }
 
         [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -30,6 +30,7 @@ sidebar:
 * Added `[Not]BeSealed` to `TypeSelectorAssertions`
 * Added `collection.Should().NotContainEquivalentTo` to use object graph comparison rules to assert absence of an element in the collection - [#1318](https://github.com/fluentassertions/fluentassertions/pull/1318).
 * Added `[Not]BeInNamespace` and `[NotBeUnderNamespace]` to `TypeSelectorAssertions` - [#1329](https://github.com/fluentassertions/fluentassertions/pull/1329).
+* The `Using` option on `BeEquivalentTo` and on `AssertionOptions.AssertEquivalencyUsing` now supports custom `IOrderingRule` implementations [#1337](https://github.com/fluentassertions/fluentassertions/pull/1337).
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).


### PR DESCRIPTION
Fixes #1336 
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/master/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com).
