### PR TITLE
Make StringAssertions.StartWith and String.StartsWith consistent

### DIFF
--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -404,11 +404,6 @@ namespace FluentAssertions.Primitives
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare start of string with <null>.");
 
-            if (expected.Length == 0)
-            {
-                throw new ArgumentException("Cannot compare start of string with empty string.", nameof(expected));
-            }
-
             var stringStartValidator = new StringStartValidator(Subject, expected, StringComparison.Ordinal, because, becauseArgs);
             stringStartValidator.Validate();
 
@@ -430,11 +425,6 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare start of string with <null>.");
-
-            if (unexpected.Length == 0)
-            {
-                throw new ArgumentException("Cannot compare start of string with empty string.", nameof(unexpected));
-            }
 
             var negatedStringStartValidator = new NegatedStringStartValidator(Subject, unexpected, StringComparison.Ordinal, because, becauseArgs);
             negatedStringStartValidator.Validate();
@@ -459,11 +449,6 @@ namespace FluentAssertions.Primitives
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare string start equivalence with <null>.");
 
-            if (expected.Length == 0)
-            {
-                throw new ArgumentException("Cannot compare string start equivalence with empty string.", nameof(expected));
-            }
-
             var stringStartValidator = new StringStartValidator(Subject, expected, StringComparison.OrdinalIgnoreCase, because, becauseArgs);
             stringStartValidator.Validate();
 
@@ -486,11 +471,6 @@ namespace FluentAssertions.Primitives
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare start of string with <null>.");
 
-            if (unexpected.Length == 0)
-            {
-                throw new ArgumentException("Cannot compare start of string with empty string.", nameof(unexpected));
-            }
-
             var negatedStringStartValidator = new NegatedStringStartValidator(Subject, unexpected, StringComparison.OrdinalIgnoreCase, because, becauseArgs);
             negatedStringStartValidator.Validate();
 
