### PR TITLE
Guard  [Not]Match, [Not]MatchEquivalentOf, [Not]MatchRegex and [Not]ContainMatch against null or empty patterns

### DIFF
--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -327,6 +327,13 @@ namespace FluentAssertions.Collections
         public AndWhichConstraint<TAssertions, string> ContainMatch(string wildcardPattern, string because = "",
             params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern), "Cannot match strings in collection against <null>. Provide a wildcard pattern or use the Contain method.");
+
+            if (wildcardPattern.Length == 0)
+            {
+                throw new ArgumentException("Cannot match strings in collection against an empty string. Provide a wildcard pattern or use the Contain method.", nameof(wildcardPattern));
+            }
+
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is object)
@@ -374,6 +381,13 @@ namespace FluentAssertions.Collections
         public AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "",
             params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern), "Cannot match strings in collection against <null>. Provide a wildcard pattern or use the NotContain method.");
+
+            if (wildcardPattern.Length == 0)
+            {
+                throw new ArgumentException("Cannot match strings in collection against an empty string. Provide a wildcard pattern or use the NotContain method.", nameof(wildcardPattern));
+            }
+
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is object)

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -186,6 +186,13 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern), "Cannot match string against <null>. Provide a wildcard pattern or use the BeNull method.");
+
+            if (wildcardPattern.Length == 0)
+            {
+                throw new ArgumentException("Cannot match string against an empty string. Provide a wildcard pattern or use the BeEmpty method.", nameof(wildcardPattern));
+            }
+
             var stringWildcardMatchingValidator = new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs);
             stringWildcardMatchingValidator.Validate();
 
@@ -207,6 +214,13 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern), "Cannot match string against <null>. Provide a wildcard pattern or use the NotBeNull method.");
+
+            if (wildcardPattern.Length == 0)
+            {
+                throw new ArgumentException("Cannot match string against an empty string. Provide a wildcard pattern or use the NotBeEmpty method.", nameof(wildcardPattern));
+            }
+
             new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs)
             {
                 Negate = true
@@ -231,6 +245,13 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "",
             params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern), "Cannot match string against <null>. Provide a wildcard pattern or use the BeNull method.");
+
+            if (wildcardPattern.Length == 0)
+            {
+                throw new ArgumentException("Cannot match string against an empty string. Provide a wildcard pattern or use the BeEmpty method.", nameof(wildcardPattern));
+            }
+
             var validator = new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs)
             {
                 IgnoreCase = true,
@@ -258,6 +279,13 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "",
             params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern), "Cannot match string against <null>. Provide a wildcard pattern or use the NotBeNull method.");
