### PR TITLE
Init EquivalencyAssetionOptions with defaults out of FluentAssertion dll

### DIFF
--- a/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptions.cs
@@ -23,7 +23,7 @@ namespace FluentAssertions.Equivalency
         {
         }
 
-        internal EquivalencyAssertionOptions(IEquivalencyAssertionOptions defaults)
+        public EquivalencyAssertionOptions(IEquivalencyAssertionOptions defaults)
             : base(defaults)
         {
         }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -642,6 +642,7 @@ namespace FluentAssertions.Equivalency
     public class EquivalencyAssertionOptions<TExpectation> : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>>
     {
         public EquivalencyAssertionOptions() { }
+        public EquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -642,6 +642,7 @@ namespace FluentAssertions.Equivalency
     public class EquivalencyAssertionOptions<TExpectation> : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>>
     {
         public EquivalencyAssertionOptions() { }
+        public EquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -642,6 +642,7 @@ namespace FluentAssertions.Equivalency
     public class EquivalencyAssertionOptions<TExpectation> : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>>
     {
         public EquivalencyAssertionOptions() { }
+        public EquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -635,6 +635,7 @@ namespace FluentAssertions.Equivalency
     public class EquivalencyAssertionOptions<TExpectation> : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>>
     {
         public EquivalencyAssertionOptions() { }
+        public EquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -642,6 +642,7 @@ namespace FluentAssertions.Equivalency
     public class EquivalencyAssertionOptions<TExpectation> : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>>
     {
         public EquivalencyAssertionOptions() { }
+        public EquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<System.Collections.Generic.IEnumerable<TExpectation>> AsCollection() { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Excluding(System.Linq.Expressions.Expression<System.Func<TExpectation, object>> expression) { }
         public FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation> Including(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }


### PR DESCRIPTION
Initialize EquivalencyAssetionOptions with defaults outside of FluentAssertion.
It can be usefull when you try to use `BeEquivalentTo` inside custom equivalency step with options specified in tests (as `config` parameter).

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).