### PR TITLE
Add missing example in introduction doc

### DIFF
--- a/docs/_pages/introduction.md
+++ b/docs/_pages/introduction.md
@@ -27,7 +27,7 @@ string actual = "ABCDEFGHI";
 actual.Should().StartWith("AB").And.EndWith("HI").And.Contain("EF").And.HaveLength(9);
 ```
 
-To verify that a collection contains a specified number of elements and that all elements match a predicate.
+To verify that all elements of a collection match a predicate and that it contains a specified number of elements.
 
 ```c#
 IEnumerable numbers = new[] { 1, 2, 3 };

--- a/docs/_pages/introduction.md
+++ b/docs/_pages/introduction.md
@@ -31,6 +31,8 @@ To verify that a collection contains a specified number of elements and that all
 
 ```c#
 IEnumerable numbers = new[] { 1, 2, 3 };
+
+numbers.Should().OnlyContain(n => n > 0);
 numbers.Should().HaveCount(4, "because we thought we put four items in the collection");
 ```
 


### PR DESCRIPTION
This assertion about all elements verifying a predicate is mentioned in the text but is not in the code example

> To verify that a collection contains a specified number of elements and that all elements match a predicate.
> 
> ```c#
> IEnumerable numbers = new[] { 1, 2, 3 };
> numbers.Should().HaveCount(4, "because we thought we put four items in the collection");
> ```
> 

## IMPORTANT 

* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).