### PR TITLE
Add an AssertionCount property on AssertionScope

### DIFF
--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -85,6 +85,11 @@ namespace FluentAssertions.Execution
         public string Context { get; set; }
 
         /// <summary>
+        /// Gets the number of assertions in the assertion scope.
+        /// </summary>
+        public int AssertionCount { get; private set; }
+
+        /// <summary>
         /// Gets the current thread-specific assertion scope.
         /// </summary>
         public static AssertionScope Current
@@ -178,6 +183,8 @@ namespace FluentAssertions.Execution
 
         public AssertionScope ForCondition(bool condition)
         {
+            AssertionCount++;
+
             succeeded = condition;
 
             return this;

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -942,6 +942,7 @@ namespace FluentAssertions.Execution
         public AssertionScope() { }
         public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
         public AssertionScope(string context) { }
+        public int AssertionCount { get; }
         public string Context { get; set; }
         public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -942,6 +942,7 @@ namespace FluentAssertions.Execution
         public AssertionScope() { }
         public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
         public AssertionScope(string context) { }
+        public int AssertionCount { get; }
         public string Context { get; set; }
         public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -942,6 +942,7 @@ namespace FluentAssertions.Execution
         public AssertionScope() { }
         public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
         public AssertionScope(string context) { }
+        public int AssertionCount { get; }
         public string Context { get; set; }
         public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -895,6 +895,7 @@ namespace FluentAssertions.Execution
         public AssertionScope() { }
         public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
         public AssertionScope(string context) { }
+        public int AssertionCount { get; }
         public string Context { get; set; }
         public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -942,6 +942,7 @@ namespace FluentAssertions.Execution
         public AssertionScope() { }
         public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
         public AssertionScope(string context) { }
+        public int AssertionCount { get; }
         public string Context { get; set; }
         public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -238,6 +238,66 @@ namespace FluentAssertions.Specs
                 .WithMessage("*but found false*but found true*");
         }
 
+        [Fact]
+        public void When_performing_two_assertions_the_assertion_count_should_be_two()
+        {
+            // Arrange
+            using var scope = new AssertionScope();
+
+            // Act
+            false.Should().BeFalse();
+            true.Should().BeTrue();
+
+            // Assert
+            scope.AssertionCount.Should().Be(2);
+        }
+
+        [Fact]
+        public void When_performing_three_chained_assertions_the_assertion_count_should_be_three()
+        {
+            // Arrange
+            using var scope = new AssertionScope();
+            var date = new DateTime(1990, 1, 1);
+
+            // Act
+            date.Should().BeAfter(new DateTime(1980, 1, 1))
+                .And.BeBefore(new DateTime(2000, 1, 1))
+                .And.NotBe(DateTime.MinValue);
+
+            // Assert
+            scope.AssertionCount.Should().Be(3);
+        }
+
+        [Fact]
+        public void When_performing_no_assertions_the_assertion_count_should_be_zero()
+        {
+            // Arrange
+            using var scope = new AssertionScope();
+
+            // Act
+
+            // Assert
+            scope.AssertionCount.Should().Be(0);
+        }
+
+        [Fact]
+        public void When_disposing_the_assertion_scope_new_assertions_should_not_count()
+        {
+            // Arrange
+            var scope = new AssertionScope();
+
+            // Act
+            false.Should().BeFalse();
+            true.Should().BeTrue();
+
+            // Assert
+            Assert.Equal(2, scope.AssertionCount); // Using Assert.Equal instead of scope.AssertionCount.Should() in order not to capture a 3rd assertion
+            scope.Dispose();
+            false.Should().BeFalse();
+            true.Should().BeTrue();
+            scope.AssertionCount.Should().Be(2);
+        }
+
         public class CustomAssertionStrategy : IAssertionStrategy
         {
             private readonly List<string> failureMessages = new List<string>();


### PR DESCRIPTION
Fixes #1380

Marked the pull request as draft because the `When_disposing_the_assertion_scope_new_assertions_should_not_count` does not pass. Getting *Expected value to be 2, but found 3.* on the last assertion. I don't know why yet.