### PR TITLE
Adds extension method for WithInnerMessageExactly for async

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -851,6 +851,29 @@ namespace FluentAssertions
             return (await task).WithInnerException<TInnerException>(because, becauseArgs);
         }
 
+        /// <summary>
+        /// Asserts that the thrown exception contains an inner exception of the exact type <typeparamref name="TInnerException" />.
+        /// </summary>
+        /// <typeparam name="TException">The expected type of the exception.</typeparam>
+        /// <typeparam name="TInnerException">The expected type of the inner exception.</typeparam>
+        /// <param name="task">The <see cref="ExceptionAssertions{TException}"/> containing the thrown exception.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public static async Task<ExceptionAssertions<TInnerException>> WithInnerExceptionExactly<TException, TInnerException>(
+            this Task<ExceptionAssertions<TException>> task,
+            string because = "",
+            params object[] becauseArgs)
+            where TException : Exception
+            where TInnerException : Exception
+        {
+            return (await task).WithInnerExceptionExactly<TInnerException>(because, becauseArgs);
+        }
+
 #pragma warning restore AV1755
     }
 }

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -1187,6 +1187,48 @@ namespace FluentAssertions.Specs // TODO Move to FluentAssertions.Specs.Exceptio
             // Assert
             await act.Should().NotThrowAsync();
         }
+
+        [Fact]
+        public async Task When_async_method_throws_the_exact_expected_inner_exception_it_should_succeed()
+        {
+            // Arrange
+            Func<Task> task = async () =>
+            {
+                await Task.Delay(100);
+                throw new AggregateException(new InvalidOperationException());
+            };
+
+            var s = await task.Should().ThrowAsync<AggregateException>();
+
+            s.WithInnerExceptionExactly<InvalidOperationException>();
+
+            // Act
+            Func<Task> action = () => task
+                .Should().ThrowAsync<AggregateException>()
+                .WithInnerExceptionExactly<AggregateException, InvalidOperationException>();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_async_method_does_not_throw_the_expected_exact_inner_exception_it_should_fail()
+        {
+            // Arrange
+            Func<Task> task = async () =>
+            {
+                await Task.Delay(100);
+                throw new AggregateException(new ArgumentException());
+            };
+
+            // Act
+            Func<Task> action = () => task
+                .Should().ThrowAsync<AggregateException>()
+                .WithInnerExceptionExactly<AggregateException, InvalidOperationException>();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
+        }
         #endregion
     }
 

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -1192,15 +1192,7 @@ namespace FluentAssertions.Specs // TODO Move to FluentAssertions.Specs.Exceptio
         public async Task When_async_method_throws_the_exact_expected_inner_exception_it_should_succeed()
         {
             // Arrange
-            Func<Task> task = async () =>
-            {
-                await Task.Delay(100);
-                throw new AggregateException(new InvalidOperationException());
-            };
-
-            var s = await task.Should().ThrowAsync<AggregateException>();
-
-            s.WithInnerExceptionExactly<InvalidOperationException>();
+            Func<Task> task = () => FromException(new AggregateException(new InvalidOperationException()));
 
             // Act
             Func<Task> action = () => task
@@ -1215,11 +1207,7 @@ namespace FluentAssertions.Specs // TODO Move to FluentAssertions.Specs.Exceptio
         public async Task When_async_method_does_not_throw_the_expected_exact_inner_exception_it_should_fail()
         {
             // Arrange
-            Func<Task> task = async () =>
-            {
-                await Task.Delay(100);
-                throw new AggregateException(new ArgumentException());
-            };
+            Func<Task> task = () => FromException(new AggregateException(new ArgumentException()));
 
             // Act
             Func<Task> action = () => task
@@ -1227,7 +1215,7 @@ namespace FluentAssertions.Specs // TODO Move to FluentAssertions.Specs.Exceptio
                 .WithInnerExceptionExactly<AggregateException, InvalidOperationException>();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
+            await action.Should().ThrowAsync<XunitException>();
         }
         #endregion
     }


### PR DESCRIPTION
Adds for the missing `WithInnerExceptionExactly` #1400 