### PR TITLE
Add ForConstraint to AssertionScope to open up OccurenceConstraint for usage in custom assertion extensions

### DIFF
--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -185,8 +185,8 @@ namespace FluentAssertions.Execution
 
         /// <summary>
         /// Makes assertion fail when <paramref name="actualOccurrences"/> does not match <paramref name="constraint"/>.
-        /// The occurrence description in natural language could then be specified with {expectedOccurrences} placeholder in
-        /// <see cref="FluentAssertions.Execution.AssertionScope.FailWith(string, object[])"/> and its overloaded versions.
+        /// The occurrence description in natural language could then be inserted in failure message by using {expectedOccurrences} placeholder in
+        /// message parameters of <see cref="FluentAssertions.Execution.AssertionScope.FailWith(string, object[])"/> and its overloaded versions.
         /// </summary>
         /// <param name="constraint"><see cref="OccurrenceConstraint"/> defining the number of expected occurrences.</param>
         /// <param name="actualOccurrences">The number of actual occurrences.</param>

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -190,7 +190,7 @@ namespace FluentAssertions.Execution
         /// </summary>
         /// <param name="constraint"><see cref="OccurrenceConstraint"/> defining the number of expected occurrences.</param>
         /// <param name="actualOccurrences">The number of actual occurrences.</param>
-        public AssertionScope ForOccurrences(OccurrenceConstraint constraint, int actualOccurrences)
+        public AssertionScope ForConstraint(OccurrenceConstraint constraint, int actualOccurrences)
         {
             constraint.RegisterReportables(this);
             succeeded = constraint.Assert(actualOccurrences);

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -185,7 +185,7 @@ namespace FluentAssertions.Execution
 
         /// <summary>
         /// Makes assertion fail when <paramref name="actualOccurrences"/> does not match <paramref name="constraint"/>.
-        /// The occurrence description in natural language could then be inserted in failure message by using {expectedOccurrences} placeholder in
+        /// The occurrence description in natural language could then be inserted in failure message by using {expectedOccurrence} placeholder in
         /// message parameters of <see cref="FluentAssertions.Execution.AssertionScope.FailWith(string, object[])"/> and its overloaded versions.
         /// </summary>
         /// <param name="constraint"><see cref="OccurrenceConstraint"/> defining the number of expected occurrences.</param>

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -183,6 +183,21 @@ namespace FluentAssertions.Execution
             return this;
         }
 
+        /// <summary>
+        /// Makes assertion fail when <paramref name="actualOccurrences"/> does not match <paramref name="constraint"/>.
+        /// The occurrence description in natural language could then be specified with {expectedOccurrences} placeholder in
+        /// <see cref="FluentAssertions.Execution.AssertionScope.FailWith(string, object[])"/> and its overloaded versions.
+        /// </summary>
+        /// <param name="constraint"><see cref="OccurrenceConstraint"/> defining the number of expected occurrences.</param>
+        /// <param name="actualOccurrences">The number of actual occurrences.</param>
+        public AssertionScope ForOccurrences(OccurrenceConstraint constraint, int actualOccurrences)
+        {
+            constraint.RegisterReportables(this);
+            succeeded = constraint.Assert(actualOccurrences);
+
+            return this;
+        }
+
         public Continuation FailWith(Func<FailReason> failReasonFunc)
         {
             return FailWith(() =>

--- a/Src/FluentAssertions/OccurrenceConstraint.cs
+++ b/Src/FluentAssertions/OccurrenceConstraint.cs
@@ -24,7 +24,7 @@ namespace FluentAssertions
 
         internal void RegisterReportables(AssertionScope scope)
         {
-            scope.AddReportable("expectedOccurrences", $"{Mode} {ExpectedCount.Times()}");
+            scope.AddReportable("expectedOccurrence", $"{Mode} {ExpectedCount.Times()}");
         }
     }
 }

--- a/Src/FluentAssertions/OccurrenceConstraint.cs
+++ b/Src/FluentAssertions/OccurrenceConstraint.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using FluentAssertions.Common;
+using FluentAssertions.Execution;
 
 namespace FluentAssertions
 {
@@ -19,5 +21,10 @@ namespace FluentAssertions
         internal abstract string Mode { get; }
 
         internal abstract bool Assert(int actual);
+
+        internal void RegisterReportables(AssertionScope scope)
+        {
+            scope.AddReportable("expectedOccurrences", $"{Mode} {ExpectedCount.Times()}");
+        }
     }
 }

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -678,7 +678,7 @@ namespace FluentAssertions.Primitives
             int actual = Subject.CountSubstring(expected, StringComparison.Ordinal);
 
             Execute.Assertion
