### PR TITLE
Update Numeric Assertions messages to display the difference between Actual vs Expected

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -381,7 +381,7 @@ namespace FluentAssertions
         [Pure]
         public static NumericAssertions<int> Should(this int actualValue)
         {
-            return new NumericAssertions<int>(actualValue);
+            return new IntAssertions(actualValue);
         }
 
         /// <summary>
@@ -391,7 +391,7 @@ namespace FluentAssertions
         [Pure]
         public static NullableNumericAssertions<int> Should(this int? actualValue)
         {
-            return new NullableNumericAssertions<int>(actualValue);
+            return new NullableIntAssertions(actualValue);
         }
 
         /// <summary>
@@ -401,7 +401,7 @@ namespace FluentAssertions
         [Pure]
         public static NumericAssertions<uint> Should(this uint actualValue)
         {
-            return new NumericAssertions<uint>(actualValue);
+            return new UIntAssertions(actualValue);
         }
 
         /// <summary>
@@ -411,7 +411,7 @@ namespace FluentAssertions
         [Pure]
         public static NullableNumericAssertions<uint> Should(this uint? actualValue)
         {
-            return new NullableNumericAssertions<uint>(actualValue);
+            return new NullableUIntAssertions(actualValue);
         }
 
         /// <summary>
@@ -421,7 +421,7 @@ namespace FluentAssertions
         [Pure]
         public static NumericAssertions<decimal> Should(this decimal actualValue)
         {
-            return new NumericAssertions<decimal>(actualValue);
+            return new DecimalAssertions(actualValue);
         }
 
         /// <summary>
@@ -431,7 +431,7 @@ namespace FluentAssertions
         [Pure]
         public static NullableNumericAssertions<decimal> Should(this decimal? actualValue)
         {
-            return new NullableNumericAssertions<decimal>(actualValue);
+            return new NullableDecimalAssertions(actualValue);
         }
 
         /// <summary>
@@ -441,7 +441,7 @@ namespace FluentAssertions
         [Pure]
         public static NumericAssertions<byte> Should(this byte actualValue)
         {
-            return new NumericAssertions<byte>(actualValue);
+            return new ByteAssertions(actualValue);
         }
 
         /// <summary>
@@ -451,7 +451,7 @@ namespace FluentAssertions
         [Pure]
         public static NullableNumericAssertions<byte> Should(this byte? actualValue)
         {
-            return new NullableNumericAssertions<byte>(actualValue);
+            return new NullableByteAssertions(actualValue);
         }
 
         /// <summary>
@@ -461,7 +461,7 @@ namespace FluentAssertions
         [Pure]
         public static NumericAssertions<sbyte> Should(this sbyte actualValue)
         {
-            return new NumericAssertions<sbyte>(actualValue);
+            return new SByteAssertions(actualValue);
         }
 
         /// <summary>
@@ -471,7 +471,7 @@ namespace FluentAssertions
         [Pure]
         public static NullableNumericAssertions<sbyte> Should(this sbyte? actualValue)
         {
-            return new NullableNumericAssertions<sbyte>(actualValue);
+            return new NullableSByteAssertions(actualValue);
         }
 
         /// <summary>
@@ -481,7 +481,7 @@ namespace FluentAssertions
         [Pure]
         public static NumericAssertions<short> Should(this short actualValue)
         {
-            return new NumericAssertions<short>(actualValue);
+            return new ShortAssertions(actualValue);
         }
 
         /// <summary>
@@ -491,7 +491,7 @@ namespace FluentAssertions
         [Pure]
         public static NullableNumericAssertions<short> Should(this short? actualValue)
         {
-            return new NullableNumericAssertions<short>(actualValue);
+            return new NullableShortAssertions(actualValue);
         }
 
         /// <summary>
@@ -501,7 +501,7 @@ namespace FluentAssertions
         [Pure]
         public static NumericAssertions<ushort> Should(this ushort actualValue)
         {
-            return new NumericAssertions<ushort>(actualValue);
+            return new UShortAssertions(actualValue);
         }
 
         /// <summary>
@@ -511,7 +511,7 @@ namespace FluentAssertions
         [Pure]
         public static NullableNumericAssertions<ushort> Should(this ushort? actualValue)
         {
-            return new NullableNumericAssertions<ushort>(actualValue);
+            return new NullableUShortAssertions(actualValue);
         }
 
         /// <summary>
@@ -521,7 +521,7 @@ namespace FluentAssertions
         [Pure]
         public static NumericAssertions<long> Should(this long actualValue)
         {
-            return new NumericAssertions<long>(actualValue);
+            return new LongAssertions(actualValue);
         }
 
         /// <summary>
@@ -531,7 +531,7 @@ namespace FluentAssertions
         [Pure]
         public static NullableNumericAssertions<long> Should(this long? actualValue)
         {
-            return new NullableNumericAssertions<long>(actualValue);
+            return new NullableLongAssertions(actualValue);
         }
 
         /// <summary>
@@ -541,7 +541,7 @@ namespace FluentAssertions
         [Pure]
         public static NumericAssertions<ulong> Should(this ulong actualValue)
         {
-            return new NumericAssertions<ulong>(actualValue);
+            return new ULongAssertions(actualValue);
         }
 
         /// <summary>
@@ -551,7 +551,7 @@ namespace FluentAssertions
         [Pure]
         public static NullableNumericAssertions<ulong> Should(this ulong? actualValue)
         {
-            return new NullableNumericAssertions<ulong>(actualValue);
+            return new NullableULongAssertions(actualValue);
         }
 
         /// <summary>
@@ -561,7 +561,7 @@ namespace FluentAssertions
         [Pure]
         public static NumericAssertions<float> Should(this float actualValue)
         {
-            return new NumericAssertions<float>(actualValue);
+            return new FloatAssertions(actualValue);
         }
 
         /// <summary>
@@ -571,7 +571,7 @@ namespace FluentAssertions
         [Pure]
         public static NullableNumericAssertions<float> Should(this float? actualValue)
         {
-            return new NullableNumericAssertions<float>(actualValue);
+            return new NullableFloatAssertions(actualValue);
         }
 
         /// <summary>
@@ -581,7 +581,7 @@ namespace FluentAssertions
         [Pure]
         public static NumericAssertions<double> Should(this double actualValue)
         {
-            return new NumericAssertions<double>(actualValue);
+            return new DoubleAssertions(actualValue);
         }
 
         /// <summary>