+
+            if (wildcardPattern.Length == 0)
+            {
+                throw new ArgumentException("Cannot match string against an empty string. Provide a wildcard pattern or use the NotBeEmpty method.", nameof(wildcardPattern));
+            }
+
             var validator = new StringWildcardMatchingValidator(Subject, wildcardPattern, because, becauseArgs)
             {
                 IgnoreCase = true,
@@ -285,7 +313,12 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<TAssertions> MatchRegex([RegexPattern] string regularExpression, string because = "", params object[] becauseArgs)
         {
-            Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>.");
+            Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");
+
+            if (regularExpression.Length == 0)
+            {
+                throw new ArgumentException("Cannot match string against an empty string. Provide a regex pattern or use the BeEmpty method.", nameof(regularExpression));
+            }
 
             Execute.Assertion
                 .ForCondition(!(Subject is null))
@@ -325,7 +358,12 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<TAssertions> NotMatchRegex([RegexPattern] string regularExpression, string because = "", params object[] becauseArgs)
         {
-            Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>.");
+            Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>. Provide a regex pattern or use the NotBeNull method.");
+
+            if (regularExpression.Length == 0)
+            {
+                throw new ArgumentException("Cannot match string against an empty regex pattern. Provide a regex pattern or use the NotBeEmpty method.", nameof(regularExpression));
+            }
 
             Execute.Assertion
                 .ForCondition(!(Subject is null))

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -1783,8 +1783,24 @@ namespace FluentAssertions.Specs
             Action action = () => collection.Should().ContainMatch(null);
 
             // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Expected collection {\"build succeded\", \"test failed\"} to contain a match of <null>.");
+            action.Should().Throw<ArgumentNullException>()
+                .WithMessage("Cannot match strings in collection against <null>. Provide a wildcard pattern or use the Contain method.*")
+                .And.ParamName.Should().Be("wildcardPattern");
+        }
+
+        [Fact]
+        public void When_asserting_collection_to_have_empty_string_match_it_should_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = new string[] { "build succeded", "test failed" };
+
+            // Act
+            Action action = () => collection.Should().ContainMatch(string.Empty);
+
+            // Assert
+            action.Should().Throw<ArgumentException>()
+                .WithMessage("Cannot match strings in collection against an empty string. Provide a wildcard pattern or use the Contain method.*")
+                .And.ParamName.Should().Be("wildcardPattern");
         }
 
         #endregion
@@ -1859,7 +1875,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_asserting_null_collection_for_not_match_it_should_throw()
+        public void When_asserting_collection_to_not_have_null_match_it_should_throw()
         {
             // Arrange
             IEnumerable<string> collection = null;
@@ -1868,8 +1884,24 @@ namespace FluentAssertions.Specs
             Action action = () => collection.Should().NotContainMatch(null);
 
             // Assert
-            action.Should().Throw<XunitException>()
-                .WithMessage("Did not expect collection to contain a match of <null>, but found <null>.");
+            action.Should().Throw<ArgumentNullException>()
+                .WithMessage("Cannot match strings in collection against <null>. Provide a wildcard pattern or use the NotContain method.*")
+                .And.ParamName.Should().Be("wildcardPattern");
+        }
+
+        [Fact]
+        public void When_asserting_collection_to_not_have_empty_string_match_it_should_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = new string[] { "build succeded", "test failed" };
+
+            // Act
+            Action action = () => collection.Should().NotContainMatch(string.Empty);
+
+            // Assert
+            action.Should().Throw<ArgumentException>()
+                .WithMessage("Cannot match strings in collection against an empty string. Provide a wildcard pattern or use the NotContain method.*")
+                .And.ParamName.Should().Be("wildcardPattern");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
@@ -377,6 +377,36 @@ namespace FluentAssertions.Specs
                 .WithMessage("Expected subject to match*\"*World*\", but*\"hello world\" does not.");
         }
 
+        [Fact]
+        public void When_a_string_is_matched_against_null_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            string subject = "hello world";
+
+            // Act
+            Action act = () => subject.Should().Match(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithMessage("Cannot match string against <null>. Provide a wildcard pattern or use the BeNull method.*")
+                .And.ParamName.Should().Be("wildcardPattern");
+        }
+
+        [Fact]
+        public void When_a_string_is_matched_against_an_empty_string_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            string subject = "hello world";
+
+            // Act
+            Action act = () => subject.Should().Match(string.Empty);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentException>()
+                .WithMessage("Cannot match string against an empty string. Provide a wildcard pattern or use the BeEmpty method.*")
+                .And.ParamName.Should().Be("wildcardPattern");
+        }
+
         #endregion
 
         #region Not Match
@@ -407,6 +437,36 @@ namespace FluentAssertions.Specs
             act
                 .Should().Throw<XunitException>().WithMessage(
                     "Did not expect subject to match*\"*world*\" because that's illegal, but*\"hello world\" matches.");
+        }
+
+        [Fact]
+        public void When_a_string_is_negatively_matched_against_null_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            string subject = "hello world";
+
+            // Act
+            Action act = () => subject.Should().NotMatch(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithMessage("Cannot match string against <null>. Provide a wildcard pattern or use the NotBeNull method.*")
+                .And.ParamName.Should().Be("wildcardPattern");
+        }
+
+        [Fact]
+        public void When_a_string_is_negatively_matched_against_an_empty_string_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            string subject = "hello world";
+
+            // Act
+            Action act = () => subject.Should().NotMatch(string.Empty);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentException>()
+                .WithMessage("Cannot match string against an empty string. Provide a wildcard pattern or use the NotBeEmpty method.*")
+                .And.ParamName.Should().Be("wildcardPattern");
         }
 
         #endregion
@@ -454,6 +514,36 @@ namespace FluentAssertions.Specs
             act.Should().NotThrow();
         }
 