@@ -512,12 +492,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> EndWith(string expected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare string end with <null>.");
-
-            if (expected.Length == 0)
-            {
-                throw new ArgumentException("Cannot compare string end with empty string.", nameof(expected));
-            }
-
+            
             if (Subject is null)
             {
                 Execute.Assertion
@@ -556,11 +531,6 @@ namespace FluentAssertions.Primitives
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare end of string with <null>.");
 
-            if (unexpected.Length == 0)
-            {
-                throw new ArgumentException("Cannot compare end of string with empty string.", nameof(unexpected));
-            }
-
             if (Subject is null)
             {
                 Execute.Assertion
@@ -591,11 +561,6 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> EndWithEquivalentOf(string expected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare string end equivalence with <null>.");
-
-            if (expected.Length == 0)
-            {
-                throw new ArgumentException("Cannot compare string end equivalence with empty string.", nameof(expected));
-            }
 
             if (Subject is null)
             {
@@ -634,11 +599,6 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotEndWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare end of string with <null>.");
-
-            if (unexpected.Length == 0)
-            {
-                throw new ArgumentException("Cannot compare end of string with empty string.", nameof(unexpected));
-            }
 
             if (Subject is null)
             {

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
@@ -898,14 +898,13 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_string_start_is_compared_with_empty_string_it_should_throw()
+        public void When_string_start_is_compared_with_empty_string_it_should_not_throw()
         {
             // Act
             Action act = () => "ABC".Should().StartWith("");
 
             // Assert
-            act.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot compare start of string with empty string.*");
+            act.Should().NotThrow();
         }
 
         [Fact]
@@ -991,8 +990,8 @@ namespace FluentAssertions.Specs
                 value.Should().NotStartWith("");
 
             // Assert
-            action.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot compare start of string with empty string.*");
+            action.Should().Throw<XunitException>().WithMessage(
+                "Expected value that does not start with \"\", but found \"ABC\".");
         }
 
         [Fact]
@@ -1056,14 +1055,13 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_string_ending_is_compared_with_empty_string_it_should_throw()
+        public void When_string_ending_is_compared_with_empty_string_it_should_not_throw()
         {
             // Act
             Action act = () => "ABC".Should().EndWith("");
 
             // Assert
-            act.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot compare string end with empty string.*");
+            act.Should().NotThrow();
         }
 
         [Fact]
@@ -1150,8 +1148,8 @@ namespace FluentAssertions.Specs
                 value.Should().NotEndWith("");
 
             // Assert
-            action.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot compare end of string with empty string.*");
+            action.Should().Throw<XunitException>().WithMessage(
+                "Expected value \"ABC\" not to end with \"\".");
         }
 
         [Fact]
@@ -1218,14 +1216,13 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_start_of_string_is_compared_with_equivalent_of_empty_string_it_should_throw()
+        public void When_start_of_string_is_compared_with_equivalent_of_empty_string_it_should_not_throw()
         {
             // Act
             Action act = () => "ABC".Should().StartWithEquivalentOf("");
 
             // Assert
-            act.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot compare string start equivalence with empty string.*");
+            act.Should().NotThrow();
         }
 
         [Fact]
@@ -1313,8 +1310,8 @@ namespace FluentAssertions.Specs
                 value.Should().NotStartWithEquivalentOf("");
 
             // Assert
-            action.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot compare start of string with empty string.*");
+            action.Should().Throw<XunitException>().WithMessage(
+                "Expected value that does not start with equivalent of \"\", but found \"ABC\".");
         }
 
         [Fact]
@@ -1380,14 +1377,13 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_end_of_string_is_compared_with_equivalent_of_empty_string_it_should_throw()
+        public void When_end_of_string_is_compared_with_equivalent_of_empty_string_it_should_not_throw()
         {
             // Act
             Action act = () => "ABC".Should().EndWithEquivalentOf("");
 
             // Assert
-            act.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot compare string end equivalence with empty string.*");
+            act.Should().NotThrow();
         }
 
         [Fact]
@@ -1474,8 +1470,8 @@ namespace FluentAssertions.Specs
                 value.Should().NotEndWithEquivalentOf("");
 
             // Assert
-            action.Should().Throw<ArgumentException>().WithMessage(
-                "Cannot compare end of string with empty string.*");
+            action.Should().Throw<XunitException>().WithMessage(
+                "Expected value that does not end with equivalent of \"\", but found \"ABC\".");
         }
 
         [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -15,7 +15,7 @@ sidebar:
 * Added `ObjectAssertions<TSubject, TAssertions>` to ease creation of custom assertion classes - [#1371](https://github.com/fluentassertions/fluentassertions/pull/1371).
 * Added `ComparingBy{Members,Value}(Type)` to allow specifying open generic types - [#1389](https://github.com/fluentassertions/fluentassertions/pull/1389).
 * Added overload of `CollectionAssertions.NotBeEquivalentTo` that takes a `config` parameter` - [#1408](https://github.com/fluentassertions/fluentassertions/pull/1408).
-* Made StringAssertions.StartWith and String.StartsWith consistent - [#1413](https://github.com/fluentassertions/fluentassertions/pull/1413).
+* Changed `StringAssertions.StartWith`, `StringAssertions.EndWith` and their `EquivalentOf` versions to allow empty strings - [#1413](https://github.com/fluentassertions/fluentassertions/pull/1413).
 
 **Fixes**
 * Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -15,6 +15,7 @@ sidebar:
 * Added `ObjectAssertions<TSubject, TAssertions>` to ease creation of custom assertion classes - [#1371](https://github.com/fluentassertions/fluentassertions/pull/1371).
 * Added `ComparingBy{Members,Value}(Type)` to allow specifying open generic types - [#1389](https://github.com/fluentassertions/fluentassertions/pull/1389).
 * Added overload of `CollectionAssertions.NotBeEquivalentTo` that takes a `config` parameter` - [#1408](https://github.com/fluentassertions/fluentassertions/pull/1408).
+* Made StringAssertions.StartWith and String.StartsWith consistent - [#1413](https://github.com/fluentassertions/fluentassertions/pull/1413).
 
 **Fixes**
 * Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).