@@ -591,7 +591,7 @@ namespace FluentAssertions
         [Pure]
         public static NullableNumericAssertions<double> Should(this double? actualValue)
         {
-            return new NullableNumericAssertions<double>(actualValue);
+            return new NullableDoubleAssertions(actualValue);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Numeric/NullableNumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableNumericAssertions.cs
@@ -7,21 +7,21 @@ using FluentAssertions.Execution;
 namespace FluentAssertions.Numeric
 {
     [DebuggerNonUserCode]
-    public class NullableNumericAssertions<T> : NullableNumericAssertions<T, NullableNumericAssertions<T>>
+    public abstract class NullableNumericAssertions<T> : NullableNumericAssertions<T, NullableNumericAssertions<T>>
         where T : struct, IComparable<T>
     {
-        public NullableNumericAssertions(T? value)
+        protected NullableNumericAssertions(T? value)
             : base(value)
         {
         }
     }
 
     [DebuggerNonUserCode]
-    public class NullableNumericAssertions<T, TAssertions> : NumericAssertions<T, TAssertions>
+    public abstract class NullableNumericAssertions<T, TAssertions> : NumericAssertions<T, TAssertions>
         where T : struct, IComparable<T>
         where TAssertions : NullableNumericAssertions<T, TAssertions>
     {
-        public NullableNumericAssertions(T? value)
+        protected NullableNumericAssertions(T? value)
             : base(value)
         {
         }

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -12,10 +12,10 @@ namespace FluentAssertions.Numeric
     /// Contains a number of methods to assert that an <see cref="IComparable{T}"/> is in the expected state.
     /// </summary>
     [DebuggerNonUserCode]
-    public class NumericAssertions<T> : NumericAssertions<T, NumericAssertions<T>>
+    public abstract class NumericAssertions<T> : NumericAssertions<T, NumericAssertions<T>>
         where T : struct, IComparable<T>
     {
-        public NumericAssertions(T value)
+        protected NumericAssertions(T value)
             : base(value)
         {
         }
@@ -25,11 +25,11 @@ namespace FluentAssertions.Numeric
     /// Contains a number of methods to assert that an <see cref="IComparable{T}"/> is in the expected state.
     /// </summary>
     [DebuggerNonUserCode]
-    public class NumericAssertions<T, TAssertions>
+    public abstract class NumericAssertions<T, TAssertions>
         where T : struct, IComparable<T>
         where TAssertions : NumericAssertions<T, TAssertions>
     {
-        public NumericAssertions(T value)
+        protected NumericAssertions(T value)
             : this((T?)value)
         {
         }
@@ -42,6 +42,10 @@ namespace FluentAssertions.Numeric
         public T Subject => SubjectInternal.Value;
 
         private protected T? SubjectInternal { get; }
+
+        private protected virtual T? CalculateDifference(T? actual, T expected) => throw new NotImplementedException();
+
+        private protected virtual T? CalculateDifference(T? actual, T? expected) => throw new NotImplementedException();
 
         /// <summary>
         /// Asserts that the integral number value is exactly the same as the <paramref name="expected"/> value.
@@ -59,7 +63,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) == 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be {0}{reason}, but found {1}.", expected, SubjectInternal);
+                .FailWith("Expected {context:value} to be {0}{reason}, but found {1}. Difference {2}.", expected, SubjectInternal, CalculateDifference(SubjectInternal, expected));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -82,7 +86,7 @@ namespace FluentAssertions.Numeric
                     (!SubjectInternal.HasValue && !expected.HasValue)
                     || (SubjectInternal.HasValue && expected.HasValue && SubjectInternal.Value.CompareTo(expected.Value) == 0))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be {0}{reason}, but found {1}.", expected, SubjectInternal);
+                .FailWith("Expected {context:value} to be {0}{reason}, but found {1}. Difference {2}.", expected, SubjectInternal, CalculateDifference(SubjectInternal, expected));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -187,7 +191,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) < 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be less than {0}{reason}, but found {1}.", expected, SubjectInternal);
+                .FailWith("Expected {context:value} to be less than {0}{reason}, but found {1}. Difference {2}.", expected, SubjectInternal, CalculateDifference(SubjectInternal, expected));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -209,7 +213,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) <= 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be less or equal to {0}{reason}, but found {1}.", expected, SubjectInternal);
+                .FailWith("Expected {context:value} to be less or equal to {0}{reason}, but found {1}. Difference {2}.", expected, SubjectInternal, CalculateDifference(SubjectInternal, expected));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -231,7 +235,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) > 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be greater than {0}{reason}, but found {1}.", expected, SubjectInternal);
+                .FailWith("Expected {context:value} to be greater than {0}{reason}, but found {1}. Difference {2}.", expected, SubjectInternal, CalculateDifference(SubjectInternal, expected));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -253,7 +257,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) >= 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be greater or equal to {0}{reason}, but found {1}.", expected, SubjectInternal);
+                .FailWith("Expected {context:value} to be greater or equal to {0}{reason}, but found {1}. Difference {2}.", expected, SubjectInternal, CalculateDifference(SubjectInternal, expected));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using FluentAssertions.Execution;
 using FluentAssertions.Numeric;
+using FluentAssertions.Primitives;
 
 namespace FluentAssertions
 {
@@ -679,7 +680,7 @@ namespace FluentAssertions
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
-            var nonNullableAssertions = new NumericAssertions<float>((float)parent.Subject);
+            var nonNullableAssertions = new FloatAssertions((float)parent.Subject);
             nonNullableAssertions.BeApproximately(expectedValue, precision, because, becauseArgs);
 
             return new AndConstraint<NullableNumericAssertions<float>>(parent);
@@ -806,7 +807,7 @@ namespace FluentAssertions
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
-            var nonNullableAssertions = new NumericAssertions<double>((double)parent.Subject);
+            var nonNullableAssertions = new DoubleAssertions((double)parent.Subject);
             BeApproximately(nonNullableAssertions, expectedValue, precision, because, becauseArgs);
 
             return new AndConstraint<NullableNumericAssertions<double>>(parent);
@@ -933,7 +934,7 @@ namespace FluentAssertions
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
-            var nonNullableAssertions = new NumericAssertions<decimal>((decimal)parent.Subject);
+            var nonNullableAssertions = new DecimalAssertions((decimal)parent.Subject);
             BeApproximately(nonNullableAssertions, expectedValue, precision, because, becauseArgs);
 
             return new AndConstraint<NullableNumericAssertions<decimal>>(parent);
@@ -1063,7 +1064,7 @@ namespace FluentAssertions
 
             if (parent.Subject != null)
             {
-                var nonNullableAssertions = new NumericAssertions<float>((float)parent.Subject);
+                var nonNullableAssertions = new FloatAssertions((float)parent.Subject);
                 nonNullableAssertions.NotBeApproximately(unexpectedValue, precision, because, becauseArgs);
             }
 
@@ -1188,7 +1189,7 @@ namespace FluentAssertions
 
             if (parent.Subject != null)
             {
-                var nonNullableAssertions = new NumericAssertions<double>((double)parent.Subject);
+                var nonNullableAssertions = new DoubleAssertions((double)parent.Subject);
                 nonNullableAssertions.NotBeApproximately(unexpectedValue, precision, because, becauseArgs);
             }
 
@@ -1313,7 +1314,7 @@ namespace FluentAssertions
 
             if (parent.Subject != null)
             {
-                var nonNullableAssertions = new NumericAssertions<decimal>((decimal)parent.Subject);
+                var nonNullableAssertions = new DecimalAssertions((decimal)parent.Subject);
                 NotBeApproximately(nonNullableAssertions, unexpectedValue, precision, because, becauseArgs);
             }
 

--- a/Src/FluentAssertions/Primitives/ByteAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ByteAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a <see cref="byte"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class ByteAssertions
+        : NumericAssertions<byte>
+    {
+        public ByteAssertions(byte value)
+            : base(value)
+        {
+        }
+
+        private protected override byte? CalculateDifference(byte? actual, byte expected) => (byte?)(actual - expected);
+
+        private protected override byte? CalculateDifference(byte? actual, byte? expected) => (byte?)(actual - expected);
+    }
+}

--- a/Src/FluentAssertions/Primitives/DecimalAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DecimalAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a <see cref="decimal"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class DecimalAssertions
+        : NumericAssertions<decimal>
+    {
+        public DecimalAssertions(decimal value)
+            : base(value)
+        {
+        }
+
+        private protected override decimal? CalculateDifference(decimal? actual, decimal expected) => actual - expected;
+
+        private protected override decimal? CalculateDifference(decimal? actual, decimal? expected) => actual - expected;
+    }
+}

--- a/Src/FluentAssertions/Primitives/DoubleAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DoubleAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a <see cref="double"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class DoubleAssertions
+        : NumericAssertions<double>
+    {
+        public DoubleAssertions(double value)
+            : base(value)
+        {
+        }
+
+        private protected override double? CalculateDifference(double? actual, double expected) => actual - expected;
+
+        private protected override double? CalculateDifference(double? actual, double? expected) => actual - expected;
+    }
+}

--- a/Src/FluentAssertions/Primitives/FloatAssertions.cs
+++ b/Src/FluentAssertions/Primitives/FloatAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a <see cref="float"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class FloatAssertions
+        : NumericAssertions<float>
+    {
+        public FloatAssertions(float value)
+            : base(value)
+        {
+        }
+
+        private protected override float? CalculateDifference(float? actual, float expected) => actual - expected;
+
+        private protected override float? CalculateDifference(float? actual, float? expected) => actual - expected;
+    }
+}

--- a/Src/FluentAssertions/Primitives/IntAssertions.cs
+++ b/Src/FluentAssertions/Primitives/IntAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a <see cref="int"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class IntAssertions
+        : NumericAssertions<int>
+    {
+        public IntAssertions(int value)
+            : base(value)
+        {
+        }
+
+        private protected override int? CalculateDifference(int? actual, int expected) => actual - expected;
+
+        private protected override int? CalculateDifference(int? actual, int? expected) => actual - expected;
+    }
+}

