### PR TITLE
Add NotContainInOrder

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -978,7 +978,7 @@ namespace FluentAssertions.Collections
             }
 
             var actualItemsSkipped = 0;
-            for (int index = 0; index < unexpectedItems.Count && actualItems.Any(); index++)
+            for (int index = 0; index < unexpectedItems.Count; index++)
             {
                 object unexpectedItem = unexpectedItems[index];
 
@@ -1001,6 +1001,10 @@ namespace FluentAssertions.Collections
                     }
 
                     actualItems = actualItems.Skip(1).ToArray();
+                }
+                else
+                {
+                    return new AndConstraint<TAssertions>((TAssertions)this);
                 }
             }
 

--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -964,10 +964,10 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot verify absence of ordered containment against a <null> collection.");
 
-            if (Subject is null)
-            {
-                return new AndConstraint<TAssertions>((TAssertions)this);
-            }
+            Execute.Assertion
+                .ForCondition(!(Subject is null))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Cannot verify absence of ordered containment in a <null> collection.");
 
             IList<object> unexpectedItems = unexpected.ConvertOrCastToList<object>();
             IList<object> actualItems = Subject.ConvertOrCastToList<object>();

--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -964,10 +964,14 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot verify absence of ordered containment against a <null> collection.");
 
-            Execute.Assertion
-                .ForCondition(!(Subject is null))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Cannot verify absence of ordered containment in a <null> collection.");
+            if (Subject is null)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Cannot verify absence of ordered containment in a <null> collection.");
+
+                return new AndConstraint<TAssertions>((TAssertions)this);
+            }
 
             IList<object> unexpectedItems = unexpected.ConvertOrCastToList<object>();
             IList<object> actualItems = Subject.ConvertOrCastToList<object>();

--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -964,7 +964,7 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot verify absence of ordered containment against a <null> collection.");
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 return new AndConstraint<TAssertions>((TAssertions)this);
             }

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -228,6 +228,32 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
+        /// Asserts the current collection of strings does not contain the specified strings in the exact same order, not necessarily consecutive.
+        /// </summary>
+        /// <param name="unexpected">An <see cref="System.Array"/> of <see cref="string"/> with the unexpected elements.</param>
+        public AndConstraint<TAssertions> NotContainInOrder(params string[] unexpected)
+        {
+            return base.NotContainInOrder(unexpected.AsEnumerable());
+        }
+
+        /// <summary>
+        /// Asserts the current collection of strings does not contain the specified strings in the exact same order, not necessarily consecutive.
+        /// </summary>
+        /// <param name="unexpected">An <see cref="IEnumerable{String}"/> with the unexpected elements.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotContainInOrder(IEnumerable<string> unexpected, string because = "",
+            params object[] becauseArgs)
+        {
+            return base.NotContainInOrder(unexpected, because, becauseArgs);
+        }
+
+        /// <summary>
         /// Expects the current collection to contain the specified elements in any order. Elements are compared
         /// using their <see cref="object.Equals(object)" /> implementation.
         /// </summary>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -319,6 +319,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params object[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