-                .ForOccurrences(occurrenceConstraint, actual)
+                .ForConstraint(occurrenceConstraint, actual)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     $"Expected {{context:string}} {{0}} to contain {{1}} {{expectedOccurrence}}{{reason}}, but found it {actual.Times()}.",
@@ -748,7 +748,7 @@ namespace FluentAssertions.Primitives
             int actual = Subject.CountSubstring(expected, StringComparison.OrdinalIgnoreCase);
 
             Execute.Assertion
-                .ForOccurrences(occurrenceConstraint, actual)
+                .ForConstraint(occurrenceConstraint, actual)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     $"Expected {{context:string}} {{0}} to contain equivalent of {{1}} {{expectedOccurrence}}{{reason}}, but found it {actual.Times()}.",

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -681,7 +681,7 @@ namespace FluentAssertions.Primitives
                 .ForOccurrences(occurrenceConstraint, actual)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
-                    $"Expected {{context:string}} {{0}} to contain {{1}} {{expectedOccurrences}}{{reason}}, but found it {actual.Times()}.",
+                    $"Expected {{context:string}} {{0}} to contain {{1}} {{expectedOccurrence}}{{reason}}, but found it {actual.Times()}.",
                     Subject, expected);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -751,7 +751,7 @@ namespace FluentAssertions.Primitives
                 .ForOccurrences(occurrenceConstraint, actual)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
-                    $"Expected {{context:string}} {{0}} to contain equivalent of {{1}} {{expectedOccurrences}}{{reason}}, but found it {actual.Times()}.",
+                    $"Expected {{context:string}} {{0}} to contain equivalent of {{1}} {{expectedOccurrence}}{{reason}}, but found it {actual.Times()}.",
                     Subject, expected);
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -678,10 +678,10 @@ namespace FluentAssertions.Primitives
             int actual = Subject.CountSubstring(expected, StringComparison.Ordinal);
 
             Execute.Assertion
-                .ForCondition(occurrenceConstraint.Assert(actual))
+                .ForOccurrences(occurrenceConstraint, actual)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
-                    $"Expected {{context:string}} {{0}} to contain {{1}} {occurrenceConstraint.Mode} {occurrenceConstraint.ExpectedCount.Times()}{{reason}}, but found it {actual.Times()}.",
+                    $"Expected {{context:string}} {{0}} to contain {{1}} {{expectedOccurrences}}{{reason}}, but found it {actual.Times()}.",
                     Subject, expected);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -748,10 +748,10 @@ namespace FluentAssertions.Primitives
             int actual = Subject.CountSubstring(expected, StringComparison.OrdinalIgnoreCase);
 
             Execute.Assertion
