### PR TITLE
Internalized some of the type extensions only meant to be used by FA

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -1632,7 +1632,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> StartWith(object element, string because = "", params object[] becauseArgs)
         {
-            AssertCollectionStartsWith(Subject?.Cast<object>(), new[] { element }, ObjectExtensions.IsSameOrEqualTo, because, becauseArgs);
+            AssertCollectionStartsWith(Subject?.Cast<object>(), new[] { element }, InternalObjectExtensions.IsSameOrEqualTo, because, becauseArgs);
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
@@ -1686,7 +1686,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> EndWith(object element, string because = "", params object[] becauseArgs)
         {
-            AssertCollectionEndsWith(Subject?.Cast<object>(), new[] { element }, ObjectExtensions.IsSameOrEqualTo, because, becauseArgs);
+            AssertCollectionEndsWith(Subject?.Cast<object>(), new[] { element }, InternalObjectExtensions.IsSameOrEqualTo, because, becauseArgs);
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 

--- a/Src/FluentAssertions/Common/CSharpAccessModifierExtensions.cs
+++ b/Src/FluentAssertions/Common/CSharpAccessModifierExtensions.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace FluentAssertions.Common
 {
-    public static class CSharpAccessModifierExtensions
+    internal static class CSharpAccessModifierExtensions
     {
         internal static CSharpAccessModifier GetCSharpAccessModifier(this MethodBase methodBase)
         {

--- a/Src/FluentAssertions/Common/InternalObjectExtensions.cs
+++ b/Src/FluentAssertions/Common/InternalObjectExtensions.cs
@@ -3,7 +3,8 @@ using System.Globalization;
 
 namespace FluentAssertions.Common
 {
-    public static class ObjectExtensions
+    // NOTE: These extension methods are covered by tests separately and therefore need to be public.
+    public static class InternalObjectExtensions
     {
         public static bool IsSameOrEqualTo(this object actual, object expected)
         {

--- a/Src/FluentAssertions/Common/InternalTypeExtensions.cs
+++ b/Src/FluentAssertions/Common/InternalTypeExtensions.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace FluentAssertions.Common
+{
+    // NOTE: These extension methods are covered by tests separately and therefore need to be public.
+    public static class InternalTypeExtensions
+    {
+        /// <summary>
+        /// For internal use only.
+        /// </summary>
+        public static bool IsSameOrInherits(this Type actualType, Type expectedType)
+        {
+            return actualType == expectedType ||
+                   expectedType.IsAssignableFrom(actualType);
+        }
+
+        /// <summary>
+        /// For internal use only.
+        /// </summary>
+        public static MethodInfo GetExplicitConversionOperator(this Type type, Type sourceType, Type targetType)
+        {
+            return type
+                .GetConversionOperators(sourceType, targetType, name => name == "op_Explicit")
+                .SingleOrDefault();
+        }
+
+        /// <summary>
+        /// For internal use only.
+        /// </summary>
+        public static MethodInfo GetImplicitConversionOperator(this Type type, Type sourceType, Type targetType)
+        {
+            return type
+                .GetConversionOperators(sourceType, targetType, name => name == "op_Implicit")
+                .SingleOrDefault();
+        }
+
+        /// <summary>
+        /// For internal use only.
+        /// </summary>
+        public static bool HasValueSemantics(this Type type)
+        {
+            return type.OverridesEquals() &&
+                   !type.IsAnonymousType() && !type.IsTuple() && !IsKeyValuePair(type);
+        }
+
+        private static bool IsTuple(this Type type)
+        {
+            if (!type.IsGenericType)
+            {
+                return false;
+            }
+
+            Type openType = type.GetGenericTypeDefinition();
+            return openType == typeof(ValueTuple<>)
+                   || openType == typeof(ValueTuple<,>)
+                   || openType == typeof(ValueTuple<,,>)
+                   || openType == typeof(ValueTuple<,,,>)
+                   || openType == typeof(ValueTuple<,,,,>)
+                   || openType == typeof(ValueTuple<,,,,,>)
+                   || openType == typeof(ValueTuple<,,,,,,>)
+                   || (openType == typeof(ValueTuple<,,,,,,,>) && IsTuple(type.GetGenericArguments()[7]))
+                   || openType == typeof(Tuple<>)
+                   || openType == typeof(Tuple<,>)
+                   || openType == typeof(Tuple<,,>)
+                   || openType == typeof(Tuple<,,,>)
+                   || openType == typeof(Tuple<,,,,>)
+                   || openType == typeof(Tuple<,,,,,>)
+                   || openType == typeof(Tuple<,,,,,,>)
+                   || (openType == typeof(Tuple<,,,,,,,>) && IsTuple(type.GetGenericArguments()[7]));
+        }
+
+        private static bool IsAnonymousType(this Type type)
+        {
+            bool nameContainsAnonymousType = type.FullName.Contains("AnonymousType", StringComparison.Ordinal);
+
+            if (!nameContainsAnonymousType)
+            {
+                return false;
+            }
+
+            bool hasCompilerGeneratedAttribute =
+                type.IsDecoratedWith<CompilerGeneratedAttribute>();
+
+            return hasCompilerGeneratedAttribute;
+        }
+
+        private static bool IsKeyValuePair(Type type)
+        {
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>);
+        }
+    }
+}

--- a/Src/FluentAssertions/Common/MethodInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/MethodInfoExtensions.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 
 namespace FluentAssertions.Common
 {
-    public static class MethodInfoExtensions
+    internal static class MethodInfoExtensions
     {
         /// <summary>
         /// A sum of all possible <see cref="MethodImplOptions"/>. It's needed to calculate what options were used when decorating with <see cref="MethodImplAttribute"/>.

--- a/Src/FluentAssertions/Common/PropertyInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/PropertyInfoExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace FluentAssertions.Common
 {
-    public static class PropertyInfoExtensions
+    internal static class PropertyInfoExtensions
     {
         internal static bool IsVirtual(this PropertyInfo property)
         {

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -3,12 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using FluentAssertions.Equivalency;
 
 namespace FluentAssertions.Common
 {
-    public static class TypeExtensions
+    internal static class TypeExtensions
     {
         private const BindingFlags PublicMembersFlag =
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
@@ -17,12 +16,6 @@ namespace FluentAssertions.Common
             PublicMembersFlag | BindingFlags.NonPublic | BindingFlags.Static;
 
         public static bool IsDecoratedWith<TAttribute>(this Type type)
-            where TAttribute : Attribute
-        {
-            return type.IsDefined(typeof(TAttribute), inherit: false);
-        }
-
-        public static bool IsDecoratedWith<TAttribute>(this TypeInfo type)
             where TAttribute : Attribute
         {
             return type.IsDefined(typeof(TAttribute), inherit: false);
@@ -43,12 +36,6 @@ namespace FluentAssertions.Common
             return type.IsDefined(typeof(TAttribute), inherit: true);
         }
 
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this TypeInfo type)
-            where TAttribute : Attribute
-        {
-            return type.IsDefined(typeof(TAttribute), inherit: true);
-        }
-
         public static bool IsDecoratedWithOrInherit<TAttribute>(this MemberInfo type)
             where TAttribute : Attribute
         {
@@ -59,12 +46,6 @@ namespace FluentAssertions.Common
         }
 
         public static bool IsDecoratedWith<TAttribute>(this Type type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : Attribute
-        {
-            return GetCustomAttributes(type, isMatchingAttributePredicate).Any();
-        }
-
-        public static bool IsDecoratedWith<TAttribute>(this TypeInfo type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
             where TAttribute : Attribute
         {
             return GetCustomAttributes(type, isMatchingAttributePredicate).Any();
@@ -82,43 +63,31 @@ namespace FluentAssertions.Common
             return GetCustomAttributes(type, isMatchingAttributePredicate, inherit: true).Any();
         }
 
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this TypeInfo type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : Attribute
-        {
-            return GetCustomAttributes(type, isMatchingAttributePredicate, inherit: true).Any();
-        }
-
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this MemberInfo type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : Attribute
-        {
-            return GetCustomAttributes(type, isMatchingAttributePredicate, inherit: true).Any();
-        }
-
-        internal static IEnumerable<TAttribute> GetMatchingAttributes<TAttribute>(this Type type)
+        public static IEnumerable<TAttribute> GetMatchingAttributes<TAttribute>(this Type type)
             where TAttribute : Attribute
         {
             return GetCustomAttributes<TAttribute>(type);
         }
 
-        internal static IEnumerable<TAttribute> GetMatchingAttributes<TAttribute>(this Type type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
+        public static IEnumerable<TAttribute> GetMatchingAttributes<TAttribute>(this Type type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
             where TAttribute : Attribute
         {
             return GetCustomAttributes(type, isMatchingAttributePredicate);
         }
 
-        internal static IEnumerable<TAttribute> GetMatchingOrInheritedAttributes<TAttribute>(this Type type)
+        public static IEnumerable<TAttribute> GetMatchingOrInheritedAttributes<TAttribute>(this Type type)
             where TAttribute : Attribute
         {
             return GetCustomAttributes<TAttribute>(type, inherit: true);
         }
 
-        internal static IEnumerable<TAttribute> GetMatchingOrInheritedAttributes<TAttribute>(this Type type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
+        public static IEnumerable<TAttribute> GetMatchingOrInheritedAttributes<TAttribute>(this Type type, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)
             where TAttribute : Attribute
         {
             return GetCustomAttributes(type, isMatchingAttributePredicate, inherit: true);
         }
 
-        internal static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(this MemberInfo type, bool inherit = false)
+        public static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(this MemberInfo type, bool inherit = false)
             where TAttribute : Attribute
         {
             // Do not use MemberInfo.GetCustomAttributes.
@@ -174,23 +143,7 @@ namespace FluentAssertions.Common
                    property.Name == otherProperty.Name;
         }
 
-        public static bool IsSameOrInherits(this Type actualType, Type expectedType)
-        {
-            return actualType == expectedType ||
-                   expectedType.IsAssignableFrom(actualType);
-        }
-
-        /// <summary>
-        /// NOTE: This method does not give the expected results with open generics
-        /// </summary>
-        public static bool Implements(this Type type, Type expectedBaseType)
-        {
-            return
-                expectedBaseType.IsAssignableFrom(type)
-                && type != expectedBaseType;
-        }
-
-        internal static Type[] GetClosedGenericInterfaces(Type type, Type openGenericType)
+        public static Type[] GetClosedGenericInterfaces(Type type, Type openGenericType)
         {
             if (type.IsGenericType && type.GetGenericTypeDefinition() == openGenericType)
             {
@@ -450,21 +403,7 @@ namespace FluentAssertions.Common
                 .SingleOrDefault(m => m.GetParameters().Select(p => p.ParameterType).SequenceEqual(parameterTypes));
         }
 
-        public static MethodInfo GetImplicitConversionOperator(this Type type, Type sourceType, Type targetType)
-        {
-            return type
-                .GetConversionOperators(sourceType, targetType, name => name == "op_Implicit")
-                .SingleOrDefault();
-        }
-
-        public static MethodInfo GetExplicitConversionOperator(this Type type, Type sourceType, Type targetType)
-        {
-            return type
-                .GetConversionOperators(sourceType, targetType, name => name == "op_Explicit")
-                .SingleOrDefault();
-        }
-
-        private static IEnumerable<MethodInfo> GetConversionOperators(this Type type, Type sourceType, Type targetType,
+        public static IEnumerable<MethodInfo> GetConversionOperators(this Type type, Type sourceType, Type targetType,
             Func<string, bool> predicate)
         {
             return type
@@ -479,59 +418,7 @@ namespace FluentAssertions.Common
                     && m.GetParameters()[0].ParameterType == sourceType);
         }
 
-        public static bool HasValueSemantics(this Type type)
-        {
-            return type.OverridesEquals() &&
-                   !type.IsAnonymousType() && !type.IsTuple() && !IsKeyValuePair(type);
-        }
-
-        private static bool IsKeyValuePair(Type type)
-        {
-            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>);
-        }
-
-        private static bool IsAnonymousType(this Type type)
-        {
-            bool nameContainsAnonymousType = type.FullName.Contains("AnonymousType", StringComparison.Ordinal);
-
-            if (!nameContainsAnonymousType)
-            {
-                return false;
-            }
-
-            bool hasCompilerGeneratedAttribute =
-                type.IsDecoratedWith<CompilerGeneratedAttribute>();
-
-            return hasCompilerGeneratedAttribute;
-        }
-
-        private static bool IsTuple(this Type type)
-        {
-            if (!type.IsGenericType)
-            {
-                return false;
-            }
-
-            Type openType = type.GetGenericTypeDefinition();
-            return openType == typeof(ValueTuple<>)
-                   || openType == typeof(ValueTuple<,>)
-                   || openType == typeof(ValueTuple<,,>)
-                   || openType == typeof(ValueTuple<,,,>)
-                   || openType == typeof(ValueTuple<,,,,>)
-                   || openType == typeof(ValueTuple<,,,,,>)
-                   || openType == typeof(ValueTuple<,,,,,,>)
-                   || (openType == typeof(ValueTuple<,,,,,,,>) && IsTuple(type.GetGenericArguments()[7]))
-                   || openType == typeof(Tuple<>)
-                   || openType == typeof(Tuple<,>)
-                   || openType == typeof(Tuple<,,>)
-                   || openType == typeof(Tuple<,,,>)
-                   || openType == typeof(Tuple<,,,,>)
-                   || openType == typeof(Tuple<,,,,,>)
-                   || openType == typeof(Tuple<,,,,,,>)
-                   || (openType == typeof(Tuple<,,,,,,,>) && IsTuple(type.GetGenericArguments()[7]));
-        }
-
-        internal static bool IsAssignableToOpenGeneric(this Type type, Type definition)
+        public static bool IsAssignableToOpenGeneric(this Type type, Type definition)
         {
             // The CLR type system does not consider anything to be assignable to an open generic type.
             // For the purposes of test assertions, the user probably means that the subject type is
@@ -546,7 +433,7 @@ namespace FluentAssertions.Common
             }
         }
 
-        internal static bool IsImplementationOfOpenGeneric(this Type type, Type definition)
+        private static bool IsImplementationOfOpenGeneric(this Type type, Type definition)
         {
             // check subject against definition
             if (type.IsInterface && type.IsGenericType &&
@@ -562,7 +449,7 @@ namespace FluentAssertions.Common
                 .Contains(definition);
         }
 
-        internal static bool IsDerivedFromOpenGeneric(this Type type, Type definition)
+        public static bool IsDerivedFromOpenGeneric(this Type type, Type definition)
         {
             if (type == definition)
             {
@@ -583,7 +470,7 @@ namespace FluentAssertions.Common
             return false;
         }
 
-        internal static bool IsUnderNamespace(this Type type, string @namespace)
+        public static bool IsUnderNamespace(this Type type, string @namespace)
         {
             return IsGlobalNamespace()
                 || IsExactNamespace()

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -181,7 +181,6 @@ namespace FluentAssertions.Equivalency
                 else
                 {
                     bool hasValueSemantics = hasValueSemanticsMap.GetOrAdd(type, t => t.HasValueSemantics());
-
                     if (hasValueSemantics)
                     {
                         strategy = EqualityStrategy.Equals;

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -509,7 +509,6 @@ namespace FluentAssertions.Common
         InvalidForCSharp = 5,
         PrivateProtected = 6,
     }
-    public static class CSharpAccessModifierExtensions { }
     public class Configuration
     {
         public Configuration(FluentAssertions.Common.IConfigurationStore store) { }
@@ -541,12 +540,17 @@ namespace FluentAssertions.Common
     {
         System.TimeSpan Elapsed { get; }
     }
-    public static class MethodInfoExtensions { }
-    public static class ObjectExtensions
+    public static class InternalObjectExtensions
     {
         public static bool IsSameOrEqualTo(this object actual, object expected) { }
     }
-    public static class PropertyInfoExtensions { }
+    public static class InternalTypeExtensions
+    {
+        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static bool HasValueSemantics(this System.Type type) { }
+        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
+    }
     public static class Services
     {
         public static FluentAssertions.Common.Configuration Configuration { get; }
@@ -554,58 +558,6 @@ namespace FluentAssertions.Common
         public static FluentAssertions.Common.IReflector Reflector { get; set; }
         public static System.Action<string> ThrowException { get; set; }
         public static void ResetToDefaults() { }
-    }
-    public static class TypeExtensions
-    {
-        public static System.Reflection.FieldInfo FindField(this System.Type type, string fieldName, System.Type preferredType) { }
-        public static FluentAssertions.Equivalency.SelectedMemberInfo FindMember(this System.Type type, string memberName, System.Type preferredType) { }
-        public static System.Reflection.PropertyInfo FindProperty(this System.Type type, string propertyName, System.Type preferredType) { }
-        public static System.Reflection.ConstructorInfo GetConstructor(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
-        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
-        public static System.Reflection.PropertyInfo GetIndexerByParameterTypes(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static System.Reflection.MethodInfo GetMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> GetNonPrivateFields(this System.Type typeToReflect) { }
-        public static System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetNonPrivateMembers(this System.Type typeToReflect) { }
-        public static System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> GetNonPrivateProperties(this System.Type typeToReflect, System.Collections.Generic.IEnumerable<string> filter = null) { }
-        public static System.Reflection.MethodInfo GetParameterlessMethod(this System.Type type, string methodName) { }
-        public static System.Reflection.PropertyInfo GetPropertyByName(this System.Type type, string propertyName) { }
-        public static bool HasExplicitlyImplementedProperty(this System.Type type, System.Type interfaceType, string propertyName) { }
-        public static bool HasMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static bool HasParameterlessMethod(this System.Type type, string methodName) { }
-        public static bool HasValueSemantics(this System.Type type) { }
-        public static bool Implements(this System.Type type, System.Type expectedBaseType) { }
-        public static bool IsCSharpAbstract(this System.Type type) { }
-        public static bool IsCSharpSealed(this System.Type type) { }
-        public static bool IsCSharpStatic(this System.Type type) { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Type type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsEquivalentTo(this FluentAssertions.Equivalency.SelectedMemberInfo property, FluentAssertions.Equivalency.SelectedMemberInfo otherProperty) { }
-        public static bool IsIndexer(this System.Reflection.PropertyInfo member) { }
-        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
-        public static bool OverridesEquals(this System.Type type) { }
     }
     public enum ValueFormatterDetectionMode
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -509,7 +509,6 @@ namespace FluentAssertions.Common
         InvalidForCSharp = 5,
         PrivateProtected = 6,
     }
-    public static class CSharpAccessModifierExtensions { }
     public class Configuration
     {
         public Configuration(FluentAssertions.Common.IConfigurationStore store) { }
@@ -541,12 +540,17 @@ namespace FluentAssertions.Common
     {
         System.TimeSpan Elapsed { get; }
     }
-    public static class MethodInfoExtensions { }
-    public static class ObjectExtensions
+    public static class InternalObjectExtensions
     {
         public static bool IsSameOrEqualTo(this object actual, object expected) { }
     }
-    public static class PropertyInfoExtensions { }
+    public static class InternalTypeExtensions
+    {
+        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static bool HasValueSemantics(this System.Type type) { }
+        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
+    }
     public static class Services
     {
         public static FluentAssertions.Common.Configuration Configuration { get; }
@@ -554,58 +558,6 @@ namespace FluentAssertions.Common
         public static FluentAssertions.Common.IReflector Reflector { get; set; }
         public static System.Action<string> ThrowException { get; set; }
         public static void ResetToDefaults() { }
-    }
-    public static class TypeExtensions
-    {
-        public static System.Reflection.FieldInfo FindField(this System.Type type, string fieldName, System.Type preferredType) { }
-        public static FluentAssertions.Equivalency.SelectedMemberInfo FindMember(this System.Type type, string memberName, System.Type preferredType) { }
-        public static System.Reflection.PropertyInfo FindProperty(this System.Type type, string propertyName, System.Type preferredType) { }
-        public static System.Reflection.ConstructorInfo GetConstructor(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
-        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
-        public static System.Reflection.PropertyInfo GetIndexerByParameterTypes(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static System.Reflection.MethodInfo GetMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> GetNonPrivateFields(this System.Type typeToReflect) { }
-        public static System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetNonPrivateMembers(this System.Type typeToReflect) { }
-        public static System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> GetNonPrivateProperties(this System.Type typeToReflect, System.Collections.Generic.IEnumerable<string> filter = null) { }
-        public static System.Reflection.MethodInfo GetParameterlessMethod(this System.Type type, string methodName) { }
-        public static System.Reflection.PropertyInfo GetPropertyByName(this System.Type type, string propertyName) { }
-        public static bool HasExplicitlyImplementedProperty(this System.Type type, System.Type interfaceType, string propertyName) { }
-        public static bool HasMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static bool HasParameterlessMethod(this System.Type type, string methodName) { }
-        public static bool HasValueSemantics(this System.Type type) { }
-        public static bool Implements(this System.Type type, System.Type expectedBaseType) { }
-        public static bool IsCSharpAbstract(this System.Type type) { }
-        public static bool IsCSharpSealed(this System.Type type) { }
-        public static bool IsCSharpStatic(this System.Type type) { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Type type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsEquivalentTo(this FluentAssertions.Equivalency.SelectedMemberInfo property, FluentAssertions.Equivalency.SelectedMemberInfo otherProperty) { }
-        public static bool IsIndexer(this System.Reflection.PropertyInfo member) { }
-        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
-        public static bool OverridesEquals(this System.Type type) { }
     }
     public enum ValueFormatterDetectionMode
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -509,7 +509,6 @@ namespace FluentAssertions.Common
         InvalidForCSharp = 5,
         PrivateProtected = 6,
     }
-    public static class CSharpAccessModifierExtensions { }
     public class Configuration
     {
         public Configuration(FluentAssertions.Common.IConfigurationStore store) { }
@@ -541,12 +540,17 @@ namespace FluentAssertions.Common
     {
         System.TimeSpan Elapsed { get; }
     }
-    public static class MethodInfoExtensions { }
-    public static class ObjectExtensions
+    public static class InternalObjectExtensions
     {
         public static bool IsSameOrEqualTo(this object actual, object expected) { }
     }
-    public static class PropertyInfoExtensions { }
+    public static class InternalTypeExtensions
+    {
+        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static bool HasValueSemantics(this System.Type type) { }
+        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
+    }
     public static class Services
     {
         public static FluentAssertions.Common.Configuration Configuration { get; }
@@ -554,58 +558,6 @@ namespace FluentAssertions.Common
         public static FluentAssertions.Common.IReflector Reflector { get; set; }
         public static System.Action<string> ThrowException { get; set; }
         public static void ResetToDefaults() { }
-    }
-    public static class TypeExtensions
-    {
-        public static System.Reflection.FieldInfo FindField(this System.Type type, string fieldName, System.Type preferredType) { }
-        public static FluentAssertions.Equivalency.SelectedMemberInfo FindMember(this System.Type type, string memberName, System.Type preferredType) { }
-        public static System.Reflection.PropertyInfo FindProperty(this System.Type type, string propertyName, System.Type preferredType) { }
-        public static System.Reflection.ConstructorInfo GetConstructor(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
-        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
-        public static System.Reflection.PropertyInfo GetIndexerByParameterTypes(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static System.Reflection.MethodInfo GetMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> GetNonPrivateFields(this System.Type typeToReflect) { }
-        public static System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetNonPrivateMembers(this System.Type typeToReflect) { }
-        public static System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> GetNonPrivateProperties(this System.Type typeToReflect, System.Collections.Generic.IEnumerable<string> filter = null) { }
-        public static System.Reflection.MethodInfo GetParameterlessMethod(this System.Type type, string methodName) { }
-        public static System.Reflection.PropertyInfo GetPropertyByName(this System.Type type, string propertyName) { }
-        public static bool HasExplicitlyImplementedProperty(this System.Type type, System.Type interfaceType, string propertyName) { }
-        public static bool HasMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static bool HasParameterlessMethod(this System.Type type, string methodName) { }
-        public static bool HasValueSemantics(this System.Type type) { }
-        public static bool Implements(this System.Type type, System.Type expectedBaseType) { }
-        public static bool IsCSharpAbstract(this System.Type type) { }
-        public static bool IsCSharpSealed(this System.Type type) { }
-        public static bool IsCSharpStatic(this System.Type type) { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Type type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsEquivalentTo(this FluentAssertions.Equivalency.SelectedMemberInfo property, FluentAssertions.Equivalency.SelectedMemberInfo otherProperty) { }
-        public static bool IsIndexer(this System.Reflection.PropertyInfo member) { }
-        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
-        public static bool OverridesEquals(this System.Type type) { }
     }
     public enum ValueFormatterDetectionMode
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -502,7 +502,6 @@ namespace FluentAssertions.Common
         InvalidForCSharp = 5,
         PrivateProtected = 6,
     }
-    public static class CSharpAccessModifierExtensions { }
     public class Configuration
     {
         public Configuration(FluentAssertions.Common.IConfigurationStore store) { }
@@ -534,12 +533,17 @@ namespace FluentAssertions.Common
     {
         System.TimeSpan Elapsed { get; }
     }
-    public static class MethodInfoExtensions { }
-    public static class ObjectExtensions
+    public static class InternalObjectExtensions
     {
         public static bool IsSameOrEqualTo(this object actual, object expected) { }
     }
-    public static class PropertyInfoExtensions { }
+    public static class InternalTypeExtensions
+    {
+        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static bool HasValueSemantics(this System.Type type) { }
+        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
+    }
     public static class Services
     {
         public static FluentAssertions.Common.Configuration Configuration { get; }
@@ -547,58 +551,6 @@ namespace FluentAssertions.Common
         public static FluentAssertions.Common.IReflector Reflector { get; set; }
         public static System.Action<string> ThrowException { get; set; }
         public static void ResetToDefaults() { }
-    }
-    public static class TypeExtensions
-    {
-        public static System.Reflection.FieldInfo FindField(this System.Type type, string fieldName, System.Type preferredType) { }
-        public static FluentAssertions.Equivalency.SelectedMemberInfo FindMember(this System.Type type, string memberName, System.Type preferredType) { }
-        public static System.Reflection.PropertyInfo FindProperty(this System.Type type, string propertyName, System.Type preferredType) { }
-        public static System.Reflection.ConstructorInfo GetConstructor(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
-        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
-        public static System.Reflection.PropertyInfo GetIndexerByParameterTypes(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static System.Reflection.MethodInfo GetMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> GetNonPrivateFields(this System.Type typeToReflect) { }
-        public static System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetNonPrivateMembers(this System.Type typeToReflect) { }
-        public static System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> GetNonPrivateProperties(this System.Type typeToReflect, System.Collections.Generic.IEnumerable<string> filter = null) { }
-        public static System.Reflection.MethodInfo GetParameterlessMethod(this System.Type type, string methodName) { }
-        public static System.Reflection.PropertyInfo GetPropertyByName(this System.Type type, string propertyName) { }
-        public static bool HasExplicitlyImplementedProperty(this System.Type type, System.Type interfaceType, string propertyName) { }
-        public static bool HasMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static bool HasParameterlessMethod(this System.Type type, string methodName) { }
-        public static bool HasValueSemantics(this System.Type type) { }
-        public static bool Implements(this System.Type type, System.Type expectedBaseType) { }
-        public static bool IsCSharpAbstract(this System.Type type) { }
-        public static bool IsCSharpSealed(this System.Type type) { }
-        public static bool IsCSharpStatic(this System.Type type) { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Type type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsEquivalentTo(this FluentAssertions.Equivalency.SelectedMemberInfo property, FluentAssertions.Equivalency.SelectedMemberInfo otherProperty) { }
-        public static bool IsIndexer(this System.Reflection.PropertyInfo member) { }
-        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
-        public static bool OverridesEquals(this System.Type type) { }
     }
     public enum ValueFormatterDetectionMode
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -509,7 +509,6 @@ namespace FluentAssertions.Common
         InvalidForCSharp = 5,
         PrivateProtected = 6,
     }
-    public static class CSharpAccessModifierExtensions { }
     public class Configuration
     {
         public Configuration(FluentAssertions.Common.IConfigurationStore store) { }
@@ -541,12 +540,17 @@ namespace FluentAssertions.Common
     {
         System.TimeSpan Elapsed { get; }
     }
-    public static class MethodInfoExtensions { }
-    public static class ObjectExtensions
+    public static class InternalObjectExtensions
     {
         public static bool IsSameOrEqualTo(this object actual, object expected) { }
     }
-    public static class PropertyInfoExtensions { }
+    public static class InternalTypeExtensions
+    {
+        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
+        public static bool HasValueSemantics(this System.Type type) { }
+        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
+    }
     public static class Services
     {
         public static FluentAssertions.Common.Configuration Configuration { get; }
@@ -554,58 +558,6 @@ namespace FluentAssertions.Common
         public static FluentAssertions.Common.IReflector Reflector { get; set; }
         public static System.Action<string> ThrowException { get; set; }
         public static void ResetToDefaults() { }
-    }
-    public static class TypeExtensions
-    {
-        public static System.Reflection.FieldInfo FindField(this System.Type type, string fieldName, System.Type preferredType) { }
-        public static FluentAssertions.Equivalency.SelectedMemberInfo FindMember(this System.Type type, string memberName, System.Type preferredType) { }
-        public static System.Reflection.PropertyInfo FindProperty(this System.Type type, string propertyName, System.Type preferredType) { }
-        public static System.Reflection.ConstructorInfo GetConstructor(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static System.Reflection.MethodInfo GetExplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
-        public static System.Reflection.MethodInfo GetImplicitConversionOperator(this System.Type type, System.Type sourceType, System.Type targetType) { }
-        public static System.Reflection.PropertyInfo GetIndexerByParameterTypes(this System.Type type, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static System.Reflection.MethodInfo GetMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> GetNonPrivateFields(this System.Type typeToReflect) { }
-        public static System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.SelectedMemberInfo> GetNonPrivateMembers(this System.Type typeToReflect) { }
-        public static System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> GetNonPrivateProperties(this System.Type typeToReflect, System.Collections.Generic.IEnumerable<string> filter = null) { }
-        public static System.Reflection.MethodInfo GetParameterlessMethod(this System.Type type, string methodName) { }
-        public static System.Reflection.PropertyInfo GetPropertyByName(this System.Type type, string propertyName) { }
-        public static bool HasExplicitlyImplementedProperty(this System.Type type, System.Type interfaceType, string propertyName) { }
-        public static bool HasMethod(this System.Type type, string methodName, System.Collections.Generic.IEnumerable<System.Type> parameterTypes) { }
-        public static bool HasParameterlessMethod(this System.Type type, string methodName) { }
-        public static bool HasValueSemantics(this System.Type type) { }
-        public static bool Implements(this System.Type type, System.Type expectedBaseType) { }
-        public static bool IsCSharpAbstract(this System.Type type) { }
-        public static bool IsCSharpSealed(this System.Type type) { }
-        public static bool IsCSharpStatic(this System.Type type) { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Type type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWith<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.MemberInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Reflection.TypeInfo type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsDecoratedWithOrInherit<TAttribute>(this System.Type type, System.Linq.Expressions.Expression<System.Func<TAttribute, bool>> isMatchingAttributePredicate)
-            where TAttribute : System.Attribute { }
-        public static bool IsEquivalentTo(this FluentAssertions.Equivalency.SelectedMemberInfo property, FluentAssertions.Equivalency.SelectedMemberInfo otherProperty) { }
-        public static bool IsIndexer(this System.Reflection.PropertyInfo member) { }
-        public static bool IsSameOrInherits(this System.Type actualType, System.Type expectedType) { }
-        public static bool OverridesEquals(this System.Type type) { }
     }
     public enum ValueFormatterDetectionMode
     {

--- a/Tests/FluentAssertions.Specs/Common/TimeSpanExtensions.cs
+++ b/Tests/FluentAssertions.Specs/Common/TimeSpanExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Common
 {
     /// <summary>
     /// Implements extensions to <see cref="TimeSpan"/> available in .NET Core 2, but not in .NET Framework.

--- a/Tests/FluentAssertions.Specs/Common/TypeExtensions.cs
+++ b/Tests/FluentAssertions.Specs/Common/TypeExtensions.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace FluentAssertions.Specs.Common
+{
+    internal static class TypeExtensions
+    {
+        private const BindingFlags AllMembersFlag =
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance;
+
+        public static MethodInfo GetParameterlessMethod(this Type type, string methodName)
+        {
+            return type.GetMethod(methodName, Enumerable.Empty<Type>());
+        }
+
+        private static MethodInfo GetMethod(this Type type, string methodName, IEnumerable<Type> parameterTypes)
+        {
+            return type.GetMethods(AllMembersFlag)
+                .SingleOrDefault(m =>
+                    m.Name == methodName && m.GetParameters().Select(p => p.ParameterType).SequenceEqual(parameterTypes));
+        }
+
+        public static PropertyInfo GetPropertyByName(this Type type, string propertyName)
+        {
+            return type.GetProperty(propertyName, AllMembersFlag);
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
@@ -160,7 +160,7 @@ namespace FluentAssertions.Specs
             public IEnumerable<SelectedMemberInfo> SelectMembers(IEnumerable<SelectedMemberInfo> selectedMembers,
                 IMemberInfo context, IEquivalencyAssertionOptions config)
             {
-                return context.CompileTimeType.GetNonPrivateProperties().Select(SelectedMemberInfo.Create);
+                return context.CompileTimeType.GetProperties().Select(SelectedMemberInfo.Create);
             }
 
             bool IMemberSelectionRule.IncludesMembers => OverridesStandardIncludeRules;
@@ -1593,7 +1593,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_selection_rules_are_configured_they_should_be_evaluated_from_right_to_left()
+        public void When_selection_rules_are_configured_they_should_be_evaluated_from_last_to_first()
         {
             // Arrange
             var list1 = new[] { new { Value = 3 } };

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using FluentAssertions.Extensions;
+using FluentAssertions.Specs.Common;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using FluentAssertions.Specs.Common;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
+using FluentAssertions.Specs.Common;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using FluentAssertions.Extensions;
+using FluentAssertions.Specs.Common;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/FluentAssertions.Specs/TypeEnumerableExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/TypeEnumerableExtensionsSpecs.cs
@@ -151,7 +151,7 @@ namespace FluentAssertions.Specs
         {
             var types = new[] { typeof(JustAClass), typeof(AStaticClass) };
 
-            types.ThatSatisfy(t => t.IsCSharpStatic())
+            types.ThatSatisfy(t => t.IsSealed && t.IsAbstract)
                 .Should()
                 .ContainSingle()
                 .Which.Should().Be(typeof(AStaticClass));

--- a/Tests/FluentAssertions.Specs/Types/MethodBaseAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodBaseAssertionSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using FluentAssertions.Common;
+using FluentAssertions.Specs.Common;
 using Xunit;
 using Xunit.Sdk;
 

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoAssertionSpecs.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using FluentAssertions.Common;
+using FluentAssertions.Specs.Common;
 using Xunit;
 using Xunit.Sdk;
 
@@ -355,7 +355,7 @@ namespace FluentAssertions.Specs
         public void When_asserting_a_constructor_is_not_decorated_with_MethodImpl_attribute_and_it_is_not_it_succeeds()
         {
             // Arrange
-            ConstructorInfo constructorMethodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetConstructor(new List<Type> { typeof(string) });
+            ConstructorInfo constructorMethodInfo = typeof(ClassWithMethodWithImplementationAttribute).GetConstructor(new[] { typeof(string) });
 
             // Act
             Action act = () =>

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -9,6 +9,11 @@ sidebar:
 
 ## 6.0.0
 
+**Breaking Changes**
+* Made the extension methods under the `FluentAssertions.Common` namespace `internal` -  [#1376](https://github.com/fluentassertions/fluentassertions/pull/1376)
+
+## 6.0.0 Alpha 1
+
 **What's New**
 * Added official support for .NET Core 3.0 - [#1227](https://github.com/fluentassertions/fluentassertions/pull/1227).
 * Added `WithOffset` extension method on `DateTime` for easier creation of `DateTimeOffset` objects - [#1235](https://github.com/fluentassertions/fluentassertions/pull/1235).


### PR DESCRIPTION
Quite some extension methods where part of a `public` class, which caused some people to use them even though they were not designed for that. I had to keep some of them public because they are covered by tests directly. 