### PR TITLE
Add NotBeEquivalentTo with config overload

### DIFF
--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -512,25 +512,45 @@ namespace FluentAssertions.Collections
                         unexpected);
             }
 
-            IEnumerable<object> actualItems = Subject.Cast<object>();
-            IEnumerable<object> unexpectedItems = unexpected.Cast<object>();
+            return NotBeEquivalentTo(unexpected.ConvertOrCastToList<object>(), config => config, because, becauseArgs);
+        }
 
-            if (actualItems.Count() == unexpectedItems.Count())
+        /// <summary>
+        /// Expects the current collection not to contain all elements of the collection identified by <paramref name="unexpected" />,
+        /// regardless of the order. Elements are compared using their <see cref="object.Equals(object)" />.
+        /// </summary>
+        /// <param name="unexpected">An <see cref="IEnumerable"/> with the unexpected elements.</param>
+        /// /// <param name="config">
+        /// A reference to the <see cref="EquivalencyAssertionOptions{TSubject}"/> configuration object that can be used
+        /// to influence the way the object graphs are compared. You can also provide an alternative instance of the
+        /// <see cref="EquivalencyAssertionOptions{TSubject}"/> class. The global defaults are determined by the
+        /// <see cref="AssertionOptions"/> class.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(IEnumerable<TExpectation> unexpected,
+            Func<EquivalencyAssertionOptions<TExpectation>, EquivalencyAssertionOptions<TExpectation>> config,
+            string because = "", params object[] becauseArgs)
+        {
+            Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot verify inequivalence against a <null> collection.");
+
+            if (ReferenceEquals(Subject, null))
             {
-                List<object> missingItems = GetMissingItems(unexpectedItems, actualItems);
-
                 Execute.Assertion
-                    .ForCondition(missingItems.Count > 0)
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} {0} not be equivalent with collection {1}{reason}.", Subject,
-                        unexpected);
+                    .FailWith("Expected {context:collection} not to be equivalent{reason}, but found <null>.");
             }
 
             string[] failures;
 
             using (var scope = new AssertionScope())
             {
-                Subject.Should().BeEquivalentTo(unexpected);
+                Subject.Should().BeEquivalentTo(unexpected, config);
 
                 failures = scope.Discard();
             }
@@ -787,26 +807,6 @@ namespace FluentAssertions.Collections
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
-        }
-
-        private static List<T> GetMissingItems<T>(IEnumerable<T> expectedItems, IEnumerable<T> actualItems)
-        {
-            List<T> missingItems = new List<T>();
-            List<T> subject = actualItems.ToList();
-
-            foreach (T expectation in expectedItems)
-            {
-                if (subject.Contains(expectation))
-                {
-                    subject.Remove(expectation);
-                }
-                else
-                {
-                    missingItems.Add(expectation);
-                }
-            }
-
-            return missingItems;
         }
 
         /// <summary>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -316,6 +316,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -316,6 +316,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -316,6 +316,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -309,6 +309,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -316,6 +316,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(System.Collections.IEnumerable unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> unexpected, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInAscendingOrder(System.Collections.Generic.IComparer<object> comparer, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInDescendingOrder(string because = "", params object[] becauseArgs) { }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -1679,6 +1679,24 @@ namespace FluentAssertions.Specs
                 "*not to be equivalent*because we want to test the behaviour with same objects*but they both reference the same object.");
         }
 
+        [Fact]
+        public void When_a_collections_is_equivalent_to_an_approximate_copy_it_should_throw()
+        {
+            // Arrange
+            var collection = new[] { 1.0, 2.0, 3.0 };
+            var collection1 = new[] { 1.5, 2.5, 3.5 };
+
+            // Act
+            Action act = () => collection.Should().NotBeEquivalentTo(collection1, opt => opt
+                .Using<double>(ctx => ctx.Subject.Should().BeApproximately(ctx.Expectation, 0.5))
+                .WhenTypeIs<double>(),
+                "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "*not to be equivalent*because we want to test the failure message*");
+        }
+
         #endregion
 
         #region Contain Equivalent Of

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -14,6 +14,7 @@ sidebar:
 * Added `[Not]BeUpperCased` and `[Not]BeLowerCased` to `StringAssertions` to be able to assert that a string is in upper or lower casing or not - [#1357](https://github.com/fluentassertions/fluentassertions/pull/1357).
 * Added `ObjectAssertions<TSubject, TAssertions>` to ease creation of custom assertion classes - [#1371](https://github.com/fluentassertions/fluentassertions/pull/1371).
 * Added `ComparingBy{Members,Value}(Type)` to allow specifying open generic types - [#1389](https://github.com/fluentassertions/fluentassertions/pull/1389).
+* Added overload of `CollectionAssertions.NotBeEquivalentTo` that takes a `config` parameter` - [#1408](https://github.com/fluentassertions/fluentassertions/pull/1408).
 
 **Fixes**
 * Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)


### PR DESCRIPTION
This PR adds an overloads of `CollectionAssertions.BeEquivalentTo` that takes a `config` parameter.

Since #593 `CollectionAssertions.BeEquivalentTo` no longer used `GetMissingItems`.
https://github.com/fluentassertions/fluentassertions/pull/593/files?file-filters%5B%5D=#diff-4cf34d1b2865162998773f88349aecab.
The same removal should be done here, as `GetMissingItems` relies on `Contains` which checks for equality and not equivalence.