@@ -478,6 +480,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<TAssertions> Equal(params string[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params string[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.Generic.IEnumerable<string> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
     public class WhichValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -319,6 +319,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params object[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
@@ -478,6 +480,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<TAssertions> Equal(params string[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params string[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.Generic.IEnumerable<string> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
     public class WhichValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -319,6 +319,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params object[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
@@ -478,6 +480,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<TAssertions> Equal(params string[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params string[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.Generic.IEnumerable<string> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
     public class WhichValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -312,6 +312,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params object[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
@@ -471,6 +473,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<TAssertions> Equal(params string[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params string[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.Generic.IEnumerable<string> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
     public class WhichValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -319,6 +319,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf<TExpectation>(TExpectation unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainEquivalentOf<TExpectation>(TExpectation unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params object[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
@@ -478,6 +480,8 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<TAssertions> Equal(params string[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, object becauseArg = null, params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params string[] unexpected) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.Generic.IEnumerable<string> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
     }
     public class WhichValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -2498,13 +2498,16 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_asserting_collection_does_not_contain_some_values_in_order_but_collection_is_null_it_should_not_throw()
+        public void When_asserting_collection_does_not_contain_some_values_in_order_but_collection_is_null_it_should_throw()
         {
             // Arrange
             IEnumerable collection = null;
 
-            // Act / Assert
-            collection.Should().NotContainInOrder(4);
+            // Act
+            Action act = () => collection.Should().NotContainInOrder(4);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Cannot verify absence of ordered containment in a <null> collection.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -2455,6 +2455,134 @@ namespace FluentAssertions.Specs
 
         #endregion
 
+        #region Not Contain In Order
+
+        [Fact]
+        public void When_two_collections_contain_the_same_items_but_in_different_order_it_should_not_throw()
+        {
+            // Arrange
+            IEnumerable collection = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            collection.Should().NotContainInOrder(2, 1);
+        }
+
+        [Fact]
+        public void When_a_collection_does_not_contain_an_ordered_item_it_should_not_throw()
+        {
+            // Arrange
+            IEnumerable collection = new[] { 1, 2, 3 };
+
+            // Act / Assert
+            collection.Should().NotContainInOrder(4, 1);
+        }
+
+        [Fact]
+        public void When_a_collection_contains_less_items_it_should_not_throw()
+        {
+            // Arrange
+            IEnumerable collection = new[] { 1, 2 };
+
+            // Act / Assert
+            collection.Should().NotContainInOrder(1, 2, 3);
+        }
+
+        [Fact]
+        public void When_a_collection_does_not_contain_a_range_twice_it_should_not_throw()
+        {
+            // Arrange
+            IEnumerable collection = new[] { 1, 2, 1, 3, 12, 2, 2 };
+
+            // Act / Assert
+            collection.Should().NotContainInOrder(1, 2, 1, 1, 2);
+        }
+
+        [Fact]
+        public void When_asserting_collection_does_not_contain_some_values_in_order_but_collection_is_null_it_should_not_throw()
+        {
+            // Arrange
+            IEnumerable collection = null;
+
+            // Act / Assert
+            collection.Should().NotContainInOrder(4);
+        }
+
+        [Fact]
+        public void When_two_collections_contain_the_same_items_in_the_same_order_it_should_throw()
+        {
+            // Arrange
+            IEnumerable collection = new[] { 1, 2, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().NotContainInOrder(new[] { 1, 2, 3 }, "that's what we expect");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {1, 2, 2, 3} to not contain items {1, 2, 3} in order because that's what we expect, " +
+                "but items appeared in order ending at index 3.");
+        }
+
+        [Fact]
+        public void When_collection_contains_contain_the_same_items_in_the_same_order_with_null_value_it_should_throw()
+        {
+            // Arrange
+            IEnumerable collection = new object[] { 1, null, 2, "string" };
+
+            // Act
+            Action act = () => collection.Should().NotContainInOrder(1, null, "string");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {1, <null>, 2, \"string\"} to not contain items {1, <null>, \"string\"} in order, " +
+                "but items appeared in order ending at index 3.");
+        }
+
+        [Fact]
+        public void When_the_first_collection_contains_a_duplicate_item_without_affecting_the_order_it_should_throw()
+        {
+            // Arrange
+            IEnumerable collection = new[] { 1, 2, 3, 2 };
+
+            // Act
+            Action act = () => collection.Should().NotContainInOrder(1, 2, 3);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {1, 2, 3, 2} to not contain items {1, 2, 3} in order, " +
+                "but items appeared in order ending at index 2.");
+        }
+
+        [Fact]
+        public void When_two_collections_contain_the_same_duplicate_items_in_the_same_order_it_should_throw()
+        {
+            // Arrange
+            IEnumerable collection = new[] { 1, 2, 1, 2, 12, 2, 2 };
+
+            // Act
+            Action act = () => collection.Should().NotContainInOrder(1, 2, 1, 2, 12, 2, 2);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {1, 2, 1, 2, 12, 2, 2} to not contain items {1, 2, 1, 2, 12, 2, 2} in order, " +
+                "but items appeared in order ending at index 6.");
+        }
+
+        [Fact]
+        public void When_passing_in_null_while_checking_for_absence_of_ordered_containment_it_should_throw()
+        {
+            // Arrange
+            IEnumerable collection = new[] { 1, 2, 3 };
+
+            // Act
+            Action act = () => collection.Should().NotContainInOrder(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithMessage(
+                "Cannot verify absence of ordered containment against a <null> collection.*");
+        }
+
+        #endregion
+
         #region (Not) be in order
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -1480,6 +1480,130 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_two_collections_contain_the_same_items_but_in_different_order_it_should_not_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = new[] { "one", "two", "three" };
+
+            // Act / Assert
+            collection.Should().NotContainInOrder("two", "one");
+        }
+
+        [Fact]
+        public void When_a_collection_does_not_contain_an_ordered_item_it_should_not_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = new[] { "one", "two", "three" };
+
+            // Act / Assert
+            collection.Should().NotContainInOrder("four", "one");
+        }
+
+        [Fact]
+        public void When_a_collection_contains_less_items_it_should_not_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = new[] { "one", "two" };
+
+            // Act / Assert
+            collection.Should().NotContainInOrder("one", "two", "three");
+        }
+
+        [Fact]
+        public void When_a_collection_does_not_contain_a_range_twice_it_should_not_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = new[] { "one", "two", "one", "three", "twelve", "two", "two" };
+
+            // Act / Assert
+            collection.Should().NotContainInOrder("one", "two", "one", "one", "two");
+        }
+
+        [Fact]
+        public void When_asserting_collection_does_not_contain_some_values_in_order_but_collection_is_null_it_should_not_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = null;
+
+            // Act / Assert
+            collection.Should().NotContainInOrder("four");
+        }
+
+        [Fact]
+        public void When_two_collections_contain_the_same_items_in_the_same_order_it_should_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = new[] { "one", "two", "two", "three" };
+
+            // Act
+            Action act = () => collection.Should().NotContainInOrder(new[] { "one", "two", "three" }, "that's what we expect");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {\"one\", \"two\", \"two\", \"three\"} to not contain items {\"one\", \"two\", \"three\"} " +
+                "in order because that's what we expect, but items appeared in order ending at index 3.");
+        }
+
+        [Fact]
+        public void When_collection_contains_contain_the_same_items_in_the_same_order_with_null_value_it_should_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = new[] { "one", null, "two", "three" };
+
+            // Act
+            Action act = () => collection.Should().NotContainInOrder("one", null, "three");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {\"one\", <null>, \"two\", \"three\"} to not contain items {\"one\", <null>, \"three\"} in order, " +
+                "but items appeared in order ending at index 3.");
+        }
+
+        [Fact]
+        public void When_the_first_collection_contains_a_duplicate_item_without_affecting_the_order_it_should_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = new[] { "one", "two", "three", "two" };
+
+            // Act
+            Action act = () => collection.Should().NotContainInOrder("one", "two", "three");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {\"one\", \"two\", \"three\", \"two\"} to not contain items {\"one\", \"two\", \"three\"} in order, " +
+                "but items appeared in order ending at index 2.");
+        }
+
+        [Fact]
+        public void When_two_collections_contain_the_same_duplicate_items_in_the_same_order_it_should_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = new[] { "one", "two", "one", "twelve", "two" };
+
+            // Act
+            Action act = () => collection.Should().NotContainInOrder("one", "two", "one", "twelve", "two");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection {\"one\", \"two\", \"one\", \"twelve\", \"two\"} to not contain items " +
+                "{\"one\", \"two\", \"one\", \"twelve\", \"two\"} in order, but items appeared in order ending at index 4.");
+        }
+
+        [Fact]
+        public void When_passing_in_null_while_checking_for_absence_of_ordered_containment_it_should_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = new[] { "one", "two", "three" };
+
+            // Act
+            Action act = () => collection.Should().NotContainInOrder(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>().WithMessage(
+                "Cannot verify absence of ordered containment against a <null> collection.*");
+        }
+
+        [Fact]
         public void When_two_collections_containing_nulls_are_equal_it_should_not_throw()
         {
             // Arrange

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -1520,13 +1520,16 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_asserting_collection_does_not_contain_some_values_in_order_but_collection_is_null_it_should_not_throw()
+        public void When_asserting_collection_does_not_contain_some_values_in_order_but_collection_is_null_it_should_throw()
         {
             // Arrange
             IEnumerable<string> collection = null;
 
-            // Act / Assert
-            collection.Should().NotContainInOrder("four");
+            // Act
+            Action act = () => collection.Should().NotContainInOrder("four");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Cannot verify absence of ordered containment in a <null> collection.");
         }
 
         [Fact]

--- a/docs/_pages/collections.md
+++ b/docs/_pages/collections.md
@@ -55,6 +55,7 @@ collection.Should().OnlyContain(x => x < 10);
 collection.Should().ContainItemsAssignableTo<int>();
 
 collection.Should().ContainInOrder(new[] { 1, 5, 8 });
+collection.Should().NotContainInOrder(new[] { 5, 1, 2 });
 
 collection.Should().NotContain(82);
 collection.Should().NotContain(new[] { 82, 83 });

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -32,6 +32,7 @@ sidebar:
 * Added `[Not]BeInNamespace` and `[NotBeUnderNamespace]` to `TypeSelectorAssertions` - [#1329](https://github.com/fluentassertions/fluentassertions/pull/1329).
 * The `Using` option on `BeEquivalentTo` and on `AssertionOptions.AssertEquivalencyUsing` now supports custom `IOrderingRule` implementations [#1337](https://github.com/fluentassertions/fluentassertions/pull/1337).
 * Added `AllBe` to `StringCollectionAssertions` to be able to assert that all strings in collection are equal to the specified string - [#1332](https://github.com/fluentassertions/fluentassertions/pull/1332).
+* Added `NotContainInOrder` to `CollectionAssertions` and `StringCollectionAssertions` to be able to assert that the collection does not contain the specified elements in the exact same order, not necessarily consecutive.
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -32,7 +32,7 @@ sidebar:
 * Added `[Not]BeInNamespace` and `[NotBeUnderNamespace]` to `TypeSelectorAssertions` - [#1329](https://github.com/fluentassertions/fluentassertions/pull/1329).
 * The `Using` option on `BeEquivalentTo` and on `AssertionOptions.AssertEquivalencyUsing` now supports custom `IOrderingRule` implementations [#1337](https://github.com/fluentassertions/fluentassertions/pull/1337).
 * Added `AllBe` to `StringCollectionAssertions` to be able to assert that all strings in collection are equal to the specified string - [#1332](https://github.com/fluentassertions/fluentassertions/pull/1332).
-* Added `NotContainInOrder` to `CollectionAssertions` and `StringCollectionAssertions` to be able to assert that the collection does not contain the specified elements in the exact same order, not necessarily consecutive.
+* Added `NotContainInOrder` to `CollectionAssertions` and `StringCollectionAssertions` to be able to assert that the collection does not contain the specified elements in the exact same order, not necessarily consecutive - [#1339](https://github.com/fluentassertions/fluentassertions/pull/1339).
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).


### PR DESCRIPTION
This PR adds `NotContainInOrder` assertion as requested in #318.

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).