### PR TITLE
Fix format string for null collections

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -1110,8 +1110,7 @@ namespace FluentAssertions.Collections
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to contain items in " + sortOrder + " order{reason}, but found {1}.",
-                        Subject);
+                    .FailWith("Expected {context:collection} to contain items in " + sortOrder + " order{reason}, but found <null>.");
             }
 
             IList<object> actualItems = Subject.ConvertOrCastToList<object>();
@@ -1228,8 +1227,7 @@ namespace FluentAssertions.Collections
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
                     .FailWith(
-                        "Did not expect {context:collection} to contain items in " + sortOrder + " order{reason}, but found {1}.",
-                        Subject);
+                        "Did not expect {context:collection} to contain items in " + sortOrder + " order{reason}, but found <null>.");
             }
 
             object[] orderedItems = (order == SortOrder.Ascending)

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -2589,6 +2589,20 @@ namespace FluentAssertions.Specs
         #region (Not) be in order
 
         [Fact]
+        public void When_asserting_a_null_collection_to_be_in_ascending_order_it_should_throw()
+        {
+            // Arrange
+            List<int> result = null;
+
+            // Act
+            Action act = () => result.Should().BeInAscendingOrder();
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*but found <null>*");
+        }
+
+        [Fact]
         public void When_asserting_the_items_in_an_ascendingly_ordered_collection_are_ordered_ascending_it_should_succeed()
         {
             // Arrange
@@ -2636,6 +2650,20 @@ namespace FluentAssertions.Specs
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected collection to contain items in ascending order because numbers are ordered," +
                     " but found {1, 6, 12, 15, 12, 17, 26} where item at index 3 is in wrong order.");
+        }
+
+        [Fact]
+        public void When_asserting_a_null_collection_to_not_be_in_ascending_order_it_should_throw()
+        {
+            // Arrange
+            List<int> result = null;
+
+            // Act
+            Action act = () => result.Should().NotBeInAscendingOrder();
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*but found <null>*");
         }
 
         [Fact]


### PR DESCRIPTION
Instead of throwing a test failure exception containing "but found <null>", we threw
```
Message: 
    System.FormatException : Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
  Stack Trace: 
    StringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ParamsArray args)
    String.FormatHelper(IFormatProvider provider, String format, ParamsArray args)
    String.Format(String format, Object[] args)
    MessageBuilder.FormatArgumentPlaceholders(String failureMessage, Object[] failureArgs)
    MessageBuilder.Build(String message, Object[] messageArgs, String reason, ContextDataItems contextData, String identifier, String fallbackIdentifier)
    <>c__DisplayClass30_0.<FailWith>b__0()
    AssertionScope.FailWith(Func`1 failReasonFunc)
    AssertionScope.FailWith(Func`1 failReasonFunc)
    AssertionScope.FailWith(String message, Object[] args)
    CollectionAssertions`2.BeInOrder(IComparer`1 comparer, SortOrder expectedOrder, String because, Object[] becauseArgs)
    CollectionAssertions`2.BeInAscendingOrder(IComparer`1 comparer, String because, Object[] becauseArgs)
    CollectionAssertions`2.BeInAscendingOrder(String because, Object[] becauseArgs)
```