### PR TITLE
Exclude primitive types when comparing by members

### DIFF
--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -544,6 +544,11 @@ namespace FluentAssertions.Equivalency
         {
             Guard.ThrowIfArgumentIsNull(type, nameof(type));
 
+            if (type.IsPrimitive)
+            {
+                throw new InvalidOperationException($"Cannot compare a primitive type such as {type.Name} by its members");
+            }
+
             if (valueTypes.Any(type.IsSameOrInherits))
             {
                 throw new InvalidOperationException(

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -164,7 +164,7 @@ namespace FluentAssertions.Equivalency
         {
             EqualityStrategy strategy;
 
-            if (referenceTypes.Any(type.IsSameOrInherits))
+            if (!type.IsPrimitive && referenceTypes.Any(type.IsSameOrInherits))
             {
                 strategy = EqualityStrategy.ForceMembers;
             }
@@ -172,7 +172,7 @@ namespace FluentAssertions.Equivalency
             {
                 strategy = EqualityStrategy.ForceEquals;
             }
-            else if (referenceTypes.Any(type.IsAssignableToOpenGeneric))
+            else if (!type.IsPrimitive && referenceTypes.Any(type.IsAssignableToOpenGeneric))
             {
                 strategy = EqualityStrategy.ForceMembers;
             }

--- a/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
@@ -474,6 +474,38 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_threating_any_type_as_reference_type_it_should_exclude_primitive_types()
+        {
+            // Arrange
+            var subject = new { Value = 1 };
+            var expected = new { Value = 2 };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expected, opt => opt
+                .ComparingByMembers<object>());
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*be 2*found 1*");
+        }
+
+        [Fact]
+        public void When_threating_an_open_type_as_reference_type_it_should_exclude_primitive_types()
+        {
+            // Arrange
+            var subject = new { Value = 1 };
+            var expected = new { Value = 2 };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expected, opt => opt
+                .ComparingByMembers(typeof(IEquatable<>)));
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*be 2*found 1*");
+        }
+
+        [Fact]
         public void When_a_type_originates_from_the_System_namespace_it_should_be_treated_as_a_value_type()
         {
             // Arrange

--- a/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
@@ -506,6 +506,22 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_threating_a_primitive_type_as_a_reference_type_it_should_throw()
+        {
+            // Arrange
+            var subject = new { Value = 1 };
+            var expected = new { Value = 2 };
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expected, opt => opt
+                .ComparingByMembers<int>());
+
+            // Assert
+            act.Should().Throw<InvalidOperationException>()
+                .WithMessage("*Cannot compare a primitive type*Int32*");
+        }
+
+        [Fact]
         public void When_a_type_originates_from_the_System_namespace_it_should_be_treated_as_a_value_type()
         {
             // Arrange

--- a/docs/_pages/extensibility.md
+++ b/docs/_pages/extensibility.md
@@ -179,6 +179,8 @@ AssertionOptions.AssertEquivalencyUsing(options => options
 ```
 
 Similarly, you can force comparing objects that do override `Equals` by their properties using `ComparingByMembers<T>`.
+This also works for open types, so if all concrete types of your `Option<T>` should be compared be their members you just call `ComparingByMembers(typeof(Option<>))`.
+Primitive types are never compared by their members and trying to call e.g. `ComparingByMembers<int>` will throw an `InvalidOperationException`.
 
 ## Equivalency assertion step by step ##
 

--- a/docs/_pages/objectgraphs.md
+++ b/docs/_pages/objectgraphs.md
@@ -53,6 +53,8 @@ AssertionOptions.AssertEquivalencyUsing(options => options
     .ComparingByValue<DirectoryInfo>());
 ```
 
+Note that primitive types are never compared by their members and trying to call e.g. `ComparingByMembers<int>` will throw an `InvalidOperationException`.
+
 ### Auto-Conversion ###
 In the past, Fluent Assertions would attempt to convert the value of a property of the subject-under-test to the type of the corresponding property on the expectation. But a lot of people complained about this behavior where a string property representing a date and time would magically match a `DateTime` property. As of 5.0, this conversion will no longer happen. However, you can still adjust the assertion by using the `WithAutoConversion` or `WithAutoConversionFor` options:
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -17,6 +17,7 @@ sidebar:
 
 **Fixes**
 * Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)
+* Guard against implicitly or explicitly trying to compare primitive types by members - [#1394](https://github.com/fluentassertions/fluentassertions/pull/1394).
 
 **Breaking Changes**
 * Made the extension methods under the `FluentAssertions.Common` namespace `internal` -  [#1376](https://github.com/fluentassertions/fluentassertions/pull/1376)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -9,9 +9,19 @@ sidebar:
 
 ## 6.0.0
 
+**What's New**
+* Added async version of `Where` extension method to `ExceptionAssertions` to be able to check asynchronously thrown exception - [#1352](https://github.com/fluentassertions/fluentassertions/pull/1352).
+* Added `[Not]BeUpperCased` and `[Not]BeLowerCased` to `StringAssertions` to be able to assert that a string is in upper or lower casing or not - [#1357](https://github.com/fluentassertions/fluentassertions/pull/1357).
+* Added `ObjectAssertions<TSubject, TAssertions>` to ease creation of custom assertion classes - [#1371](https://github.com/fluentassertions/fluentassertions/pull/1371).
+* Added `ComparingBy{Members,Value}(Type)` to allow specifying open generic types - [#1389](https://github.com/fluentassertions/fluentassertions/pull/1389).
+
+**Fixes**
+* Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)
+
 **Breaking Changes**
 * Made the extension methods under the `FluentAssertions.Common` namespace `internal` -  [#1376](https://github.com/fluentassertions/fluentassertions/pull/1376)
 * Moved `[Not]HaveFlag` from `ObjectAssertions` to `EnumAssertions` - [#1375](https://github.com/fluentassertions/fluentassertions/pull/1375).
+* Requesting an unsupported test framework via `Services.Configuration.TestFrameworkName` or `"FluentAssertions.TestFramework"` now throws an exception instead of using the fallback - [#1366](https://github.com/fluentassertions/fluentassertions/pull/1366).
 
 ## 6.0.0 Alpha 1
 
@@ -40,10 +50,6 @@ sidebar:
 * Added `AllBe` to `StringCollectionAssertions` to be able to assert that all strings in collection are equal to the specified string - [#1332](https://github.com/fluentassertions/fluentassertions/pull/1332).
 * Added `ForConstraint` method to `AssertionScope` to open up `OccurenceConstraint` for usage in custom assertion extensions - [#1341](https://github.com/fluentassertions/fluentassertions/pull/1341).
 * Added `NotContainInOrder` to `CollectionAssertions` and `StringCollectionAssertions` to be able to assert that the collection does not contain the specified elements in the exact same order, not necessarily consecutive - [#1339](https://github.com/fluentassertions/fluentassertions/pull/1339).
-* Added async version of `Where` extension method to `ExceptionAssertions` to be able to check asynchronously thrown exception - [#1352](https://github.com/fluentassertions/fluentassertions/pull/1352).
-* Added `[Not]BeUpperCased` and `[Not]BeLowerCased` to `StringAssertions` to be able to assert that a string is in upper or lower casing or not - [#1357](https://github.com/fluentassertions/fluentassertions/pull/1357).
-* Added `ObjectAssertions<TSubject, TAssertions>` to ease creation of custom assertion classes - [#1371](https://github.com/fluentassertions/fluentassertions/pull/1371).
-* Added `ComparingBy{Members,Value}(Type)` to allow specifying open generic types - [#1389](https://github.com/fluentassertions/fluentassertions/pull/1389).
 
 **Fixes**
 * Reported actual value when it contained `{{{{` or `}}}}` - [#1234](https://github.com/fluentassertions/fluentassertions/pull/1234).
@@ -53,7 +59,6 @@ sidebar:
 * Fixed an `InvalidCastException` that `BeEquivalentTo` could throw while debugging - [#1325](https://github.com/fluentassertions/fluentassertions/pull/1325)
 * Ensured that `Given` will no longer evaluate its predicate if the preceding `FailWith` raised an assertion failure - [#1325](https://github.com/fluentassertions/fluentassertions/pull/1325)
 * Improved the message that `RaisePropertyChangeFor` throws when the wrong property was detected - [#1333](https://github.com/fluentassertions/fluentassertions/pull/1333)
-* Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)
 
 **Breaking Changes**
 * Dropped support for .NET Framework 4.5, .NET Standard 1.3 and 1.6 - [#1227](https://github.com/fluentassertions/fluentassertions/pull/1227).
@@ -86,7 +91,6 @@ sidebar:
 * Removed `Succeeded` and `SourceSucceeded` from `Continuation` and `IAssertionScope` - [#1325](https://github.com/fluentassertions/fluentassertions/pull/1325)
 * Removed synchronous assertions on asynchronous operations (`Throw`, `NotThrow`, `CompleteWithin`, ...) [#1324](https://github.com/fluentassertions/fluentassertions/pull/1324)
 * Do not modify `SynchronizationContext.Current` while asserting asynchronous operations. In case hitting deadlocks in your tests please check whether you mix synchronous and asynchronous operations. [#1324](https://github.com/fluentassertions/fluentassertions/pull/1324)
-* Requesting an unsupported test framework via `Services.Configuration.TestFrameworkName` or `"FluentAssertions.TestFramework"` now throws an exception instead of using the fallback - [#1366](https://github.com/fluentassertions/fluentassertions/pull/1366).
 
 ## 5.10.3
 **Fixes**


### PR DESCRIPTION
As primitive types do not have members, it does not make sense to try to compare them by members.
On all but one of the target frameworks two different primitives are currently incorrectly evaluated as being equivalent (#1374).
On net472 it will even hit `"The maximum recursion depth was reached"`.

This PR excludes primitive types from being compared by members.

Thought:
Should we add a guard check in `ComparingByMembers` if someone writes
`ComparingByMembers<int>()` and wonders why `int`s are still not compared by members?

For those interested in the complete set of primitive types, here are the facts from in .netcoreapp3.0 
```cs
AllTypes
  .From(typeof(int).Assembly)
  .Where(e => e.IsPrimitive)
  .Select(e => e.Name)
  .ToList();
```

```
"Boolean"
"Byte"
"Char"
"Double"
"Int16"
"Int32"
"Int64"
"IntPtr"
"SByte"
"Single"
"UInt16"
"UInt32"
"UInt64"
"UIntPtr"
```