--- a/Src/FluentAssertions/Primitives/LongAssertions.cs
+++ b/Src/FluentAssertions/Primitives/LongAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a <see cref="long"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class LongAssertions
+        : NumericAssertions<long>
+    {
+        public LongAssertions(long value)
+            : base(value)
+        {
+        }
+
+        private protected override long? CalculateDifference(long? actual, long expected) => actual - expected;
+
+        private protected override long? CalculateDifference(long? actual, long? expected) => actual - expected;
+    }
+}

--- a/Src/FluentAssertions/Primitives/NullableByteAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableByteAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <see cref="byte"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class NullableByteAssertions
+        : NullableNumericAssertions<byte>
+    {
+        public NullableByteAssertions(byte? value)
+            : base(value)
+        {
+        }
+
+        private protected override byte? CalculateDifference(byte? actual, byte expected) => (byte?)(actual - expected);
+
+        private protected override byte? CalculateDifference(byte? actual, byte? expected) => (byte?)(actual - expected);
+    }
+}

--- a/Src/FluentAssertions/Primitives/NullableDecimalAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDecimalAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <see cref="decimal"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class NullableDecimalAssertions
+        : NullableNumericAssertions<decimal>
+    {
+        public NullableDecimalAssertions(decimal? value)
+            : base(value)
+        {
+        }
+
+        private protected override decimal? CalculateDifference(decimal? actual, decimal expected) => actual - expected;
+
+        private protected override decimal? CalculateDifference(decimal? actual, decimal? expected) => actual - expected;
+    }
+}

--- a/Src/FluentAssertions/Primitives/NullableDoubleAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDoubleAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <see cref="double"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class NullableDoubleAssertions
+        : NullableNumericAssertions<double>
+    {
+        public NullableDoubleAssertions(double? value)
+            : base(value)
+        {
+        }
+
+        private protected override double? CalculateDifference(double? actual, double expected) => actual - expected;
+
+        private protected override double? CalculateDifference(double? actual, double? expected) => actual - expected;
+    }
+}

--- a/Src/FluentAssertions/Primitives/NullableFloatAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableFloatAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <see cref="float"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class NullableFloatAssertions
+        : NullableNumericAssertions<float>
+    {
+        public NullableFloatAssertions(float? value)
+            : base(value)
+        {
+        }
+
+        private protected override float? CalculateDifference(float? actual, float expected) => actual - expected;
+
+        private protected override float? CalculateDifference(float? actual, float? expected) => actual - expected;
+    }
+}

--- a/Src/FluentAssertions/Primitives/NullableIntAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableIntAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <see cref="int"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class NullableIntAssertions
+        : NullableNumericAssertions<int>
+    {
+        public NullableIntAssertions(int? value)
+            : base(value)
+        {
+        }
+
+        private protected override int? CalculateDifference(int? actual, int expected) => actual - expected;
+
+        private protected override int? CalculateDifference(int? actual, int? expected) => actual - expected;
+    }
+}

--- a/Src/FluentAssertions/Primitives/NullableLongAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableLongAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <see cref="long"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class NullableLongAssertions
+        : NullableNumericAssertions<long>
+    {
+        public NullableLongAssertions(long? value)
+            : base(value)
+        {
+        }
+
+        private protected override long? CalculateDifference(long? actual, long expected) => actual - expected;
+
+        private protected override long? CalculateDifference(long? actual, long? expected) => actual - expected;
+    }
+}

--- a/Src/FluentAssertions/Primitives/NullableSByteAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableSByteAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <see cref="sbyte"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class NullableSByteAssertions
+        : NullableNumericAssertions<sbyte>
+    {
+        public NullableSByteAssertions(sbyte? value)
+            : base(value)
+        {
+        }
+
+        private protected override sbyte? CalculateDifference(sbyte? actual, sbyte expected) => (sbyte?)(actual - expected);
+
+        private protected override sbyte? CalculateDifference(sbyte? actual, sbyte? expected) => (sbyte?)(actual - expected);
+    }
+}

--- a/Src/FluentAssertions/Primitives/NullableShortAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableShortAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <see cref="short"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class NullableShortAssertions
+        : NullableNumericAssertions<short>
+    {
+        public NullableShortAssertions(short? value)
+            : base(value)
+        {
+        }
+
+        private protected override short? CalculateDifference(short? actual, short expected) => (short?)(actual - expected);
+
+        private protected override short? CalculateDifference(short? actual, short? expected) => (short?)(actual - expected);
+    }
+}

--- a/Src/FluentAssertions/Primitives/NullableUIntAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableUIntAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <see cref="uint"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class NullableUIntAssertions
+        : NullableNumericAssertions<uint>
+    {
+        public NullableUIntAssertions(uint? value)
+            : base(value)
+        {
+        }
+
+        private protected override uint? CalculateDifference(uint? actual, uint? expected) => actual - expected;
+
+        private protected override uint? CalculateDifference(uint? actual, uint expected) => actual - expected;
+    }
+}

--- a/Src/FluentAssertions/Primitives/NullableULongAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableULongAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <see cref="ulong"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class NullableULongAssertions
+        : NullableNumericAssertions<ulong>
+    {
+        public NullableULongAssertions(ulong? value)
+            : base(value)
+        {
+        }
+
+        private protected override ulong? CalculateDifference(ulong? actual, ulong expected) => actual - expected;
+
+        private protected override ulong? CalculateDifference(ulong? actual, ulong? expected) => actual - expected;
+    }
+}

--- a/Src/FluentAssertions/Primitives/NullableUShortAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableUShortAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <see cref="ushort"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class NullableUShortAssertions
+        : NullableNumericAssertions<ushort>
+    {
+        public NullableUShortAssertions(ushort? value)
+            : base(value)
+        {
+        }
+
+        private protected override ushort? CalculateDifference(ushort? actual, ushort expected) => (ushort?)(actual - expected);
+
+        private protected override ushort? CalculateDifference(ushort? actual, ushort? expected) => (ushort?)(actual - expected);
+    }
+}

--- a/Src/FluentAssertions/Primitives/SByteAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SByteAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a <see cref="sbyte"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class SByteAssertions
+        : NumericAssertions<sbyte>
+    {
+        public SByteAssertions(sbyte value)
+            : base(value)
+        {
+        }
+
+        private protected override sbyte? CalculateDifference(sbyte? actual, sbyte expected) => (sbyte?)(actual - expected);
+
+        private protected override sbyte? CalculateDifference(sbyte? actual, sbyte? expected) => (sbyte?)(actual - expected);
+    }
+}

--- a/Src/FluentAssertions/Primitives/ShortAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ShortAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a <see cref="short"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class ShortAssertions
+        : NumericAssertions<short>
+    {
+        public ShortAssertions(short value)
+            : base(value)
+        {
+        }
+
+        private protected override short? CalculateDifference(short? actual, short expected) => (short?)(actual - expected);
+
+        private protected override short? CalculateDifference(short? actual, short? expected) => (short?)(actual - expected);
+    }
+}

--- a/Src/FluentAssertions/Primitives/UIntAssertions.cs
+++ b/Src/FluentAssertions/Primitives/UIntAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a <see cref="uint"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class UIntAssertions
+        : NumericAssertions<uint>
+    {
+        public UIntAssertions(uint value)
+            : base(value)
+        {
+        }
+
+        private protected override uint? CalculateDifference(uint? actual, uint expected) => actual - expected;
+
+        private protected override uint? CalculateDifference(uint? actual, uint? expected) => actual - expected;
+    }
+}

--- a/Src/FluentAssertions/Primitives/ULongAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ULongAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a <see cref="ulong"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class ULongAssertions
+        : NumericAssertions<ulong>
+    {
+        public ULongAssertions(ulong value)
+            : base(value)
+        {
+        }
+
+        private protected override ulong? CalculateDifference(ulong? actual, ulong expected) => actual - expected;
+
+        private protected override ulong? CalculateDifference(ulong? actual, ulong? expected) => actual - expected;
+    }
+}

