### PR TITLE
Update objectgraphs.md

### DIFF
--- a/docs/_pages/objectgraphs.md
+++ b/docs/_pages/objectgraphs.md
@@ -136,19 +136,19 @@ This behavior can be changed:
 ```csharp
 // Include Fields
 orderDto.Should().BeEquivalentTo(order, options => options
-    .IncludingFields();
+    .IncludingFields());
 
 // Include Properties
 orderDto.Should().BeEquivalentTo(order, options => options
-    .IncludingProperties();
+    .IncludingProperties());
 
 // Exclude Fields
 orderDto.Should().BeEquivalentTo(order, options => options
-    .ExcludingFields();
+    .ExcludingFields());
 
 // Exclude Properties
 orderDto.Should().BeEquivalentTo(order, options => options
-    .ExcludingProperties();
+    .ExcludingProperties());
 ```
 
 This configuration affects the initial inclusion of members and happens before any `Exclude`s or other `IMemberSelectionRule`s.


### PR DESCRIPTION
closing bracket was missing at 'Include properties and/or fields' section

## IMPORTANT 

* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).