-                .ForCondition(occurrenceConstraint.Assert(actual))
+                .ForOccurrences(occurrenceConstraint, actual)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
-                    $"Expected {{context:string}} {{0}} to contain equivalent of {{1}} {occurrenceConstraint.Mode} {occurrenceConstraint.ExpectedCount.Times()}{{reason}}, but found it {actual.Times()}.",
+                    $"Expected {{context:string}} {{0}} to contain equivalent of {{1}} {{expectedOccurrences}}{{reason}}, but found it {actual.Times()}.",
                     Subject, expected);
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -995,6 +995,7 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.AssertionScope ForOccurrences(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public T Get<T>(string key) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public bool HasFailures() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -995,7 +995,7 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
-        public FluentAssertions.Execution.AssertionScope ForOccurrences(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
+        public FluentAssertions.Execution.AssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public T Get<T>(string key) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public bool HasFailures() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -995,6 +995,7 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.AssertionScope ForOccurrences(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public T Get<T>(string key) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public bool HasFailures() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -995,7 +995,7 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
-        public FluentAssertions.Execution.AssertionScope ForOccurrences(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
+        public FluentAssertions.Execution.AssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public T Get<T>(string key) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public bool HasFailures() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -995,6 +995,7 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.AssertionScope ForOccurrences(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public T Get<T>(string key) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public bool HasFailures() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -995,7 +995,7 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
-        public FluentAssertions.Execution.AssertionScope ForOccurrences(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
+        public FluentAssertions.Execution.AssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public T Get<T>(string key) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public bool HasFailures() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -948,7 +948,7 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
-        public FluentAssertions.Execution.AssertionScope ForOccurrences(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
+        public FluentAssertions.Execution.AssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public T Get<T>(string key) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public bool HasFailures() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -948,6 +948,7 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.AssertionScope ForOccurrences(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public T Get<T>(string key) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public bool HasFailures() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -995,6 +995,7 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
+        public FluentAssertions.Execution.AssertionScope ForOccurrences(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public T Get<T>(string key) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public bool HasFailures() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -995,7 +995,7 @@ namespace FluentAssertions.Execution
         public FluentAssertions.Execution.Continuation FailWith(string message, params System.Func<>[] argProviders) { }
         public FluentAssertions.Execution.Continuation FailWith(string message, params object[] args) { }
         public FluentAssertions.Execution.AssertionScope ForCondition(bool condition) { }
-        public FluentAssertions.Execution.AssertionScope ForOccurrences(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
+        public FluentAssertions.Execution.AssertionScope ForConstraint(FluentAssertions.OccurrenceConstraint constraint, int actualOccurrences) { }
         public T Get<T>(string key) { }
         public FluentAssertions.Execution.GivenSelector<T> Given<T>(System.Func<T> selector) { }
         public bool HasFailures() { }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -32,7 +32,7 @@ sidebar:
 * Added `[Not]BeInNamespace` and `[NotBeUnderNamespace]` to `TypeSelectorAssertions` - [#1329](https://github.com/fluentassertions/fluentassertions/pull/1329).
 * The `Using` option on `BeEquivalentTo` and on `AssertionOptions.AssertEquivalencyUsing` now supports custom `IOrderingRule` implementations [#1337](https://github.com/fluentassertions/fluentassertions/pull/1337).
 * Added `AllBe` to `StringCollectionAssertions` to be able to assert that all strings in collection are equal to the specified string - [#1332](https://github.com/fluentassertions/fluentassertions/pull/1332).
-* Added `ForOccurrences` method to `AssertionScope` to open up `OccurenceConstraint` for usage in custom assertion extensions.
+* Added `ForOccurrences` method to `AssertionScope` to open up `OccurenceConstraint` for usage in custom assertion extensions - [#1341](https://github.com/fluentassertions/fluentassertions/pull/1341).
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -32,6 +32,7 @@ sidebar:
 * Added `[Not]BeInNamespace` and `[NotBeUnderNamespace]` to `TypeSelectorAssertions` - [#1329](https://github.com/fluentassertions/fluentassertions/pull/1329).
 * The `Using` option on `BeEquivalentTo` and on `AssertionOptions.AssertEquivalencyUsing` now supports custom `IOrderingRule` implementations [#1337](https://github.com/fluentassertions/fluentassertions/pull/1337).
 * Added `AllBe` to `StringCollectionAssertions` to be able to assert that all strings in collection are equal to the specified string - [#1332](https://github.com/fluentassertions/fluentassertions/pull/1332).
+* Added `ForOccurrences` method to `AssertionScope` to open up `OccurenceConstraint` for usage in custom assertion extensions.
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -32,7 +32,7 @@ sidebar:
 * Added `[Not]BeInNamespace` and `[NotBeUnderNamespace]` to `TypeSelectorAssertions` - [#1329](https://github.com/fluentassertions/fluentassertions/pull/1329).
 * The `Using` option on `BeEquivalentTo` and on `AssertionOptions.AssertEquivalencyUsing` now supports custom `IOrderingRule` implementations [#1337](https://github.com/fluentassertions/fluentassertions/pull/1337).
 * Added `AllBe` to `StringCollectionAssertions` to be able to assert that all strings in collection are equal to the specified string - [#1332](https://github.com/fluentassertions/fluentassertions/pull/1332).
-* Added `ForOccurrences` method to `AssertionScope` to open up `OccurenceConstraint` for usage in custom assertion extensions - [#1341](https://github.com/fluentassertions/fluentassertions/pull/1341).
+* Added `ForConstraint` method to `AssertionScope` to open up `OccurenceConstraint` for usage in custom assertion extensions - [#1341](https://github.com/fluentassertions/fluentassertions/pull/1341).
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).


### PR DESCRIPTION
Improves library extension interface as requested in #1281.

Some equivalent `ForCondition` usages are replaced with `ForOccurrences` (`StringAssertions.Contain` and `StringAssertions.ContainEquivalentOf`), and as methods containing them covered with unit test, I consider `ForOccurrences` covered enough as well.  

The existence of `{expectedOccurrences}` placeholder is mentioned in documentation comment for `ForOccurrences` method. I don't think it should be in `FailWith` doc comment as it would make it too large and hard to read.

## IMPORTANT 

* [X] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [X] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [X] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [X] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [X] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).