### PR TITLE
Make IgnoringCyclicReferences working for the types overriding Equals()

### DIFF
--- a/Src/FluentAssertions/Common/InternalTypeExtensions.cs
+++ b/Src/FluentAssertions/Common/InternalTypeExtensions.cs
@@ -43,7 +43,7 @@ namespace FluentAssertions.Common
         /// </summary>
         public static bool HasValueSemantics(this Type type)
         {
-            return type.OverridesEquals() &&
+            return type.IsSimpleType() &&
                    !type.IsAnonymousType() && !type.IsTuple() && !IsKeyValuePair(type);
         }
 

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -143,15 +143,6 @@ namespace FluentAssertions.Common
                     .ToArray();
         }
 
-        public static bool OverridesEquals(this Type type)
-        {
-            MethodInfo method = type
-                .GetMethod("Equals", new[] { typeof(object) });
-
-            return method != null
-                && method.GetBaseDefinition().DeclaringType != method.DeclaringType;
-        }
-
         /// <summary>
         /// Finds a member by its case-sensitive name.
         /// </summary>
@@ -466,6 +457,31 @@ namespace FluentAssertions.Common
             bool IsExactNamespace() => IsNamespacePrefix() && type.Namespace.Length == @namespace.Length;
             bool IsParentNamespace() => IsNamespacePrefix() && type.Namespace[@namespace.Length] == '.';
             bool IsNamespacePrefix() => type.Namespace?.StartsWith(@namespace, StringComparison.Ordinal) == true;
+        }
+
+        /// <summary>
+        /// Returns true if the type is a primitive type, date, decimal, string, or GUID
+        /// </summary>
+        /// <param name="type">Type to be checked</param>
+        /// <returns></returns>
+        public static bool IsSimpleType(this Type type)
+        {
+            if (type == null)
+            {
+                return false;
+            }
+
+            if (type.GetTypeInfo().IsGenericType && type.GetTypeInfo().GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                type = Nullable.GetUnderlyingType(type);
+            }
+
+            return type.GetTypeInfo().IsPrimitive
+                   || type == typeof(DateTime)
+                   || type == typeof(string)
+                   || type == typeof(Guid)
+                   || type == typeof(decimal)
+                   || type.GetTypeInfo().IsEnum;
         }
     }
 }

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -104,7 +104,7 @@ namespace FluentAssertions.Equivalency
 
             if (!isComplexTypeMap.TryGetValue(type, out bool isComplexType))
             {
-                isComplexType = !type.OverridesEquals();
+                isComplexType = !type.IsSimpleType();
                 isComplexTypeMap[type] = isComplexType;
             }
 

--- a/Src/FluentAssertions/Equivalency/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/ObjectReference.cs
@@ -67,6 +67,6 @@ namespace FluentAssertions.Equivalency
             return $"{{\"{path}\", {@object}}}";
         }
 
-        public bool IsComplexType => isComplexType ?? (!(@object is null) && !@object.GetType().OverridesEquals());
+        public bool IsComplexType => isComplexType ?? (!(@object is null) && !@object.GetType().IsSimpleType());
     }
 }

--- a/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
@@ -3473,6 +3473,36 @@ namespace FluentAssertions.Specs
             action.Should().NotThrow();
         }
 
+        [Fact]
+        public void When_validating_nested_properties_of_type_overriding_equals_and_ignoring_cyclic_references_it_should_succeed()
+        {
+            // Arrange
+            var cyclicRoot = new CyclicValueObjectRoot()
+            {
+                Text = "Root"
+            };
+            cyclicRoot.Level = new CyclicValueObjectLevel1()
+            {
+                Text = "Level1",
+                Root = cyclicRoot
+            };
+            var cyclicRootDto = new CyclicValueObjectRootDto()
+            {
+                Text = "Root"
+            };
+            cyclicRootDto.Level = new CyclicValueObjectLevel1Dto()
+            {
+                Text = "Level1",
+                Root = cyclicRootDto
+            };
+
+            // Act
+            Action act = () => cyclicRoot.Should().BeEquivalentTo(cyclicRootDto, opt => opt.IgnoringCyclicReferences());
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
         #endregion
 
         #region Tuples
@@ -4418,6 +4448,17 @@ namespace FluentAssertions.Specs
         public CyclicLevel1 Level { get; set; }
     }
 
