### PR TITLE
Added XSD validation for XDocument assertions.

### DIFF
--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -32,6 +32,7 @@ sidebar:
 * Added `[Not]BeInNamespace` and `[NotBeUnderNamespace]` to `TypeSelectorAssertions` - [#1329](https://github.com/fluentassertions/fluentassertions/pull/1329).
 * The `Using` option on `BeEquivalentTo` and on `AssertionOptions.AssertEquivalencyUsing` now supports custom `IOrderingRule` implementations [#1337](https://github.com/fluentassertions/fluentassertions/pull/1337).
 * Added `AllBe` to `StringCollectionAssertions` to be able to assert that all strings in collection are equal to the specified string - [#1332](https://github.com/fluentassertions/fluentassertions/pull/1332).
+* Added `BeValidByXsd` to validate `XDocument` by XSD schema - [#1343](https://github.com/fluentassertions/fluentassertions/pull/1343).
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).

--- a/docs/_pages/xml.md
+++ b/docs/_pages/xml.md
@@ -44,3 +44,10 @@ xDocument.Should().HaveElement("child")
   .Which.Should().BeOfType<XElement>()
     .And.HaveAttribute("attr", "1");
 ```
+
+Validate document by XSD
+```csharp
+string xsdSample = Resources.SomeXsd;
+
+xDocument.Should().BeValidByXsd(xsdSample);
+```


### PR DESCRIPTION
## IMPORTANT 

* [X] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [X] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [X] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [X] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [X] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).