--- a/Src/FluentAssertions/Primitives/UShortAssertions.cs
+++ b/Src/FluentAssertions/Primitives/UShortAssertions.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a <see cref="ushort"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class UShortAssertions
+        : NumericAssertions<ushort>
+    {
+        public UShortAssertions(ushort value)
+            : base(value)
+        {
+        }
+
+        private protected override ushort? CalculateDifference(ushort? actual, ushort expected) => (ushort?)(actual - expected);
+
+        private protected override ushort? CalculateDifference(ushort? actual, ushort? expected) => (ushort?)(actual - expected);
+    }
+}

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -1325,16 +1325,16 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NullableNumericAssertions<T, FluentAssertions.Numeric.NullableNumericAssertions<T>>
+    public abstract class NullableNumericAssertions<T> : FluentAssertions.Numeric.NullableNumericAssertions<T, FluentAssertions.Numeric.NullableNumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
-        public NullableNumericAssertions(T? value) { }
+        protected NullableNumericAssertions(T? value) { }
     }
-    public class NullableNumericAssertions<T, TAssertions> : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
+    public abstract class NullableNumericAssertions<T, TAssertions> : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
         where T :  struct, System.IComparable<T>
         where TAssertions : FluentAssertions.Numeric.NullableNumericAssertions<T, TAssertions>
     {
-        public NullableNumericAssertions(T? value) { }
+        protected NullableNumericAssertions(T? value) { }
         public T? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1342,16 +1342,16 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T, FluentAssertions.Numeric.NumericAssertions<T>>
+    public abstract class NumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T, FluentAssertions.Numeric.NumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
-        public NumericAssertions(T value) { }
+        protected NumericAssertions(T value) { }
     }
