### PR TITLE
Improve test framework detection messages

### DIFF
--- a/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
+++ b/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
@@ -35,7 +35,7 @@ namespace FluentAssertions.Execution
             }
         }
 
-        protected abstract string AssemblyName { get; }
+        protected internal abstract string AssemblyName { get; }
 
         protected abstract string ExceptionFullName { get; }
     }

--- a/Src/FluentAssertions/Execution/MSTestFrameworkV2.cs
+++ b/Src/FluentAssertions/Execution/MSTestFrameworkV2.cs
@@ -4,6 +4,6 @@
     {
         protected override string ExceptionFullName => "Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException";
 
-        protected override string AssemblyName => "Microsoft.VisualStudio.TestPlatform.TestFramework";
+        protected internal override string AssemblyName => "Microsoft.VisualStudio.TestPlatform.TestFramework";
     }
 }

--- a/Src/FluentAssertions/Execution/MSpecFramework.cs
+++ b/Src/FluentAssertions/Execution/MSpecFramework.cs
@@ -2,7 +2,7 @@
 {
     internal class MSpecFramework : LateBoundTestFramework
     {
-        protected override string AssemblyName => "Machine.Specifications";
+        protected internal override string AssemblyName => "Machine.Specifications";
 
         protected override string ExceptionFullName => "Machine.Specifications.SpecificationException";
     }

--- a/Src/FluentAssertions/Execution/NUnitTestFramework.cs
+++ b/Src/FluentAssertions/Execution/NUnitTestFramework.cs
@@ -2,7 +2,7 @@
 {
     internal class NUnitTestFramework : LateBoundTestFramework
     {
-        protected override string AssemblyName => "nunit.framework";
+        protected internal override string AssemblyName => "nunit.framework";
 
         protected override string ExceptionFullName => "NUnit.Framework.AssertionException";
     }

--- a/docs/_pages/introduction.md
+++ b/docs/_pages/introduction.md
@@ -69,7 +69,7 @@ If, for some unknown reason, Fluent Assertions fails to find the assembly, and y
 ```xml
 <configuration>
   <appSettings>
-    <!-- Supported values: nunit, xunit, mstest, nspec and mspec -->
+    <!-- Supported values: nunit, xunit2, mstestv2, nspec3 and mspec -->
     <add key="FluentAssertions.TestFramework" value="nunit"/>
   </appSettings>
 </configuration>

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -75,6 +75,7 @@ sidebar:
 * Removed `Succeeded` and `SourceSucceeded` from `Continuation` and `IAssertionScope` - [#1325](https://github.com/fluentassertions/fluentassertions/pull/1325)
 * Removed synchronous assertions on asynchronous operations (`Throw`, `NotThrow`, `CompleteWithin`, ...) [#1324](https://github.com/fluentassertions/fluentassertions/pull/1324)
 * Do not modify `SynchronizationContext.Current` while asserting asynchronous operations. In case hitting deadlocks in your tests please check whether you mix synchronous and asynchronous operations. [#1324](https://github.com/fluentassertions/fluentassertions/pull/1324)
+* Requesting an unsupported test framework via `Services.Configuration.TestFrameworkName` or `"FluentAssertions.TestFramework"` now throws an exception instead of using the fallback - [#1366](https://github.com/fluentassertions/fluentassertions/pull/1366).
 
 ## 5.10.3
 **Fixes**


### PR DESCRIPTION
If a user request an unsupported test framework via app settings, FA will now throw an exception instead of trying to detect a test framework with `AttemptToDetectUsingDynamicScanning`.

If the requested test framework is not available the failure message will contain the missing assembly name.

In both cases the failure message will contain the names of all supported frameworks.

This fixes #1359