### PR TITLE
Guard against negative values as precision arguments

### DIFF
--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -669,6 +669,11 @@ namespace FluentAssertions
             float expectedValue, float precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             Execute.Assertion
                 .ForCondition(parent.Subject != null)
                 .BecauseOf(because, becauseArgs)
@@ -702,6 +707,11 @@ namespace FluentAssertions
             float? expectedValue, float precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             if (parent.Subject is null && expectedValue is null)
             {
                 return new AndConstraint<NullableNumericAssertions<float>>(parent);
@@ -742,6 +752,11 @@ namespace FluentAssertions
             float expectedValue, float precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             if (float.IsPositiveInfinity(expectedValue))
             {
                 FailIfDifferenceOutsidePrecision(float.IsPositiveInfinity(parent.Subject), parent, expectedValue, precision, float.NaN, because, becauseArgs);
@@ -781,6 +796,11 @@ namespace FluentAssertions
             double expectedValue, double precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             Execute.Assertion
                 .ForCondition(parent.Subject != null)
                 .BecauseOf(because, becauseArgs)
@@ -814,6 +834,11 @@ namespace FluentAssertions
             double? expectedValue, double precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             if (parent.Subject is null && expectedValue is null)
             {
                 return new AndConstraint<NullableNumericAssertions<double>>(parent);
@@ -854,6 +879,11 @@ namespace FluentAssertions
             double expectedValue, double precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             if (double.IsPositiveInfinity(expectedValue))
             {
                 FailIfDifferenceOutsidePrecision(double.IsPositiveInfinity(parent.Subject), parent, expectedValue, precision, double.NaN, because, becauseArgs);
@@ -893,6 +923,11 @@ namespace FluentAssertions
             decimal expectedValue, decimal precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             Execute.Assertion
                 .ForCondition(parent.Subject != null)
                 .BecauseOf(because, becauseArgs)
@@ -926,6 +961,11 @@ namespace FluentAssertions
             decimal? expectedValue, decimal precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             if (parent.Subject is null && expectedValue is null)
             {
                 return new AndConstraint<NullableNumericAssertions<decimal>>(parent);
@@ -966,6 +1006,11 @@ namespace FluentAssertions
             decimal expectedValue, decimal precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             decimal actualDifference = Math.Abs(expectedValue - parent.Subject);
 
             FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference, because, becauseArgs);
@@ -1011,6 +1056,11 @@ namespace FluentAssertions
             float unexpectedValue, float precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             if (parent.Subject != null)
             {
                 var nonNullableAssertions = new NumericAssertions<float>((float)parent.Subject);
@@ -1042,6 +1092,11 @@ namespace FluentAssertions
             float? unexpectedValue, float precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             if (parent.Subject is null ^ unexpectedValue is null)
             {
                 return new AndConstraint<NullableNumericAssertions<float>>(parent);
@@ -1082,6 +1137,11 @@ namespace FluentAssertions
             float unexpectedValue, float precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             if (float.IsPositiveInfinity(unexpectedValue))
             {
                 FailIfDifferenceWithinPrecision(parent, !float.IsPositiveInfinity(parent.Subject), unexpectedValue, precision, float.NaN, because, becauseArgs);
@@ -1121,6 +1181,11 @@ namespace FluentAssertions
             double unexpectedValue, double precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             if (parent.Subject != null)
             {
                 var nonNullableAssertions = new NumericAssertions<double>((double)parent.Subject);
@@ -1152,6 +1217,11 @@ namespace FluentAssertions
             double? unexpectedValue, double precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             if (parent.Subject is null ^ unexpectedValue is null)
             {
                 return new AndConstraint<NullableNumericAssertions<double>>(parent);
@@ -1192,6 +1262,11 @@ namespace FluentAssertions
             double unexpectedValue, double precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             if (double.IsPositiveInfinity(unexpectedValue))
             {
                 FailIfDifferenceWithinPrecision(parent, !double.IsPositiveInfinity(parent.Subject), unexpectedValue, precision, double.NaN, because, becauseArgs);
@@ -1231,6 +1306,11 @@ namespace FluentAssertions
             decimal unexpectedValue, decimal precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             if (parent.Subject != null)
             {
                 var nonNullableAssertions = new NumericAssertions<decimal>((decimal)parent.Subject);
@@ -1262,6 +1342,11 @@ namespace FluentAssertions
             decimal? unexpectedValue, decimal precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             if (parent.Subject is null ^ unexpectedValue is null)
             {
                 return new AndConstraint<NullableNumericAssertions<decimal>>(parent);
@@ -1302,6 +1387,11 @@ namespace FluentAssertions
             decimal unexpectedValue, decimal precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             decimal actualDifference = Math.Abs(unexpectedValue - parent.Subject);
 
             FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference, because, becauseArgs);

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -111,6 +111,11 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> BeCloseTo(DateTime nearbyTime, TimeSpan precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             long distanceToMinInTicks = (nearbyTime - DateTime.MinValue).Ticks;
             DateTime minimumValue = nearbyTime.AddTicks(-Math.Min(precision.Ticks, distanceToMinInTicks));
 
@@ -151,6 +156,11 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotBeCloseTo(DateTime distantTime, TimeSpan precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             long distanceToMinInTicks = (distantTime - DateTime.MinValue).Ticks;
             DateTime minimumValue = distantTime.AddTicks(-Math.Min(precision.Ticks, distanceToMinInTicks));
 

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -114,6 +114,11 @@ namespace FluentAssertions.Primitives
             string because = "",
             params object[] becauseArgs)
         {
+            if (precision < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             long distanceToMinInTicks = (nearbyTime - DateTimeOffset.MinValue).Ticks;
             DateTimeOffset minimumValue = nearbyTime.AddTicks(-Math.Min(precision.Ticks, distanceToMinInTicks));
 
@@ -154,6 +159,11 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotBeCloseTo(DateTimeOffset distantTime, TimeSpan precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             long distanceToMinInTicks = (distantTime - DateTimeOffset.MinValue).Ticks;
             DateTimeOffset minimumValue = distantTime.AddTicks(-Math.Min(precision.Ticks, distanceToMinInTicks));
 

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -272,6 +272,11 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> BeCloseTo(TimeSpan nearbyTime, TimeSpan precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             TimeSpan minimumValue = nearbyTime - precision;
             TimeSpan maximumValue = nearbyTime + precision;
 
@@ -309,6 +314,11 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotBeCloseTo(TimeSpan distantTime, TimeSpan precision, string because = "",
             params object[] becauseArgs)
         {
+            if (precision < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             TimeSpan minimumValue = distantTime - precision;
             TimeSpan maximumValue = distantTime + precision;
 

--- a/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
@@ -191,6 +191,11 @@ namespace FluentAssertions.Specialized
         /// </param>
         public AndConstraint<ExecutionTimeAssertions> BeCloseTo(TimeSpan expectedDuration, TimeSpan precision, string because = "", params object[] becauseArgs)
         {
+            if (precision < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
+            }
+
             TimeSpan minimumValue = expectedDuration - precision;
             TimeSpan maximumValue = expectedDuration + precision;
 

--- a/Tests/FluentAssertions.Specs/Numeric/NullableNumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NullableNumericAssertionSpecs.cs
@@ -209,6 +209,35 @@ namespace FluentAssertions.Specs
         #region Be Approximately
 
         [Fact]
+        public void When_approximating_a_nullable_double_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            double? value = 3.1415927;
+
+            // Act
+            Action act = () => value.Should().BeApproximately(3.14, -0.1);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
+
+        [Fact]
+        public void When_approximating_two_nullable_doubles_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            double? value = 3.1415927;
+            double? expected = 3.14;
+
+            // Act
+            Action act = () => value.Should().BeApproximately(expected, -0.1);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
+
+        [Fact]
         public void When_nullable_double_is_indeed_approximating_a_value_it_should_not_throw()
         {
             // Arrange
@@ -323,6 +352,35 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_approximating_a_nullable_float_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            float? value = 3.1415927F;
+
+            // Act
+            Action act = () => value.Should().BeApproximately(3.14F, -0.1F);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
+
+        [Fact]
+        public void When_approximating_two_nullable_floats_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            float? value = 3.1415927F;
+            float? expected = 3.14F;
+
+            // Act
+            Action act = () => value.Should().BeApproximately(expected, -0.1F);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
+
+        [Fact]
         public void When_nullable_float_is_indeed_approximating_a_value_it_should_not_throw()
         {
             // Arrange
@@ -421,6 +479,35 @@ namespace FluentAssertions.Specs
                 .Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected value to approximate *1* +/- *0.1* but 3.14* differed by*");
+        }
+
+        [Fact]
+        public void When_approximating_a_nullable_decimal_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            decimal? value = 3.1415927m;
+
+            // Act
+            Action act = () => value.Should().BeApproximately(3.14m, -0.1m);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
+
+        [Fact]
+        public void When_approximating_two_nullable_decimals_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            decimal? value = 3.1415927m;
+            decimal? expected = 3.14m;
+
+            // Act
+            Action act = () => value.Should().BeApproximately(expected, -0.1m);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
         }
 
         [Fact]
@@ -541,6 +628,35 @@ namespace FluentAssertions.Specs
         #region Not Be Approximately
 
         [Fact]
+        public void When_not_approximating_a_nullable_double_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            double? value = 3.1415927;
+
+            // Act
+            Action act = () => value.Should().NotBeApproximately(3.14, -0.1);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
+
+        [Fact]
+        public void When_not_approximating_two_nullable_doubles_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            double? value = 3.1415927;
+            double? expected = 3.14;
+
+            // Act
+            Action act = () => value.Should().NotBeApproximately(expected, -0.1);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
+
+        [Fact]
         public void When_asserting_not_approximately_and_nullable_double_is_not_approximating_a_value_it_should_not_throw()
         {
             // Arrange
@@ -653,6 +769,35 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_not_approximating_a_nullable_float_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            float? value = 3.1415927F;
+
+            // Act
+            Action act = () => value.Should().NotBeApproximately(3.14F, -0.1F);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
+
+        [Fact]
+        public void When_not_approximating_two_nullable_floats_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            float? value = 3.1415927F;
+            float? expected = 3.14F;
+
+            // Act
+            Action act = () => value.Should().NotBeApproximately(expected, -0.1F);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
+
+        [Fact]
         public void When_asserting_not_approximately_and_nullable_float_is_not_approximating_a_value_it_should_not_throw()
         {
             // Arrange
@@ -761,6 +906,35 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_not_approximating_a_nullable_decimal_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            decimal? value = 3.1415927m;
+
+            // Act
+            Action act = () => value.Should().NotBeApproximately(3.14m, -0.1m);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
+
+        [Fact]
+        public void When_not_approximating_two_nullable_decimals_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            decimal? value = 3.1415927m;
+            decimal? expected = 3.14m;
+
+            // Act
+            Action act = () => value.Should().NotBeApproximately(expected, -0.1m);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
@@ -1086,6 +1086,20 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_approximating_a_float_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            float value = 3.1415927F;
+
+            // Act
+            Action act = () => value.Should().BeApproximately(3.14F, -0.1F);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
+
+        [Fact]
         public void When_float_is_not_approximating_a_range_it_should_throw()
         {
             // Arrange
@@ -1216,6 +1230,20 @@ namespace FluentAssertions.Specs
             act
                 .Should().Throw<XunitException>()
                 .WithMessage("Expected value to approximate*3.14* +/-*0.001*, but it was <null>.");
+        }
+
+        [Fact]
+        public void When_not_approximating_a_float_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            float value = 3.1415927F;
+
+            // Act
+            Action act = () => value.Should().NotBeApproximately(3.14F, -0.1F);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
         }
 
         [Fact]
@@ -1352,6 +1380,20 @@ namespace FluentAssertions.Specs
         #endregion
 
         #region double
+
+        [Fact]
+        public void When_approximating_a_double_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            double value = 3.1415927;
+
+            // Act
+            Action act = () => value.Should().BeApproximately(3.14, -0.1);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
 
         [Fact]
         public void When_asserting_that_a_double_value_is_equal_to_a_different_value_it_should_throw()
@@ -1516,6 +1558,20 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_not_approximating_a_double_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            double value = 3.1415927;
+
+            // Act
+            Action act = () => value.Should().NotBeApproximately(3.14, -0.1);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
+
+        [Fact]
         public void When_double_is_approximating_a_range_and_should_not_approximate_it_should_throw()
         {
             // Arrange
@@ -1652,6 +1708,20 @@ namespace FluentAssertions.Specs
         #region decimal
 
         [Fact]
+        public void When_approximating_a_decimale_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            decimal value = 3.1415927M;
+
+            // Act
+            Action act = () => value.Should().BeApproximately(3.14m, -0.1m);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
+
+        [Fact]
         public void When_asserting_that_a_decimal_value_is_equal_to_a_different_value_it_should_throw()
         {
             // Arrange
@@ -1773,6 +1843,20 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_not_approximating_a_decimal_with_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            decimal value = 3.1415927m;
+
+            // Act
+            Action act = () => value.Should().NotBeApproximately(3.14m, -0.1m);
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
@@ -307,6 +307,21 @@ namespace FluentAssertions.Specs
         #region (Not) Be Close To
 
         [Fact]
+        public void When_asserting_that_time_is_close_to_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            var dateTime = DateTime.UtcNow;
+            var actual = new DateTime(dateTime.Ticks - 1);
+
+            // Act
+            Action act = () => actual.Should().BeCloseTo(dateTime, -1.Ticks());
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
+
+        [Fact]
         public void When_a_datetime_is_close_to_a_later_datetime_by_one_tick_it_should_succeed()
         {
             // Arrange
@@ -360,6 +375,21 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_that_time_is_not_close_to_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            var dateTime = DateTime.UtcNow;
+            var actual = new DateTime(dateTime.Ticks - 1);
+
+            // Act
+            Action act = () => actual.Should().NotBeCloseTo(dateTime, -1.Ticks());
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
@@ -308,6 +308,21 @@ namespace FluentAssertions.Specs
         #region (Not) Be Close To
 
         [Fact]
+        public void When_asserting_that_time_is_close_to_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            var dateTime = DateTimeOffset.UtcNow;
+            var actual = new DateTimeOffset(dateTime.Ticks - 1, TimeSpan.Zero);
+
+            // Act
+            Action act = () => actual.Should().BeCloseTo(dateTime, -1.Ticks());
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
+
+        [Fact]
         public void When_a_datetimeoffset_is_close_to_a_later_datetimeoffset_by_one_tick_it_should_succeed()
         {
             // Arrange
@@ -361,6 +376,21 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_that_time_is_not_close_to_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            var dateTime = DateTimeOffset.UtcNow;
+            var actual = new DateTimeOffset(dateTime.Ticks - 1, TimeSpan.Zero);
+
+            // Act
+            Action act = () => actual.Should().NotBeCloseTo(dateTime, -1.Ticks());
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
@@ -503,6 +503,21 @@ namespace FluentAssertions.Specs
         #region Be Close To
 
         [Fact]
+        public void When_asserting_that_time_is_close_to_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            var time = new TimeSpan(1, 12, 15, 30, 980);
+            var nearbyTime = new TimeSpan(1, 12, 15, 31, 000);
+
+            // Act
+            Action act = () => time.Should().BeCloseTo(nearbyTime, -1.Ticks());
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
+
+        [Fact]
         public void When_time_is_less_then_but_close_to_another_value_it_should_succeed()
         {
             // Arrange
@@ -610,6 +625,21 @@ namespace FluentAssertions.Specs
         #endregion
 
         #region Not Be Close To
+
+        [Fact]
+        public void When_asserting_that_time_is_not_close_to_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            var time = new TimeSpan(1, 12, 15, 30, 980);
+            var nearbyTime = new TimeSpan(1, 12, 15, 31, 000);
+
+            // Act
+            Action act = () => time.Should().NotBeCloseTo(nearbyTime, -1.Ticks());
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
 
         [Fact]
         public void When_asserting_subject_time_is_not_close_to_a_later_time_it_should_throw()

--- a/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
@@ -341,6 +341,21 @@ namespace FluentAssertions.Specs
 
         #region BeCloseTo
         [Fact]
+        public void When_asserting_that_execution_time_is_close_to_a_negative_precision_it_should_throw()
+        {
+            // Arrange
+            var subject = new SleepingClass();
+
+            // Act
+            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(200)).Should().BeCloseTo(100.Milliseconds(),
+                -1.Ticks());
+
+            // Assert
+            act.Should().Throw<ArgumentOutOfRangeException>()
+                .WithMessage("* value of precision must be non-negative*");
+        }
+
+        [Fact]
         public void When_the_execution_time_of_a_member_is_not_close_to_a_limit_it_should_throw()
         {
             // Arrange

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -43,6 +43,7 @@ sidebar:
 * Fixed an `InvalidCastException` that `BeEquivalentTo` could throw while debugging - [#1325](https://github.com/fluentassertions/fluentassertions/pull/1325)
 * Ensured that `Given` will no longer evaluate its predicate if the preceding `FailWith` raised an assertion failure - [#1325](https://github.com/fluentassertions/fluentassertions/pull/1325)
 * Improved the message that `RaisePropertyChangeFor` throws when the wrong property was detected - [#1333](https://github.com/fluentassertions/fluentassertions/pull/1333)
+* Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)
 
 **Breaking Changes**
 * Dropped support for .NET Framework 4.5, .NET Standard 1.3 and 1.6 - [#1227](https://github.com/fluentassertions/fluentassertions/pull/1227).


### PR DESCRIPTION
If a negative `precision` argument is provided, this innocent looking test
```cs
double value = 1.5;
value.Should().BeApproximately(value, -1);
```

fails with the slightly confusing failure message
```
Expected value to approximate 1.5 +/- -1.0, but 1.5 differed by 0.0.
```

Instead explicitly guard against negative `precision`.

Note:
`NumericAssertionsExtensions.BeCloseTo` for integer values uses a unsigned `delta` parameter to guard against negative values.

This fixes #1384