+    public class CyclicValueObjectRoot
+    {
+        public string Text { get; set; }
+
+        public CyclicValueObjectLevel1 Level { get; set; }
+
+        public override bool Equals(object obj) => obj is CyclicValueObjectRoot c && c.Text.Equals(Text, StringComparison.Ordinal);
+
+        public override int GetHashCode() => Text.GetHashCode();
+    }
+
     public class CyclicRootWithValueObject
     {
         public ValueObject Object { get; set; }
@@ -4452,6 +4493,17 @@ namespace FluentAssertions.Specs
         public CyclicRoot Root { get; set; }
     }
 
+    public class CyclicValueObjectLevel1
+    {
+        public string Text { get; set; }
+
+        public CyclicValueObjectRoot Root { get; set; }
+
+        public override bool Equals(object obj) => obj is CyclicValueObjectLevel1 c && c.Text.Equals(Text, StringComparison.Ordinal);
+
+        public override int GetHashCode() => Text.GetHashCode();
+    }
+
     public class CyclicLevelWithValueObject
     {
         public ValueObject Object { get; set; }
@@ -4466,11 +4518,33 @@ namespace FluentAssertions.Specs
         public CyclicLevel1Dto Level { get; set; }
     }
 
+    public class CyclicValueObjectRootDto
+    {
+        public string Text { get; set; }
+
+        public CyclicValueObjectLevel1Dto Level { get; set; }
+
+        public override bool Equals(object obj) => obj is CyclicValueObjectRootDto c && c.Text.Equals(Text, StringComparison.Ordinal);
+
+        public override int GetHashCode() => Text.GetHashCode();
+    }
+
     public class CyclicLevel1Dto
     {
         public string Text { get; set; }
 
         public CyclicRootDto Root { get; set; }
+    }
+
+    public class CyclicValueObjectLevel1Dto
+    {
+        public string Text { get; set; }
+
+        public CyclicValueObjectRootDto Root { get; set; }
+
+        public override bool Equals(object obj) => obj is CyclicValueObjectLevel1Dto c && c.Text.Equals(Text, StringComparison.Ordinal);
+
+        public override int GetHashCode() => Text.GetHashCode();
     }
 
     #endregion

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -20,12 +20,13 @@ sidebar:
 **Fixes**
 * Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)
 * Guard against implicitly or explicitly trying to compare primitive types by members - [#1394](https://github.com/fluentassertions/fluentassertions/pull/1394).
+* Guard against implicitly or explicitly trying to compare primitive types by members - [#1394](https://github.com/fluentassertions/fluentassertions/pull/1394).
 
 **Breaking Changes**
 * Made the extension methods under the `FluentAssertions.Common` namespace `internal` -  [#1376](https://github.com/fluentassertions/fluentassertions/pull/1376)
 * Moved `[Not]HaveFlag` from `ObjectAssertions` to `EnumAssertions` - [#1375](https://github.com/fluentassertions/fluentassertions/pull/1375).
 * Requesting an unsupported test framework via `Services.Configuration.TestFrameworkName` or `"FluentAssertions.TestFramework"` now throws an exception instead of using the fallback - [#1366](https://github.com/fluentassertions/fluentassertions/pull/1366).
-* Guard `[Not]Match`, `[Not]MatchEquivalentOf`, `[Not]MatchRegex` and `[Not]ContainMatch` against `null` or empty patterns - [#1401](https://github.com/fluentassertions/fluentassertions/pull/1401).
+* Fixed `IgnoringCyclicReferences` so that it works for the types overriding `Equals()` - [#1417](https://github.com/fluentassertions/fluentassertions/pull/1417).
 
 ## 6.0.0 Alpha 1
 


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).

Fixes #1370