### PR TITLE
Move `FallbackTestFramework` from supported to fallback test framework

### DIFF
--- a/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
+++ b/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
@@ -15,8 +15,7 @@ namespace FluentAssertions.Execution
             ["nspec3"] = new NSpecFramework(),
             ["nunit"] = new NUnitTestFramework(),
             ["mstestv2"] = new MSTestFrameworkV2(),
-            ["xunit2"] = new XUnit2TestFramework(),
-            ["fallback"] = new FallbackTestFramework()
+            ["xunit2"] = new XUnit2TestFramework()
         };
 
         private static ITestFramework testFramework;
@@ -36,7 +35,8 @@ namespace FluentAssertions.Execution
         private static ITestFramework DetectFramework()
         {
             ITestFramework detectedFramework = AttemptToDetectUsingAppSetting()
-                ?? AttemptToDetectUsingDynamicScanning();
+                ?? AttemptToDetectUsingDynamicScanning()
+                ?? new FallbackTestFramework();
 
             return detectedFramework;
         }


### PR DESCRIPTION
Make `FallbackTestFramework` a *fallback* instead of a *supported* test framework.

With the changes in #1366 this PR introduces a breaking runtime change if a consumer deliberately requested `"fallback"`. 
It will now throw an exception that `"fallback"` is not a supported test framework.

A technical improvement:
* The order of `Dictionary.Value` is unspecified.
* `FallbackTestFramework.IsAvailable` always returns `true`.

So `AttemptToDetectUsingDynamicScanning` *could* chose to pick `FallbackTestFramework` over a real and available test framework.