### PR TITLE
Added `CompareBy{Members,Value}(Type)`

### DIFF
--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -172,6 +172,14 @@ namespace FluentAssertions.Equivalency
             {
                 strategy = EqualityStrategy.ForceEquals;
             }
+            else if (referenceTypes.Any(type.IsAssignableToOpenGeneric))
+            {
+                strategy = EqualityStrategy.ForceMembers;
+            }
+            else if (valueTypes.Any(type.IsAssignableToOpenGeneric))
+            {
+                strategy = EqualityStrategy.ForceEquals;
+            }
             else
             {
                 if (getDefaultEqualityStrategy != null)
@@ -526,15 +534,23 @@ namespace FluentAssertions.Equivalency
         /// Marks the <typeparamref name="T" /> as a type that should be compared by its members even though it may override
         /// the <see cref="object.Equals(object)" /> method.
         /// </summary>
-        public TSelf ComparingByMembers<T>()
+        public TSelf ComparingByMembers<T>() => ComparingByMembers(typeof(T));
+
+        /// <summary>
+        /// Marks <paramref name="type" /> as a type that should be compared by its members even though it may override
+        /// the <see cref="object.Equals(object)" /> method.
+        /// </summary>
+        public TSelf ComparingByMembers(Type type)
         {
-            if (valueTypes.Any(typeof(T).IsSameOrInherits))
+            Guard.ThrowIfArgumentIsNull(type, nameof(type));
+
+            if (valueTypes.Any(type.IsSameOrInherits))
             {
                 throw new InvalidOperationException(
-                    $"Can't compare {typeof(T).Name} by its members if it already setup to be compared by value");
+                    $"Can't compare {type.Name} by its members if it already setup to be compared by value");
             }
 
-            referenceTypes.Add(typeof(T));
+            referenceTypes.Add(type);
             return (TSelf)this;
         }
 
@@ -542,15 +558,23 @@ namespace FluentAssertions.Equivalency
         /// Marks the <typeparamref name="T" /> as a value type which must be compared using its
         /// <see cref="object.Equals(object)" /> method, regardless of it overriding it or not.
         /// </summary>
-        public TSelf ComparingByValue<T>()
+        public TSelf ComparingByValue<T>() => ComparingByValue(typeof(T));
+
+        /// <summary>
+        /// Marks <paramref name="type" /> as a value type which must be compared using its
+        /// <see cref="object.Equals(object)" /> method, regardless of it overriding it or not.
+        /// </summary>
+        public TSelf ComparingByValue(Type type)
         {
-            if (referenceTypes.Any(typeof(T).IsSameOrInherits))
+            Guard.ThrowIfArgumentIsNull(type, nameof(type));
+
+            if (referenceTypes.Any(type.IsSameOrInherits))
             {
                 throw new InvalidOperationException(
-                    $"Can't compare {typeof(T).Name} by value if it already setup to be compared by its members");
+                    $"Can't compare {type.Name} by value if it already setup to be compared by its members");
             }
 
-            valueTypes.Add(typeof(T));
+            valueTypes.Add(type);
             return (TSelf)this;
         }
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -807,7 +807,9 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }
+        public TSelf ComparingByMembers(System.Type type) { }
         public TSelf ComparingByMembers<T>() { }
+        public TSelf ComparingByValue(System.Type type) { }
         public TSelf ComparingByValue<T>() { }
         public TSelf ComparingEnumsByName() { }
         public TSelf ComparingEnumsByValue() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -807,7 +807,9 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }
+        public TSelf ComparingByMembers(System.Type type) { }
         public TSelf ComparingByMembers<T>() { }
+        public TSelf ComparingByValue(System.Type type) { }
         public TSelf ComparingByValue<T>() { }
         public TSelf ComparingEnumsByName() { }
         public TSelf ComparingEnumsByValue() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -807,7 +807,9 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }
+        public TSelf ComparingByMembers(System.Type type) { }
         public TSelf ComparingByMembers<T>() { }
+        public TSelf ComparingByValue(System.Type type) { }
         public TSelf ComparingByValue<T>() { }
         public TSelf ComparingEnumsByName() { }
         public TSelf ComparingEnumsByValue() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -800,7 +800,9 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }
+        public TSelf ComparingByMembers(System.Type type) { }
         public TSelf ComparingByMembers<T>() { }
+        public TSelf ComparingByValue(System.Type type) { }
         public TSelf ComparingByValue<T>() { }
         public TSelf ComparingEnumsByName() { }
         public TSelf ComparingEnumsByValue() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -807,7 +807,9 @@ namespace FluentAssertions.Equivalency
         public FluentAssertions.Equivalency.ITraceWriter TraceWriter { get; }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }
+        public TSelf ComparingByMembers(System.Type type) { }
         public TSelf ComparingByMembers<T>() { }
+        public TSelf ComparingByValue(System.Type type) { }
         public TSelf ComparingByValue<T>() { }
         public TSelf ComparingEnumsByName() { }
         public TSelf ComparingEnumsByValue() { }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -43,6 +43,7 @@ sidebar:
 * Added async version of `Where` extension method to `ExceptionAssertions` to be able to check asynchronously thrown exception - [#1352](https://github.com/fluentassertions/fluentassertions/pull/1352).
 * Added `[Not]BeUpperCased` and `[Not]BeLowerCased` to `StringAssertions` to be able to assert that a string is in upper or lower casing or not - [#1357](https://github.com/fluentassertions/fluentassertions/pull/1357).
 * Added `ObjectAssertions<TSubject, TAssertions>` to ease creation of custom assertion classes - [#1371](https://github.com/fluentassertions/fluentassertions/pull/1371).
+* Added `ComparingBy{Members,Value}(Type)` to allow specifying open generic types - [#1389](https://github.com/fluentassertions/fluentassertions/pull/1389).
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).


### PR DESCRIPTION
The new overloads allows you to use an open generic type.
If both an open and closed type are specified, the closed type takes precedence.

This fixes #1388, #1023