-    public class NumericAssertions<T, TAssertions>
+    public abstract class NumericAssertions<T, TAssertions>
         where T :  struct, System.IComparable<T>
         where TAssertions : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
     {
-        public NumericAssertions(T value) { }
+        protected NumericAssertions(T value) { }
         public T Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
@@ -1387,6 +1387,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class ByteAssertions : FluentAssertions.Numeric.NumericAssertions<byte>
+    {
+        public ByteAssertions(byte value) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>
     {
@@ -1495,6 +1499,14 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
     }
+    public class DecimalAssertions : FluentAssertions.Numeric.NumericAssertions<decimal>
+    {
+        public DecimalAssertions(decimal value) { }
+    }
+    public class DoubleAssertions : FluentAssertions.Numeric.NumericAssertions<double>
+    {
+        public DoubleAssertions(double value) { }
+    }
     public class EnumAssertions : FluentAssertions.Primitives.EnumAssertions<System.Enum, FluentAssertions.Primitives.EnumAssertions>
     {
         public EnumAssertions(System.Enum subject) { }
@@ -1509,6 +1521,10 @@ namespace FluentAssertions.Primitives
             where T :  struct, TEnum { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveFlag<T>(T unexpectedFlag, string because = "", params object[] becauseArgs)
             where T :  struct, TEnum { }
+    }
+    public class FloatAssertions : FluentAssertions.Numeric.NumericAssertions<float>
+    {
+        public FloatAssertions(float value) { }
     }
     public class GuidAssertions : FluentAssertions.Primitives.GuidAssertions<FluentAssertions.Primitives.GuidAssertions>
     {
@@ -1525,6 +1541,14 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
     }
+    public class IntAssertions : FluentAssertions.Numeric.NumericAssertions<int>
+    {
+        public IntAssertions(int value) { }
+    }
+    public class LongAssertions : FluentAssertions.Numeric.NumericAssertions<long>
+    {
+        public LongAssertions(long value) { }
+    }
     public class NullableBooleanAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<FluentAssertions.Primitives.NullableBooleanAssertions>
     {
         public NullableBooleanAssertions(bool? value) { }
@@ -1540,6 +1564,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableByteAssertions : FluentAssertions.Numeric.NullableNumericAssertions<byte>
+    {
+        public NullableByteAssertions(byte? value) { }
     }
     public class NullableDateTimeAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<FluentAssertions.Primitives.NullableDateTimeAssertions>
     {
@@ -1569,6 +1597,18 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
+    public class NullableDecimalAssertions : FluentAssertions.Numeric.NullableNumericAssertions<decimal>
+    {
+        public NullableDecimalAssertions(decimal? value) { }
+    }
+    public class NullableDoubleAssertions : FluentAssertions.Numeric.NullableNumericAssertions<double>
+    {
+        public NullableDoubleAssertions(double? value) { }
+    }
+    public class NullableFloatAssertions : FluentAssertions.Numeric.NullableNumericAssertions<float>
+    {
+        public NullableFloatAssertions(float? value) { }
+    }
     public class NullableGuidAssertions : FluentAssertions.Primitives.NullableGuidAssertions<FluentAssertions.Primitives.NullableGuidAssertions>
     {
         public NullableGuidAssertions(System.Guid? value) { }
@@ -1583,6 +1623,22 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
+    public class NullableIntAssertions : FluentAssertions.Numeric.NullableNumericAssertions<int>
+    {
+        public NullableIntAssertions(int? value) { }
+    }
+    public class NullableLongAssertions : FluentAssertions.Numeric.NullableNumericAssertions<long>
+    {
+        public NullableLongAssertions(long? value) { }
+    }
+    public class NullableSByteAssertions : FluentAssertions.Numeric.NullableNumericAssertions<sbyte>
+    {
+        public NullableSByteAssertions(sbyte? value) { }
+    }
+    public class NullableShortAssertions : FluentAssertions.Numeric.NullableNumericAssertions<short>
+    {
+        public NullableShortAssertions(short? value) { }
+    }
     public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions>
     {
         public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
@@ -1596,6 +1652,18 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableUIntAssertions : FluentAssertions.Numeric.NullableNumericAssertions<uint>
+    {
+        public NullableUIntAssertions(uint? value) { }
+    }
+    public class NullableULongAssertions : FluentAssertions.Numeric.NullableNumericAssertions<ulong>
+    {
+        public NullableULongAssertions(ulong? value) { }
+    }
+    public class NullableUShortAssertions : FluentAssertions.Numeric.NullableNumericAssertions<ushort>
+    {
+        public NullableUShortAssertions(ushort? value) { }
     }
     public class ObjectAssertions : FluentAssertions.Primitives.ObjectAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
     {
@@ -1634,6 +1702,14 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SByteAssertions : FluentAssertions.Numeric.NumericAssertions<sbyte>
+    {
+        public SByteAssertions(sbyte value) { }
+    }
+    public class ShortAssertions : FluentAssertions.Numeric.NumericAssertions<short>
+    {
+        public ShortAssertions(short value) { }
     }
     public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>
     {
@@ -1717,6 +1793,18 @@ namespace FluentAssertions.Primitives
         Exactly = 2,
         Within = 3,
         LessThan = 4,
+    }
+    public class UIntAssertions : FluentAssertions.Numeric.NumericAssertions<uint>
+    {
+        public UIntAssertions(uint value) { }
+    }
+    public class ULongAssertions : FluentAssertions.Numeric.NumericAssertions<ulong>
+    {
+        public ULongAssertions(ulong value) { }
+    }
+    public class UShortAssertions : FluentAssertions.Numeric.NumericAssertions<ushort>
+    {
+        public UShortAssertions(ushort value) { }
     }
 }
 namespace FluentAssertions.Reflection

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -1325,16 +1325,16 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NullableNumericAssertions<T, FluentAssertions.Numeric.NullableNumericAssertions<T>>
+    public abstract class NullableNumericAssertions<T> : FluentAssertions.Numeric.NullableNumericAssertions<T, FluentAssertions.Numeric.NullableNumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
-        public NullableNumericAssertions(T? value) { }
+        protected NullableNumericAssertions(T? value) { }
     }
-    public class NullableNumericAssertions<T, TAssertions> : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
+    public abstract class NullableNumericAssertions<T, TAssertions> : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
         where T :  struct, System.IComparable<T>
         where TAssertions : FluentAssertions.Numeric.NullableNumericAssertions<T, TAssertions>
     {
-        public NullableNumericAssertions(T? value) { }
+        protected NullableNumericAssertions(T? value) { }
         public T? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1342,16 +1342,16 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T, FluentAssertions.Numeric.NumericAssertions<T>>
+    public abstract class NumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T, FluentAssertions.Numeric.NumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
-        public NumericAssertions(T value) { }
+        protected NumericAssertions(T value) { }
     }
-    public class NumericAssertions<T, TAssertions>
+    public abstract class NumericAssertions<T, TAssertions>
         where T :  struct, System.IComparable<T>
         where TAssertions : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
     {
-        public NumericAssertions(T value) { }
+        protected NumericAssertions(T value) { }
         public T Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
@@ -1387,6 +1387,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class ByteAssertions : FluentAssertions.Numeric.NumericAssertions<byte>
+    {
+        public ByteAssertions(byte value) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>
     {
@@ -1495,6 +1499,14 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
     }
+    public class DecimalAssertions : FluentAssertions.Numeric.NumericAssertions<decimal>
+    {
+        public DecimalAssertions(decimal value) { }
+    }
+    public class DoubleAssertions : FluentAssertions.Numeric.NumericAssertions<double>
+    {
+        public DoubleAssertions(double value) { }
+    }
     public class EnumAssertions : FluentAssertions.Primitives.EnumAssertions<System.Enum, FluentAssertions.Primitives.EnumAssertions>
     {
         public EnumAssertions(System.Enum subject) { }
@@ -1509,6 +1521,10 @@ namespace FluentAssertions.Primitives
             where T :  struct, TEnum { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveFlag<T>(T unexpectedFlag, string because = "", params object[] becauseArgs)
             where T :  struct, TEnum { }
+    }
+    public class FloatAssertions : FluentAssertions.Numeric.NumericAssertions<float>
+    {
+        public FloatAssertions(float value) { }
     }
     public class GuidAssertions : FluentAssertions.Primitives.GuidAssertions<FluentAssertions.Primitives.GuidAssertions>
     {
@@ -1525,6 +1541,14 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
     }
+    public class IntAssertions : FluentAssertions.Numeric.NumericAssertions<int>
+    {
+        public IntAssertions(int value) { }
+    }
+    public class LongAssertions : FluentAssertions.Numeric.NumericAssertions<long>
+    {
+        public LongAssertions(long value) { }
+    }
     public class NullableBooleanAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<FluentAssertions.Primitives.NullableBooleanAssertions>
     {
         public NullableBooleanAssertions(bool? value) { }
@@ -1540,6 +1564,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableByteAssertions : FluentAssertions.Numeric.NullableNumericAssertions<byte>
+    {
+        public NullableByteAssertions(byte? value) { }
     }
     public class NullableDateTimeAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<FluentAssertions.Primitives.NullableDateTimeAssertions>
     {
@@ -1569,6 +1597,18 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
+    public class NullableDecimalAssertions : FluentAssertions.Numeric.NullableNumericAssertions<decimal>
+    {
+        public NullableDecimalAssertions(decimal? value) { }
+    }
+    public class NullableDoubleAssertions : FluentAssertions.Numeric.NullableNumericAssertions<double>
+    {
+        public NullableDoubleAssertions(double? value) { }
+    }
+    public class NullableFloatAssertions : FluentAssertions.Numeric.NullableNumericAssertions<float>
+    {
+        public NullableFloatAssertions(float? value) { }
+    }
     public class NullableGuidAssertions : FluentAssertions.Primitives.NullableGuidAssertions<FluentAssertions.Primitives.NullableGuidAssertions>
     {
         public NullableGuidAssertions(System.Guid? value) { }
@@ -1583,6 +1623,22 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
+    public class NullableIntAssertions : FluentAssertions.Numeric.NullableNumericAssertions<int>
+    {
+        public NullableIntAssertions(int? value) { }
+    }
+    public class NullableLongAssertions : FluentAssertions.Numeric.NullableNumericAssertions<long>
+    {
+        public NullableLongAssertions(long? value) { }
+    }
+    public class NullableSByteAssertions : FluentAssertions.Numeric.NullableNumericAssertions<sbyte>
+    {
+        public NullableSByteAssertions(sbyte? value) { }
+    }
+    public class NullableShortAssertions : FluentAssertions.Numeric.NullableNumericAssertions<short>
+    {
+        public NullableShortAssertions(short? value) { }
+    }
     public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions>
     {
         public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
@@ -1596,6 +1652,18 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableUIntAssertions : FluentAssertions.Numeric.NullableNumericAssertions<uint>
+    {
+        public NullableUIntAssertions(uint? value) { }
+    }
+    public class NullableULongAssertions : FluentAssertions.Numeric.NullableNumericAssertions<ulong>
+    {
+        public NullableULongAssertions(ulong? value) { }
+    }
+    public class NullableUShortAssertions : FluentAssertions.Numeric.NullableNumericAssertions<ushort>
+    {
+        public NullableUShortAssertions(ushort? value) { }
     }
     public class ObjectAssertions : FluentAssertions.Primitives.ObjectAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
     {
@@ -1634,6 +1702,14 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SByteAssertions : FluentAssertions.Numeric.NumericAssertions<sbyte>
+    {
+        public SByteAssertions(sbyte value) { }
+    }
+    public class ShortAssertions : FluentAssertions.Numeric.NumericAssertions<short>
+    {
+        public ShortAssertions(short value) { }
     }
     public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>
     {
@@ -1717,6 +1793,18 @@ namespace FluentAssertions.Primitives
         Exactly = 2,
         Within = 3,
         LessThan = 4,
+    }
+    public class UIntAssertions : FluentAssertions.Numeric.NumericAssertions<uint>
+    {
+        public UIntAssertions(uint value) { }
+    }
+    public class ULongAssertions : FluentAssertions.Numeric.NumericAssertions<ulong>
+    {
+        public ULongAssertions(ulong value) { }
+    }
+    public class UShortAssertions : FluentAssertions.Numeric.NumericAssertions<ushort>
+    {
+        public UShortAssertions(ushort value) { }
     }
 }
 namespace FluentAssertions.Reflection

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -1325,16 +1325,16 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NullableNumericAssertions<T, FluentAssertions.Numeric.NullableNumericAssertions<T>>
+    public abstract class NullableNumericAssertions<T> : FluentAssertions.Numeric.NullableNumericAssertions<T, FluentAssertions.Numeric.NullableNumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
-        public NullableNumericAssertions(T? value) { }
+        protected NullableNumericAssertions(T? value) { }
     }
-    public class NullableNumericAssertions<T, TAssertions> : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
+    public abstract class NullableNumericAssertions<T, TAssertions> : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
         where T :  struct, System.IComparable<T>
         where TAssertions : FluentAssertions.Numeric.NullableNumericAssertions<T, TAssertions>
     {
-        public NullableNumericAssertions(T? value) { }
+        protected NullableNumericAssertions(T? value) { }
         public T? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1342,16 +1342,16 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T, FluentAssertions.Numeric.NumericAssertions<T>>
+    public abstract class NumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T, FluentAssertions.Numeric.NumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
-        public NumericAssertions(T value) { }
+        protected NumericAssertions(T value) { }
     }
-    public class NumericAssertions<T, TAssertions>
+    public abstract class NumericAssertions<T, TAssertions>
         where T :  struct, System.IComparable<T>
         where TAssertions : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
     {
-        public NumericAssertions(T value) { }
+        protected NumericAssertions(T value) { }
         public T Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
@@ -1387,6 +1387,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class ByteAssertions : FluentAssertions.Numeric.NumericAssertions<byte>
+    {
+        public ByteAssertions(byte value) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>
     {
@@ -1495,6 +1499,14 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
     }
+    public class DecimalAssertions : FluentAssertions.Numeric.NumericAssertions<decimal>
+    {
+        public DecimalAssertions(decimal value) { }
+    }
+    public class DoubleAssertions : FluentAssertions.Numeric.NumericAssertions<double>
+    {
+        public DoubleAssertions(double value) { }
+    }
     public class EnumAssertions : FluentAssertions.Primitives.EnumAssertions<System.Enum, FluentAssertions.Primitives.EnumAssertions>
     {
         public EnumAssertions(System.Enum subject) { }
@@ -1509,6 +1521,10 @@ namespace FluentAssertions.Primitives
             where T :  struct, TEnum { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveFlag<T>(T unexpectedFlag, string because = "", params object[] becauseArgs)
             where T :  struct, TEnum { }
+    }
+    public class FloatAssertions : FluentAssertions.Numeric.NumericAssertions<float>
+    {
+        public FloatAssertions(float value) { }
     }
     public class GuidAssertions : FluentAssertions.Primitives.GuidAssertions<FluentAssertions.Primitives.GuidAssertions>
     {
@@ -1525,6 +1541,14 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
     }
+    public class IntAssertions : FluentAssertions.Numeric.NumericAssertions<int>
+    {
+        public IntAssertions(int value) { }
+    }
+    public class LongAssertions : FluentAssertions.Numeric.NumericAssertions<long>
+    {
+        public LongAssertions(long value) { }
+    }
     public class NullableBooleanAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<FluentAssertions.Primitives.NullableBooleanAssertions>
     {
         public NullableBooleanAssertions(bool? value) { }
@@ -1540,6 +1564,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableByteAssertions : FluentAssertions.Numeric.NullableNumericAssertions<byte>
+    {
+        public NullableByteAssertions(byte? value) { }
     }
     public class NullableDateTimeAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<FluentAssertions.Primitives.NullableDateTimeAssertions>
     {
@@ -1569,6 +1597,18 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
+    public class NullableDecimalAssertions : FluentAssertions.Numeric.NullableNumericAssertions<decimal>
+    {
+        public NullableDecimalAssertions(decimal? value) { }
+    }
+    public class NullableDoubleAssertions : FluentAssertions.Numeric.NullableNumericAssertions<double>
+    {
+        public NullableDoubleAssertions(double? value) { }
+    }
+    public class NullableFloatAssertions : FluentAssertions.Numeric.NullableNumericAssertions<float>
+    {
+        public NullableFloatAssertions(float? value) { }
+    }
     public class NullableGuidAssertions : FluentAssertions.Primitives.NullableGuidAssertions<FluentAssertions.Primitives.NullableGuidAssertions>
     {
         public NullableGuidAssertions(System.Guid? value) { }
@@ -1583,6 +1623,22 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
+    public class NullableIntAssertions : FluentAssertions.Numeric.NullableNumericAssertions<int>
+    {
+        public NullableIntAssertions(int? value) { }
+    }
+    public class NullableLongAssertions : FluentAssertions.Numeric.NullableNumericAssertions<long>
+    {
+        public NullableLongAssertions(long? value) { }
+    }
+    public class NullableSByteAssertions : FluentAssertions.Numeric.NullableNumericAssertions<sbyte>
+    {
+        public NullableSByteAssertions(sbyte? value) { }
+    }
+    public class NullableShortAssertions : FluentAssertions.Numeric.NullableNumericAssertions<short>
+    {
+        public NullableShortAssertions(short? value) { }
+    }
     public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions>
     {
         public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
@@ -1596,6 +1652,18 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableUIntAssertions : FluentAssertions.Numeric.NullableNumericAssertions<uint>
+    {
+        public NullableUIntAssertions(uint? value) { }
+    }
+    public class NullableULongAssertions : FluentAssertions.Numeric.NullableNumericAssertions<ulong>
+    {
+        public NullableULongAssertions(ulong? value) { }
+    }
+    public class NullableUShortAssertions : FluentAssertions.Numeric.NullableNumericAssertions<ushort>
+    {
+        public NullableUShortAssertions(ushort? value) { }
     }
     public class ObjectAssertions : FluentAssertions.Primitives.ObjectAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
     {
@@ -1634,6 +1702,14 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SByteAssertions : FluentAssertions.Numeric.NumericAssertions<sbyte>
+    {
+        public SByteAssertions(sbyte value) { }
+    }
+    public class ShortAssertions : FluentAssertions.Numeric.NumericAssertions<short>
+    {
+        public ShortAssertions(short value) { }
     }
     public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>
     {
@@ -1717,6 +1793,18 @@ namespace FluentAssertions.Primitives
         Exactly = 2,
         Within = 3,
         LessThan = 4,
+    }
+    public class UIntAssertions : FluentAssertions.Numeric.NumericAssertions<uint>
+    {
+        public UIntAssertions(uint value) { }
+    }
+    public class ULongAssertions : FluentAssertions.Numeric.NumericAssertions<ulong>
+    {
+        public ULongAssertions(ulong value) { }
+    }
+    public class UShortAssertions : FluentAssertions.Numeric.NumericAssertions<ushort>
+    {
+        public UShortAssertions(ushort value) { }
     }
 }
 namespace FluentAssertions.Reflection

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1278,16 +1278,16 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NullableNumericAssertions<T, FluentAssertions.Numeric.NullableNumericAssertions<T>>
+    public abstract class NullableNumericAssertions<T> : FluentAssertions.Numeric.NullableNumericAssertions<T, FluentAssertions.Numeric.NullableNumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
-        public NullableNumericAssertions(T? value) { }
+        protected NullableNumericAssertions(T? value) { }
     }
-    public class NullableNumericAssertions<T, TAssertions> : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
+    public abstract class NullableNumericAssertions<T, TAssertions> : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
         where T :  struct, System.IComparable<T>
         where TAssertions : FluentAssertions.Numeric.NullableNumericAssertions<T, TAssertions>
     {
-        public NullableNumericAssertions(T? value) { }
+        protected NullableNumericAssertions(T? value) { }
         public T? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1295,16 +1295,16 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T, FluentAssertions.Numeric.NumericAssertions<T>>
+    public abstract class NumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T, FluentAssertions.Numeric.NumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
-        public NumericAssertions(T value) { }
+        protected NumericAssertions(T value) { }
     }
-    public class NumericAssertions<T, TAssertions>
+    public abstract class NumericAssertions<T, TAssertions>
         where T :  struct, System.IComparable<T>
         where TAssertions : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
     {
-        public NumericAssertions(T value) { }
+        protected NumericAssertions(T value) { }
         public T Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
@@ -1340,6 +1340,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class ByteAssertions : FluentAssertions.Numeric.NumericAssertions<byte>
+    {
+        public ByteAssertions(byte value) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>
     {
@@ -1448,6 +1452,14 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
     }
+    public class DecimalAssertions : FluentAssertions.Numeric.NumericAssertions<decimal>
+    {
+        public DecimalAssertions(decimal value) { }
+    }
+    public class DoubleAssertions : FluentAssertions.Numeric.NumericAssertions<double>
+    {
+        public DoubleAssertions(double value) { }
+    }
     public class EnumAssertions : FluentAssertions.Primitives.EnumAssertions<System.Enum, FluentAssertions.Primitives.EnumAssertions>
     {
         public EnumAssertions(System.Enum subject) { }
@@ -1462,6 +1474,10 @@ namespace FluentAssertions.Primitives
             where T :  struct, TEnum { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveFlag<T>(T unexpectedFlag, string because = "", params object[] becauseArgs)
             where T :  struct, TEnum { }
+    }
+    public class FloatAssertions : FluentAssertions.Numeric.NumericAssertions<float>
+    {
+        public FloatAssertions(float value) { }
     }
     public class GuidAssertions : FluentAssertions.Primitives.GuidAssertions<FluentAssertions.Primitives.GuidAssertions>
     {
@@ -1478,6 +1494,14 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
     }
+    public class IntAssertions : FluentAssertions.Numeric.NumericAssertions<int>
+    {
+        public IntAssertions(int value) { }
+    }
+    public class LongAssertions : FluentAssertions.Numeric.NumericAssertions<long>
+    {
+        public LongAssertions(long value) { }
+    }
     public class NullableBooleanAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<FluentAssertions.Primitives.NullableBooleanAssertions>
     {
         public NullableBooleanAssertions(bool? value) { }
@@ -1493,6 +1517,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableByteAssertions : FluentAssertions.Numeric.NullableNumericAssertions<byte>
+    {
+        public NullableByteAssertions(byte? value) { }
     }
     public class NullableDateTimeAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<FluentAssertions.Primitives.NullableDateTimeAssertions>
     {
@@ -1522,6 +1550,18 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
+    public class NullableDecimalAssertions : FluentAssertions.Numeric.NullableNumericAssertions<decimal>
+    {
+        public NullableDecimalAssertions(decimal? value) { }
+    }
+    public class NullableDoubleAssertions : FluentAssertions.Numeric.NullableNumericAssertions<double>
+    {
+        public NullableDoubleAssertions(double? value) { }
+    }
+    public class NullableFloatAssertions : FluentAssertions.Numeric.NullableNumericAssertions<float>
+    {
+        public NullableFloatAssertions(float? value) { }
+    }
     public class NullableGuidAssertions : FluentAssertions.Primitives.NullableGuidAssertions<FluentAssertions.Primitives.NullableGuidAssertions>
     {
         public NullableGuidAssertions(System.Guid? value) { }
@@ -1536,6 +1576,22 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
+    public class NullableIntAssertions : FluentAssertions.Numeric.NullableNumericAssertions<int>
+    {
+        public NullableIntAssertions(int? value) { }
+    }
+    public class NullableLongAssertions : FluentAssertions.Numeric.NullableNumericAssertions<long>
+    {
+        public NullableLongAssertions(long? value) { }
+    }
+    public class NullableSByteAssertions : FluentAssertions.Numeric.NullableNumericAssertions<sbyte>
+    {
+        public NullableSByteAssertions(sbyte? value) { }
+    }
+    public class NullableShortAssertions : FluentAssertions.Numeric.NullableNumericAssertions<short>
+    {
+        public NullableShortAssertions(short? value) { }
+    }
     public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions>
     {
         public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
@@ -1549,6 +1605,18 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableUIntAssertions : FluentAssertions.Numeric.NullableNumericAssertions<uint>
+    {
+        public NullableUIntAssertions(uint? value) { }
+    }
+    public class NullableULongAssertions : FluentAssertions.Numeric.NullableNumericAssertions<ulong>
+    {
+        public NullableULongAssertions(ulong? value) { }
+    }
+    public class NullableUShortAssertions : FluentAssertions.Numeric.NullableNumericAssertions<ushort>
+    {
+        public NullableUShortAssertions(ushort? value) { }
     }
     public class ObjectAssertions : FluentAssertions.Primitives.ObjectAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
     {
@@ -1587,6 +1655,14 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SByteAssertions : FluentAssertions.Numeric.NumericAssertions<sbyte>
+    {
+        public SByteAssertions(sbyte value) { }
+    }
+    public class ShortAssertions : FluentAssertions.Numeric.NumericAssertions<short>
+    {
+        public ShortAssertions(short value) { }
     }
     public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>
     {
@@ -1670,6 +1746,18 @@ namespace FluentAssertions.Primitives
         Exactly = 2,
         Within = 3,
         LessThan = 4,
+    }
+    public class UIntAssertions : FluentAssertions.Numeric.NumericAssertions<uint>
+    {
+        public UIntAssertions(uint value) { }
+    }
+    public class ULongAssertions : FluentAssertions.Numeric.NumericAssertions<ulong>
+    {
+        public ULongAssertions(ulong value) { }
+    }
+    public class UShortAssertions : FluentAssertions.Numeric.NumericAssertions<ushort>
+    {
+        public UShortAssertions(ushort value) { }
     }
 }
 namespace FluentAssertions.Reflection

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -1325,16 +1325,16 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeRankedEquallyTo(T unexpected, string because = "", params object[] becauseArgs) { }
     }
-    public class NullableNumericAssertions<T> : FluentAssertions.Numeric.NullableNumericAssertions<T, FluentAssertions.Numeric.NullableNumericAssertions<T>>
+    public abstract class NullableNumericAssertions<T> : FluentAssertions.Numeric.NullableNumericAssertions<T, FluentAssertions.Numeric.NullableNumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
-        public NullableNumericAssertions(T? value) { }
+        protected NullableNumericAssertions(T? value) { }
     }
-    public class NullableNumericAssertions<T, TAssertions> : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
+    public abstract class NullableNumericAssertions<T, TAssertions> : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
         where T :  struct, System.IComparable<T>
         where TAssertions : FluentAssertions.Numeric.NullableNumericAssertions<T, TAssertions>
     {
-        public NullableNumericAssertions(T? value) { }
+        protected NullableNumericAssertions(T? value) { }
         public T? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1342,16 +1342,16 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
-    public class NumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T, FluentAssertions.Numeric.NumericAssertions<T>>
+    public abstract class NumericAssertions<T> : FluentAssertions.Numeric.NumericAssertions<T, FluentAssertions.Numeric.NumericAssertions<T>>
         where T :  struct, System.IComparable<T>
     {
-        public NumericAssertions(T value) { }
+        protected NumericAssertions(T value) { }
     }
-    public class NumericAssertions<T, TAssertions>
+    public abstract class NumericAssertions<T, TAssertions>
         where T :  struct, System.IComparable<T>
         where TAssertions : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
     {
-        public NumericAssertions(T value) { }
+        protected NumericAssertions(T value) { }
         public T Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
@@ -1387,6 +1387,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class ByteAssertions : FluentAssertions.Numeric.NumericAssertions<byte>
+    {
+        public ByteAssertions(byte value) { }
     }
     public class DateTimeAssertions : FluentAssertions.Primitives.DateTimeAssertions<FluentAssertions.Primitives.DateTimeAssertions>
     {
@@ -1495,6 +1499,14 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
     }
+    public class DecimalAssertions : FluentAssertions.Numeric.NumericAssertions<decimal>
+    {
+        public DecimalAssertions(decimal value) { }
+    }
+    public class DoubleAssertions : FluentAssertions.Numeric.NumericAssertions<double>
+    {
+        public DoubleAssertions(double value) { }
+    }
     public class EnumAssertions : FluentAssertions.Primitives.EnumAssertions<System.Enum, FluentAssertions.Primitives.EnumAssertions>
     {
         public EnumAssertions(System.Enum subject) { }
@@ -1509,6 +1521,10 @@ namespace FluentAssertions.Primitives
             where T :  struct, TEnum { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveFlag<T>(T unexpectedFlag, string because = "", params object[] becauseArgs)
             where T :  struct, TEnum { }
+    }
+    public class FloatAssertions : FluentAssertions.Numeric.NumericAssertions<float>
+    {
+        public FloatAssertions(float value) { }
     }
     public class GuidAssertions : FluentAssertions.Primitives.GuidAssertions<FluentAssertions.Primitives.GuidAssertions>
     {
@@ -1525,6 +1541,14 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
     }
+    public class IntAssertions : FluentAssertions.Numeric.NumericAssertions<int>
+    {
+        public IntAssertions(int value) { }
+    }
+    public class LongAssertions : FluentAssertions.Numeric.NumericAssertions<long>
+    {
+        public LongAssertions(long value) { }
+    }
     public class NullableBooleanAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<FluentAssertions.Primitives.NullableBooleanAssertions>
     {
         public NullableBooleanAssertions(bool? value) { }
@@ -1540,6 +1564,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeTrue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableByteAssertions : FluentAssertions.Numeric.NullableNumericAssertions<byte>
+    {
+        public NullableByteAssertions(byte? value) { }
     }
     public class NullableDateTimeAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<FluentAssertions.Primitives.NullableDateTimeAssertions>
     {
@@ -1569,6 +1597,18 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
+    public class NullableDecimalAssertions : FluentAssertions.Numeric.NullableNumericAssertions<decimal>
+    {
+        public NullableDecimalAssertions(decimal? value) { }
+    }
+    public class NullableDoubleAssertions : FluentAssertions.Numeric.NullableNumericAssertions<double>
+    {
+        public NullableDoubleAssertions(double? value) { }
+    }
+    public class NullableFloatAssertions : FluentAssertions.Numeric.NullableNumericAssertions<float>
+    {
+        public NullableFloatAssertions(float? value) { }
+    }
     public class NullableGuidAssertions : FluentAssertions.Primitives.NullableGuidAssertions<FluentAssertions.Primitives.NullableGuidAssertions>
     {
         public NullableGuidAssertions(System.Guid? value) { }
@@ -1583,6 +1623,22 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
+    public class NullableIntAssertions : FluentAssertions.Numeric.NullableNumericAssertions<int>
+    {
+        public NullableIntAssertions(int? value) { }
+    }
+    public class NullableLongAssertions : FluentAssertions.Numeric.NullableNumericAssertions<long>
+    {
+        public NullableLongAssertions(long? value) { }
+    }
+    public class NullableSByteAssertions : FluentAssertions.Numeric.NullableNumericAssertions<sbyte>
+    {
+        public NullableSByteAssertions(sbyte? value) { }
+    }
+    public class NullableShortAssertions : FluentAssertions.Numeric.NullableNumericAssertions<short>
+    {
+        public NullableShortAssertions(short? value) { }
+    }
     public class NullableSimpleTimeSpanAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions>
     {
         public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
@@ -1596,6 +1652,18 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableUIntAssertions : FluentAssertions.Numeric.NullableNumericAssertions<uint>
+    {
+        public NullableUIntAssertions(uint? value) { }
+    }
+    public class NullableULongAssertions : FluentAssertions.Numeric.NullableNumericAssertions<ulong>
+    {
+        public NullableULongAssertions(ulong? value) { }
+    }
+    public class NullableUShortAssertions : FluentAssertions.Numeric.NullableNumericAssertions<ushort>
+    {
+        public NullableUShortAssertions(ushort? value) { }
     }
     public class ObjectAssertions : FluentAssertions.Primitives.ObjectAssertions<object, FluentAssertions.Primitives.ObjectAssertions>
     {
@@ -1634,6 +1702,14 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType(System.Type unexpectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOfType<T>(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameAs(TSubject unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class SByteAssertions : FluentAssertions.Numeric.NumericAssertions<sbyte>
+    {
+        public SByteAssertions(sbyte value) { }
+    }
+    public class ShortAssertions : FluentAssertions.Numeric.NumericAssertions<short>
+    {
+        public ShortAssertions(short value) { }
     }
     public class SimpleTimeSpanAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<FluentAssertions.Primitives.SimpleTimeSpanAssertions>
     {
@@ -1717,6 +1793,18 @@ namespace FluentAssertions.Primitives
         Exactly = 2,
         Within = 3,
         LessThan = 4,
+    }
+    public class UIntAssertions : FluentAssertions.Numeric.NumericAssertions<uint>
+    {
+        public UIntAssertions(uint value) { }
+    }
+    public class ULongAssertions : FluentAssertions.Numeric.NumericAssertions<ulong>
+    {
+        public ULongAssertions(ulong value) { }
+    }
+    public class UShortAssertions : FluentAssertions.Numeric.NumericAssertions<ushort>
+    {
+        public UShortAssertions(ushort value) { }
     }
 }
 namespace FluentAssertions.Reflection

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
@@ -447,7 +447,7 @@ namespace FluentAssertions.Specs
             Action act = () => collection.Should().ContainSingle().Which.Should().BeGreaterThan(4);
 
             // Assert
-            const string expectedMessage = "Expected collection to be greater than 4, but found 3.";
+            const string expectedMessage = "Expected collection to be greater than 4, but found 3. Difference -1.";
 
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }
@@ -1597,14 +1597,14 @@ namespace FluentAssertions.Specs
 *Expected customer.Age to be less than 21, but found 21
 *Expected customer.Items to satisfy all inspectors, but some inspectors are not satisfied:
 *At index 0:
-*Expected item to be 2, but found 1
+*Expected item to be 2, but found 1. Difference -1
 *At index 1:
-*Expected item to be 1, but found 2
+*Expected item to be 1, but found 2. Difference 1
 *At index 1:
 *Expected customer.Age to be less than 22, but found 22
 *Expected customer.Items to satisfy all inspectors, but some inspectors are not satisfied:
 *At index 0:
-*Expected item to be 2, but found 3"
+*Expected item to be 2, but found 3. Difference 1"
 );
         }
 

--- a/Tests/FluentAssertions.Specs/Numeric/NullableNumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NullableNumericAssertionSpecs.cs
@@ -203,7 +203,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*2 because we want to test the failure message, but found 1.");
+                .WithMessage("Expected*2 because we want to test the failure message, but found 1. Difference -1.");
         }
 
         #region Be Approximately

--- a/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
@@ -191,7 +191,7 @@ namespace FluentAssertions.Specs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be 2 because we want to test the failure message, but found 1.");
+                .WithMessage("Expected value to be 2 because we want to test the failure message, but found 1. Difference -1.");
         }
 
         [Fact]
@@ -222,7 +222,7 @@ namespace FluentAssertions.Specs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected*<null>, but found 2.");
+                .WithMessage("Expected*<null>, but found 2. Difference <null>.");
         }
 
         [Fact]
@@ -237,7 +237,7 @@ namespace FluentAssertions.Specs
             // Assert
             action
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected*2, but found <null>.");
+                .WithMessage("Expected*2, but found <null>. Difference <null>.");
         }
 
         [Fact]
@@ -443,7 +443,7 @@ namespace FluentAssertions.Specs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be greater than 3 because we want to test the failure message, but found 2.");
+                .WithMessage("Expected value to be greater than 3 because we want to test the failure message, but found 2. Difference -1.");
         }
 
         [Fact]
@@ -502,7 +502,7 @@ namespace FluentAssertions.Specs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be greater or equal to 3 because we want to test the failure message, but found 2.");
+                .WithMessage("Expected value to be greater or equal to 3 because we want to test the failure message, but found 2. Difference -1.");
         }
 
         [Fact]
@@ -594,7 +594,7 @@ namespace FluentAssertions.Specs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be less than 1 because we want to test the failure message, but found 2.");
+                .WithMessage("Expected value to be less than 1 because we want to test the failure message, but found 2. Difference 1.");
         }
 
         [Fact]
@@ -652,7 +652,7 @@ namespace FluentAssertions.Specs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be less or equal to 1 because we want to test the failure message, but found 2.");
+                .WithMessage("Expected value to be less or equal to 1 because we want to test the failure message, but found 2. Difference 1.");
         }
 
         [Fact]
@@ -1082,7 +1082,7 @@ namespace FluentAssertions.Specs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be *3.5* but found <null>.");
+                .WithMessage("Expected value to be *3.5* but found <null>. Difference <null>.");
         }
 
         [Fact]
@@ -1408,7 +1408,7 @@ namespace FluentAssertions.Specs
             act
                 .Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected value to be 3.4 because we want to test the error message, but found 3.5.");
+                    "Expected value to be 3.4 because we want to test the error message, but found 3.5. Difference 0.10000000000000009.");
         }
 
         [Fact]
@@ -1437,7 +1437,7 @@ namespace FluentAssertions.Specs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be 3.5, but found <null>.");
+                .WithMessage("Expected value to be 3.5, but found <null>. Difference <null>.");
         }
 
         [Fact]
@@ -1763,7 +1763,7 @@ namespace FluentAssertions.Specs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be*3.5*, but found <null>.");
+                .WithMessage("Expected value to be*3.5*, but found <null>. Difference <null>.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
@@ -55,7 +55,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Expected * to be 42, but found 99.");
+                .WithMessage("Expected * to be 42, but found 99. Difference 57.");
         }
 
         [Fact]


### PR DESCRIPTION
Initial spike on #1412 that includes difference between actual and expected for `NumericAssertions` & `NullableNumericAssertions` for:

- `Be`
- `BeLessThan`
- `BeLessOrEqualTo`
- `BeGreaterThan`
- `BeGreaterOrEqualTo`

---

Some possible items to be discussed:

1. `BeLessThan` and `BeGreaterThan` shows `actual - expected` as difference for consistency with the other assertions. It may make sense to subtract `1` for `BeLessThan` and add `1` for `BeGreaterThan` to show a value that satisfy the condition

2. `BeInRange` and `NotBeInRange` could display the difference between minimum value or maximum value depending on the side of the range if falls (or display both)

3. `BeOneOf` could display the difference of each element in the list of expected values

4. `NotBe`, `BePositive`, `BeNegative`, `BeOfType`, `NotBeOfType`, `Match` wouldn't have any difference to display