+        [Fact]
+        public void When_a_string_is_matched_against_the_equivalent_of_null_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            string subject = "hello world";
+
+            // Act
+            Action act = () => subject.Should().MatchEquivalentOf(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithMessage("Cannot match string against <null>. Provide a wildcard pattern or use the BeNull method.*")
+                .And.ParamName.Should().Be("wildcardPattern");
+        }
+
+        [Fact]
+        public void When_a_string_is_matched_against_the_equivalent_of_an_empty_string_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            string subject = "hello world";
+
+            // Act
+            Action act = () => subject.Should().MatchEquivalentOf(string.Empty);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentException>()
+                .WithMessage("Cannot match string against an empty string. Provide a wildcard pattern or use the BeEmpty method.*")
+                .And.ParamName.Should().Be("wildcardPattern");
+        }
+
         #endregion
 
         #region Not Match Equivalent Of
@@ -498,6 +588,36 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_a_string_is_negatively_matched_against_the_equivalent_of_null_pattern_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            string subject = "hello world";
+
+            // Act
+            Action act = () => subject.Should().NotMatchEquivalentOf(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithMessage("Cannot match string against <null>. Provide a wildcard pattern or use the NotBeNull method.*")
+                .And.ParamName.Should().Be("wildcardPattern");
+        }
+
+        [Fact]
+        public void When_a_string_is_negatively_matched_against_the_equivalent_of_an_empty_string_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            string subject = "hello world";
+
+            // Act
+            Action act = () => subject.Should().NotMatchEquivalentOf(string.Empty);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentException>()
+                .WithMessage("Cannot match string against an empty string. Provide a wildcard pattern or use the NotBeEmpty method.*")
+                .And.ParamName.Should().Be("wildcardPattern");
         }
 
         #endregion
@@ -558,7 +678,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
-               .WithMessage("Cannot match string against <null>.*")
+               .WithMessage("Cannot match string against <null>. Provide a regex pattern or use the BeNull method.*")
                .And.ParamName.Should().Be("regularExpression");
         }
 
@@ -595,6 +715,21 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>()
                 .Which.Message.Should().Contain("is not a valid regular expression")
                     .And.NotContain("does not match");
+        }
+
+        [Fact]
+        public void When_a_string_is_matched_against_an_empty_regex_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            string subject = "hello world";
+
+            // Act
+            Action act = () => subject.Should().MatchRegex(string.Empty);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentException>()
+                .WithMessage("Cannot match string against an empty string. Provide a regex pattern or use the BeEmpty method.*")
+                .And.ParamName.Should().Be("regularExpression");
         }
 
         #endregion
@@ -653,7 +788,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
-               .WithMessage("Cannot match string against <null>.*")
+               .WithMessage("Cannot match string against <null>. Provide a regex pattern or use the NotBeNull method.*")
                .And.ParamName.Should().Be("regularExpression");
         }
 
@@ -690,6 +825,21 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>()
                 .Which.Message.Should().Contain("is not a valid regular expression")
                     .And.NotContain("matches");
+        }
+
+        [Fact]
+        public void When_a_string_is_negatively_matched_against_an_empty_regex_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            string subject = "hello world";
+
+            // Act
+            Action act = () => subject.Should().NotMatchRegex(string.Empty);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentException>()
+                .WithMessage("Cannot match string against an empty regex pattern. Provide a regex pattern or use the NotBeEmpty method.*")
+                .And.ParamName.Should().Be("regularExpression");
         }
 
         #endregion

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -23,6 +23,7 @@ sidebar:
 * Made the extension methods under the `FluentAssertions.Common` namespace `internal` -  [#1376](https://github.com/fluentassertions/fluentassertions/pull/1376)
 * Moved `[Not]HaveFlag` from `ObjectAssertions` to `EnumAssertions` - [#1375](https://github.com/fluentassertions/fluentassertions/pull/1375).
 * Requesting an unsupported test framework via `Services.Configuration.TestFrameworkName` or `"FluentAssertions.TestFramework"` now throws an exception instead of using the fallback - [#1366](https://github.com/fluentassertions/fluentassertions/pull/1366).
+* Guard `[Not]Match`, `[Not]MatchEquivalentOf`, `[Not]MatchRegex` and `[Not]ContainMatch` against `null` or empty patterns - [#1401](https://github.com/fluentassertions/fluentassertions/pull/1401).
 
 ## 6.0.0 Alpha 1
 


### PR DESCRIPTION
For `String` assertions, `[Not]Match`, `[Not]MatchEquivalentOf`, `[Not]MatchRegex` and `[Not]ContainMatch` no longer accept a `null` or empty string as parameter.

The exception suggests to add a pattern or use one of the `[Not]BeNull`, `[Not]BeEmpty` or`[Not]Contain` methods if that behavior was intended.

Should also close #1243

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).