### PR TITLE
Issue 1404: Escape brackets for ContainSingle(...)

### DIFF
--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Text.RegularExpressions;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
@@ -646,8 +647,9 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
 
+            var body = Regex.Replace(predicate.Body.ToString(), @"{(\d+)}", @"{{$1}}");
             string expectationPrefix =
-                string.Format("Expected {{context:collection}} to contain a single item matching {0}{{reason}}, ", predicate.Body);
+                $"Expected {{context:collection}} to contain a single item matching {body}{{reason}}, ";
 
             if (Subject is null)
             {

--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -646,22 +646,21 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
 
-            var body = predicate.Body.ToString().EscapePlaceholders();
             string expectationPrefix =
-                $"Expected {{context:collection}} to contain a single item matching {body}{{reason}}, ";
+                "Expected {context:collection} to contain a single item matching {0}{reason}, ";
 
             if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith(expectationPrefix + "but found {0}.", Subject);
+                    .FailWith(expectationPrefix + "but found {1}.", predicate.Body, Subject);
             }
 
             ICollection<T> actualItems = Subject.ConvertOrCastToCollection();
             Execute.Assertion
                 .ForCondition(actualItems.Any())
                 .BecauseOf(because, becauseArgs)
-                .FailWith(expectationPrefix + "but the collection is empty.");
+                .FailWith(expectationPrefix + "but the collection is empty.", predicate.Body);
 
             T[] matchingElements = actualItems.Where(predicate.Compile()).ToArray();
             int count = matchingElements.Length;
@@ -669,13 +668,13 @@ namespace FluentAssertions.Collections
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith(expectationPrefix + "but no such item was found.");
+                    .FailWith(expectationPrefix + "but no such item was found.", predicate.Body);
             }
             else if (count > 1)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith(expectationPrefix + "but " + count.ToString() + " such items were found.");
+                    .FailWith(expectationPrefix + "but " + count.ToString() + " such items were found.", predicate.Body);
             }
             else
             {

--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text.RegularExpressions;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
@@ -647,7 +646,7 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
 
-            var body = Regex.Replace(predicate.Body.ToString(), @"{(\d+)}", @"{{$1}}");
+            var body = predicate.Body.ToString().EscapePlaceholders();
             string expectationPrefix =
                 $"Expected {{context:collection}} to contain a single item matching {body}{{reason}}, ";
 

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
@@ -362,6 +362,34 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>().WithMessage("Expected*greater*4*2*");
         }
 
+        [Fact]
+        public void When_single_item_contains_brackets_it_should_escape_them()
+        {
+            // Arrange
+            IEnumerable<string> collection = new[] { "" };
+
+            // Act
+            Action act = () => collection.Should().ContainSingle(item => item == "{123}");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection to contain a single item matching (item == \"{123}\"), but no such item was found.");
+        }
+
+        [Fact]
+        public void When_single_item_contains_string_interpolation_it_should_escape_brackets()
+        {
+            // Arrange
+            IEnumerable<string> collection = new[] { "" };
+
+            // Act
+            Action act = () => collection.Should().ContainSingle(item => item == $"{123}");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection to contain a single item matching (item == Format(\"{0}\", Convert(123))), but no such item was found.");
+        }
+
         #endregion
 
         #region Contain Single

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
@@ -363,7 +363,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_single_item_contains_brackets_it_should_not_fail()
+        public void When_single_item_contains_brackets_it_should_format_them_properly()
         {
             // Arrange
             IEnumerable<string> collection = new[] { "" };

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
@@ -377,7 +377,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_single_item_contains_string_interpolation_it_should_not_fail()
+        public void When_single_item_contains_string_interpolation_it_should_format_brackets_properly()
         {
             // Arrange
             IEnumerable<string> collection = new[] { "" };

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
@@ -363,7 +363,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_single_item_contains_brackets_it_should_escape_them()
+        public void When_single_item_contains_brackets_it_should_not_fail()
         {
             // Arrange
             IEnumerable<string> collection = new[] { "" };
@@ -377,7 +377,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_single_item_contains_string_interpolation_it_should_escape_brackets()
+        public void When_single_item_contains_string_interpolation_it_should_not_fail()
         {
             // Arrange
             IEnumerable<string> collection = new[] { "" };
@@ -387,7 +387,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain a single item matching (item == Format(\"{0}\", Convert(123))), but no such item was found.");
+                "Expected collection to contain a single item matching (item == Format(\"{0}\", Convert(123*))), but no such item was found.");
         }
 
         #endregion

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -18,7 +18,7 @@ sidebar:
 **Fixes**
 * Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)
 * Guard against implicitly or explicitly trying to compare primitive types by members - [#1394](https://github.com/fluentassertions/fluentassertions/pull/1394).
-* Escaped brackets in expressions passed to ContainSingle(...) - [#1405](https://github.com/fluentassertions/fluentassertions/pull/1405). 
+* Escaped brackets in expressions passed to ContainSingle(...) - [#1406](https://github.com/fluentassertions/fluentassertions/pull/1406). 
 
 **Breaking Changes**
 * Made the extension methods under the `FluentAssertions.Common` namespace `internal` -  [#1376](https://github.com/fluentassertions/fluentassertions/pull/1376)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -18,6 +18,7 @@ sidebar:
 **Fixes**
 * Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)
 * Guard against implicitly or explicitly trying to compare primitive types by members - [#1394](https://github.com/fluentassertions/fluentassertions/pull/1394).
+* Escaped brackets in expressions passed to ContainSingle(...) - [#1405](https://github.com/fluentassertions/fluentassertions/pull/1405). 
 
 **Breaking Changes**
 * Made the extension methods under the `FluentAssertions.Common` namespace `internal` -  [#1376](https://github.com/fluentassertions/fluentassertions/pull/1376)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -18,7 +18,7 @@ sidebar:
 **Fixes**
 * Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)
 * Guard against implicitly or explicitly trying to compare primitive types by members - [#1394](https://github.com/fluentassertions/fluentassertions/pull/1394).
-* Escaped brackets in expressions passed to ContainSingle(...) - [#1406](https://github.com/fluentassertions/fluentassertions/pull/1406). 
+* Fixed formatting of brackets in expressions passed to ContainSingle(...) - [#1406](https://github.com/fluentassertions/fluentassertions/pull/1406). 
 
 **Breaking Changes**
 * Made the extension methods under the `FluentAssertions.Common` namespace `internal` -  [#1376](https://github.com/fluentassertions/fluentassertions/pull/1376)


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).