### PR TITLE
Allow to override SelectedMemeberInfo in user libraries

### DIFF
--- a/Src/FluentAssertions/Equivalency/FieldSelectedMemberInfo.cs
+++ b/Src/FluentAssertions/Equivalency/FieldSelectedMemberInfo.cs
@@ -30,8 +30,8 @@ namespace FluentAssertions.Equivalency
 
         public override Type MemberType => fieldInfo.FieldType;
 
-        internal override CSharpAccessModifier GetGetAccessModifier() => fieldInfo.GetCSharpAccessModifier();
+        public override CSharpAccessModifier GetGetAccessModifier() => fieldInfo.GetCSharpAccessModifier();
 
-        internal override CSharpAccessModifier GetSetAccessModifier() => fieldInfo.GetCSharpAccessModifier();
+        public override CSharpAccessModifier GetSetAccessModifier() => fieldInfo.GetCSharpAccessModifier();
     }
 }

--- a/Src/FluentAssertions/Equivalency/PropertySelectedMemberInfo.cs
+++ b/Src/FluentAssertions/Equivalency/PropertySelectedMemberInfo.cs
@@ -19,9 +19,9 @@ namespace FluentAssertions.Equivalency
 
         public override Type MemberType => propertyInfo.PropertyType;
 
-        internal override CSharpAccessModifier GetGetAccessModifier() => propertyInfo.GetGetMethod(nonPublic: true).GetCSharpAccessModifier();
+        public override CSharpAccessModifier GetGetAccessModifier() => propertyInfo.GetGetMethod(nonPublic: true).GetCSharpAccessModifier();
 
-        internal override CSharpAccessModifier GetSetAccessModifier() => propertyInfo.GetSetMethod(nonPublic: true).GetCSharpAccessModifier();
+        public override CSharpAccessModifier GetSetAccessModifier() => propertyInfo.GetSetMethod(nonPublic: true).GetCSharpAccessModifier();
 
         public override object GetValue(object obj, object[] index)
         {

--- a/Src/FluentAssertions/Equivalency/SelectedMemberInfo.cs
+++ b/Src/FluentAssertions/Equivalency/SelectedMemberInfo.cs
@@ -47,12 +47,12 @@ namespace FluentAssertions.Equivalency
         /// <summary>
         /// Gets the access modifier for the getter of this member.
         /// </summary>
-        internal abstract CSharpAccessModifier GetGetAccessModifier();
+        public abstract CSharpAccessModifier GetGetAccessModifier();
 
         /// <summary>
         /// Gets the access modifier for the setter of this member.
         /// </summary>
-        internal abstract CSharpAccessModifier GetSetAccessModifier();
+        public abstract CSharpAccessModifier GetSetAccessModifier();
 
         /// <summary>
         /// Returns the member value of a specified object with optional index values for indexed properties or methods.

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -834,6 +834,8 @@ namespace FluentAssertions.Equivalency
         public abstract System.Type DeclaringType { get; }
         public abstract System.Type MemberType { get; }
         public abstract string Name { get; }
+        public abstract FluentAssertions.Common.CSharpAccessModifier GetGetAccessModifier();
+        public abstract FluentAssertions.Common.CSharpAccessModifier GetSetAccessModifier();
         public abstract object GetValue(object obj, object[] index);
         public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.FieldInfo fieldInfo) { }
         public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.PropertyInfo propertyInfo) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -834,6 +834,8 @@ namespace FluentAssertions.Equivalency
         public abstract System.Type DeclaringType { get; }
         public abstract System.Type MemberType { get; }
         public abstract string Name { get; }
+        public abstract FluentAssertions.Common.CSharpAccessModifier GetGetAccessModifier();
+        public abstract FluentAssertions.Common.CSharpAccessModifier GetSetAccessModifier();
         public abstract object GetValue(object obj, object[] index);
         public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.FieldInfo fieldInfo) { }
         public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.PropertyInfo propertyInfo) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -834,6 +834,8 @@ namespace FluentAssertions.Equivalency
         public abstract System.Type DeclaringType { get; }
         public abstract System.Type MemberType { get; }
         public abstract string Name { get; }
+        public abstract FluentAssertions.Common.CSharpAccessModifier GetGetAccessModifier();
+        public abstract FluentAssertions.Common.CSharpAccessModifier GetSetAccessModifier();
         public abstract object GetValue(object obj, object[] index);
         public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.FieldInfo fieldInfo) { }
         public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.PropertyInfo propertyInfo) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -827,6 +827,8 @@ namespace FluentAssertions.Equivalency
         public abstract System.Type DeclaringType { get; }
         public abstract System.Type MemberType { get; }
         public abstract string Name { get; }
+        public abstract FluentAssertions.Common.CSharpAccessModifier GetGetAccessModifier();
+        public abstract FluentAssertions.Common.CSharpAccessModifier GetSetAccessModifier();
         public abstract object GetValue(object obj, object[] index);
         public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.FieldInfo fieldInfo) { }
         public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.PropertyInfo propertyInfo) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -834,6 +834,8 @@ namespace FluentAssertions.Equivalency
         public abstract System.Type DeclaringType { get; }
         public abstract System.Type MemberType { get; }
         public abstract string Name { get; }
+        public abstract FluentAssertions.Common.CSharpAccessModifier GetGetAccessModifier();
+        public abstract FluentAssertions.Common.CSharpAccessModifier GetSetAccessModifier();
         public abstract object GetValue(object obj, object[] index);
         public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.FieldInfo fieldInfo) { }
         public static FluentAssertions.Equivalency.SelectedMemberInfo Create(System.Reflection.PropertyInfo propertyInfo) { }


### PR DESCRIPTION
Now it is not possible to create class in user library inherited from `SelectedMemberInfo` as it contains `internal abstract` members. In this PR i've just make them `public`.

Some additional info:
Creating custom SelectedMemberInfo allow to users create its own inheritors to implement completely different mechanism in IMemberMatchingRule (for example compare values between levels, etc.)


## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).