### PR TITLE
Implemented string upper/lower case assertions

### DIFF
--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -1175,7 +1175,7 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Asserts that all characters in a string are not in upper casing.
+        /// Asserts that all characters in a string are not in lower casing.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -1115,7 +1115,7 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Asserts that a string is uppercase.
+        /// Asserts that all characters in a string are in upper casing.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -1124,18 +1124,18 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> BeUpper(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeUpperCased(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject?.All(char.IsUpper) == true)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:string} to be upper{reason}, but found {0}.", Subject);
+                .FailWith("Expected all characters in {context:string} to be upper cased{reason}, but found {0}.", Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
-        /// Asserts that a string is not uppercase.
+        /// Asserts that all characters in a string are not in upper casing.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -1144,18 +1144,18 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotBeUpper(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBeUpperCased(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject is null || Subject.Any(ch => !char.IsUpper(ch)))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {context:string} to be upper{reason}.");
+                .FailWith("Did not expect any characters in {context:string} to be upper cased{reason}.");
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
-        /// Asserts that a string is lowercase.
+        /// Asserts that all characters in a string are in lower casing.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -1164,18 +1164,18 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> BeLower(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeLowerCased(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject?.All(char.IsLower) == true)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:string} to be lower{reason}, but found {0}.", Subject);
+                .FailWith("Expected all characters in {context:string} to be lower cased{reason}, but found {0}.", Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
-        /// Asserts that a string is not lowercase.
+        /// Asserts that all characters in a string are not in upper casing.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -1184,12 +1184,12 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotBeLower(string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotBeLowerCased(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject is null || Subject.Any(ch => !char.IsLower(ch)))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {context:string} to be lower{reason}.");
+                .FailWith("Did not expect any characters in {context:string} to be lower cased{reason}.");
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -1114,6 +1114,86 @@ namespace FluentAssertions.Primitives
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
+        /// <summary>
+        /// Asserts that a string is uppercase.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> BeUpper(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(Subject?.All(char.IsUpper) == true)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:string} to be upper{reason}, but found {0}.", Subject);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that a string is not uppercase.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotBeUpper(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(Subject is null || Subject.Any(ch => !char.IsUpper(ch)))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Did not expect {context:string} to be upper{reason}.");
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that a string is lowercase.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> BeLower(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(Subject?.All(char.IsLower) == true)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:string} to be lower{reason}, but found {0}.", Subject);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that a string is not lowercase.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotBeLower(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(Subject is null || Subject.Any(ch => !char.IsLower(ch)))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Did not expect {context:string} to be lower{reason}.");
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
         private static void ThrowIfValuesNullOrEmpty(IEnumerable<string> values)
         {
             Guard.ThrowIfArgumentIsNull(values, nameof(values), "Cannot assert string containment of values in null collection");

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -1690,12 +1690,12 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeLower(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLowerCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params string[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeUpper(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeUpperCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainAll(params string[] values) { }
@@ -1713,10 +1713,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeLower(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeLowerCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeUpper(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeUpperCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(params string[] values) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -1690,10 +1690,12 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLower(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params string[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeUpper(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainAll(params string[] values) { }
@@ -1711,8 +1713,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeLower(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeUpper(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(params string[] values) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -1690,12 +1690,12 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeLower(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLowerCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params string[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeUpper(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeUpperCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainAll(params string[] values) { }
@@ -1713,10 +1713,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeLower(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeLowerCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeUpper(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeUpperCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(params string[] values) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -1690,10 +1690,12 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLower(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params string[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeUpper(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainAll(params string[] values) { }
@@ -1711,8 +1713,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeLower(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeUpper(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(params string[] values) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -1690,12 +1690,12 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeLower(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLowerCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params string[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeUpper(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeUpperCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainAll(params string[] values) { }
@@ -1713,10 +1713,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeLower(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeLowerCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeUpper(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeUpperCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(params string[] values) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -1690,10 +1690,12 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLower(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params string[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeUpper(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainAll(params string[] values) { }
@@ -1711,8 +1713,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeLower(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeUpper(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(params string[] values) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1643,12 +1643,12 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeLower(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLowerCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params string[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeUpper(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeUpperCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainAll(params string[] values) { }
@@ -1666,10 +1666,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeLower(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeLowerCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeUpper(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeUpperCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(params string[] values) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1643,10 +1643,12 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLower(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params string[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeUpper(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainAll(params string[] values) { }
@@ -1664,8 +1666,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeLower(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeUpper(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(params string[] values) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -1690,12 +1690,12 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeLower(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLowerCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params string[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> BeUpper(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeUpperCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainAll(params string[] values) { }
@@ -1713,10 +1713,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeLower(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeLowerCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotBeUpper(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeUpperCased(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(params string[] values) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -1690,10 +1690,12 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(string expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLower(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params string[] validValues) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(System.Collections.Generic.IEnumerable<string> validValues, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeUpper(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(string expected, FluentAssertions.OccurrenceConstraint occurrenceConstraint, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainAll(params string[] values) { }
@@ -1711,8 +1713,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeLower(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNullOrWhiteSpace(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeUpper(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(params string[] values) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainAll(System.Collections.Generic.IEnumerable<string> values, string because = "", params object[] becauseArgs) { }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
@@ -3243,5 +3243,220 @@ namespace FluentAssertions.Specs
         }
 
         #endregion
+
+        #region (Not) Upper
+
+        [Fact]
+        public void Should_succeed_when_asserting_upper_string_to_be_upper()
+        {
+            // Arrange
+            string actual = "ABC";
+
+            // Act / Assert
+            actual.Should().BeUpper();
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_non_upper_string_to_be_upper()
+        {
+            // Arrange
+            string actual = "abc";
+
+            // Act
+            Action act = () => actual.Should().BeUpper();
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Should_fail_with_descriptive_message_when_asserting_non_upper_string_to_be_upper()
+        {
+            // Arrange
+            string actual = "abc";
+
+            // Act
+            Action act = () => actual.Should().BeUpper("because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                @"Expected actual to be upper because we want to test the failure message, but found ""abc"".");
+        }
+
+        [Fact]
+        public void When_checking_for_an_upper_string_and_it_is_null_it_should_throw()
+        {
+            // Arrange
+            string nullString = null;
+
+            // Act
+            Action act = () => nullString.Should().BeUpper("because strings should never be {0}", "null");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected nullString to be upper because strings should never be null, but found <null>.");
+        }
+
+        [Fact]
+        public void Should_succeed_when_asserting_non_upper_string_to_be_non_upper()
+        {
+            // Arrange
+            string actual = "abc";
+
+            // Act / Assert
+            actual.Should().NotBeUpper();
+        }
+
+        [Fact]
+        public void When_asserting_null_string_to_not_be_upper_it_should_succeed()
+        {
+            // Arrange
+            string actual = null;
+
+            // Act / Assert
+            actual.Should().NotBeUpper();
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_upper_string_not_to_be_upper()
+        {
+            // Arrange
+            string actual = "ABC";
+
+            // Act
+            Action act = () => actual.Should().NotBeUpper();
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Should_fail_with_descriptive_message_when_asserting_upper_string_not_to_be_upper()
+        {
+            // Arrange
+            string actual = "ABC";
+
+            // Act
+            Action act = () => actual.Should().NotBeUpper("because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect actual to be upper because we want to test the failure message.");
+        }
+
+        #endregion (Not) Upper
+
+        #region (Not) Lower
+
+        [Fact]
+        public void Should_succeed_when_asserting_lower_string_to_be_lower()
+        {
+            // Arrange
+            string actual = "abc";
+
+            // Act / Assert
+            actual.Should().BeLower();
+        }
+
+        [Fact]
+        public void Should_succeed_when_asserting_empty_string_to_be_lower()
+        {
+            // Arrange
+            string actual = "";
+
+            // Act / Assert
+            actual.Should().BeLower();
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_non_lower_string_to_be_lower()
+        {
+            // Arrange
+            string actual = "ABC";
+
+            // Act
+            Action act = () => actual.Should().BeLower();
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Should_fail_with_descriptive_message_when_asserting_non_lower_string_to_be_lower()
+        {
+            // Arrange
+            string actual = "ABC";
+
+            // Act
+            Action act = () => actual.Should().BeLower("because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected actual to be lower because we want to test the failure message, but found \"ABC\".");
+        }
+
+        [Fact]
+        public void When_checking_for_a_lower_string_and_it_is_null_it_should_throw()
+        {
+            // Arrange
+            string nullString = null;
+
+            // Act
+            Action act = () => nullString.Should().BeLower("because strings should never be {0}", "null");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected nullString to be lower because strings should never be null, but found <null>.");
+        }
+
+        [Fact]
+        public void Should_succeed_when_asserting_non_lower_string_to_be_upper()
+        {
+            // Arrange
+            string actual = "ABC";
+
+            // Act / Assert
+            actual.Should().NotBeLower();
+        }
+
+        [Fact]
+        public void When_asserting_null_string_to_not_be_lower_it_should_succeed()
+        {
+            // Arrange
+            string actual = null;
+
+            // Act / Assert
+            actual.Should().NotBeLower();
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_lower_string_to_be_upper()
+        {
+            // Arrange
+            string actual = "abc";
+
+            // Act
+            Action act = () => actual.Should().NotBeLower();
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Should_fail_with_descriptive_message_when_asserting_lower_string_to_be_not_lower()
+        {
+            // Arrange
+            string actual = "abc";
+
+            // Act
+            Action act = () => actual.Should().NotBeLower("because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect actual to be lower because we want to test the failure message.");
+        }
+
+        #endregion (Not) Lower
+
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
@@ -3247,40 +3247,53 @@ namespace FluentAssertions.Specs
         #region (Not) Upper
 
         [Fact]
-        public void Should_succeed_when_asserting_upper_string_to_be_upper()
+        public void When_an_upper_case_string_is_supposed_to_be_in_upper_case_only_it_should_not_throw()
         {
             // Arrange
             string actual = "ABC";
 
             // Act / Assert
-            actual.Should().BeUpper();
+            actual.Should().BeUpperCased();
         }
 
         [Fact]
-        public void Should_fail_when_asserting_non_upper_string_to_be_upper()
+        public void When_a_non_upper_string_is_supposed_to_be_upper_it_should_throw()
         {
             // Arrange
             string actual = "abc";
 
             // Act
-            Action act = () => actual.Should().BeUpper();
+            Action act = () => actual.Should().BeUpperCased();
 
             // Assert
             act.Should().Throw<XunitException>();
         }
 
         [Fact]
-        public void Should_fail_with_descriptive_message_when_asserting_non_upper_string_to_be_upper()
+        public void When_an_upper_case_string_with_numbers_is_supposed_to_be_in_upper_case_only_it_should_throw()
+        {
+            // Arrange
+            string actual = "A1";
+
+            // Act
+            Action act = () => actual.Should().BeUpperCased();
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_a_non_upper_string_is_supposed_to_be_upper_it_should_fail_with_descriptive_message()
         {
             // Arrange
             string actual = "abc";
 
             // Act
-            Action act = () => actual.Should().BeUpper("because we want to test the failure {0}", "message");
+            Action act = () => actual.Should().BeUpperCased("because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                @"Expected actual to be upper because we want to test the failure message, but found ""abc"".");
+                @"Expected all characters in actual to be upper cased because we want to test the failure message, but found ""abc"".");
         }
 
         [Fact]
@@ -3290,58 +3303,68 @@ namespace FluentAssertions.Specs
             string nullString = null;
 
             // Act
-            Action act = () => nullString.Should().BeUpper("because strings should never be {0}", "null");
+            Action act = () => nullString.Should().BeUpperCased("because strings should never be {0}", "null");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected nullString to be upper because strings should never be null, but found <null>.");
+                "Expected all characters in nullString to be upper cased because strings should never be null, but found <null>.");
         }
 
         [Fact]
-        public void Should_succeed_when_asserting_non_upper_string_to_be_non_upper()
+        public void When_a_non_upper_string_is_supposed_to_be_non_upper_it_should_succeed()
         {
             // Arrange
             string actual = "abc";
 
             // Act / Assert
-            actual.Should().NotBeUpper();
+            actual.Should().NotBeUpperCased();
         }
 
         [Fact]
-        public void When_asserting_null_string_to_not_be_upper_it_should_succeed()
+        public void When_a_null_string_is_not_supposed_to_be_upper_it_should_succeed()
         {
             // Arrange
             string actual = null;
 
             // Act / Assert
-            actual.Should().NotBeUpper();
+            actual.Should().NotBeUpperCased();
         }
 
         [Fact]
-        public void Should_fail_when_asserting_upper_string_not_to_be_upper()
+        public void When_an_upper_string_is_not_supposed_to_be_upper_it_should_throw()
         {
             // Arrange
             string actual = "ABC";
 
             // Act
-            Action act = () => actual.Should().NotBeUpper();
+            Action act = () => actual.Should().NotBeUpperCased();
 
             // Assert
             act.Should().Throw<XunitException>();
         }
 
         [Fact]
-        public void Should_fail_with_descriptive_message_when_asserting_upper_string_not_to_be_upper()
+        public void When_an_upper_case_string_with_numbers_is_not_supposed_to_be_in_upper_case_only_it_should_succeed()
+        {
+            // Arrange
+            string actual = "a1";
+
+            // Act / Assert
+            Action act = () => actual.Should().NotBeUpperCased();
+        }
+
+        [Fact]
+        public void When_an_upper_string_is_not_supposed_to_be_upper_it_should_fail_with_descriptive_message()
         {
             // Arrange
             string actual = "ABC";
 
             // Act
-            Action act = () => actual.Should().NotBeUpper("because we want to test the failure {0}", "message");
+            Action act = () => actual.Should().NotBeUpperCased("because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect actual to be upper because we want to test the failure message.");
+                "Did not expect any characters in actual to be upper cased because we want to test the failure message.");
         }
 
         #endregion (Not) Upper
@@ -3349,50 +3372,63 @@ namespace FluentAssertions.Specs
         #region (Not) Lower
 
         [Fact]
-        public void Should_succeed_when_asserting_lower_string_to_be_lower()
+        public void When_a_lower_string_is_supposed_to_be_lower_it_should_succeed()
         {
             // Arrange
             string actual = "abc";
 
             // Act / Assert
-            actual.Should().BeLower();
+            actual.Should().BeLowerCased();
         }
 
         [Fact]
-        public void Should_succeed_when_asserting_empty_string_to_be_lower()
+        public void When_an_empty_string_is_supposed_to_be_lower_it_should_succeed()
         {
             // Arrange
             string actual = "";
 
             // Act / Assert
-            actual.Should().BeLower();
+            actual.Should().BeLowerCased();
         }
 
         [Fact]
-        public void Should_fail_when_asserting_non_lower_string_to_be_lower()
+        public void When_a_non_lower_string_is_supposed_to_be_lower_it_should_fail()
         {
             // Arrange
             string actual = "ABC";
 
             // Act
-            Action act = () => actual.Should().BeLower();
+            Action act = () => actual.Should().BeLowerCased();
 
             // Assert
             act.Should().Throw<XunitException>();
         }
 
         [Fact]
-        public void Should_fail_with_descriptive_message_when_asserting_non_lower_string_to_be_lower()
+        public void When_a_lower_case_string_with_numbers_is_supposed_to_be_in_lower_case_only_it_should_throw()
+        {
+            // Arrange
+            string actual = "a1";
+
+            // Act
+            Action act = () => actual.Should().BeLowerCased();
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_a_non_lower_string_is_supposed_to_be_lower_it_should_fail_with_descriptive_message()
         {
             // Arrange
             string actual = "ABC";
 
             // Act
-            Action act = () => actual.Should().BeLower("because we want to test the failure {0}", "message");
+            Action act = () => actual.Should().BeLowerCased("because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected actual to be lower because we want to test the failure message, but found \"ABC\".");
+                "Expected all characters in actual to be lower cased because we want to test the failure message, but found \"ABC\".");
         }
 
         [Fact]
@@ -3402,58 +3438,68 @@ namespace FluentAssertions.Specs
             string nullString = null;
 
             // Act
-            Action act = () => nullString.Should().BeLower("because strings should never be {0}", "null");
+            Action act = () => nullString.Should().BeLowerCased("because strings should never be {0}", "null");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected nullString to be lower because strings should never be null, but found <null>.");
+                "Expected all characters in nullString to be lower cased because strings should never be null, but found <null>.");
         }
 
         [Fact]
-        public void Should_succeed_when_asserting_non_lower_string_to_be_upper()
+        public void When_a_non_lower_string_is_supposed_to_be_upper_it_should_succeed()
         {
             // Arrange
             string actual = "ABC";
 
             // Act / Assert
-            actual.Should().NotBeLower();
+            actual.Should().NotBeLowerCased();
         }
 
         [Fact]
-        public void When_asserting_null_string_to_not_be_lower_it_should_succeed()
+        public void When_a_null_string_is_not_supposed_to_be_lower_it_should_succeed()
         {
             // Arrange
             string actual = null;
 
             // Act / Assert
-            actual.Should().NotBeLower();
+            actual.Should().NotBeLowerCased();
         }
 
         [Fact]
-        public void Should_fail_when_asserting_lower_string_to_be_upper()
+        public void When_a_lower_string_is_supposed_to_be_upper_it_should_throw()
         {
             // Arrange
             string actual = "abc";
 
             // Act
-            Action act = () => actual.Should().NotBeLower();
+            Action act = () => actual.Should().NotBeLowerCased();
 
             // Assert
             act.Should().Throw<XunitException>();
         }
 
         [Fact]
-        public void Should_fail_with_descriptive_message_when_asserting_lower_string_to_be_not_lower()
+        public void When_a_lower_case_string_with_numbers_is_not_supposed_to_be_in_lower_case_only_it_should_succeed()
+        {
+            // Arrange
+            string actual = "A1";
+
+            // Act / Assert
+            Action act = () => actual.Should().NotBeLowerCased();
+        }
+
+        [Fact]
+        public void When_a_lower_string_is_not_supposed_to_be_lower_it_should_fail_with_descriptive_message()
         {
             // Arrange
             string actual = "abc";
 
             // Act
-            Action act = () => actual.Should().NotBeLower("because we want to test the failure {0}", "message");
+            Action act = () => actual.Should().NotBeLowerCased("because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect actual to be lower because we want to test the failure message.");
+                "Did not expect any characters in actual to be lower cased because we want to test the failure message.");
         }
 
         #endregion (Not) Lower

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -34,6 +34,7 @@ sidebar:
 * Added `AllBe` to `StringCollectionAssertions` to be able to assert that all strings in collection are equal to the specified string - [#1332](https://github.com/fluentassertions/fluentassertions/pull/1332).
 * Added `ForConstraint` method to `AssertionScope` to open up `OccurenceConstraint` for usage in custom assertion extensions - [#1341](https://github.com/fluentassertions/fluentassertions/pull/1341).
 * Added `NotContainInOrder` to `CollectionAssertions` and `StringCollectionAssertions` to be able to assert that the collection does not contain the specified elements in the exact same order, not necessarily consecutive - [#1339](https://github.com/fluentassertions/fluentassertions/pull/1339).
+* Added `[Not]BeUpperCase` and `[Not]BeLowerCase` to `StringAssertions` to be able to assert that a string is in upper or lower casing or not - [#1357](https://github.com/fluentassertions/fluentassertions/pull/1357).
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -34,7 +34,7 @@ sidebar:
 * Added `AllBe` to `StringCollectionAssertions` to be able to assert that all strings in collection are equal to the specified string - [#1332](https://github.com/fluentassertions/fluentassertions/pull/1332).
 * Added `ForConstraint` method to `AssertionScope` to open up `OccurenceConstraint` for usage in custom assertion extensions - [#1341](https://github.com/fluentassertions/fluentassertions/pull/1341).
 * Added `NotContainInOrder` to `CollectionAssertions` and `StringCollectionAssertions` to be able to assert that the collection does not contain the specified elements in the exact same order, not necessarily consecutive - [#1339](https://github.com/fluentassertions/fluentassertions/pull/1339).
-* Added `[Not]BeUpperCase` and `[Not]BeLowerCase` to `StringAssertions` to be able to assert that a string is in upper or lower casing or not - [#1357](https://github.com/fluentassertions/fluentassertions/pull/1357).
+* Added `[Not]BeUpperCased` and `[Not]BeLowerCased` to `StringAssertions` to be able to assert that a string is in upper or lower casing or not - [#1357](https://github.com/fluentassertions/fluentassertions/pull/1357).
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).

--- a/docs/_pages/strings.md
+++ b/docs/_pages/strings.md
@@ -7,7 +7,7 @@ sidebar:
   nav: "sidebar"
 ---
 
-For asserting whether a string is null, empty or contains whitespace only, you have a wide range of methods to your disposal.
+For asserting whether a string is null, empty, contains whitespace only, or is in upper/lower case, you have a wide range of methods to your disposal.
 
 ```csharp
 string theString = "";
@@ -18,6 +18,10 @@ theString.Should().NotBeEmpty("because the string is not empty");
 theString.Should().HaveLength(0);
 theString.Should().BeNullOrWhiteSpace(); // either null, empty or whitespace only
 theString.Should().NotBeNullOrWhiteSpace();
+theString.Should().BeUpperCase();
+theString.Should().NotBeUpperCase();
+theString.Should().BeLowerCase();
+theString.Should().NotBeLowerCase();
 ```
 
 Obviously you’ll find all the methods you would expect for string assertions.

--- a/docs/_pages/strings.md
+++ b/docs/_pages/strings.md
@@ -18,10 +18,10 @@ theString.Should().NotBeEmpty("because the string is not empty");
 theString.Should().HaveLength(0);
 theString.Should().BeNullOrWhiteSpace(); // either null, empty or whitespace only
 theString.Should().NotBeNullOrWhiteSpace();
-theString.Should().BeUpperCase();
-theString.Should().NotBeUpperCase();
-theString.Should().BeLowerCase();
-theString.Should().NotBeLowerCase();
+theString.Should().BeUpperCased();
+theString.Should().NotBeUpperCased();
+theString.Should().BeLowerCased();
+theString.Should().NotBeLowerCased();
 ```
 
 Obviously you’ll find all the methods you would expect for string assertions.


### PR DESCRIPTION
Adds the following `Should`s to `string`, to assert its casing:

- `BeUpper`
- `NotBeUpper`
- `BeLower`
- `NotBeLower`

Fixes #1356