### PR TITLE
Add support for asserting on DataSet, DataTable, DataColumn, DataRow

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Data;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions.Collections;
+using FluentAssertions.Data;
 #if !NETSTANDARD2_0
 using FluentAssertions.Events;
 #endif
@@ -341,6 +343,16 @@ namespace FluentAssertions
             where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
         {
             return new GenericDictionaryAssertions<TCollection, TKey, TValue>(actualValue);
+        }
+
+        /// <summary>
+        /// Returns a <see cref="DataColumnAssertions"/> object that can be used to assert the
+        /// current <see cref="DataColumn"/>.
+        /// </summary>
+        [Pure]
+        public static DataColumnAssertions Should(this DataColumn actualValue)
+        {
+            return new DataColumnAssertions(actualValue);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/AssertionOptions.cs
+++ b/Src/FluentAssertions/AssertionOptions.cs
@@ -21,6 +21,14 @@ namespace FluentAssertions
             return new EquivalencyAssertionOptions<T>(defaults);
         }
 
+        public static TOptions CloneDefaults<T, TOptions>()
+            where TOptions : EquivalencyAssertionOptions<T>
+        {
+            return (TOptions)Activator.CreateInstance(
+                typeof(TOptions),
+                defaults);
+        }
+
         /// <summary>
         /// Allows configuring the defaults used during a structural equivalency assertion.
         /// </summary>

--- a/Src/FluentAssertions/Data/DataColumnAssertions.cs
+++ b/Src/FluentAssertions/Data/DataColumnAssertions.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Data;
+using System.Diagnostics;
+
+using FluentAssertions.Common;
+using FluentAssertions.Equivalency;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+
+namespace FluentAssertions.Data
+{
+    /// <summary>
+    /// Provides convenient assertion methods on a <see cref="DataColumn"/> that can be
+    /// used to assert equivalency.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class DataColumnAssertions : ReferenceTypeAssertions<DataColumn, DataColumnAssertions>
+    {
+        public DataColumnAssertions(DataColumn dataColumn)
+            : base(dataColumn)
+        {
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataColumn"/> is equivalent to another.
+        /// </summary>
+        /// <remarks>
+        /// Data columns are equivalent when the following members have the same values:
+        /// 
+        /// <list type="bullet">
+        ///   <item><description>AllowDBNull</description></item>
+        ///   <item><description>AutoIncrement</description></item>
+        ///   <item><description>AutoIncrementSeed</description></item>
+        ///   <item><description>AutoIncrementStep</description></item>
+        ///   <item><description>Caption</description></item>
+        ///   <item><description>ColumnName</description></item>
+        ///   <item><description>DataType</description></item>
+        ///   <item><description>DateTimeMode</description></item>
+        ///   <item><description>DefaultValue</description></item>
+        ///   <item><description>Expression</description></item>
+        ///   <item><description>ExtendedProperties</description></item>
+        ///   <item><description>MaxLength</description></item>
+        ///   <item><description>Namespace</description></item>
+        ///   <item><description>Prefix</description></item>
+        ///   <item><description>ReadOnly</description></item>
+        ///   <item><description>Unique</description></item>
+        /// </list>
+        /// </remarks>
+        /// <param name="expectation">A <see cref="DataColumn"/> with the expected configuration.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndConstraint<DataColumnAssertions> BeEquivalentTo(DataColumn expectation, string because = "", params object[] becauseArgs)
+        {
+            return BeEquivalentTo(
+                expectation,
+                options => options,
+                because,
+                becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataColumn"/> is equivalent to another.
+        /// </summary>
+        /// <remarks>
+        /// Data columns are equivalent when the following members have the same values:
+        /// 
+        /// <list type="bullet">
+        ///   <item><description>AllowDBNull</description></item>
+        ///   <item><description>AutoIncrement</description></item>
+        ///   <item><description>AutoIncrementSeed</description></item>
+        ///   <item><description>AutoIncrementStep</description></item>
+        ///   <item><description>Caption</description></item>
+        ///   <item><description>ColumnName</description></item>
+        ///   <item><description>DataType</description></item>
+        ///   <item><description>DateTimeMode</description></item>
+        ///   <item><description>DefaultValue</description></item>
+        ///   <item><description>Expression</description></item>
+        ///   <item><description>ExtendedProperties</description></item>
+        ///   <item><description>MaxLength</description></item>
+        ///   <item><description>Namespace</description></item>
+        ///   <item><description>Prefix</description></item>
+        ///   <item><description>ReadOnly</description></item>
+        ///   <item><description>Unique</description></item>
+        /// </list>
+        /// 
+        /// Testing of any property can be overridden using the <paramref name="config"/> callback. Exclude specific properties using
+        /// <see cref="IDataEquivalencyAssertionOptions{T}.Excluding(System.Linq.Expressions.Expression{Func{T, object}})"/>.
+        /// 
+        /// If <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingColumn(DataColumn)"/> or a related function is
+        /// used and the exclusion matches the subject <see cref="DataColumn"/>, then the equivalency test will never
+        /// fail.
+        /// </remarks>
+        /// <param name="expectation">A <see cref="DataColumn"/> with the expected configuration.</param>
+        /// <param name="config">
+        /// A reference to the <see cref="IDataEquivalencyAssertionOptions{DataColumn}"/> configuration object that can be used
+        /// to influence the way the object graphs are compared. You can also provide an alternative instance of the
+        /// <see cref="IDataEquivalencyAssertionOptions{DataColumn}"/> class. The global defaults are determined by the
+        /// <see cref="AssertionOptions"/> class.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndConstraint<DataColumnAssertions> BeEquivalentTo(DataColumn expectation, Func<IDataEquivalencyAssertionOptions<DataColumn>, IDataEquivalencyAssertionOptions<DataColumn>> config, string because = "", params object[] becauseArgs)
+        {
+            Guard.ThrowIfArgumentIsNull(config, nameof(config));
+
+            var options = config(AssertionOptions.CloneDefaults<DataColumn, DataEquivalencyAssertionOptions<DataColumn>>());
+
+            var callerIdentity = new Lazy<string>(CallerIdentifier.DetermineCallerIdentity);
+
+            var context = new EquivalencyValidationContext(Node.From<DataColumn>(() => callerIdentity.Value))
+            {
+                Subject = Subject,
+                Expectation = expectation,
+                CompileTimeType = typeof(DataColumn),
+                Reason = new Reason(because, becauseArgs),
+                TraceWriter = options.TraceWriter
+            };
+
+            var equivalencyValidator = new EquivalencyValidator(options);
+            equivalencyValidator.AssertEquality(context);
+
+            return new AndConstraint<DataColumnAssertions>(this);
+        }
+
+        protected override string Identifier => "DataColumn";
+    }
+}

--- a/Src/FluentAssertions/Data/DataEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Data/DataEquivalencyAssertionOptions.cs
@@ -1,0 +1,316 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq.Expressions;
+using System.Reflection;
+
+using FluentAssertions.Equivalency;
+
+namespace FluentAssertions.Data
+{
+#pragma warning disable CA1812 // Internal class that is apparently never instantiated; this class is instantiated dynamically by AssertionOptions.CloneDefaults
+    internal class DataEquivalencyAssertionOptions<T> : EquivalencyAssertionOptions<T>, IDataEquivalencyAssertionOptions<T>
+#pragma warning restore CA1812
+    {
+        private readonly HashSet<string> excludeTableNames = new HashSet<string>();
+        private readonly HashSet<string> excludeColumnNames = new HashSet<string>();
+        private readonly Dictionary<string, HashSet<string>> excludeColumnNamesByTableName = new Dictionary<string, HashSet<string>>();
+
+        private bool allowMismatchedTypes;
+        private bool ignoreUnmatchedColumns;
+        private RowMatchMode rowMatchMode;
+        private bool excludeOriginalData;
+
+        public bool AllowMismatchedTypes => allowMismatchedTypes;
+
+        public bool IgnoreUnmatchedColumns => ignoreUnmatchedColumns;
+
+        public bool ExcludeOriginalData => excludeOriginalData;
+
+        public RowMatchMode RowMatchMode => rowMatchMode;
+
+        public ISet<string> ExcludeTableNames => excludeTableNames;
+
+        public ISet<string> ExcludeColumnNames => excludeColumnNames;
+
+        public IReadOnlyDictionary<string, ISet<string>> ExcludeColumnNamesByTableName { get; }
+
+        private class ColumnNamesByTableNameAdapter : IReadOnlyDictionary<string, ISet<string>>
+        {
+            private readonly DataEquivalencyAssertionOptions<T> owner;
+
+            public ColumnNamesByTableNameAdapter(DataEquivalencyAssertionOptions<T> owner)
+            {
+                this.owner = owner;
+            }
+
+            public ISet<string> this[string key] => owner.excludeColumnNamesByTableName[key];
+
+            public IEnumerable<string> Keys => owner.excludeColumnNamesByTableName.Keys;
+
+            public IEnumerable<ISet<string>> Values => owner.excludeColumnNamesByTableName.Values;
+
+            public int Count => owner.excludeColumnNamesByTableName.Count;
+
+            public bool ContainsKey(string key) => owner.excludeColumnNamesByTableName.ContainsKey(key);
+
+            public bool TryGetValue(string key, out ISet<string> value)
+            {
+                bool result = owner.excludeColumnNamesByTableName.TryGetValue(key, out var concreteValue);
+
+                value = concreteValue;
+
+                return result;
+            }
+
+            public IEnumerator<KeyValuePair<string, ISet<string>>> GetEnumerator()
+            {
+                foreach (var entry in owner.excludeColumnNamesByTableName)
+                {
+                    yield return new KeyValuePair<string, ISet<string>>(entry.Key, entry.Value);
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        public DataEquivalencyAssertionOptions(EquivalencyAssertionOptions defaults)
+            : base(defaults)
+        {
+            ExcludeColumnNamesByTableName = new ColumnNamesByTableNameAdapter(this);
+        }
+
+        public IDataEquivalencyAssertionOptions<T> AllowingMismatchedTypes()
+        {
+            allowMismatchedTypes = true;
+            return this;
+        }
+
+        public IDataEquivalencyAssertionOptions<T> IgnoringUnmatchedColumns()
+        {
+            ignoreUnmatchedColumns = true;
+            return this;
+        }
+
+        public IDataEquivalencyAssertionOptions<T> UsingRowMatchMode(RowMatchMode newRowMatchMode)
+        {
+            rowMatchMode = newRowMatchMode;
+            return this;
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingOriginalData()
+        {
+            excludeOriginalData = true;
+            return this;
+        }
+
+        public new IDataEquivalencyAssertionOptions<T> Excluding(Expression<Func<T, object>> expression)
+        {
+            base.Excluding(expression);
+            return this;
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingRelated(Expression<Func<DataRelation, object>> expression)
+        {
+            ExcludeMemberOfRelatedTypeByGeneratedPredicate(expression);
+            return this;
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingRelated(Expression<Func<DataTable, object>> expression)
+        {
+            ExcludeMemberOfRelatedTypeByGeneratedPredicate(expression);
+            return this;
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingRelated(Expression<Func<DataColumn, object>> expression)
+        {
+            ExcludeMemberOfRelatedTypeByGeneratedPredicate(expression);
+            return this;
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingRelated(Expression<Func<DataRow, object>> expression)
+        {
+            ExcludeMemberOfRelatedTypeByGeneratedPredicate(expression);
+            return this;
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingRelated(Expression<Func<Constraint, object>> expression)
+        {
+            ExcludeMemberOfSubtypeOfRelatedTypeByGeneratedPredicate<Constraint, ForeignKeyConstraint, object>(expression);
+            ExcludeMemberOfSubtypeOfRelatedTypeByGeneratedPredicate<Constraint, UniqueConstraint, object>(expression);
+            return this;
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingRelated(Expression<Func<ForeignKeyConstraint, object>> expression)
+        {
+            ExcludeMemberOfRelatedTypeByGeneratedPredicate(expression);
+            return this;
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingRelated(Expression<Func<UniqueConstraint, object>> expression)
+        {
+            ExcludeMemberOfRelatedTypeByGeneratedPredicate(expression);
+            return this;
+        }
+
+        private void ExcludeMemberOfRelatedTypeByGeneratedPredicate<TDeclaringType, TPropertyType>(Expression<Func<TDeclaringType, TPropertyType>> expression)
+        {
+            var predicate = BuildMemberSelectionPredicate(
+                typeof(TDeclaringType),
+                GetMemberAccessTargetMember(expression.Body));
+
+            Excluding(predicate);
+        }
+
+        private void ExcludeMemberOfSubtypeOfRelatedTypeByGeneratedPredicate<TDeclaringType, TInheritingType, TPropertyType>(Expression<Func<TDeclaringType, TPropertyType>> expression)
+            where TInheritingType : TDeclaringType
+        {
+            var predicate = BuildMemberSelectionPredicate(
+                typeof(TInheritingType),
+                GetMemberAccessTargetMember(expression.Body));
+
+            Excluding(predicate);
+        }
+
+        private static MemberInfo GetMemberAccessTargetMember(Expression expression)
+        {
+            if ((expression is UnaryExpression unaryExpression)
+             && (unaryExpression.NodeType == ExpressionType.Convert))
+            {
+                // If the expression is a value type, then accessing it will involve an
+                // implicit boxing convertion to type object that we need to ignore.
+                expression = unaryExpression.Operand;
+            }
+
+            if (expression is MemberExpression memberExpression)
+            {
+                return memberExpression.Member;
+            }
+
+            throw new Exception("Expression must be a simple member access");
+        }
+
+        private static Expression<Func<IMemberInfo, bool>> BuildMemberSelectionPredicate(Type relatedSubjectType, MemberInfo referencedMember)
+        {
+            var predicateMemberInfoArgument = Expression.Parameter(typeof(IMemberInfo));
+
+            var typeComparison = Expression.Equal(
+                Expression.MakeMemberAccess(
+                    predicateMemberInfoArgument,
+                    typeof(IMemberInfo).GetProperty(nameof(IMemberInfo.DeclaringType))),
+                Expression.Constant(relatedSubjectType));
+
+            var memberNameComparison = Expression.Equal(
+                Expression.MakeMemberAccess(
+                    predicateMemberInfoArgument,
+                    typeof(IMemberInfo).GetProperty(nameof(IMemberInfo.Name))),
+                Expression.Constant(referencedMember.Name));
+
+            var predicateBody = Expression.AndAlso(
+                typeComparison,
+                memberNameComparison);
+
+            return Expression.Lambda<Func<IMemberInfo, bool>>(
+                predicateBody,
+                predicateMemberInfoArgument);
+        }
+
+        public new IDataEquivalencyAssertionOptions<T> Excluding(Expression<Func<IMemberInfo, bool>> predicate)
+        {
+            base.Excluding(predicate);
+            return this;
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingTable(string tableName)
+        {
+            return ExcludingTables(tableName);
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingTables(params string[] tableNames)
+        {
+            return ExcludingTables((IEnumerable<string>)tableNames);
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingTables(IEnumerable<string> tableNames)
+        {
+            excludeTableNames.UnionWith(tableNames);
+            return this;
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingColumnInAllTables(string columnName)
+        {
+            return ExcludingColumnsInAllTables(columnName);
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingColumnsInAllTables(params string[] columnNames)
+        {
+            return ExcludingColumnsInAllTables((IEnumerable<string>)columnNames);
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingColumnsInAllTables(IEnumerable<string> columnNames)
+        {
+            excludeColumnNames.UnionWith(columnNames);
+            return this;
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingColumn(DataColumn column)
+        {
+            return ExcludingColumn(column.Table.TableName, column.ColumnName);
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingColumns(params DataColumn[] columns)
+        {
+            return ExcludingColumns((IEnumerable<DataColumn>)columns);
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingColumns(IEnumerable<DataColumn> columns)
+        {
+            foreach (var column in columns)
+            {
+                ExcludingColumn(column);
+            }
+
+            return this;
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingColumn(string tableName, string columnName)
+        {
+            return ExcludingColumns(tableName, columnName);
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingColumns(string tableName, params string[] columnNames)
+        {
+            return ExcludingColumns(tableName, (IEnumerable<string>)columnNames);
+        }
+
+        public IDataEquivalencyAssertionOptions<T> ExcludingColumns(string tableName, IEnumerable<string> columnNames)
+        {
+            if (!excludeColumnNamesByTableName.TryGetValue(tableName, out var excludeColumnNames))
+            {
+                excludeColumnNames = new HashSet<string>();
+                excludeColumnNamesByTableName[tableName] = excludeColumnNames;
+            }
+
+            excludeColumnNames.UnionWith(columnNames);
+
+            return this;
+        }
+
+        public bool ShouldExcludeColumn(DataColumn column)
+        {
+            if (excludeColumnNames.Contains(column.ColumnName))
+            {
+                return true;
+            }
+
+            if (excludeColumnNamesByTableName.TryGetValue(column.Table.TableName, out var excludeColumnsForTable)
+             && excludeColumnsForTable.Contains(column.ColumnName))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Src/FluentAssertions/Data/DataRowAssertions.cs
+++ b/Src/FluentAssertions/Data/DataRowAssertions.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics;
+using System.Linq;
+
+using FluentAssertions.Common;
+using FluentAssertions.Equivalency;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+
+namespace FluentAssertions.Data
+{
+    /// <summary>
+    /// Provides convenient assertion methods on a <see cref="DataRow"/> that can be
+    /// used to assert equivalency and the presence of columns.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class DataRowAssertions<TDataRow> : ReferenceTypeAssertions<TDataRow, DataRowAssertions<TDataRow>>
+        where TDataRow : DataRow
+    {
+        public DataRowAssertions(TDataRow dataRow)
+            : base(dataRow)
+        {
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataRow"/> has a column with the expected column name.
+        /// </summary>
+        /// <param name="expectedColumnName">The value that is expected in <see cref="DataColumn.ColumnName"/>.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndWhichConstraint<DataRowAssertions<TDataRow>, DataColumn> HaveColumn(string expectedColumnName, string because = "", params object[] becauseArgs)
+        {
+            var subjectColumn = default(DataColumn);
+
+            if (Subject is null)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:DataRow} to contain a column named '{0}'{reason}, but found <null>.", expectedColumnName);
+            }
+            else if (!Subject.Table.Columns.Contains(expectedColumnName))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:DataRow} to contain a column named '{0}'{reason}, but it does not.", expectedColumnName);
+            }
+            else
+            {
+                subjectColumn = Subject.Table.Columns[expectedColumnName];
+            }
+
+            return new AndWhichConstraint<DataRowAssertions<TDataRow>, DataColumn>(this, subjectColumn);
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataRow"/> has columns with all of the supplied expected column names.
+        /// </summary>
+        /// <param name="expectedColumnNames">An array of values expected in <see cref="DataColumn.ColumnName"/>.</param>
+        public AndConstraint<DataRowAssertions<TDataRow>> HaveColumns(params string[] expectedColumnNames)
+        {
+            return HaveColumns((IEnumerable<string>)expectedColumnNames);
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataRow"/> has columns with all of the supplied expected column names.
+        /// </summary>
+        /// <param name="expectedColumnNames">An <see cref="IEnumerable{T}"/> of string values expected in <see cref="DataColumn.ColumnName"/>.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndConstraint<DataRowAssertions<TDataRow>> HaveColumns(IEnumerable<string> expectedColumnNames, string because = "", params object[] becauseArgs)
+        {
+            if (Subject is null)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:DataRow} to be in a table containing {0} column(s) with specific names{reason}, but found <null>.", expectedColumnNames.Count());
+            }
+
+            foreach (var expectedColumnName in expectedColumnNames)
+            {
+                Execute.Assertion
+                    .ForCondition(Subject.Table.Columns.Contains(expectedColumnName))
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected table containing {context:DataRow} to contain a column named '{0}'{reason}, but it does not.", expectedColumnName);
+            }
+
+            return new AndConstraint<DataRowAssertions<TDataRow>>(this);
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataRow"/> is equivalent to another.
+        /// </summary>
+        /// <remarks>
+        /// Data rows are equivalent when they contain identical field data for the row they represent, and
+        /// the following members have the same values:
+        /// 
+        /// <list type="bullet">
+        ///   <item><description>HasErrors</description></item>
+        ///   <item><description>RowState</description></item>
+        /// </list>
+        /// 
+        /// The <see cref="DataRow"/> objects must be of the same type; if two <see cref="DataRow"/> objects
+        /// are equivalent in all ways, except that one is part of a typed <see cref="DataTable"/> and is of a subclass
+        /// of <see cref="DataRow"/>, then by default, they will not be considered equivalent. This can be overridden
+        /// with the <see cref="BeEquivalentTo(DataRow, Func{IDataEquivalencyAssertionOptions{DataRow}, IDataEquivalencyAssertionOptions{DataRow}}, string, object[])"/>
+        /// overload.
+        /// </remarks>
+        /// <param name="expectation">A <see cref="DataColumn"/> with the expected configuration.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndConstraint<DataRowAssertions<TDataRow>> BeEquivalentTo(DataRow expectation, string because = "", params object[] becauseArgs)
+        {
+            return BeEquivalentTo(
+                expectation,
+                options => options,
+                because,
+                becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataRow"/> is equivalent to another.
+        /// </summary>
+        /// <remarks>
+        /// Data rows are equivalent when they contain identical field data for the row they represent, and
+        /// the following members have the same values:
+        /// 
+        /// <list type="bullet">
+        ///   <item><description>HasErrors</description></item>
+        ///   <item><description>RowState</description></item>
+        /// </list>
+        /// 
+        /// The <see cref="DataRow"/> objects must be of the same type; if two <see cref="DataRow"/> objects
+        /// are equivalent in all ways, except that one is part of a typed <see cref="DataTable"/> and is of a subclass
+        /// of <see cref="DataRow"/>, then by default, they will not be considered equivalent.
+        /// 
+        /// This, as well as testing of any property can be overridden using the <paramref name="config"/> callback.
+        /// By calling <see cref="IDataEquivalencyAssertionOptions{T}.AllowingMismatchedTypes"/>, two <see cref="DataRow"/>
+        /// objects of differing types can be considered equivalent. Exclude specific properties using
+        /// <see cref="IDataEquivalencyAssertionOptions{T}.Excluding(System.Linq.Expressions.Expression{Func{T, object}})"/>.
+        /// Exclude columns of the data table (which also excludes the related field data in <see cref="DataRow"/>
+        /// objects) using <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingColumn(DataColumn)"/> or a related function.
+        /// </remarks>
+        /// 
+        /// You can use <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingRelated(System.Linq.Expressions.Expression{Func{DataTable, object}})"/>
+        /// and related functions to exclude properties on other related System.Data types.
+        /// <param name="expectation">A <see cref="DataColumn"/> with the expected configuration.</param>
+        /// <param name="config">
+        /// A reference to the <see cref="IDataEquivalencyAssertionOptions{DataRow}"/> configuration object that can be used
+        /// to influence the way the object graphs are compared. You can also provide an alternative instance of the
+        /// <see cref="IDataEquivalencyAssertionOptions{DataRow}"/> class. The global defaults are determined by the
+        /// <see cref="AssertionOptions"/> class.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndConstraint<DataRowAssertions<TDataRow>> BeEquivalentTo(DataRow expectation, Func<IDataEquivalencyAssertionOptions<DataRow>, IDataEquivalencyAssertionOptions<DataRow>> config, string because = "", params object[] becauseArgs)
+        {
+            Guard.ThrowIfArgumentIsNull(config, nameof(config));
+
+            var options = config(AssertionOptions.CloneDefaults<DataRow, DataEquivalencyAssertionOptions<DataRow>>());
+
+            var callerIdentity = new Lazy<string>(CallerIdentifier.DetermineCallerIdentity);
+
+            var context = new EquivalencyValidationContext(Node.From<DataRow>(() => callerIdentity.Value))
+            {
+                Subject = Subject,
+                Expectation = expectation,
+                CompileTimeType = typeof(TDataRow),
+                Reason = new Reason(because, becauseArgs),
+                TraceWriter = options.TraceWriter
+            };
+
+            var equivalencyValidator = new EquivalencyValidator(options);
+            equivalencyValidator.AssertEquality(context);
+
+            return new AndConstraint<DataRowAssertions<TDataRow>>(this);
+        }
+
+        protected override string Identifier => "DataRow";
+    }
+}

--- a/Src/FluentAssertions/Data/DataSetAssertions.cs
+++ b/Src/FluentAssertions/Data/DataSetAssertions.cs
@@ -1,0 +1,254 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics;
+using System.Linq;
+
+using FluentAssertions.Common;
+using FluentAssertions.Equivalency;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+
+namespace FluentAssertions.Data
+{
+    /// <summary>
+    /// Provides convenient assertion methods on a <see cref="DataSet"/> that can be
+    /// used to assert equivalency and the presence of tables.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class DataSetAssertions<TDataSet> : ReferenceTypeAssertions<DataSet, DataSetAssertions<TDataSet>>
+        where TDataSet : DataSet
+    {
+        public DataSetAssertions(TDataSet dataSet)
+            : base(dataSet)
+        {
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataSet"/> contains exactly the expected number of tables in its <see cref="DataSet.Tables"/> collection.
+        /// </summary>
+        /// <param name="expected">The expected number of rows.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndConstraint<DataSetAssertions<TDataSet>> HaveTableCount(int expected, string because = "", params object[] becauseArgs)
+        {
+            if (Subject is null)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:DataSet} to contain exactly {0} table(s){reason}, but found <null>.", expected);
+            }
+
+            int actualCount = Subject.Tables.Count;
+
+            Execute.Assertion
+                .ForCondition(actualCount == expected)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:DataSet} to contain exactly {0} table(s){reason}, but found {1}.", expected, actualCount);
+
+            return new AndConstraint<DataSetAssertions<TDataSet>>(this);
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataSet"/> contains a table with the expected name.
+        /// </summary>
+        /// <param name="expectedTableName">The value that is expected in <see cref="DataTable.TableName"/>.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndWhichConstraint<DataSetAssertions<TDataSet>, DataTable> HaveTable(string expectedTableName, string because = "", params object[] becauseArgs)
+        {
+            var subjectTable = default(DataTable);
+
+            if (Subject is null)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:DataSet} to contain a table named '{0}'{reason}, but found <null>.", expectedTableName);
+            }
+            else if (!Subject.Tables.Contains(expectedTableName))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:DataSet} to contain a table named '{0}'{reason}, but it does not.", expectedTableName);
+            }
+            else
+            {
+                subjectTable = Subject.Tables[expectedTableName];
+            }
+
+            return new AndWhichConstraint<DataSetAssertions<TDataSet>, DataTable>(this, subjectTable);
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataSet"/> has tables with all of the supplied expected column names.
+        /// </summary>
+        /// <param name="expectedTableNames">An array of values expected in <see cref="DataTable.TableName"/>.</param>
+        public AndConstraint<DataSetAssertions<TDataSet>> HaveTables(params string[] expectedTableNames)
+        {
+            return HaveTables((IEnumerable<string>)expectedTableNames);
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataSet"/> has tables with all of the supplied expected table names.
+        /// </summary>
+        /// <param name="expectedTableNames">An <see cref="IEnumerable{T}"/> of string values expected in <see cref="DataTable.TableName"/>.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndConstraint<DataSetAssertions<TDataSet>> HaveTables(IEnumerable<string> expectedTableNames, string because = "", params object[] becauseArgs)
+        {
+            if (Subject is null)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:DataSet} to contain {0} table(s) with specific names{reason}, but found <null>.", expectedTableNames.Count());
+            }
+
+            foreach (var expectedTableName in expectedTableNames)
+            {
+                Execute.Assertion
+                    .ForCondition(Subject.Tables.Contains(expectedTableName))
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:DataSet} to contain a table named '{0}'{reason}, but it does not.", expectedTableName);
+            }
+
+            return new AndConstraint<DataSetAssertions<TDataSet>>(this);
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataSet"/> is equivalent to another.
+        /// </summary>
+        /// <remarks>
+        /// Data sets are equivalent when their <see cref="DataSet.Tables"/> and <see cref="DataSet.ExtendedProperties"/>
+        /// collections are equivalent and the following members have the same values:
+        /// 
+        /// <list type="bullet">
+        ///   <item><description>DataSetName</description></item>
+        ///   <item><description>CaseSensitive</description></item>
+        ///   <item><description>EnforceConstraints</description></item>
+        ///   <item><description>HasErrors</description></item>
+        ///   <item><description>Locale</description></item>
+        ///   <item><description>Namespace</description></item>
+        ///   <item><description>Prefix</description></item>
+        ///   <item><description>RemotingFormat</description></item>
+        ///   <item><description>SchemaSerializationMode</description></item>
+        /// </list>
+        /// 
+        /// The <see cref="DataSet"/> objects must be of the same type; if two <see cref="DataSet"/> objects
+        /// are equivalent in all ways, except that one is a custom subclass of <see cref="DataSet"/> (e.g. to provide
+        /// typed accessors for <see cref="DataTable"/> values contained by the <see cref="DataSet"/>), then by default,
+        /// they will not be considered equivalent. This can be overridden with the
+        /// <see cref="BeEquivalentTo(DataSet, Func{IDataEquivalencyAssertionOptions{DataSet}, IDataEquivalencyAssertionOptions{DataSet}}, string, object[])"/>
+        /// overload.
+        /// </remarks>
+        /// <param name="expectation">A <see cref="DataColumn"/> with the expected configuration.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndConstraint<DataSetAssertions<TDataSet>> BeEquivalentTo(DataSet expectation, string because = "", params object[] becauseArgs)
+        {
+            return BeEquivalentTo(
+                expectation,
+                options => options,
+                because,
+                becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataSet"/> is equivalent to another.
+        /// </summary>
+        /// <remarks>
+        /// Data sets are equivalent when their <see cref="DataSet.Tables"/> and <see cref="DataSet.ExtendedProperties"/>
+        /// collections are equivalent and the following members have the same values:
+        /// 
+        /// <list type="bullet">
+        ///   <item><description>DataSetName</description></item>
+        ///   <item><description>CaseSensitive</description></item>
+        ///   <item><description>EnforceConstraints</description></item>
+        ///   <item><description>HasErrors</description></item>
+        ///   <item><description>Locale</description></item>
+        ///   <item><description>Namespace</description></item>
+        ///   <item><description>Prefix</description></item>
+        ///   <item><description>RemotingFormat</description></item>
+        ///   <item><description>SchemaSerializationMode</description></item>
+        /// </list>
+        /// 
+        /// The <see cref="DataSet"/> objects must be of the same type; if two <see cref="DataSet"/> objects
+        /// are equivalent in all ways, except that one is a custom subclass of <see cref="DataSet"/> (e.g. to provide
+        /// typed accessors for <see cref="DataTable"/> values contained by the <see cref="DataSet"/>), then by default,
+        /// they will not be considered equivalent.
+        /// 
+        /// This, as well as testing of any property can be overridden using the <paramref name="config"/> callback.
+        /// By calling <see cref="IDataEquivalencyAssertionOptions{T}.AllowingMismatchedTypes"/>, two <see cref="DataSet"/>
+        /// objects of differing types can be considered equivalent. This setting applies to all types recursively tested
+        /// as part of the <see cref="DataSet"/>.
+        ///
+        /// Exclude specific properties using <see cref="IDataEquivalencyAssertionOptions{T}.Excluding(System.Linq.Expressions.Expression{Func{T, object}})"/>.
+        /// Exclude specific tables within the data set using <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingTable(string)"/>
+        /// or a related function. You can also indicate that columns should be excluded within the <see cref="DataTable"/>
+        /// objects recursively tested as part of the <see cref="DataSet"/> using <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingColumn(DataColumn)"/>
+        /// or a related function. The <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingColumnInAllTables(string)"/> method
+        /// can be used to exclude columns across all <see cref="DataTable"/> objects in the <see cref="DataSet"/> that share
+        /// the same name.
+        /// 
+        /// You can use <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingRelated(System.Linq.Expressions.Expression{Func{DataTable, object}})"/>
+        /// and related functions to exclude properties on other related System.Data types.
+        /// </remarks>
+        /// <param name="expectation">A <see cref="DataColumn"/> with the expected configuration.</param>
+        /// <param name="config">
+        /// A reference to the <see cref="IDataEquivalencyAssertionOptions{DataSet}"/> configuration object that can be used
+        /// to influence the way the object graphs are compared. You can also provide an alternative instance of the
+        /// <see cref="IDataEquivalencyAssertionOptions{DataSet}"/> class. The global defaults are determined by the
+        /// <see cref="AssertionOptions"/> class.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndConstraint<DataSetAssertions<TDataSet>> BeEquivalentTo(DataSet expectation, Func<IDataEquivalencyAssertionOptions<DataSet>, IDataEquivalencyAssertionOptions<DataSet>> config, string because = "", params object[] becauseArgs)
+        {
+            Guard.ThrowIfArgumentIsNull(config, nameof(config));
+
+            var options = config(AssertionOptions.CloneDefaults<DataSet, DataEquivalencyAssertionOptions<DataSet>>());
+
+            var callerIdentity = new Lazy<string>(CallerIdentifier.DetermineCallerIdentity);
+
+            var context = new EquivalencyValidationContext(Node.From<DataSet>(() => callerIdentity.Value))
+            {
+                Subject = Subject,
+                Expectation = expectation,
+                CompileTimeType = typeof(TDataSet),
+                Reason = new Reason(because, becauseArgs),
+                TraceWriter = options.TraceWriter
+            };
+
+            var equivalencyValidator = new EquivalencyValidator(options);
+            equivalencyValidator.AssertEquality(context);
+
+            return new AndConstraint<DataSetAssertions<TDataSet>>(this);
+        }
+
+        protected override string Identifier => "DataSet";
+    }
+}

--- a/Src/FluentAssertions/Data/DataTableAssertions.cs
+++ b/Src/FluentAssertions/Data/DataTableAssertions.cs
@@ -1,0 +1,267 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics;
+using System.Linq;
+
+using FluentAssertions.Common;
+using FluentAssertions.Equivalency;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+
+namespace FluentAssertions.Data
+{
+    /// <summary>
+    /// Provides convenient assertion methods on a <see cref="DataTable"/> that can be
+    /// used to assert equivalency and the presence of rows and columns.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class DataTableAssertions<TDataTable> : ReferenceTypeAssertions<DataTable, DataTableAssertions<TDataTable>>
+        where TDataTable : DataTable
+    {
+        public DataTableAssertions(TDataTable dataTable)
+            : base(dataTable)
+        {
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataTable"/> contains exactly the expected number of rows in its <see cref="DataTable.Rows"/> collection.
+        /// </summary>
+        /// <param name="expected">The expected number of rows.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndConstraint<DataTableAssertions<TDataTable>> HaveRowCount(int expected, string because = "", params object[] becauseArgs)
+        {
+            if (Subject is null)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:DataTable} to contain exactly {0} row(s){reason}, but found <null>.", expected);
+            }
+
+            int actualCount = Subject.Rows.Count;
+
+            Execute.Assertion
+                .ForCondition(actualCount == expected)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:DataTable} to contain exactly {0} row(s){reason}, but found {1}.", expected, actualCount);
+
+            return new AndConstraint<DataTableAssertions<TDataTable>>(this);
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataTable"/> has a column with the expected column name.
+        /// </summary>
+        /// <param name="expectedColumnName">The value that is expected in <see cref="DataColumn.ColumnName"/>.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndWhichConstraint<DataTableAssertions<TDataTable>, DataColumn> HaveColumn(string expectedColumnName, string because = "", params object[] becauseArgs)
+        {
+            var subjectColumn = default(DataColumn);
+
+            if (Subject is null)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:DataTable} to contain a column named '{0}'{reason}, but found <null>.", expectedColumnName);
+            }
+            else if (!Subject.Columns.Contains(expectedColumnName))
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:DataTable} to contain a column named '{0}'{reason}, but it does not.", expectedColumnName);
+            }
+            else
+            {
+                subjectColumn = Subject.Columns[expectedColumnName];
+            }
+
+            return new AndWhichConstraint<DataTableAssertions<TDataTable>, DataColumn>(this, subjectColumn);
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataTable"/> has columns with all of the supplied expected column names.
+        /// </summary>
+        /// <param name="expectedColumnNames">An array of values expected in <see cref="DataColumn.ColumnName"/>.</param>
+        public AndConstraint<DataTableAssertions<TDataTable>> HaveColumns(params string[] expectedColumnNames)
+        {
+            return HaveColumns((IEnumerable<string>)expectedColumnNames);
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataTable"/> has columns with all of the supplied expected column names.
+        /// </summary>
+        /// <param name="expectedColumnNames">An <see cref="IEnumerable{T}"/> of string values expected in <see cref="DataColumn.ColumnName"/>.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndConstraint<DataTableAssertions<TDataTable>> HaveColumns(IEnumerable<string> expectedColumnNames, string because = "", params object[] becauseArgs)
+        {
+            if (Subject is null)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:DataTable} to contain {0} column(s) with specific names{reason}, but found <null>.", expectedColumnNames.Count());
+            }
+
+            foreach (var expectedColumnName in expectedColumnNames)
+            {
+                Execute.Assertion
+                    .ForCondition(Subject.Columns.Contains(expectedColumnName))
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context:DataTable} to contain a column named '{0}'{reason}, but it does not.", expectedColumnName);
+            }
+
+            return new AndConstraint<DataTableAssertions<TDataTable>>(this);
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataTable"/> is equivalent to another.
+        /// </summary>
+        /// <remarks>
+        /// Data tables are equivalent when the following members have the same values:
+        /// 
+        /// <list type="bullet">
+        ///   <item><description>TableName</description></item>
+        ///   <item><description>CaseSensitive</description></item>
+        ///   <item><description>DisplayExpression</description></item>
+        ///   <item><description>HasErrors</description></item>
+        ///   <item><description>Locale</description></item>
+        ///   <item><description>Namespace</description></item>
+        ///   <item><description>Prefix</description></item>
+        ///   <item><description>RemotingFormat</description></item>
+        /// </list>
+        /// 
+        /// In addition, the following collections must contain equivalent data:
+        /// 
+        /// <list type="type=bullet">
+        ///   <item><description>ChildRelations</description></item>
+        ///   <item><description>Columns</description></item>
+        ///   <item><description>Constraints</description></item>
+        ///   <item><description>ExtendedProperties</description></item>
+        ///   <item><description>ParentRelations</description></item>
+        ///   <item><description>PrimaryKey</description></item>
+        ///   <item><description>Rows</description></item>
+        /// </list>
+        /// 
+        /// The <see cref="DataTable"/> objects must be of the same type; if two <see cref="DataTable"/> objects
+        /// are equivalent in all ways, except that one is a typed <see cref="DataTable"/> that is a subclass
+        /// of <see cref="DataTable"/>, then by default, they will not be considered equivalent. This can be overridden
+        /// with the <see cref="BeEquivalentTo(DataTable, Func{IDataEquivalencyAssertionOptions{DataTable}, IDataEquivalencyAssertionOptions{DataTable}}, string, object[])"/>
+        /// overload.
+        /// </remarks>
+        /// <param name="expectation">A <see cref="DataColumn"/> with the expected configuration.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndConstraint<DataTableAssertions<TDataTable>> BeEquivalentTo(DataTable expectation, string because = "", params object[] becauseArgs)
+        {
+            return BeEquivalentTo(
+                expectation,
+                options => options,
+                because,
+                becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts that an instance of <see cref="DataTable"/> is equivalent to another.
+        /// </summary>
+        /// <remarks>
+        /// Data tables are equivalent when the following members have the same values:
+        /// 
+        /// <list type="bullet">
+        ///   <item><description>TableName</description></item>
+        ///   <item><description>CaseSensitive</description></item>
+        ///   <item><description>DisplayExpression</description></item>
+        ///   <item><description>HasErrors</description></item>
+        ///   <item><description>Locale</description></item>
+        ///   <item><description>Namespace</description></item>
+        ///   <item><description>Prefix</description></item>
+        ///   <item><description>RemotingFormat</description></item>
+        /// </list>
+        /// 
+        /// In addition, the following collections must contain equivalent data:
+        /// 
+        /// <list type="type=bullet">
+        ///   <item><description>ChildRelations</description></item>
+        ///   <item><description>Columns</description></item>
+        ///   <item><description>Constraints</description></item>
+        ///   <item><description>ExtendedProperties</description></item>
+        ///   <item><description>ParentRelations</description></item>
+        ///   <item><description>PrimaryKey</description></item>
+        ///   <item><description>Rows</description></item>
+        /// </list>
+        /// 
+        /// The <see cref="DataTable"/> objects must be of the same type; if two <see cref="DataTable"/> objects
+        /// are equivalent in all ways, except that one is a typed <see cref="DataTable"/> that is a subclass
+        /// of <see cref="DataTable"/>, then by default, they will not be considered equivalent.
+        /// 
+        /// This, as well as testing of any property can be overridden using the <paramref name="config"/> callback.
+        /// By calling <see cref="IDataEquivalencyAssertionOptions{T}.AllowingMismatchedTypes"/>, two <see cref="DataTable"/>
+        /// objects of differing types can be considered equivalent. Exclude specific properties using
+        /// <see cref="IDataEquivalencyAssertionOptions{T}.Excluding(System.Linq.Expressions.Expression{Func{T, object}})"/>.
+        /// Exclude columns of the data table using <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingColumn(DataColumn)"/>
+        /// or a related function -- this excludes both the <see cref="DataColumn"/> objects in <see cref="DataTable.Columns"/>
+        /// and associated field data in <see cref="DataRow"/> objects within the <see cref="DataTable"/>.
+        /// 
+        /// You can use <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingRelated(System.Linq.Expressions.Expression{Func{DataTable, object}})"/>
+        /// and related functions to exclude properties on other related System.Data types.
+        /// </remarks>
+        /// <param name="expectation">A <see cref="DataColumn"/> with the expected configuration.</param>
+        /// <param name="config">
+        /// A reference to the <see cref="IDataEquivalencyAssertionOptions{DataTable}"/> configuration object that can be used
+        /// to influence the way the object graphs are compared. You can also provide an alternative instance of the
+        /// <see cref="IDataEquivalencyAssertionOptions{DataTable}"/> class. The global defaults are determined by the
+        /// <see cref="AssertionOptions"/> class.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndConstraint<DataTableAssertions<TDataTable>> BeEquivalentTo(DataTable expectation, Func<IDataEquivalencyAssertionOptions<DataTable>, IDataEquivalencyAssertionOptions<DataTable>> config, string because = "", params object[] becauseArgs)
+        {
+            Guard.ThrowIfArgumentIsNull(config, nameof(config));
+
+            var options = config(AssertionOptions.CloneDefaults<DataTable, DataEquivalencyAssertionOptions<DataTable>>());
+
+            var callerIdentity = new Lazy<string>(CallerIdentifier.DetermineCallerIdentity);
+
+            var context = new EquivalencyValidationContext(Node.From<DataTable>(() => callerIdentity.Value))
+            {
+                Subject = Subject,
+                Expectation = expectation,
+                CompileTimeType = typeof(TDataTable),
+                Reason = new Reason(because, becauseArgs),
+                TraceWriter = options.TraceWriter
+            };
+
+            var equivalencyValidator = new EquivalencyValidator(options);
+            equivalencyValidator.AssertEquality(context);
+
+            return new AndConstraint<DataTableAssertions<TDataTable>>(this);
+        }
+
+        protected override string Identifier => "DataTable";
+    }
+}

--- a/Src/FluentAssertions/Data/IDataEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Data/IDataEquivalencyAssertionOptions.cs
@@ -1,0 +1,195 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq.Expressions;
+
+using FluentAssertions.Equivalency;
+
+namespace FluentAssertions.Data
+{
+    /// <summary>
+    /// Provides access to configuration for equivalency assertions on System.Data types (<see cref="DataSet"/>,
+    /// <see cref="DataTable"/>, <see cref="DataRow"/>, <see cref="DataColumn"/>, <see cref="DataRelation"/>,
+    /// <see cref="Constraint"/>).
+    /// </summary>
+    /// <typeparam name="T">The System.Data type being tested for equivalency.</typeparam>
+    public interface IDataEquivalencyAssertionOptions<T> : IEquivalencyAssertionOptions
+    {
+        /// <summary>
+        /// Specifies that the subject and the expectation should not be considered non-equivalent if their exact data types do not match.
+        /// </summary>
+        IDataEquivalencyAssertionOptions<T> AllowingMismatchedTypes();
+
+        /// <summary>
+        /// Specifies that when comparing <see cref="DataTable.Columns"/>, columns that are unmatched between the subject and the expectation should be ignored.
+        /// </summary>
+        IDataEquivalencyAssertionOptions<T> IgnoringUnmatchedColumns();
+
+        /// <summary>
+        /// Specifies the <see cref="RowMatchMode"/> that should be used when comparing <see cref="DataTable.Rows"/>. By default, rows are matched by their index in the <see cref="DataTable.Rows"/> collection. But, if the <see cref="DataTable"/> has a <see cref="DataTable.PrimaryKey"/> set, it is possible to use <see cref="RowMatchMode.PrimaryKey"/> to indicate that rows should be matched by their primary key values, irrespective of their index within the <see cref="DataTable.Rows"/> collection.
+        /// </summary>
+        /// <param name="rowMatchMode">The <see cref="RowMatchMode"/> to use when comparing <see cref="DataTable.Rows"/> between the subject and the expectation.</param>
+        IDataEquivalencyAssertionOptions<T> UsingRowMatchMode(RowMatchMode rowMatchMode);
+
+        /// <summary>
+        /// Specifies that when comparing <see cref="DataRow"/> objects that are in the <see cref="DataRowState.Modified"/> state, only the current field values should be compared. Original field values are excluded from comparison. This only affects comparisons where both the subject and the expectation are in the modified state.
+        /// </summary>
+        IDataEquivalencyAssertionOptions<T> ExcludingOriginalData();
+
+        /// <summary>
+        /// Excludes members of the objects under test from comparison by means of a predicate that selects members based on <see cref="IMemberInfo"/> objects describing them.
+        /// </summary>
+        /// <param name="predicate">A functor that returns true if the <see cref="IMemberInfo"/> parameter refers to a member that should be excluded.</param>
+        IDataEquivalencyAssertionOptions<T> Excluding(Expression<Func<IMemberInfo, bool>> predicate);
+
+        /// <summary>
+        /// Excludes a member of the objects under test from comparison by means of an <see cref="Expression{TDelegate}"/> that refers to the member in question.
+        /// </summary>
+        /// <param name="expression">An <see cref="Expression{TDelegate}"/> that accesses the member to be excluded.</param>
+        IDataEquivalencyAssertionOptions<T> Excluding(Expression<Func<T, object>> expression);
+
+        /// <summary>
+        /// Excludes an entire table from comparison. When comparing <see cref="DataSet"/> objects, if a table is present by the supplied name, it is not considered for the purpose of determining equivalency. This configuration option has no effect when comparing other types of object, including <see cref="DataTable"/>.
+        /// </summary>
+        /// <param name="tableName">The value for <see cref="DataTable.TableName"/> for which tables within a <see cref="DataSet"/> should be ignored.</param>
+        IDataEquivalencyAssertionOptions<T> ExcludingTable(string tableName);
+
+        /// <summary>
+        /// Excludes tables from comparison using names in an <see cref="IEnumerable{T}"/> set. When comparing <see cref="DataSet"/> objects, if a table is present by one of the supplied names, it is not considered for the purpose of determining equivalency. This configuration option has no effect when comparing other types of object, including <see cref="DataTable"/>.
+        /// </summary>
+        /// <param name="tableNames">An <see cref="IEnumerable{T}"/> of <see cref="string"/> values for <see cref="DataTable.TableName"/> for which tables within a <see cref="DataSet"/> should be ignored.</param>
+        IDataEquivalencyAssertionOptions<T> ExcludingTables(IEnumerable<string> tableNames);
+
+        /// <summary>
+        /// Excludes tables from comparison using an array of table names. When comparing <see cref="DataSet"/> objects, if a table is present by one of the supplied names, it is not considered for the purpose of determining equivalency. This configuration option has no effect when comparing other types of object, including <see cref="DataTable"/>.
+        /// </summary>
+        /// <param name="tableNames">An array of <see cref="string"/> values for <see cref="DataTable.TableName"/> for which tables within a <see cref="DataSet"/> should be ignored.</param>
+        IDataEquivalencyAssertionOptions<T> ExcludingTables(params string[] tableNames);
+
+        /// <summary>
+        /// Excludes a column from comparison by <see cref="DataColumn"/>. The column to be excluded is matched by the name of its associated <see cref="DataTable"/> and its own <see cref="DataColumn.ColumnName"/>.
+        /// </summary>
+        /// <param name="column">A <see cref="DataColumn"/> object that specifies which column should be ignored.</param>
+        /// <remarks>
+        /// When comparing <see cref="DataColumn"/> objects (e.g. within <see cref="DataColumnCollection"/>), excluded columns are ignored completely. When comparing <see cref="DataRow"/> objects, the data associated with excluded columns is ignored.
+        /// </remarks>
+        IDataEquivalencyAssertionOptions<T> ExcludingColumn(DataColumn column);
+
+        /// <summary>
+        /// Excludes a column from comparison by the name of its associated <see cref="DataTable"/> and its own <see cref="DataColumn.ColumnName"/>.
+        /// </summary>
+        /// <param name="tableName">The value for <see cref="DataTable.TableName"/> for which columns should be ignored.</param>
+        /// <param name="columnName">The value for <see cref="DataColumn.ColumnName"/> for which columns should be ignored.</param>
+        /// <remarks>
+        /// When comparing <see cref="DataColumn"/> objects (e.g. within <see cref="DataColumnCollection"/>), excluded columns are ignored completely. When comparing <see cref="DataRow"/> objects, the data associated with excluded columns is ignored.
+        /// </remarks>
+        IDataEquivalencyAssertionOptions<T> ExcludingColumn(string tableName, string columnName);
+
+        /// <summary>
+        /// Exclude an enumerable set of columns from comparison by <see cref="DataColumn"/>. For each item in the enumeration, the column to be excluded is matched by the name of its associated <see cref="DataTable"/> and its own <see cref="DataColumn.ColumnName"/>.
+        /// </summary>
+        /// <param name="columns">An <see cref="IEnumerable{T}"/> object that specifies which column(s) should be ignored.</param>
+        /// <remarks>
+        /// When comparing <see cref="DataColumn"/> objects (e.g. within <see cref="DataColumnCollection"/>), excluded columns are ignored completely. When comparing <see cref="DataRow"/> objects, the data associated with excluded columns is ignored.
+        /// </remarks>
+        IDataEquivalencyAssertionOptions<T> ExcludingColumns(IEnumerable<DataColumn> columns);
+
+        /// <summary>
+        /// Excludes an array of columns from comparison by <see cref="DataColumn"/>. For each element in the array, the column to be excluded is matched by the name of its associated <see cref="DataTable"/> and its own <see cref="DataColumn.ColumnName"/>.
+        /// </summary>
+        /// <param name="columns">An array of <see cref="DataColumn"/> objects that specify which columns should be ignored.</param>
+        /// <remarks>
+        /// When comparing <see cref="DataColumn"/> objects (e.g. within <see cref="DataColumnCollection"/>), excluded columns are ignored completely. When comparing <see cref="DataRow"/> objects, the data associated with excluded columns is ignored.
+        /// </remarks>
+        IDataEquivalencyAssertionOptions<T> ExcludingColumns(params DataColumn[] columns);
+
+        /// <summary>
+        /// Excludes an enumerable set of columns from comparison by name, within tables with a specified name./>.
+        /// </summary>
+        /// <param name="tableName">The value for <see cref="DataTable.TableName"/> for which columns should be ignored.</param>
+        /// <param name="columnNames">An <see cref="IEnumerable{T}"/> of <see cref="string"/> values that specify the <see cref="DataColumn.ColumnName"/> values for which columns should be ignored.</param>
+        /// <remarks>
+        /// When comparing <see cref="DataColumn"/> objects (e.g. within <see cref="DataColumnCollection"/>), excluded columns are ignored completely. When comparing <see cref="DataRow"/> objects, the data associated with excluded columns is ignored.
+        /// </remarks>
+        IDataEquivalencyAssertionOptions<T> ExcludingColumns(string tableName, IEnumerable<string> columnNames);
+
+        /// <summary>
+        /// Excludes an array of columns from comparison by name, within tables with a specified name./>.
+        /// </summary>
+        /// <param name="tableName">The value for <see cref="DataTable.TableName"/> for which columns should be ignored.</param>
+        /// <param name="columnNames">An array of <see cref="string"/> values that specify the <see cref="DataColumn.ColumnName"/> values for which columns should be ignored.</param>
+        /// <remarks>
+        /// When comparing <see cref="DataColumn"/> objects (e.g. within <see cref="DataColumnCollection"/>), excluded columns are ignored completely. When comparing <see cref="DataRow"/> objects, the data associated with excluded columns is ignored.
+        /// </remarks>
+        IDataEquivalencyAssertionOptions<T> ExcludingColumns(string tableName, params string[] columnNames);
+
+        /// <summary>
+        /// Excludes columns from comparison by <see cref="DataColumn"/> comparing only the <see cref="DataColumn.ColumnName"/>. If columns exist by the same name in multiple <see cref="DataTable"/> objects within a <see cref="DataSet"/>, they are all excluded from comparison.
+        /// </summary>
+        /// <param name="columnName">The value for <see cref="DataColumn.ColumnName"/> for which columns should be ignored.</param>
+        /// <remarks>
+        /// When comparing <see cref="DataColumn"/> objects (e.g. within <see cref="DataColumnCollection"/>), excluded columns are ignored completely. When comparing <see cref="DataRow"/> objects, the data associated with excluded columns is ignored.
+        /// </remarks>
+        IDataEquivalencyAssertionOptions<T> ExcludingColumnInAllTables(string columnName);
+
+        /// <summary>
+        /// Excludes columns from comparison by <see cref="DataColumn"/> comparing only the <see cref="DataColumn.ColumnName"/>. If columns exist by the same name in multiple <see cref="DataTable"/> objects within a <see cref="DataSet"/>, they are all excluded from comparison.
+        /// </summary>
+        /// <param name="columnNames">An <see cref="IEnumerable{T}"/> of <see cref="string"/> values that specify the <see cref="DataColumn.ColumnName"/> values for which columns should be ignored.</param>
+        /// <remarks>
+        /// When comparing <see cref="DataColumn"/> objects (e.g. within <see cref="DataColumnCollection"/>), excluded columns are ignored completely. When comparing <see cref="DataRow"/> objects, the data associated with excluded columns is ignored.
+        /// </remarks>
+        IDataEquivalencyAssertionOptions<T> ExcludingColumnsInAllTables(IEnumerable<string> columnNames);
+
+        /// <summary>
+        /// Excludes columns from comparison by <see cref="DataColumn"/> comparing only the <see cref="DataColumn.ColumnName"/>. If columns exist by the same name in multiple <see cref="DataTable"/> objects within a <see cref="DataSet"/>, they are all excluded from comparison.
+        /// </summary>
+        /// <param name="columnNames">An array of <see cref="string"/> values that specify the <see cref="DataColumn.ColumnName"/> values for which columns should be ignored.</param>
+        /// <remarks>
+        /// When comparing <see cref="DataColumn"/> objects (e.g. within <see cref="DataColumnCollection"/>), excluded columns are ignored completely. When comparing <see cref="DataRow"/> objects, the data associated with excluded columns is ignored.
+        /// </remarks>
+        IDataEquivalencyAssertionOptions<T> ExcludingColumnsInAllTables(params string[] columnNames);
+
+        /// <summary>
+        /// Excludes properties of <see cref="Constraint"/> from comparison by means of an<see cref= "Expression{TDelegate}" /> that refers to the member in question.
+        /// </summary>
+        /// <param name="expression">An <see cref="Expression{TDelegate}"/> that accesses the member to be excluded.</param>
+        IDataEquivalencyAssertionOptions<T> ExcludingRelated(Expression<Func<Constraint, object>> expression);
+
+        /// <summary>
+        /// Excludes properties of <see cref="Constraint"/> from comparison by means of an<see cref= "Expression{TDelegate}" /> that refers to the member in question.
+        /// </summary>
+        /// <param name="expression">An <see cref="Expression{TDelegate}"/> that accesses the member to be excluded.</param>
+        IDataEquivalencyAssertionOptions<T> ExcludingRelated(Expression<Func<ForeignKeyConstraint, object>> expression);
+
+        /// <summary>
+        /// Excludes properties of <see cref="Constraint"/> from comparison by means of an<see cref= "Expression{TDelegate}" /> that refers to the member in question.
+        /// </summary>
+        /// <param name="expression">An <see cref="Expression{TDelegate}"/> that accesses the member to be excluded.</param>
+        IDataEquivalencyAssertionOptions<T> ExcludingRelated(Expression<Func<UniqueConstraint, object>> expression);
+
+        /// <summary>
+        /// Excludes properties of <see cref="DataColumn"/> from comparison by means of an<see cref= "Expression{TDelegate}" /> that refers to the member in question.
+        /// </summary>
+        /// <param name="expression">An <see cref="Expression{TDelegate}"/> that accesses the member to be excluded.</param>
+        IDataEquivalencyAssertionOptions<T> ExcludingRelated(Expression<Func<DataColumn, object>> expression);
+
+        /// <summary>
+        /// Excludes properties of <see cref="DataRelation"/> from comparison by means of an<see cref= "Expression{TDelegate}" /> that refers to the member in question.
+        /// </summary>
+        /// <param name="expression">An <see cref="Expression{TDelegate}"/> that accesses the member to be excluded.</param>
+        IDataEquivalencyAssertionOptions<T> ExcludingRelated(Expression<Func<DataRelation, object>> expression);
+
+        /// <summary>
+        /// Excludes properties of <see cref="DataRow"/> from comparison by means of an<see cref= "Expression{TDelegate}" /> that refers to the member in question.
+        /// </summary>
+        /// <param name="expression">An <see cref="Expression{TDelegate}"/> that accesses the member to be excluded.</param>
+        IDataEquivalencyAssertionOptions<T> ExcludingRelated(Expression<Func<DataRow, object>> expression);
+
+        /// <summary>
+        /// Excludes properties of <see cref="DataTable"/> from comparison by means of an<see cref= "Expression{TDelegate}" /> that refers to the member in question.
+        /// </summary>
+        /// <param name="expression">An <see cref="Expression{TDelegate}"/> that accesses the member to be excluded.</param>
+        IDataEquivalencyAssertionOptions<T> ExcludingRelated(Expression<Func<DataTable, object>> expression);
+    }
+}

--- a/Src/FluentAssertions/Data/RowMatchMode.cs
+++ b/Src/FluentAssertions/Data/RowMatchMode.cs
@@ -1,0 +1,25 @@
+﻿using System.Data;
+
+namespace FluentAssertions.Data
+{
+    /// <summary>
+    /// Indicates how <see cref="DataRow"/> objects from different <see cref="DataTable"/> objects should be matched
+    /// up for equivalency comparisons.
+    /// </summary>
+    public enum RowMatchMode
+    {
+        /// <summary>
+        /// Indicates that <see cref="DataRow"/> objects should be matched up by their index within the
+        /// <see cref="DataTable.Rows"/> collection. This is the default.
+        /// </summary>
+        Index,
+
+        /// <summary>
+        /// Indicates that <see cref="DataRow"/> objects should be matched up by the values they have for
+        /// the table's <see cref="DataTable.PrimaryKey"/>. For this to work, the rows must be from
+        /// <see cref="DataTable"/> objects with exactly equivalent <see cref="DataTable.PrimaryKey"/>
+        /// configuration.
+        /// </summary>
+        PrimaryKey,
+    }
+}

--- a/Src/FluentAssertions/DataRowAssertionExtensions.cs
+++ b/Src/FluentAssertions/DataRowAssertionExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System.Data;
+using System.Diagnostics;
+
+using FluentAssertions.Data;
+
+using JetBrains.Annotations;
+
+namespace FluentAssertions
+{
+    /// <summary>
+    /// Contains an extension method for custom assertions in unit tests related to DataRow objects.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public static class DataRowAssertionExtensions
+    {
+        /// <summary>
+        /// Returns a <see cref="DataRowAssertions{DataRow}"/> object that can be used to assert the
+        /// current <see cref="DataRow"/>.
+        /// </summary>
+        [Pure]
+        public static DataRowAssertions<TDataRow> Should<TDataRow>(this TDataRow actualValue)
+            where TDataRow : DataRow
+        {
+            return new DataRowAssertions<TDataRow>(actualValue);
+        }
+    }
+}

--- a/Src/FluentAssertions/DataSetAssertionExtensions.cs
+++ b/Src/FluentAssertions/DataSetAssertionExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System.Data;
+using System.Diagnostics;
+
+using FluentAssertions.Data;
+
+using JetBrains.Annotations;
+
+namespace FluentAssertions
+{
+    /// <summary>
+    /// Contains an extension method for custom assertions in unit tests related to DataSet objects.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public static class DataSetAssertionExtensions
+    {
+        /// <summary>
+        /// Returns a <see cref="DataSetAssertions{DataSet}"/> object that can be used to assert the
+        /// current <see cref="DataSet"/>.
+        /// </summary>
+        [Pure]
+        public static DataSetAssertions<TDataSet> Should<TDataSet>(this TDataSet actualValue)
+            where TDataSet : DataSet
+        {
+            return new DataSetAssertions<TDataSet>(actualValue);
+        }
+    }
+}

--- a/Src/FluentAssertions/DataTableAssertionExtensions.cs
+++ b/Src/FluentAssertions/DataTableAssertionExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System.Data;
+using System.Diagnostics;
+
+using FluentAssertions.Data;
+
+using JetBrains.Annotations;
+
+namespace FluentAssertions
+{
+    /// <summary>
+    /// Contains an extension method for custom assertions in unit tests related to DataTable objects.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public static class DataTableAssertionExtensions
+    {
+        /// <summary>
+        /// Returns a <see cref="DataTableAssertions{DataTable}"/> object that can be used to assert the
+        /// current <see cref="DataTable"/>.
+        /// </summary>
+        [Pure]
+        public static DataTableAssertions<TDataTable> Should<TDataTable>(this TDataTable actualValue)
+            where TDataTable : DataTable
+        {
+            return new DataTableAssertions<TDataTable>(actualValue);
+        }
+    }
+}

--- a/Src/FluentAssertions/Equivalency/ConstraintCollectionEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/ConstraintCollectionEquivalencyStep.cs
@@ -1,0 +1,62 @@
+﻿using System.Data;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Equivalency
+{
+    public class ConstraintCollectionEquivalencyStep : IEquivalencyStep
+    {
+        public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
+        {
+            return typeof(ConstraintCollection).IsAssignableFrom(config.GetExpectationType(context.RuntimeType, context.CompileTimeType));
+        }
+
+        [SuppressMessage("Style", "IDE0038:Use pattern matching", Justification = "Would decrease code clarity")]
+        public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
+        {
+            if (!(context.Subject is ConstraintCollection))
+            {
+                AssertionScope.Current
+                    .FailWith("Expected a value of type ConstraintCollection at {context:Constraints}, but found {0}", context.Subject.GetType());
+            }
+            else
+            {
+                var subject = (ConstraintCollection)context.Subject;
+                var expectation = (ConstraintCollection)context.Expectation;
+
+                var subjectConstraints = subject.Cast<Constraint>().ToDictionary(constraint => constraint.ConstraintName);
+                var expectationConstraints = expectation.Cast<Constraint>().ToDictionary(constraint => constraint.ConstraintName);
+
+                var constraintNames = subjectConstraints.Keys.Union(expectationConstraints.Keys);
+
+                foreach (var constraintName in constraintNames)
+                {
+                    AssertionScope.Current
+                        .ForCondition(subjectConstraints.TryGetValue(constraintName, out var subjectConstraint))
+                        .FailWith("Expected constraint named {0} in {context:Constraints collection}{reason}, but did not find one", constraintName);
+
+                    AssertionScope.Current
+                        .ForCondition(expectationConstraints.TryGetValue(constraintName, out var expectationConstraint))
+                        .FailWith("Found unexpected constraint named {0} in {context:Constraints collection}", constraintName);
+
+                    if ((subjectConstraint != null) && (expectationConstraint != null))
+                    {
+                        var nestedContext = context.AsCollectionItem(
+                            constraintName,
+                            subjectConstraint,
+                            expectationConstraint);
+
+                        if (nestedContext != null)
+                        {
+                            parent.AssertEqualityUsing(nestedContext);
+                        }
+                    }
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Src/FluentAssertions/Equivalency/ConstraintEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/ConstraintEquivalencyStep.cs
@@ -1,0 +1,263 @@
+﻿using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+
+using FluentAssertions.Execution;
+using FluentAssertions.Formatting;
+
+namespace FluentAssertions.Equivalency
+{
+    public class ConstraintEquivalencyStep : IEquivalencyStep
+    {
+        public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
+        {
+            return typeof(Constraint).IsAssignableFrom(config.GetExpectationType(context.RuntimeType, context.CompileTimeType));
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0038:Use pattern matching", Justification = "Would decrease code clarity")]
+        public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
+        {
+            if (!(context.Subject is Constraint))
+            {
+                AssertionScope.Current
+                    .FailWith("Expected {context:constraint} to be a value of type Constraint, but found {0}", context.Subject.GetType());
+            }
+            else
+            {
+                var subject = (Constraint)context.Subject;
+                var expectation = (Constraint)context.Expectation;
+
+                var selectedMembers = GetMembersFromExpectation(context, config)
+                    .ToDictionary(member => member.Name);
+
+                CompareCommonProperties(context, parent, config, subject, expectation, selectedMembers);
+
+                bool matchingType = subject.GetType() == expectation.GetType();
+
+                AssertionScope.Current
+                    .ForCondition(matchingType)
+                    .FailWith("Expected {context:constraint} to be of type {0}, but found {1}", expectation.GetType(), subject.GetType());
+
+                if (matchingType)
+                {
+                    if ((subject is UniqueConstraint subjectUniqueConstraint)
+                     && (expectation is UniqueConstraint expectationUniqueConstraint))
+                    {
+                        CompareConstraints(parent, context, subjectUniqueConstraint, expectationUniqueConstraint, selectedMembers);
+                    }
+                    else if ((subject is ForeignKeyConstraint subjectForeignKeyConstraint)
+                          && (expectation is ForeignKeyConstraint expectationForeignKeyConstraint))
+                    {
+                        CompareConstraints(parent, context, subjectForeignKeyConstraint, expectationForeignKeyConstraint, selectedMembers);
+                    }
+                    else
+                    {
+                        AssertionScope.Current
+                            .FailWith("Don't know how to handle {constraint:a Constraint} of type {0}", subject.GetType());
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private static void CompareCommonProperties(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config, Constraint subject, Constraint expectation, Dictionary<string, IMember> selectedMembers)
+        {
+            if (selectedMembers.ContainsKey("ConstraintName"))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.ConstraintName == expectation.ConstraintName)
+                    .FailWith("Expected {context:constraint} to have a ConstraintName of {0}{reason}, but found {1}", expectation.ConstraintName, subject.ConstraintName);
+            }
+
+            if (selectedMembers.ContainsKey("Table"))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.Table.TableName == expectation.Table.TableName)
+                    .FailWith("Expected {context:constraint} to be associated with a Table with TableName of {0}{reason}, but found {1}", expectation.Table.TableName, subject.Table.TableName);
+            }
+
+            if (selectedMembers.TryGetValue("ExtendedProperties", out var expectationMember))
+            {
+                var matchingMember = FindMatchFor(expectationMember, context, config);
+
+                if (matchingMember != null)
+                {
+                    IEquivalencyValidationContext nestedContext =
+                        context.AsNestedMember(expectationMember, matchingMember);
+
+                    if (nestedContext != null)
+                    {
+                        parent.AssertEqualityUsing(nestedContext);
+                    }
+                }
+            }
+        }
+
+        private static void CompareConstraints(IEquivalencyValidator parent, IEquivalencyValidationContext context, UniqueConstraint subject, UniqueConstraint expectation, Dictionary<string, IMember> selectedMembers)
+        {
+            AssertionScope.Current
+                .ForCondition(subject.ConstraintName == expectation.ConstraintName)
+                .FailWith("Expected {context:constraint} to be named {0}{reason}, but found {1}", expectation.ConstraintName, subject.ConstraintName);
+
+            parent.AssertEqualityUsing(
+                CreateNestedContext(context, nameof(subject.ExtendedProperties)));
+
+            if (selectedMembers.ContainsKey(nameof(expectation.IsPrimaryKey)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.IsPrimaryKey == expectation.IsPrimaryKey)
+                    .FailWith("Expected {context:constraint} to be a {0} constraint{reason}, but found a {1} constraint",
+                        expectation.IsPrimaryKey ? "Primary Key" : "Foreign Key",
+                        subject.IsPrimaryKey ? "Primary Key" : "Foreign Key");
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.Columns)))
+            {
+                CompareConstraintColumns(subject.Columns, expectation.Columns);
+            }
+        }
+
+        private static void CompareConstraints(IEquivalencyValidator parent, IEquivalencyValidationContext context, ForeignKeyConstraint subject, ForeignKeyConstraint expectation, Dictionary<string, IMember> selectedMembers)
+        {
+            AssertionScope.Current
+                .ForCondition(subject.ConstraintName == expectation.ConstraintName)
+                .FailWith("Expected {context:constraint} to be named {0}{reason}, but found {1}", expectation.ConstraintName, subject.ConstraintName);
+
+            parent.AssertEqualityUsing(
+                CreateNestedContext(context, nameof(subject.ExtendedProperties)));
+
+            if (selectedMembers.ContainsKey(nameof(expectation.RelatedTable)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.RelatedTable.TableName == expectation.RelatedTable.TableName)
+                    .FailWith("Expected {context:constraint} to have a related table named {0}{reason}, but found {1}", expectation.RelatedTable.TableName, subject.RelatedTable.TableName);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.AcceptRejectRule)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.AcceptRejectRule == expectation.AcceptRejectRule)
+                    .FailWith("Expected {context:constraint} to have AcceptRejectRule.{0}{reason}, but found AcceptRejectRule.{1}", expectation.AcceptRejectRule, subject.AcceptRejectRule);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.DeleteRule)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.DeleteRule == expectation.DeleteRule)
+                    .FailWith("Expected {context:constraint} to have DeleteRule Rule.{0}{reason}, but found Rule.{1}", expectation.DeleteRule, subject.DeleteRule);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.UpdateRule)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.UpdateRule == expectation.UpdateRule)
+                    .FailWith("Expected {context:constraint} to have UpdateRule Rule.{0}{reason}, but found Rule.{1}", expectation.UpdateRule, subject.UpdateRule);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.Columns)))
+            {
+                CompareConstraintColumns(subject.Columns, expectation.Columns);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.RelatedColumns)))
+            {
+                CompareConstraintColumns(subject.RelatedColumns, expectation.RelatedColumns);
+            }
+        }
+
+        private static void CompareConstraintColumns(DataColumn[] subjectColumns, DataColumn[] expectationColumns)
+        {
+            var subjectColumnNames = new HashSet<string>(subjectColumns.Select(col => col.ColumnName));
+            var expectationColumnNames = new HashSet<string>(expectationColumns.Select(col => col.ColumnName));
+
+            var missingColumnNames = expectationColumnNames.Except(subjectColumnNames).ToList();
+            var extraColumnNames = subjectColumnNames.Except(expectationColumnNames).ToList();
+
+            var failureMessage = new StringBuilder();
+
+            if (missingColumnNames.Any())
+            {
+                failureMessage.Append("Expected {context:constraint} to include ");
+
+                if (missingColumnNames.Count == 1)
+                {
+                    failureMessage.Append("column ").Append(missingColumnNames.Single());
+                }
+                else
+                {
+                    failureMessage.Append("columns ").Append(missingColumnNames.JoinUsingWritingStyle());
+                }
+
+                failureMessage.Append("{reason}, but constraint does not include ");
+                failureMessage.Append((missingColumnNames.Count == 1)
+                    ? "that column. "
+                    : "these columns. ");
+            }
+
+            if (extraColumnNames.Any())
+            {
+                failureMessage.Append("Did not expect {context:constraint} to include ");
+
+                if (extraColumnNames.Count == 1)
+                {
+                    failureMessage.Append("column ").Append(extraColumnNames.Single());
+                }
+                else
+                {
+                    failureMessage.Append("columns ").Append(extraColumnNames.JoinUsingWritingStyle());
+                }
+
+                failureMessage.Append("{reason}, but it does.");
+            }
+
+            bool successful = failureMessage.Length == 0;
+
+            AssertionScope.Current
+                .ForCondition(successful)
+                .FailWith(failureMessage.ToString());
+        }
+
+        private static IEquivalencyValidationContext CreateNestedContext(IEquivalencyValidationContext context, string name)
+        {
+            var nestedMember = new Property(
+                typeof(Constraint).GetProperty(name),
+                context.CurrentNode);
+
+            return context.AsNestedMember(nestedMember, nestedMember);
+        }
+
+        private static IMember FindMatchFor(IMember selectedMemberInfo, IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
+        {
+            IEnumerable<IMember> query =
+                from rule in config.MatchingRules
+                let match = rule.Match(selectedMemberInfo, context.Subject, context.CurrentNode, config)
+                where match != null
+                select match;
+
+            return query.FirstOrDefault();
+        }
+
+        private static IEnumerable<IMember> GetMembersFromExpectation(IEquivalencyValidationContext context,
+            IEquivalencyAssertionOptions config)
+        {
+            IEnumerable<IMember> members = Enumerable.Empty<IMember>();
+
+            foreach (IMemberSelectionRule rule in config.SelectionRules)
+            {
+                // Within a ConstraintCollection, different types of Constraint are kept polymorphically.
+                // As such, the concept of "compile-time type" isn't meaningful, and we override this
+                // with the discovered type of the constraint at runtime.
+                members = rule.SelectMembers(context.CurrentNode, members, new MemberSelectionContext
+                {
+                    CompileTimeType = context.RuntimeType, // intentional
+                    RuntimeType = context.RuntimeType,
+                    Options = config
+                });
+            }
+
+            return members;
+        }
+    }
+}

--- a/Src/FluentAssertions/Equivalency/DataColumnEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataColumnEquivalencyStep.cs
@@ -1,0 +1,150 @@
+﻿using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+
+using FluentAssertions.Data;
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Equivalency
+{
+    public class DataColumnEquivalencyStep : IEquivalencyStep
+    {
+        public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
+        {
+            return typeof(DataColumn).IsAssignableFrom(config.GetExpectationType(context.RuntimeType, context.CompileTimeType));
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
+        public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
+        {
+            var subject = context.Subject as DataColumn;
+            var expectation = context.Expectation as DataColumn;
+
+            if (expectation == null)
+            {
+                if (subject != null)
+                {
+                    AssertionScope.Current.FailWith("Expected {context:DataColumn} value to be null, but found {0}", subject);
+                }
+            }
+            else
+            {
+                if (subject == null)
+                {
+                    if (context.Subject == null)
+                    {
+                        AssertionScope.Current.FailWith("Expected {context:DataColumn} to be non-null, but found null");
+                    }
+                    else
+                    {
+                        AssertionScope.Current.FailWith("Expected {context:DataColumn} to be of type {0}, but found {1} instead", expectation.GetType(), context.Subject.GetType());
+                    }
+                }
+                else
+                {
+                    CompareSubjectAndExpectationOfTypeDataColumn(context, parent, config, subject);
+                }
+            }
+
+            return true;
+        }
+
+        private static void CompareSubjectAndExpectationOfTypeDataColumn(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config, DataColumn subject)
+        {
+            bool compareColumn = true;
+
+            var dataSetConfig = config as DataEquivalencyAssertionOptions<DataSet>;
+            var dataTableConfig = config as DataEquivalencyAssertionOptions<DataTable>;
+            var dataColumnConfig = config as DataEquivalencyAssertionOptions<DataColumn>;
+
+            if (((dataSetConfig != null) && dataSetConfig.ShouldExcludeColumn(subject))
+             || ((dataTableConfig != null) && dataTableConfig.ShouldExcludeColumn(subject))
+             || ((dataColumnConfig != null) && dataColumnConfig.ShouldExcludeColumn(subject)))
+            {
+                compareColumn = false;
+            }
+
+            if (compareColumn)
+            {
+                foreach (var expectationMember in GetMembersFromExpectation(context, config))
+                {
+                    if (expectationMember.Name != nameof(subject.Table))
+                    {
+                        CompareMember(expectationMember, parent, context, config);
+                    }
+                }
+            }
+        }
+
+        private static void CompareMember(IMember expectationMember, IEquivalencyValidator parent, IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
+        {
+            var matchingMember = FindMatchFor(expectationMember, context, config);
+
+            if (matchingMember != null)
+            {
+                IEquivalencyValidationContext nestedContext =
+                            context.AsNestedMember(expectationMember, matchingMember);
+
+                if (nestedContext != null)
+                {
+                    parent.AssertEqualityUsing(nestedContext);
+                }
+            }
+        }
+
+        private static IMember FindMatchFor(IMember selectedMemberInfo, IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
+        {
+            IEnumerable<IMember> query =
+                from rule in config.MatchingRules
+                let match = rule.Match(selectedMemberInfo, context.Subject, context.CurrentNode, config)
+                where match != null
+                select match;
+
+            return query.FirstOrDefault();
+        }
+
+        // Note: This list of candidate members is duplicated in the XML documentation for the
+        // DataColumn.BeEquivalentTo extension method in DataColumnAssertions.cs. If this ever
+        // needs to change, keep them in sync.
+        private static readonly ISet<string> CandidateMembers =
+            new HashSet<string>()
+            {
+                nameof(DataColumn.AllowDBNull),
+                nameof(DataColumn.AutoIncrement),
+                nameof(DataColumn.AutoIncrementSeed),
+                nameof(DataColumn.AutoIncrementStep),
+                nameof(DataColumn.Caption),
+                nameof(DataColumn.ColumnName),
+                nameof(DataColumn.DataType),
+                nameof(DataColumn.DateTimeMode),
+                nameof(DataColumn.DefaultValue),
+                nameof(DataColumn.Expression),
+                nameof(DataColumn.ExtendedProperties),
+                nameof(DataColumn.MaxLength),
+                nameof(DataColumn.Namespace),
+                nameof(DataColumn.Prefix),
+                nameof(DataColumn.ReadOnly),
+                nameof(DataColumn.Unique),
+            };
+
+        private static IEnumerable<IMember> GetMembersFromExpectation(IEquivalencyValidationContext context,
+            IEquivalencyAssertionOptions config)
+        {
+            IEnumerable<IMember> members = Enumerable.Empty<IMember>();
+
+            foreach (IMemberSelectionRule rule in config.SelectionRules)
+            {
+                members = rule.SelectMembers(context.CurrentNode, members, new MemberSelectionContext
+                {
+                    CompileTimeType = context.CompileTimeType,
+                    RuntimeType = context.RuntimeType,
+                    Options = config
+                });
+            }
+
+            members = members.Where(member => CandidateMembers.Contains(member.Name));
+
+            return members;
+        }
+    }
+}

--- a/Src/FluentAssertions/Equivalency/DataRelationEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRelationEquivalencyStep.cs
@@ -1,0 +1,236 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Equivalency
+{
+    public class DataRelationEquivalencyStep : IEquivalencyStep
+    {
+        public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
+        {
+            return typeof(DataRelation).IsAssignableFrom(config.GetExpectationType(context.RuntimeType, context.CompileTimeType));
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
+        public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
+        {
+            var subject = context.Subject as DataRelation;
+            var expectation = context.Expectation as DataRelation;
+
+            if (expectation == null)
+            {
+                if (subject != null)
+                {
+                    AssertionScope.Current.FailWith("Expected {context:DataRelation} to be null, but found {0}", subject);
+                }
+            }
+            else
+            {
+                if (subject == null)
+                {
+                    if (context.Subject == null)
+                    {
+                        AssertionScope.Current.FailWith("Expected {context:DataRelation} value to be non-null, but found null");
+                    }
+                    else
+                    {
+                        AssertionScope.Current.FailWith("Expected {context:DataRelation} of type {0}, but found {1} instead", expectation.GetType(), context.Subject.GetType());
+                    }
+                }
+                else
+                {
+                    var selectedMembers = GetMembersFromExpectation(context, config)
+                        .ToDictionary(member => member.Name);
+
+                    CompareScalarProperties(subject, expectation, selectedMembers);
+
+                    CompareCollections(context, parent, config, expectation, selectedMembers);
+
+                    CompareRelationConstraints(context, parent, config, subject, expectation, selectedMembers);
+                }
+            }
+
+            return true;
+        }
+
+        private static void CompareScalarProperties(DataRelation subject, DataRelation expectation, Dictionary<string, IMember> selectedMembers)
+        {
+            if (selectedMembers.ContainsKey(nameof(expectation.RelationName)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.RelationName == expectation.RelationName)
+                    .FailWith("Expected {context:DataRelation} to have RelationName of '{0}'{reason}, but found '{1}'", expectation.RelationName, subject.RelationName);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.Nested)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.Nested == expectation.Nested)
+                    .FailWith("Expected {context:DataRelation} to have Nested value of '{0}'{reason}, but found '{1}'", expectation.Nested, subject.Nested);
+            }
+
+            // Special case: Compare name only
+            if (selectedMembers.ContainsKey(nameof(expectation.DataSet)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.DataSet?.DataSetName == expectation.DataSet?.DataSetName)
+                    .FailWith("Expected containing DataSet of {context:DataRelation} to be {0}{reason}, but found {1}",
+                        expectation.DataSet?.DataSetName ?? "<null>",
+                        subject.DataSet?.DataSetName ?? "<null>");
+            }
+        }
+
+        private static void CompareCollections(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config, DataRelation expectation, Dictionary<string, IMember> selectedMembers)
+        {
+            if (selectedMembers.TryGetValue(nameof(expectation.ExtendedProperties), out var expectationMember))
+            {
+                var matchingMember = FindMatchFor(expectationMember, context, config);
+
+                if (matchingMember != null)
+                {
+                    IEquivalencyValidationContext nestedContext =
+                            context.AsNestedMember(expectationMember, matchingMember);
+
+                    if (nestedContext != null)
+                    {
+                        parent.AssertEqualityUsing(nestedContext);
+                    }
+                }
+            }
+        }
+
+        private static void CompareRelationConstraints(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config, DataRelation subject, DataRelation expectation, Dictionary<string, IMember> selectedMembers)
+        {
+            CompareDataRelationConstraints(
+                parent, context, config, subject, expectation, selectedMembers,
+                "Child",
+                selectedMembers.ContainsKey(nameof(DataRelation.ChildTable)),
+                selectedMembers.ContainsKey(nameof(DataRelation.ChildColumns)),
+                selectedMembers.ContainsKey(nameof(DataRelation.ChildKeyConstraint)),
+                r => r.ChildColumns,
+                r => r.ChildTable);
+
+            CompareDataRelationConstraints(
+                parent, context, config, subject, expectation, selectedMembers,
+                "Parent",
+                selectedMembers.ContainsKey(nameof(DataRelation.ParentTable)),
+                selectedMembers.ContainsKey(nameof(DataRelation.ParentColumns)),
+                selectedMembers.ContainsKey(nameof(DataRelation.ParentKeyConstraint)),
+                r => r.ParentColumns,
+                r => r.ParentTable);
+        }
+
+        private static void CompareDataRelationConstraints(
+            IEquivalencyValidator parent, IEquivalencyValidationContext context, IEquivalencyAssertionOptions config, DataRelation subject, DataRelation expectation, Dictionary<string, IMember> selectedMembers,
+            string relationDirection,
+            bool compareTable, bool compareColumns, bool compareKeyConstraint,
+            Func<DataRelation, DataColumn[]> getColumns,
+            Func<DataRelation, DataTable> getOtherTable)
+        {
+            if (compareColumns)
+            {
+                CompareDataRelationColumns(subject, expectation, getColumns);
+            }
+
+            if (compareTable)
+            {
+                CompareDataRelationTable(subject, expectation, getOtherTable);
+            }
+
+            if (compareKeyConstraint)
+            {
+                CompareDataRelationKeyConstraint(parent, context, config, selectedMembers, relationDirection);
+            }
+        }
+
+        private static void CompareDataRelationColumns(DataRelation subject, DataRelation expectation, Func<DataRelation, DataColumn[]> getColumns)
+        {
+            var subjectColumns = getColumns(subject);
+            var expectationColumns = getColumns(expectation);
+
+            // These column references are in different tables in different data sets that _should_ be equivalent
+            // to one another.
+            AssertionScope.Current
+                .ForCondition(subjectColumns.Length == expectationColumns.Length)
+                .FailWith("Expected {context:DataRelation} to reference {0} column(s){reason}, but found {subjectColumns.Length}", expectationColumns.Length, subjectColumns.Length);
+
+            if (subjectColumns.Length == expectationColumns.Length)
+            {
+                for (int i = 0; i < expectationColumns.Length; i++)
+                {
+                    var subjectColumn = subjectColumns[i];
+                    var expectationColumn = expectationColumns[i];
+
+                    bool columnsAreEquivalent =
+                        (subjectColumn.Table.TableName == expectationColumn.Table.TableName) &&
+                        (subjectColumn.ColumnName == expectationColumn.ColumnName);
+
+                    AssertionScope.Current
+                        .ForCondition(columnsAreEquivalent)
+                        .FailWith("Expected {context:DataRelation} to reference column {0} in table {1}{reason}, but found a reference to {2} in table {3} instead",
+                            expectationColumn.ColumnName,
+                            expectationColumn.Table.TableName,
+                            subjectColumn.ColumnName,
+                            subjectColumn.Table.TableName);
+                }
+            }
+        }
+
+        private static void CompareDataRelationTable(DataRelation subject, DataRelation expectation, Func<DataRelation, DataTable> getOtherTable)
+        {
+            var subjectTable = getOtherTable(subject);
+            var expectationTable = getOtherTable(expectation);
+
+            AssertionScope.Current
+                .ForCondition(subjectTable.TableName == expectationTable.TableName)
+                .FailWith("Expected {context:DataRelation} to reference a table named {0}{reason}, but found {1} instead", expectationTable.TableName, subjectTable.TableName);
+        }
+
+        private static void CompareDataRelationKeyConstraint(IEquivalencyValidator parent, IEquivalencyValidationContext context, IEquivalencyAssertionOptions config, Dictionary<string, IMember> selectedMembers, string relationDirection)
+        {
+            if (selectedMembers.TryGetValue(relationDirection + "KeyConstraint", out var expectationMember))
+            {
+                var subjectMember = FindMatchFor(expectationMember, context, config);
+
+                var nestedContext = context.AsNestedMember(expectationMember, subjectMember);
+
+                if (nestedContext != null)
+                {
+                    parent.AssertEqualityUsing(nestedContext);
+                }
+            }
+        }
+
+        private static IMember FindMatchFor(IMember selectedMemberInfo, IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
+        {
+            IEnumerable<IMember> query =
+                from rule in config.MatchingRules
+                let match = rule.Match(selectedMemberInfo, context.Subject, context.CurrentNode, config)
+                where match != null
+                select match;
+
+            return query.FirstOrDefault();
+        }
+
+        private static IEnumerable<IMember> GetMembersFromExpectation(IEquivalencyValidationContext context,
+            IEquivalencyAssertionOptions config)
+        {
+            IEnumerable<IMember> members = Enumerable.Empty<IMember>();
+
+            foreach (IMemberSelectionRule rule in config.SelectionRules)
+            {
+                members = rule.SelectMembers(context.CurrentNode, members, new MemberSelectionContext
+                {
+                    CompileTimeType = context.CompileTimeType,
+                    RuntimeType = context.RuntimeType,
+                    Options = config
+                });
+            }
+
+            return members;
+        }
+    }
+}

--- a/Src/FluentAssertions/Equivalency/DataRowCollectionEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRowCollectionEquivalencyStep.cs
@@ -1,0 +1,262 @@
+﻿using System;
+using System.Data;
+using System.Linq;
+
+using FluentAssertions.Data;
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Equivalency
+{
+    public class DataRowCollectionEquivalencyStep : IEquivalencyStep
+    {
+        public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
+        {
+            return typeof(DataRowCollection).IsAssignableFrom(config.GetExpectationType(context.RuntimeType, context.CompileTimeType));
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0038:Use pattern matching", Justification = "Would decrease code clarity")]
+        public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
+        {
+            if (!(context.Subject is DataRowCollection))
+            {
+                AssertionScope.Current
+                    .FailWith("Expected {context:value} to be of type DataRowCollection, but found {0}", context.Subject.GetType());
+            }
+            else
+            {
+                RowMatchMode rowMatchMode = RowMatchMode.Index;
+
+                if (config is DataEquivalencyAssertionOptions<DataSet> dataSetConfig)
+                {
+                    rowMatchMode = dataSetConfig.RowMatchMode;
+                }
+                else if (config is DataEquivalencyAssertionOptions<DataTable> dataTableConfig)
+                {
+                    rowMatchMode = dataTableConfig.RowMatchMode;
+                }
+
+                var subject = (DataRowCollection)context.Subject;
+                var expectation = (DataRowCollection)context.Expectation;
+
+                AssertionScope.Current
+                    .ForCondition(subject.Count == expectation.Count)
+                    .FailWith("Expected {context:DataRowCollection} to contain {0} row(s){reason}, but found {1}", expectation.Count, subject.Count);
+
+                switch (rowMatchMode)
+                {
+                    case RowMatchMode.Index:
+                        MatchRowsByIndexAndCompare(context, parent, subject, expectation);
+                        break;
+
+                    case RowMatchMode.PrimaryKey:
+                        MatchRowsByPrimaryKeyAndCompare(parent, context, subject, expectation);
+                        break;
+
+                    default:
+                        AssertionScope.Current.FailWith("Unknown RowMatchMode {0} when trying to compare {context:DataRowCollection}", rowMatchMode);
+                        break;
+                }
+            }
+
+            return true;
+        }
+
+        private static void MatchRowsByIndexAndCompare(IEquivalencyValidationContext context, IEquivalencyValidator parent, DataRowCollection subject, DataRowCollection expectation)
+        {
+            for (int i = 0; i < expectation.Count; i++)
+            {
+                var nestedContext = context.AsCollectionItem(
+                    i.ToString(),
+                    subject[i],
+                    expectation[i]);
+
+                if (nestedContext != null)
+                {
+                    parent.AssertEqualityUsing(nestedContext);
+                }
+            }
+        }
+
+        private static void MatchRowsByPrimaryKeyAndCompare(IEquivalencyValidator parent, IEquivalencyValidationContext context, DataRowCollection subject, DataRowCollection expectation)
+        {
+            Type[] subjectPrimaryKeyTypes = null;
+            Type[] expectationPrimaryKeyTypes = null;
+
+            if (subject.Count > 0)
+            {
+                subjectPrimaryKeyTypes = GatherPrimaryKeyColumnTypes(subject[0].Table, "subject");
+            }
+
+            if (expectation.Count > 0)
+            {
+                expectationPrimaryKeyTypes = GatherPrimaryKeyColumnTypes(expectation[0].Table, "expectation");
+            }
+
+            bool matchingTypes = ComparePrimaryKeyTypes(subjectPrimaryKeyTypes, expectationPrimaryKeyTypes);
+
+            if (matchingTypes)
+            {
+                GatherRowsByPrimaryKeyAndCompareData(parent, context, subject, expectation);
+            }
+        }
+
+        private static Type[] GatherPrimaryKeyColumnTypes(DataTable table, string comparisonTerm)
+        {
+            Type[] primaryKeyTypes = null;
+
+            if ((table.PrimaryKey == null) || (table.PrimaryKey.Length == 0))
+            {
+                AssertionScope.Current
+                    .FailWith("Table '{0}' containing {1} {context:DataRowCollection} does not have a primary key. RowMatchMode.PrimaryKey cannot be applied.", table.TableName, comparisonTerm);
+            }
+            else
+            {
+                primaryKeyTypes = new Type[table.PrimaryKey.Length];
+
+                for (int i = 0; i < table.PrimaryKey.Length; i++)
+                {
+                    primaryKeyTypes[i] = table.PrimaryKey[i].DataType;
+                }
+            }
+
+            return primaryKeyTypes;
+        }
+
+        private static bool ComparePrimaryKeyTypes(Type[] subjectPrimaryKeyTypes, Type[] expectationPrimaryKeyTypes)
+        {
+            bool matchingTypes = false;
+
+            if ((subjectPrimaryKeyTypes != null) && (expectationPrimaryKeyTypes != null))
+            {
+                matchingTypes = subjectPrimaryKeyTypes.Length == expectationPrimaryKeyTypes.Length;
+
+                for (int i = 0; matchingTypes && (i < subjectPrimaryKeyTypes.Length); i++)
+                {
+                    if (subjectPrimaryKeyTypes[i] != expectationPrimaryKeyTypes[i])
+                    {
+                        matchingTypes = false;
+                    }
+                }
+
+                if (!matchingTypes)
+                {
+                    AssertionScope.Current
+                        .FailWith("Subject and expectation primary keys of table containing {context:DataRowCollection} do not have the same schema and cannot be compared. RowMatchMode.PrimaryKey cannot be applied.");
+                }
+            }
+
+            return matchingTypes;
+        }
+
+        private static void GatherRowsByPrimaryKeyAndCompareData(IEquivalencyValidator parent, IEquivalencyValidationContext context, DataRowCollection subject, DataRowCollection expectation)
+        {
+            var expectationRowByKey = expectation.Cast<DataRow>()
+                .ToDictionary(row => ExtractPrimaryKey(row));
+
+            foreach (var subjectRow in subject.Cast<DataRow>())
+            {
+                var key = ExtractPrimaryKey(subjectRow);
+
+                if (!expectationRowByKey.TryGetValue(key, out var expectationRow))
+                {
+                    AssertionScope.Current
+                        .FailWith("Found unexpected row in {context:DataRowCollection} with key {0}", key);
+                }
+                else
+                {
+                    expectationRowByKey.Remove(key);
+
+                    var nestedContext = context.AsCollectionItem(
+                        key.ToString(),
+                        subjectRow,
+                        expectationRow);
+
+                    if (nestedContext != null)
+                    {
+                        parent.AssertEqualityUsing(nestedContext);
+                    }
+                }
+            }
+
+            if (expectationRowByKey.Count > 0)
+            {
+                if (expectationRowByKey.Count > 1)
+                {
+                    AssertionScope.Current
+                        .FailWith("{0} rows were expected in {context:DataRowCollection} and not found", expectationRowByKey.Count);
+                }
+                else
+                {
+                    AssertionScope.Current
+                        .FailWith("Expected to find a row with key {0} in {context:DataRowCollection}{reason}, but no such row was found", expectationRowByKey.Keys.Single());
+                }
+            }
+        }
+
+        private class CompoundKey : IEquatable<CompoundKey>
+        {
+            private readonly object[] values;
+
+            public CompoundKey(params object[] values)
+            {
+                this.values = values;
+            }
+
+            public bool Equals(CompoundKey other)
+            {
+                if (other == null)
+                {
+                    return false;
+                }
+
+                if (values.Length != other.values.Length)
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < values.Length; i++)
+                {
+                    if (!values[i].Equals(other.values[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            public override bool Equals(object obj) => Equals(obj as CompoundKey);
+
+            public override int GetHashCode()
+            {
+                int hash = 0;
+
+                for (int i = 0; i < values.Length; i++)
+                {
+                    hash = (hash * 389) ^ values[i].GetHashCode();
+                }
+
+                return hash;
+            }
+
+            public override string ToString()
+            {
+                return "{ " + string.Join(", ", values) + " }";
+            }
+        }
+
+        private static CompoundKey ExtractPrimaryKey(DataRow row)
+        {
+            var primaryKey = row.Table.PrimaryKey;
+
+            var values = new object[primaryKey.Length];
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                values[i] = row[primaryKey[i]];
+            }
+
+            return new CompoundKey(values);
+        }
+    }
+}

--- a/Src/FluentAssertions/Equivalency/DataRowEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRowEquivalencyStep.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Data;
+using System.Linq;
+
+using FluentAssertions.Data;
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Equivalency
+{
+    public class DataRowEquivalencyStep : IEquivalencyStep
+    {
+        public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
+        {
+            return typeof(DataRow).IsAssignableFrom(config.GetExpectationType(context.RuntimeType, context.CompileTimeType));
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
+        public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
+        {
+            var subject = context.Subject as DataRow;
+            var expectation = context.Expectation as DataRow;
+
+            if (expectation == null)
+            {
+                if (subject != null)
+                {
+                    AssertionScope.Current.FailWith("Expected {context:DataRow} value to be null, but found {0}", subject);
+                }
+            }
+            else
+            {
+                if (subject == null)
+                {
+                    if (context.Subject == null)
+                    {
+                        AssertionScope.Current.FailWith("Expected {context:DataRow} to be non-null, but found null");
+                    }
+                    else
+                    {
+                        AssertionScope.Current.FailWith("Expected {context:DataRow} to be of type {0}, but found {1} instead", expectation.GetType(), context.Subject.GetType());
+                    }
+                }
+                else
+                {
+                    var dataSetConfig = config as DataEquivalencyAssertionOptions<DataSet>;
+                    var dataTableConfig = config as DataEquivalencyAssertionOptions<DataTable>;
+                    var dataRowConfig = config as DataEquivalencyAssertionOptions<DataRow>;
+
+                    if (((dataSetConfig == null) || !dataSetConfig.AllowMismatchedTypes)
+                     && ((dataTableConfig == null) || !dataTableConfig.AllowMismatchedTypes)
+                     && ((dataRowConfig == null) || !dataRowConfig.AllowMismatchedTypes))
+                    {
+                        AssertionScope.Current
+                            .ForCondition(subject.GetType() == expectation.GetType())
+                            .FailWith("Expected {context:DataRow} to be of type '{0}'{reason}, but found '{1}'", expectation.GetType(), subject.GetType());
+                    }
+
+                    var selectedMembers = GetMembersFromExpectation(context, config);
+
+                    CompareScalarProperties(subject, expectation, selectedMembers);
+
+                    CompareFieldValues(context, parent, subject, expectation, dataSetConfig, dataTableConfig, dataRowConfig);
+                }
+            }
+
+            return true;
+        }
+
+        private static void CompareScalarProperties(DataRow subject, DataRow expectation, SelectedDataRowMembers selectedMembers)
+        {
+            // Note: The members here are listed in the XML documentation for the DataRow.BeEquivalentTo extension
+            // method in DataRowAssertions.cs. If this ever needs to change, keep them in sync.
+            if (selectedMembers.HasErrors)
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.HasErrors == expectation.HasErrors)
+                    .FailWith("Expected {context:DataRow} to have HasErrors value of '{0}'{reason}, but found '{1}' instead", expectation.HasErrors, subject.HasErrors);
+            }
+
+            if (selectedMembers.RowState)
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.RowState == expectation.RowState)
+                    .FailWith("Expected {context:DataRow} to have RowState value of '{0}'{reason}, but found '{1}' instead", expectation.RowState, subject.RowState);
+            }
+        }
+
+        private static void CompareFieldValues(IEquivalencyValidationContext context, IEquivalencyValidator parent, DataRow subject, DataRow expectation, DataEquivalencyAssertionOptions<DataSet> dataSetConfig, DataEquivalencyAssertionOptions<DataTable> dataTableConfig, DataEquivalencyAssertionOptions<DataRow> dataRowConfig)
+        {
+            var expectationColumnNames = expectation.Table.Columns.OfType<DataColumn>()
+                .Select(col => col.ColumnName);
+
+            var subjectColumnNames = subject.Table.Columns.OfType<DataColumn>()
+                .Select(col => col.ColumnName);
+
+            bool ignoreUnmatchedColumns =
+                ((dataSetConfig != null) && dataSetConfig.IgnoreUnmatchedColumns) ||
+                ((dataTableConfig != null) && dataTableConfig.IgnoreUnmatchedColumns) ||
+                ((dataRowConfig != null) && dataRowConfig.IgnoreUnmatchedColumns);
+
+            var subjectVersion =
+                (subject.RowState == DataRowState.Deleted)
+                ? DataRowVersion.Original
+                : DataRowVersion.Current;
+
+            var expectationVersion =
+                (expectation.RowState == DataRowState.Deleted)
+                ? DataRowVersion.Original
+                : DataRowVersion.Current;
+
+            bool compareOriginalVersions = (subject.RowState == DataRowState.Modified) && (expectation.RowState == DataRowState.Modified);
+
+            if (((dataSetConfig != null) && dataSetConfig.ExcludeOriginalData)
+             || ((dataTableConfig != null) && dataTableConfig.ExcludeOriginalData)
+             || ((dataRowConfig != null) && dataRowConfig.ExcludeOriginalData))
+            {
+                compareOriginalVersions = false;
+            }
+
+            foreach (var columnName in expectationColumnNames.Union(subjectColumnNames))
+            {
+                var expectationColumn = expectation.Table.Columns[columnName];
+                var subjectColumn = subject.Table.Columns[columnName];
+
+                if (((dataSetConfig != null) && dataSetConfig.ShouldExcludeColumn(subjectColumn))
+                 || ((dataTableConfig != null) && dataTableConfig.ShouldExcludeColumn(subjectColumn))
+                 || ((dataRowConfig != null) && dataRowConfig.ShouldExcludeColumn(subjectColumn)))
+                {
+                    continue;
+                }
+
+                if (!ignoreUnmatchedColumns)
+                {
+                    AssertionScope.Current
+                        .ForCondition(subjectColumn != null)
+                        .FailWith("Expected {context:DataRow} to have column '{0}'{reason}, but found none", columnName);
+
+                    AssertionScope.Current
+                        .ForCondition(expectationColumn != null)
+                        .FailWith("Found unexpected column '{0}' in {context:DataRow}", columnName);
+                }
+
+                if ((subjectColumn != null) && (expectationColumn != null))
+                {
+                    CompareFieldValue(context, parent, subject, expectation, subjectColumn, subjectVersion, expectationColumn, expectationVersion);
+
+                    if (compareOriginalVersions)
+                    {
+                        CompareFieldValue(context, parent, subject, expectation, subjectColumn, DataRowVersion.Original, expectationColumn, DataRowVersion.Original);
+                    }
+                }
+            }
+        }
+
+        private static void CompareFieldValue(IEquivalencyValidationContext context, IEquivalencyValidator parent, DataRow subject, DataRow expectation, DataColumn subjectColumn, DataRowVersion subjectVersion, DataColumn expectationColumn, DataRowVersion expectationVersion)
+        {
+            var nestedContext = context.AsCollectionItem(
+                subjectVersion == DataRowVersion.Current
+                ? subjectColumn.ColumnName
+                : $"{subjectColumn.ColumnName}, DataRowVersion.Original",
+                subject[subjectColumn, subjectVersion],
+                expectation[expectationColumn, expectationVersion]);
+
+            if (nestedContext != null)
+            {
+                parent.AssertEqualityUsing(nestedContext);
+            }
+        }
+
+        private class SelectedDataRowMembers
+        {
+            public bool HasErrors { get; set; }
+
+            public bool RowState { get; set; }
+        }
+
+        private static readonly ConcurrentDictionary<(Type CompileTimeType, Type RuntimeType, IEquivalencyAssertionOptions Config), SelectedDataRowMembers> SelectedMembersCache
+            = new ConcurrentDictionary<(Type CompileTimeType, Type RuntimeType, IEquivalencyAssertionOptions Config), SelectedDataRowMembers>();
+
+        private static SelectedDataRowMembers GetMembersFromExpectation(IEquivalencyValidationContext context,
+            IEquivalencyAssertionOptions config)
+        {
+            var cacheKey = (context.CompileTimeType, context.RuntimeType, config);
+
+            if (!SelectedMembersCache.TryGetValue(cacheKey, out var selectedMembers))
+            {
+                var members = Enumerable.Empty<IMember>();
+
+                foreach (IMemberSelectionRule rule in config.SelectionRules)
+                {
+                    members = rule.SelectMembers(context.CurrentNode, members, new MemberSelectionContext
+                    {
+                        CompileTimeType = context.CompileTimeType,
+                        RuntimeType = context.RuntimeType,
+                        Options = config
+                    });
+                }
+
+                selectedMembers = new SelectedDataRowMembers();
+
+                selectedMembers.HasErrors = members.Any(m => m.Name == nameof(DataRow.HasErrors));
+                selectedMembers.RowState = members.Any(m => m.Name == nameof(DataRow.RowState));
+
+                SelectedMembersCache.TryAdd(cacheKey, selectedMembers);
+            }
+
+            return selectedMembers;
+        }
+    }
+}

--- a/Src/FluentAssertions/Equivalency/DataSetEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataSetEquivalencyStep.cs
@@ -1,0 +1,254 @@
+﻿using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+
+using FluentAssertions.Data;
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Equivalency
+{
+    public class DataSetEquivalencyStep : IEquivalencyStep
+    {
+        public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
+        {
+            return typeof(DataSet).IsAssignableFrom(config.GetExpectationType(context.RuntimeType, context.CompileTimeType));
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
+        public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
+        {
+            var subject = context.Subject as DataSet;
+            var expectation = context.Expectation as DataSet;
+
+            if (expectation == null)
+            {
+                if (subject != null)
+                {
+                    AssertionScope.Current.FailWith("Expected {context:DataSet} value to be null, but found {0}", subject);
+                }
+            }
+            else
+            {
+                if (subject == null)
+                {
+                    if (context.Subject == null)
+                    {
+                        AssertionScope.Current.FailWith("Expected {context:DataSet} to be non-null, but found null");
+                    }
+                    else
+                    {
+                        AssertionScope.Current.FailWith("Expected {context:DataSet} to be of type {0}, but found {1} instead", expectation.GetType(), context.Subject.GetType());
+                    }
+                }
+                else
+                {
+                    var dataConfig = config as DataEquivalencyAssertionOptions<DataSet>;
+
+                    if ((dataConfig == null) || !dataConfig.AllowMismatchedTypes)
+                    {
+                        AssertionScope.Current
+                            .ForCondition(subject.GetType() == expectation.GetType())
+                            .FailWith("Expected {context:DataSet} to be of type '{0}'{reason}, but found '{1}'", expectation.GetType(), subject.GetType());
+                    }
+
+                    var selectedMembers = GetMembersFromExpectation(context, config)
+                        .ToDictionary(member => member.Name);
+
+                    CompareScalarProperties(subject, expectation, selectedMembers);
+
+                    CompareCollections(context, parent, config, subject, expectation, dataConfig, selectedMembers);
+                }
+            }
+
+            return true;
+        }
+
+        private static void CompareScalarProperties(DataSet subject, DataSet expectation, Dictionary<string, IMember> selectedMembers)
+        {
+            // Note: The members here are listed in the XML documentation for the DataSet.BeEquivalentTo extension
+            // method in DataSetAssertions.cs. If this ever needs to change, keep them in sync.
+            if (selectedMembers.ContainsKey(nameof(expectation.DataSetName)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.DataSetName == expectation.DataSetName)
+                    .FailWith("Expected {context:DataSet} to have DataSetName '{0}'{reason}, but found '{1}' instead", expectation.DataSetName, subject.DataSetName);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.CaseSensitive)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.CaseSensitive == expectation.CaseSensitive)
+                    .FailWith("Expected {context:DataSet} to have CaseSensitive value of '{0}'{reason}, but found '{1}' instead", expectation.CaseSensitive, subject.CaseSensitive);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.EnforceConstraints)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.EnforceConstraints == expectation.EnforceConstraints)
+                    .FailWith("Expected {context:DataSet} to have EnforceConstraints value of '{0}'{reason}, but found '{1}' instead", expectation.EnforceConstraints, subject.EnforceConstraints);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.HasErrors)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.HasErrors == expectation.HasErrors)
+                    .FailWith("Expected {context:DataSet} to have HasErrors value of '{0}'{reason}, but found '{1}' instead", expectation.HasErrors, subject.HasErrors);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.Locale)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.Locale == expectation.Locale)
+                    .FailWith("Expected {context:DataSet} to have Locale value of '{0}'{reason}, but found '{1}' instead", expectation.Locale, subject.Locale);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.Namespace)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.Namespace == expectation.Namespace)
+                    .FailWith("Expected {context:DataSet} to have Namespace value of '{0}'{reason}, but found '{1}' instead", expectation.Namespace, subject.Namespace);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.Prefix)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.Prefix == expectation.Prefix)
+                    .FailWith("Expected {context:DataSet} to have Prefix value of '{0}'{reason}, but found '{1}' instead", expectation.Prefix, subject.Prefix);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.RemotingFormat)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.RemotingFormat == expectation.RemotingFormat)
+                    .FailWith("Expected {context:DataSet} to have RemotingFormat value of '{0}'{reason}, but found '{1}' instead", expectation.RemotingFormat, subject.RemotingFormat);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.SchemaSerializationMode)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.SchemaSerializationMode == expectation.SchemaSerializationMode)
+                    .FailWith("Expected {context:DataSet} to have SchemaSerializationMode value of '{0}'{reason}, but found '{1}' instead", expectation.SchemaSerializationMode, subject.SchemaSerializationMode);
+            }
+        }
+
+        private static void CompareCollections(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config, DataSet subject, DataSet expectation, DataEquivalencyAssertionOptions<DataSet> dataConfig, Dictionary<string, IMember> selectedMembers)
+        {
+            // Note: The collections here are listed in the XML documentation for the DataSet.BeEquivalentTo extension
+            // method in DataSetAssertions.cs. If this ever needs to change, keep them in sync.
+            CompareExtendedProperties(context, parent, config, expectation, selectedMembers);
+
+            CompareTables(context, parent, subject, expectation, dataConfig, selectedMembers);
+        }
+
+        private static void CompareExtendedProperties(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config, DataSet expectation, Dictionary<string, IMember> selectedMembers)
+        {
+            foreach (var collectionName in new[] { nameof(expectation.ExtendedProperties), nameof(expectation.Relations) })
+            {
+                if (selectedMembers.TryGetValue(collectionName, out var expectationMember))
+                {
+                    var matchingMember = FindMatchFor(expectationMember, context, config);
+
+                    if (matchingMember != null)
+                    {
+                        IEquivalencyValidationContext nestedContext =
+                                context.AsNestedMember(expectationMember, matchingMember);
+
+                        if (nestedContext != null)
+                        {
+                            parent.AssertEqualityUsing(nestedContext);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void CompareTables(IEquivalencyValidationContext context, IEquivalencyValidator parent, DataSet subject, DataSet expectation, DataEquivalencyAssertionOptions<DataSet> dataConfig, Dictionary<string, IMember> selectedMembers)
+        {
+            if (selectedMembers.ContainsKey(nameof(expectation.Tables)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.Tables.Count == expectation.Tables.Count)
+                    .FailWith("Expected {context:DataSet} to contain {0}, but found {1} table(s)", expectation.Tables.Count, subject.Tables.Count);
+
+                if (dataConfig != null)
+                {
+                    bool excludeCaseSensitive = !selectedMembers.ContainsKey(nameof(DataSet.CaseSensitive));
+                    bool excludeLocale = !selectedMembers.ContainsKey(nameof(DataSet.Locale));
+
+                    if (excludeCaseSensitive || excludeLocale)
+                    {
+                        dataConfig.Excluding((IMemberInfo memberInfo) =>
+                                (memberInfo.DeclaringType == typeof(DataTable)) &&
+                            (
+                                    (excludeCaseSensitive && (memberInfo.Name == nameof(DataTable.CaseSensitive)))
+                            ||
+                                    (excludeLocale && (memberInfo.Name == nameof(DataTable.Locale)))));
+                    }
+                }
+
+                var expectationTableNames = expectation.Tables.OfType<DataTable>()
+                    .Select(table => table.TableName);
+                var subjectTableNames = subject.Tables.OfType<DataTable>()
+                    .Select(table => table.TableName);
+
+                foreach (string tableName in expectationTableNames.Union(subjectTableNames))
+                {
+                    if ((dataConfig != null) && dataConfig.ExcludeTableNames.Contains(tableName))
+                    {
+                        continue;
+                    }
+
+                    var expectationTable = expectation.Tables[tableName];
+                    var subjectTable = subject.Tables[tableName];
+
+                    AssertionScope.Current
+                        .ForCondition(subjectTable != null)
+                        .FailWith("Expected {context:DataSet} to contain table '{0}'{reason}, but did not find it", tableName);
+
+                    AssertionScope.Current
+                        .ForCondition(expectationTable != null)
+                        .FailWith("Found unexpected table '{0}' in DataSet", tableName);
+
+                    var nestedContext = context.AsCollectionItem(
+                        tableName,
+                        subjectTable,
+                        expectationTable);
+
+                    if (nestedContext != null)
+                    {
+                        parent.AssertEqualityUsing(nestedContext);
+                    }
+                }
+            }
+        }
+
+        private static IMember FindMatchFor(IMember selectedMemberInfo, IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
+        {
+            IEnumerable<IMember> query =
+                from rule in config.MatchingRules
+                let match = rule.Match(selectedMemberInfo, context.Subject, context.CurrentNode, config)
+                where match != null
+                select match;
+
+            return query.FirstOrDefault();
+        }
+
+        private static IEnumerable<IMember> GetMembersFromExpectation(IEquivalencyValidationContext context,
+            IEquivalencyAssertionOptions config)
+        {
+            IEnumerable<IMember> members = Enumerable.Empty<IMember>();
+
+            foreach (IMemberSelectionRule rule in config.SelectionRules)
+            {
+                members = rule.SelectMembers(context.CurrentNode, members, new MemberSelectionContext
+                {
+                    CompileTimeType = context.CompileTimeType,
+                    RuntimeType = context.RuntimeType,
+                    Options = config
+                });
+            }
+
+            return members;
+        }
+    }
+}

--- a/Src/FluentAssertions/Equivalency/DataTableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataTableEquivalencyStep.cs
@@ -1,0 +1,193 @@
+﻿using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+
+using FluentAssertions.Data;
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Equivalency
+{
+    public class DataTableEquivalencyStep : IEquivalencyStep
+    {
+        public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
+        {
+            return typeof(DataTable).IsAssignableFrom(config.GetExpectationType(context.RuntimeType, context.CompileTimeType));
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
+        public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
+        {
+            var subject = context.Subject as DataTable;
+            var expectation = context.Expectation as DataTable;
+
+            if (expectation == null)
+            {
+                if (subject != null)
+                {
+                    AssertionScope.Current.FailWith("Expected {context:DataTable} value to be null, but found {0}", subject);
+                }
+            }
+            else
+            {
+                if (subject == null)
+                {
+                    if (context.Subject == null)
+                    {
+                        AssertionScope.Current.FailWith("Expected {context:DataTable} to be non-null, but found null");
+                    }
+                    else
+                    {
+                        AssertionScope.Current.FailWith("Expected {context:DataTable} to be of type {0}, but found {1} instead", expectation.GetType(), context.Subject.GetType());
+                    }
+                }
+                else
+                {
+                    var dataSetConfig = config as DataEquivalencyAssertionOptions<DataSet>;
+                    var dataTableConfig = config as DataEquivalencyAssertionOptions<DataTable>;
+
+                    if (((dataSetConfig == null) || !dataSetConfig.AllowMismatchedTypes)
+                     && ((dataTableConfig == null) || !dataTableConfig.AllowMismatchedTypes))
+                    {
+                        AssertionScope.Current
+                            .ForCondition(subject.GetType() == expectation.GetType())
+                            .FailWith("Expected {context:DataTable} to be of type '{0}'{reason}, but found '{1}'", expectation.GetType(), subject.GetType());
+                    }
+
+                    var selectedMembers = GetMembersFromExpectation(context, config)
+                        .ToDictionary(member => member.Name);
+
+                    CompareScalarProperties(subject, expectation, selectedMembers);
+
+                    CompareCollections(context, parent, config, expectation, selectedMembers);
+                }
+            }
+
+            return true;
+        }
+
+        private static void CompareScalarProperties(DataTable subject, DataTable expectation, Dictionary<string, IMember> selectedMembers)
+        {
+            // Note: The members here are listed in the XML documentation for the DataTable.BeEquivalentTo extension
+            // method in DataTableAssertions.cs. If this ever needs to change, keep them in sync.
+            if (selectedMembers.ContainsKey(nameof(expectation.TableName)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.TableName == expectation.TableName)
+                    .FailWith("Expected {context:DataTable} to have TableName '{0}'{reason}, but found '{1}' instead", expectation.TableName, subject.TableName);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.CaseSensitive)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.CaseSensitive == expectation.CaseSensitive)
+                    .FailWith("Expected {context:DataTable} to have CaseSensitive value of '{0}'{reason}, but found '{1}' instead", expectation.CaseSensitive, subject.CaseSensitive);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.DisplayExpression)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.DisplayExpression == expectation.DisplayExpression)
+                    .FailWith("Expected {context:DataTable} to have DisplayExpression value of '{0}'{reason}, but found '{1}' instead", expectation.DisplayExpression, subject.DisplayExpression);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.HasErrors)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.HasErrors == expectation.HasErrors)
+                    .FailWith("Expected {context:DataTable} to have HasErrors value of '{0}'{reason}, but found '{1}' instead", expectation.HasErrors, subject.HasErrors);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.Locale)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.Locale == expectation.Locale)
+                    .FailWith("Expected {context:DataTable} to have Locale value of '{0}'{reason}, but found '{1}' instead", expectation.Locale, subject.Locale);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.Namespace)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.Namespace == expectation.Namespace)
+                    .FailWith("Expected {context:DataTable} to have Namespace value of '{0}'{reason}, but found '{1}' instead", expectation.Namespace, subject.Namespace);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.Prefix)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.Prefix == expectation.Prefix)
+                    .FailWith("Expected {context:DataTable} to have Prefix value of '{0}'{reason}, but found '{1}' instead", expectation.Prefix, subject.Prefix);
+            }
+
+            if (selectedMembers.ContainsKey(nameof(expectation.RemotingFormat)))
+            {
+                AssertionScope.Current
+                    .ForCondition(subject.RemotingFormat == expectation.RemotingFormat)
+                    .FailWith("Expected {context:DataTable} to have RemotingFormat value of '{0}'{reason}, but found '{1}' instead", expectation.RemotingFormat, subject.RemotingFormat);
+            }
+        }
+
+        private static void CompareCollections(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config, DataTable expectation, Dictionary<string, IMember> selectedMembers)
+        {
+            // Note: The collections here are listed in the XML documentation for the DataTable.BeEquivalentTo extension
+            // method in DataTableAssertions.cs. If this ever needs to change, keep them in sync.
+            var collectionNames = new[]
+            {
+                nameof(expectation.ChildRelations),
+                nameof(expectation.Columns),
+                nameof(expectation.Constraints),
+                nameof(expectation.ExtendedProperties),
+                nameof(expectation.ParentRelations),
+                nameof(expectation.PrimaryKey),
+                nameof(expectation.Rows),
+            };
+
+            foreach (var collectionName in collectionNames)
+            {
+                if (selectedMembers.TryGetValue(collectionName, out var expectationMember))
+                {
+                    var matchingMember = FindMatchFor(expectationMember, context, config);
+
+                    if (matchingMember != null)
+                    {
+                        IEquivalencyValidationContext nestedContext =
+                                context.AsNestedMember(expectationMember, matchingMember);
+
+                        if (nestedContext != null)
+                        {
+                            parent.AssertEqualityUsing(nestedContext);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static IMember FindMatchFor(IMember selectedMemberInfo, IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
+        {
+            IEnumerable<IMember> query =
+                from rule in config.MatchingRules
+                let match = rule.Match(selectedMemberInfo, context.Subject, context.CurrentNode, config)
+                where match != null
+                select match;
+
+            return query.FirstOrDefault();
+        }
+
+        private static IEnumerable<IMember> GetMembersFromExpectation(IEquivalencyValidationContext context,
+            IEquivalencyAssertionOptions config)
+        {
+            IEnumerable<IMember> members = Enumerable.Empty<IMember>();
+
+            foreach (IMemberSelectionRule rule in config.SelectionRules)
+            {
+                members = rule.SelectMembers(context.CurrentNode, members, new MemberSelectionContext
+                {
+                    CompileTimeType = context.CompileTimeType,
+                    RuntimeType = context.RuntimeType,
+                    Options = config
+                });
+            }
+
+            return members;
+        }
+    }
+}

--- a/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
@@ -37,18 +37,15 @@ namespace FluentAssertions.Equivalency
 
         private static Type[] GetIDictionaryInterfaces(Type type)
         {
+            // Avoid expensive calculation when the type in question can't possibly implement IDictionary<,>.
             if (Type.GetTypeCode(type) != TypeCode.Object)
             {
-                // Avoid expensive calculation when type cannot possibly implement the interface we
-                // care about. The only TypeCode that can implement IDictionary<,> is Object.
                 return Array.Empty<Type>();
             }
-            else
-            {
-                return Common.TypeExtensions.GetClosedGenericInterfaces(
-                    type,
-                    typeof(IDictionary<,>));
-            }
+
+            return Common.TypeExtensions.GetClosedGenericInterfaces(
+                type,
+                typeof(IDictionary<,>));
         }
 
         private static bool PreconditionsAreMet(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)

--- a/Src/FluentAssertions/Equivalency/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericEnumerableEquivalencyStep.cs
@@ -106,20 +106,15 @@ namespace FluentAssertions.Equivalency
 
         private static Type[] GetIEnumerableInterfaces(Type type)
         {
+            // Avoid expensive calculation when the type in question can't possibly implement IEnumerable<>.
             if (Type.GetTypeCode(type) != TypeCode.Object)
             {
-                // Avoid expensive calculation when type cannot possibly implement the interface we
-                // care about. The only TypeCode other than Object that can implement IEnumerable<>
-                // is TypeCode.String, and we don't consider strings to be enumerables for
-                // equivalency.
                 return Array.Empty<Type>();
             }
-            else
-            {
-                Type soughtType = typeof(IEnumerable<>);
 
-                return Common.TypeExtensions.GetClosedGenericInterfaces(type, soughtType);
-            }
+            Type soughtType = typeof(IEnumerable<>);
+
+            return Common.TypeExtensions.GetClosedGenericInterfaces(type, soughtType);
         }
 
         private static Type GetTypeOfEnumeration(Type enumerableType)

--- a/Src/FluentAssertions/EquivalencyStepCollection.cs
+++ b/Src/FluentAssertions/EquivalencyStepCollection.cs
@@ -110,12 +110,20 @@ namespace FluentAssertions
 
         private static List<IEquivalencyStep> GetDefaultSteps()
         {
-            return new List<IEquivalencyStep>(12)
+            return new List<IEquivalencyStep>(18)
             {
                 new RunAllUserStepsEquivalencyStep(),
                 new AutoConversionStep(),
                 new ReferenceEqualityEquivalencyStep(),
                 new GenericDictionaryEquivalencyStep(),
+                new DataSetEquivalencyStep(),
+                new DataTableEquivalencyStep(),
+                new DataColumnEquivalencyStep(),
+                new DataRelationEquivalencyStep(),
+                new DataRowCollectionEquivalencyStep(),
+                new DataRowEquivalencyStep(),
+                new ConstraintCollectionEquivalencyStep(),
+                new ConstraintEquivalencyStep(),
                 new DictionaryEquivalencyStep(),
                 new MultiDimensionalArrayEquivalencyStep(),
                 new GenericEnumerableEquivalencyStep(),
@@ -124,7 +132,7 @@ namespace FluentAssertions
                 new EnumEqualityStep(),
                 new ValueTypeEquivalencyStep(),
                 new StructuralEqualityEquivalencyStep(),
-                new SimpleEqualityEquivalencyStep()
+                new SimpleEqualityEquivalencyStep(),
             };
         }
     }

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -31,7 +31,8 @@
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f</_Parameter1>
-    </AssemblyAttribute>  </ItemGroup>
+    </AssemblyAttribute>
+  </ItemGroup>
   <ItemGroup>
     <None Remove="BannedSymbols.txt" />
   </ItemGroup>
@@ -70,6 +71,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>

--- a/Src/FluentAssertions/Formatting/EnumerableExtensions.cs
+++ b/Src/FluentAssertions/Formatting/EnumerableExtensions.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Text;
+
+namespace FluentAssertions.Formatting
+{
+    internal static class EnumerableExtensions
+    {
+        internal static string JoinUsingWritingStyle<T>(this IEnumerable<T> items)
+        {
+            var buffer = new StringBuilder();
+
+            T lastItem = default(T);
+            bool first = true;
+
+            foreach (var item in items)
+            {
+                if (first)
+                {
+                    first = false;
+                }
+                else
+                {
+                    if (buffer.Length > 0)
+                    {
+                        buffer.Append(", ");
+                    }
+
+                    buffer.Append(lastItem);
+                }
+
+                lastItem = item;
+            }
+
+            if (buffer.Length > 0)
+            {
+                buffer.Append(" and ");
+            }
+
+            buffer.Append(lastItem);
+
+            return buffer.ToString();
+        }
+    }
+}

--- a/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
@@ -49,7 +49,7 @@ namespace FluentAssertions.Formatting
             }
             else
             {
-                return sign + JoinUsingWritingStyle(fragments);
+                return sign + fragments.JoinUsingWritingStyle();
             }
         }
 
@@ -115,16 +115,6 @@ namespace FluentAssertions.Formatting
             {
                 fragments.Add(timeSpan.Days.ToString(CultureInfo.InvariantCulture) + "d");
             }
-        }
-
-        private static string JoinUsingWritingStyle(IEnumerable<string> fragments)
-        {
-            return string.Join(", ", AllButLastFragment(fragments)) + " and " + fragments.Last();
-        }
-
-        private static string[] AllButLastFragment(IEnumerable<string> fragments)
-        {
-            return fragments.Take(fragments.Count() - 1).ToArray();
         }
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -43,6 +43,7 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
         public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
         public static FluentAssertions.Collections.NonGenericCollectionAssertions Should(this System.Collections.IEnumerable actualValue) { }
+        public static FluentAssertions.Data.DataColumnAssertions Should(this System.Data.DataColumn actualValue) { }
         public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
@@ -109,6 +110,8 @@ namespace FluentAssertions
         public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
+        public static TOptions CloneDefaults<T, TOptions>()
+            where TOptions : FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> { }
     }
     public static class AtLeast
     {
@@ -133,6 +136,21 @@ namespace FluentAssertions
     public class CustomAssertionAttribute : System.Attribute
     {
         public CustomAssertionAttribute() { }
+    }
+    public static class DataRowAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataRowAssertions<TDataRow> Should<TDataRow>(this TDataRow actualValue)
+            where TDataRow : System.Data.DataRow { }
+    }
+    public static class DataSetAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataSetAssertions<TDataSet> Should<TDataSet>(this TDataSet actualValue)
+            where TDataSet : System.Data.DataSet { }
+    }
+    public static class DataTableAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataTableAssertions<TDataTable> Should<TDataTable>(this TDataTable actualValue)
+            where TDataTable : System.Data.DataTable { }
     }
     public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
     {
@@ -589,6 +607,84 @@ namespace FluentAssertions.Common
         Scan = 2,
     }
 }
+namespace FluentAssertions.Data
+{
+    public class DataColumnAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataColumn, FluentAssertions.Data.DataColumnAssertions>
+    {
+        public DataColumnAssertions(System.Data.DataColumn dataColumn) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataColumnAssertions> BeEquivalentTo(System.Data.DataColumn expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataColumnAssertions> BeEquivalentTo(System.Data.DataColumn expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataColumn>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataColumn>> config, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataRowAssertions<TDataRow> : FluentAssertions.Primitives.ReferenceTypeAssertions<TDataRow, FluentAssertions.Data.DataRowAssertions<TDataRow>>
+        where TDataRow : System.Data.DataRow
+    {
+        public DataRowAssertions(TDataRow dataRow) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> BeEquivalentTo(System.Data.DataRow expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> BeEquivalentTo(System.Data.DataRow expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataRow>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataRow>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>, System.Data.DataColumn> HaveColumn(string expectedColumnName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> HaveColumns(params string[] expectedColumnNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> HaveColumns(System.Collections.Generic.IEnumerable<string> expectedColumnNames, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataSetAssertions<TDataSet> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataSet, FluentAssertions.Data.DataSetAssertions<TDataSet>>
+        where TDataSet : System.Data.DataSet
+    {
+        public DataSetAssertions(TDataSet dataSet) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> BeEquivalentTo(System.Data.DataSet expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> BeEquivalentTo(System.Data.DataSet expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataSet>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataSet>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>, System.Data.DataTable> HaveTable(string expectedTableName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTableCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTables(params string[] expectedTableNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTables(System.Collections.Generic.IEnumerable<string> expectedTableNames, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataTableAssertions<TDataTable> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataTable, FluentAssertions.Data.DataTableAssertions<TDataTable>>
+        where TDataTable : System.Data.DataTable
+    {
+        public DataTableAssertions(TDataTable dataTable) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> BeEquivalentTo(System.Data.DataTable expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> BeEquivalentTo(System.Data.DataTable expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataTable>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataTable>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>, System.Data.DataColumn> HaveColumn(string expectedColumnName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveColumns(params string[] expectedColumnNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveColumns(System.Collections.Generic.IEnumerable<string> expectedColumnNames, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveRowCount(int expected, string because = "", params object[] becauseArgs) { }
+    }
+    public interface IDataEquivalencyAssertionOptions<T> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
+    {
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> AllowingMismatchedTypes();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> Excluding(System.Linq.Expressions.Expression<System.Func<T, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumn(System.Data.DataColumn column);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumn(string tableName, string columnName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnInAllTables(string columnName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(System.Collections.Generic.IEnumerable<System.Data.DataColumn> columns);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(params System.Data.DataColumn[] columns);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(string tableName, System.Collections.Generic.IEnumerable<string> columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(string tableName, params string[] columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnsInAllTables(System.Collections.Generic.IEnumerable<string> columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnsInAllTables(params string[] columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingOriginalData();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.Constraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataColumn, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataRelation, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataRow, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataTable, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.ForeignKeyConstraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.UniqueConstraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTable(string tableName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTables(System.Collections.Generic.IEnumerable<string> tableNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTables(params string[] tableNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> IgnoringUnmatchedColumns();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> UsingRowMatchMode(FluentAssertions.Data.RowMatchMode rowMatchMode);
+    }
+    public enum RowMatchMode
+    {
+        Index = 0,
+        PrimaryKey = 1,
+    }
+}
 namespace FluentAssertions.Equivalency
 {
     public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
@@ -605,6 +701,18 @@ namespace FluentAssertions.Equivalency
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public override string ToString() { }
     }
+    public class ConstraintCollectionEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ConstraintCollectionEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class ConstraintEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ConstraintEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
     public class ConversionSelector
     {
         public ConversionSelector() { }
@@ -619,6 +727,42 @@ namespace FluentAssertions.Equivalency
     {
         Ignore = 0,
         ThrowException = 1,
+    }
+    public class DataColumnEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataColumnEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataRelationEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataRelationEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataRowCollectionEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataRowCollectionEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataRowEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataRowEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataSetEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataSetEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataTableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataTableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
     }
     public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -43,6 +43,7 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
         public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
         public static FluentAssertions.Collections.NonGenericCollectionAssertions Should(this System.Collections.IEnumerable actualValue) { }
+        public static FluentAssertions.Data.DataColumnAssertions Should(this System.Data.DataColumn actualValue) { }
         public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
@@ -109,6 +110,8 @@ namespace FluentAssertions
         public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
+        public static TOptions CloneDefaults<T, TOptions>()
+            where TOptions : FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> { }
     }
     public static class AtLeast
     {
@@ -133,6 +136,21 @@ namespace FluentAssertions
     public class CustomAssertionAttribute : System.Attribute
     {
         public CustomAssertionAttribute() { }
+    }
+    public static class DataRowAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataRowAssertions<TDataRow> Should<TDataRow>(this TDataRow actualValue)
+            where TDataRow : System.Data.DataRow { }
+    }
+    public static class DataSetAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataSetAssertions<TDataSet> Should<TDataSet>(this TDataSet actualValue)
+            where TDataSet : System.Data.DataSet { }
+    }
+    public static class DataTableAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataTableAssertions<TDataTable> Should<TDataTable>(this TDataTable actualValue)
+            where TDataTable : System.Data.DataTable { }
     }
     public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
     {
@@ -589,6 +607,84 @@ namespace FluentAssertions.Common
         Scan = 2,
     }
 }
+namespace FluentAssertions.Data
+{
+    public class DataColumnAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataColumn, FluentAssertions.Data.DataColumnAssertions>
+    {
+        public DataColumnAssertions(System.Data.DataColumn dataColumn) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataColumnAssertions> BeEquivalentTo(System.Data.DataColumn expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataColumnAssertions> BeEquivalentTo(System.Data.DataColumn expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataColumn>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataColumn>> config, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataRowAssertions<TDataRow> : FluentAssertions.Primitives.ReferenceTypeAssertions<TDataRow, FluentAssertions.Data.DataRowAssertions<TDataRow>>
+        where TDataRow : System.Data.DataRow
+    {
+        public DataRowAssertions(TDataRow dataRow) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> BeEquivalentTo(System.Data.DataRow expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> BeEquivalentTo(System.Data.DataRow expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataRow>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataRow>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>, System.Data.DataColumn> HaveColumn(string expectedColumnName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> HaveColumns(params string[] expectedColumnNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> HaveColumns(System.Collections.Generic.IEnumerable<string> expectedColumnNames, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataSetAssertions<TDataSet> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataSet, FluentAssertions.Data.DataSetAssertions<TDataSet>>
+        where TDataSet : System.Data.DataSet
+    {
+        public DataSetAssertions(TDataSet dataSet) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> BeEquivalentTo(System.Data.DataSet expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> BeEquivalentTo(System.Data.DataSet expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataSet>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataSet>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>, System.Data.DataTable> HaveTable(string expectedTableName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTableCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTables(params string[] expectedTableNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTables(System.Collections.Generic.IEnumerable<string> expectedTableNames, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataTableAssertions<TDataTable> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataTable, FluentAssertions.Data.DataTableAssertions<TDataTable>>
+        where TDataTable : System.Data.DataTable
+    {
+        public DataTableAssertions(TDataTable dataTable) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> BeEquivalentTo(System.Data.DataTable expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> BeEquivalentTo(System.Data.DataTable expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataTable>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataTable>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>, System.Data.DataColumn> HaveColumn(string expectedColumnName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveColumns(params string[] expectedColumnNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveColumns(System.Collections.Generic.IEnumerable<string> expectedColumnNames, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveRowCount(int expected, string because = "", params object[] becauseArgs) { }
+    }
+    public interface IDataEquivalencyAssertionOptions<T> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
+    {
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> AllowingMismatchedTypes();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> Excluding(System.Linq.Expressions.Expression<System.Func<T, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumn(System.Data.DataColumn column);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumn(string tableName, string columnName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnInAllTables(string columnName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(System.Collections.Generic.IEnumerable<System.Data.DataColumn> columns);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(params System.Data.DataColumn[] columns);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(string tableName, System.Collections.Generic.IEnumerable<string> columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(string tableName, params string[] columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnsInAllTables(System.Collections.Generic.IEnumerable<string> columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnsInAllTables(params string[] columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingOriginalData();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.Constraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataColumn, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataRelation, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataRow, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataTable, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.ForeignKeyConstraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.UniqueConstraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTable(string tableName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTables(System.Collections.Generic.IEnumerable<string> tableNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTables(params string[] tableNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> IgnoringUnmatchedColumns();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> UsingRowMatchMode(FluentAssertions.Data.RowMatchMode rowMatchMode);
+    }
+    public enum RowMatchMode
+    {
+        Index = 0,
+        PrimaryKey = 1,
+    }
+}
 namespace FluentAssertions.Equivalency
 {
     public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
@@ -605,6 +701,18 @@ namespace FluentAssertions.Equivalency
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public override string ToString() { }
     }
+    public class ConstraintCollectionEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ConstraintCollectionEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class ConstraintEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ConstraintEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
     public class ConversionSelector
     {
         public ConversionSelector() { }
@@ -619,6 +727,42 @@ namespace FluentAssertions.Equivalency
     {
         Ignore = 0,
         ThrowException = 1,
+    }
+    public class DataColumnEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataColumnEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataRelationEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataRelationEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataRowCollectionEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataRowCollectionEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataRowEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataRowEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataSetEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataSetEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataTableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataTableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
     }
     public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -43,6 +43,7 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
         public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
         public static FluentAssertions.Collections.NonGenericCollectionAssertions Should(this System.Collections.IEnumerable actualValue) { }
+        public static FluentAssertions.Data.DataColumnAssertions Should(this System.Data.DataColumn actualValue) { }
         public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
@@ -109,6 +110,8 @@ namespace FluentAssertions
         public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
+        public static TOptions CloneDefaults<T, TOptions>()
+            where TOptions : FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> { }
     }
     public static class AtLeast
     {
@@ -133,6 +136,21 @@ namespace FluentAssertions
     public class CustomAssertionAttribute : System.Attribute
     {
         public CustomAssertionAttribute() { }
+    }
+    public static class DataRowAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataRowAssertions<TDataRow> Should<TDataRow>(this TDataRow actualValue)
+            where TDataRow : System.Data.DataRow { }
+    }
+    public static class DataSetAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataSetAssertions<TDataSet> Should<TDataSet>(this TDataSet actualValue)
+            where TDataSet : System.Data.DataSet { }
+    }
+    public static class DataTableAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataTableAssertions<TDataTable> Should<TDataTable>(this TDataTable actualValue)
+            where TDataTable : System.Data.DataTable { }
     }
     public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
     {
@@ -589,6 +607,84 @@ namespace FluentAssertions.Common
         Scan = 2,
     }
 }
+namespace FluentAssertions.Data
+{
+    public class DataColumnAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataColumn, FluentAssertions.Data.DataColumnAssertions>
+    {
+        public DataColumnAssertions(System.Data.DataColumn dataColumn) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataColumnAssertions> BeEquivalentTo(System.Data.DataColumn expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataColumnAssertions> BeEquivalentTo(System.Data.DataColumn expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataColumn>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataColumn>> config, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataRowAssertions<TDataRow> : FluentAssertions.Primitives.ReferenceTypeAssertions<TDataRow, FluentAssertions.Data.DataRowAssertions<TDataRow>>
+        where TDataRow : System.Data.DataRow
+    {
+        public DataRowAssertions(TDataRow dataRow) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> BeEquivalentTo(System.Data.DataRow expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> BeEquivalentTo(System.Data.DataRow expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataRow>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataRow>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>, System.Data.DataColumn> HaveColumn(string expectedColumnName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> HaveColumns(params string[] expectedColumnNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> HaveColumns(System.Collections.Generic.IEnumerable<string> expectedColumnNames, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataSetAssertions<TDataSet> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataSet, FluentAssertions.Data.DataSetAssertions<TDataSet>>
+        where TDataSet : System.Data.DataSet
+    {
+        public DataSetAssertions(TDataSet dataSet) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> BeEquivalentTo(System.Data.DataSet expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> BeEquivalentTo(System.Data.DataSet expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataSet>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataSet>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>, System.Data.DataTable> HaveTable(string expectedTableName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTableCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTables(params string[] expectedTableNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTables(System.Collections.Generic.IEnumerable<string> expectedTableNames, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataTableAssertions<TDataTable> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataTable, FluentAssertions.Data.DataTableAssertions<TDataTable>>
+        where TDataTable : System.Data.DataTable
+    {
+        public DataTableAssertions(TDataTable dataTable) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> BeEquivalentTo(System.Data.DataTable expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> BeEquivalentTo(System.Data.DataTable expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataTable>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataTable>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>, System.Data.DataColumn> HaveColumn(string expectedColumnName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveColumns(params string[] expectedColumnNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveColumns(System.Collections.Generic.IEnumerable<string> expectedColumnNames, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveRowCount(int expected, string because = "", params object[] becauseArgs) { }
+    }
+    public interface IDataEquivalencyAssertionOptions<T> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
+    {
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> AllowingMismatchedTypes();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> Excluding(System.Linq.Expressions.Expression<System.Func<T, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumn(System.Data.DataColumn column);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumn(string tableName, string columnName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnInAllTables(string columnName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(System.Collections.Generic.IEnumerable<System.Data.DataColumn> columns);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(params System.Data.DataColumn[] columns);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(string tableName, System.Collections.Generic.IEnumerable<string> columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(string tableName, params string[] columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnsInAllTables(System.Collections.Generic.IEnumerable<string> columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnsInAllTables(params string[] columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingOriginalData();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.Constraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataColumn, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataRelation, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataRow, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataTable, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.ForeignKeyConstraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.UniqueConstraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTable(string tableName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTables(System.Collections.Generic.IEnumerable<string> tableNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTables(params string[] tableNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> IgnoringUnmatchedColumns();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> UsingRowMatchMode(FluentAssertions.Data.RowMatchMode rowMatchMode);
+    }
+    public enum RowMatchMode
+    {
+        Index = 0,
+        PrimaryKey = 1,
+    }
+}
 namespace FluentAssertions.Equivalency
 {
     public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
@@ -605,6 +701,18 @@ namespace FluentAssertions.Equivalency
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public override string ToString() { }
     }
+    public class ConstraintCollectionEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ConstraintCollectionEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class ConstraintEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ConstraintEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
     public class ConversionSelector
     {
         public ConversionSelector() { }
@@ -619,6 +727,42 @@ namespace FluentAssertions.Equivalency
     {
         Ignore = 0,
         ThrowException = 1,
+    }
+    public class DataColumnEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataColumnEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataRelationEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataRelationEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataRowCollectionEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataRowCollectionEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataRowEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataRowEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataSetEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataSetEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataTableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataTableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
     }
     public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -42,6 +42,7 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
         public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
         public static FluentAssertions.Collections.NonGenericCollectionAssertions Should(this System.Collections.IEnumerable actualValue) { }
+        public static FluentAssertions.Data.DataColumnAssertions Should(this System.Data.DataColumn actualValue) { }
         public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
@@ -108,6 +109,8 @@ namespace FluentAssertions
         public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
+        public static TOptions CloneDefaults<T, TOptions>()
+            where TOptions : FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> { }
     }
     public static class AtLeast
     {
@@ -132,6 +135,21 @@ namespace FluentAssertions
     public class CustomAssertionAttribute : System.Attribute
     {
         public CustomAssertionAttribute() { }
+    }
+    public static class DataRowAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataRowAssertions<TDataRow> Should<TDataRow>(this TDataRow actualValue)
+            where TDataRow : System.Data.DataRow { }
+    }
+    public static class DataSetAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataSetAssertions<TDataSet> Should<TDataSet>(this TDataSet actualValue)
+            where TDataSet : System.Data.DataSet { }
+    }
+    public static class DataTableAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataTableAssertions<TDataTable> Should<TDataTable>(this TDataTable actualValue)
+            where TDataTable : System.Data.DataTable { }
     }
     public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
     {
@@ -582,6 +600,84 @@ namespace FluentAssertions.Common
         Scan = 2,
     }
 }
+namespace FluentAssertions.Data
+{
+    public class DataColumnAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataColumn, FluentAssertions.Data.DataColumnAssertions>
+    {
+        public DataColumnAssertions(System.Data.DataColumn dataColumn) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataColumnAssertions> BeEquivalentTo(System.Data.DataColumn expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataColumnAssertions> BeEquivalentTo(System.Data.DataColumn expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataColumn>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataColumn>> config, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataRowAssertions<TDataRow> : FluentAssertions.Primitives.ReferenceTypeAssertions<TDataRow, FluentAssertions.Data.DataRowAssertions<TDataRow>>
+        where TDataRow : System.Data.DataRow
+    {
+        public DataRowAssertions(TDataRow dataRow) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> BeEquivalentTo(System.Data.DataRow expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> BeEquivalentTo(System.Data.DataRow expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataRow>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataRow>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>, System.Data.DataColumn> HaveColumn(string expectedColumnName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> HaveColumns(params string[] expectedColumnNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> HaveColumns(System.Collections.Generic.IEnumerable<string> expectedColumnNames, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataSetAssertions<TDataSet> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataSet, FluentAssertions.Data.DataSetAssertions<TDataSet>>
+        where TDataSet : System.Data.DataSet
+    {
+        public DataSetAssertions(TDataSet dataSet) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> BeEquivalentTo(System.Data.DataSet expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> BeEquivalentTo(System.Data.DataSet expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataSet>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataSet>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>, System.Data.DataTable> HaveTable(string expectedTableName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTableCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTables(params string[] expectedTableNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTables(System.Collections.Generic.IEnumerable<string> expectedTableNames, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataTableAssertions<TDataTable> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataTable, FluentAssertions.Data.DataTableAssertions<TDataTable>>
+        where TDataTable : System.Data.DataTable
+    {
+        public DataTableAssertions(TDataTable dataTable) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> BeEquivalentTo(System.Data.DataTable expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> BeEquivalentTo(System.Data.DataTable expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataTable>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataTable>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>, System.Data.DataColumn> HaveColumn(string expectedColumnName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveColumns(params string[] expectedColumnNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveColumns(System.Collections.Generic.IEnumerable<string> expectedColumnNames, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveRowCount(int expected, string because = "", params object[] becauseArgs) { }
+    }
+    public interface IDataEquivalencyAssertionOptions<T> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
+    {
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> AllowingMismatchedTypes();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> Excluding(System.Linq.Expressions.Expression<System.Func<T, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumn(System.Data.DataColumn column);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumn(string tableName, string columnName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnInAllTables(string columnName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(System.Collections.Generic.IEnumerable<System.Data.DataColumn> columns);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(params System.Data.DataColumn[] columns);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(string tableName, System.Collections.Generic.IEnumerable<string> columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(string tableName, params string[] columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnsInAllTables(System.Collections.Generic.IEnumerable<string> columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnsInAllTables(params string[] columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingOriginalData();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.Constraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataColumn, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataRelation, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataRow, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataTable, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.ForeignKeyConstraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.UniqueConstraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTable(string tableName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTables(System.Collections.Generic.IEnumerable<string> tableNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTables(params string[] tableNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> IgnoringUnmatchedColumns();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> UsingRowMatchMode(FluentAssertions.Data.RowMatchMode rowMatchMode);
+    }
+    public enum RowMatchMode
+    {
+        Index = 0,
+        PrimaryKey = 1,
+    }
+}
 namespace FluentAssertions.Equivalency
 {
     public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
@@ -598,6 +694,18 @@ namespace FluentAssertions.Equivalency
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public override string ToString() { }
     }
+    public class ConstraintCollectionEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ConstraintCollectionEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class ConstraintEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ConstraintEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
     public class ConversionSelector
     {
         public ConversionSelector() { }
@@ -612,6 +720,42 @@ namespace FluentAssertions.Equivalency
     {
         Ignore = 0,
         ThrowException = 1,
+    }
+    public class DataColumnEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataColumnEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataRelationEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataRelationEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataRowCollectionEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataRowCollectionEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataRowEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataRowEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataSetEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataSetEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataTableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataTableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
     }
     public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -43,6 +43,7 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.ActionAssertions Should(this System.Action action) { }
         public static FluentAssertions.Collections.StringCollectionAssertions Should(this System.Collections.Generic.IEnumerable<string> @this) { }
         public static FluentAssertions.Collections.NonGenericCollectionAssertions Should(this System.Collections.IEnumerable actualValue) { }
+        public static FluentAssertions.Data.DataColumnAssertions Should(this System.Data.DataColumn actualValue) { }
         public static FluentAssertions.Primitives.DateTimeAssertions Should(this System.DateTime actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
@@ -109,6 +110,8 @@ namespace FluentAssertions
         public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
+        public static TOptions CloneDefaults<T, TOptions>()
+            where TOptions : FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> { }
     }
     public static class AtLeast
     {
@@ -133,6 +136,21 @@ namespace FluentAssertions
     public class CustomAssertionAttribute : System.Attribute
     {
         public CustomAssertionAttribute() { }
+    }
+    public static class DataRowAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataRowAssertions<TDataRow> Should<TDataRow>(this TDataRow actualValue)
+            where TDataRow : System.Data.DataRow { }
+    }
+    public static class DataSetAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataSetAssertions<TDataSet> Should<TDataSet>(this TDataSet actualValue)
+            where TDataSet : System.Data.DataSet { }
+    }
+    public static class DataTableAssertionExtensions
+    {
+        public static FluentAssertions.Data.DataTableAssertions<TDataTable> Should<TDataTable>(this TDataTable actualValue)
+            where TDataTable : System.Data.DataTable { }
     }
     public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
     {
@@ -589,6 +607,84 @@ namespace FluentAssertions.Common
         Scan = 2,
     }
 }
+namespace FluentAssertions.Data
+{
+    public class DataColumnAssertions : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataColumn, FluentAssertions.Data.DataColumnAssertions>
+    {
+        public DataColumnAssertions(System.Data.DataColumn dataColumn) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataColumnAssertions> BeEquivalentTo(System.Data.DataColumn expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataColumnAssertions> BeEquivalentTo(System.Data.DataColumn expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataColumn>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataColumn>> config, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataRowAssertions<TDataRow> : FluentAssertions.Primitives.ReferenceTypeAssertions<TDataRow, FluentAssertions.Data.DataRowAssertions<TDataRow>>
+        where TDataRow : System.Data.DataRow
+    {
+        public DataRowAssertions(TDataRow dataRow) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> BeEquivalentTo(System.Data.DataRow expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> BeEquivalentTo(System.Data.DataRow expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataRow>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataRow>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>, System.Data.DataColumn> HaveColumn(string expectedColumnName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> HaveColumns(params string[] expectedColumnNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataRowAssertions<TDataRow>> HaveColumns(System.Collections.Generic.IEnumerable<string> expectedColumnNames, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataSetAssertions<TDataSet> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataSet, FluentAssertions.Data.DataSetAssertions<TDataSet>>
+        where TDataSet : System.Data.DataSet
+    {
+        public DataSetAssertions(TDataSet dataSet) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> BeEquivalentTo(System.Data.DataSet expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> BeEquivalentTo(System.Data.DataSet expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataSet>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataSet>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>, System.Data.DataTable> HaveTable(string expectedTableName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTableCount(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTables(params string[] expectedTableNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataSetAssertions<TDataSet>> HaveTables(System.Collections.Generic.IEnumerable<string> expectedTableNames, string because = "", params object[] becauseArgs) { }
+    }
+    public class DataTableAssertions<TDataTable> : FluentAssertions.Primitives.ReferenceTypeAssertions<System.Data.DataTable, FluentAssertions.Data.DataTableAssertions<TDataTable>>
+        where TDataTable : System.Data.DataTable
+    {
+        public DataTableAssertions(TDataTable dataTable) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> BeEquivalentTo(System.Data.DataTable expectation, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> BeEquivalentTo(System.Data.DataTable expectation, System.Func<FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataTable>, FluentAssertions.Data.IDataEquivalencyAssertionOptions<System.Data.DataTable>> config, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>, System.Data.DataColumn> HaveColumn(string expectedColumnName, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveColumns(params string[] expectedColumnNames) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveColumns(System.Collections.Generic.IEnumerable<string> expectedColumnNames, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Data.DataTableAssertions<TDataTable>> HaveRowCount(int expected, string because = "", params object[] becauseArgs) { }
+    }
+    public interface IDataEquivalencyAssertionOptions<T> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
+    {
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> AllowingMismatchedTypes();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> Excluding(System.Linq.Expressions.Expression<System.Func<T, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumn(System.Data.DataColumn column);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumn(string tableName, string columnName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnInAllTables(string columnName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(System.Collections.Generic.IEnumerable<System.Data.DataColumn> columns);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(params System.Data.DataColumn[] columns);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(string tableName, System.Collections.Generic.IEnumerable<string> columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumns(string tableName, params string[] columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnsInAllTables(System.Collections.Generic.IEnumerable<string> columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingColumnsInAllTables(params string[] columnNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingOriginalData();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.Constraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataColumn, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataRelation, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataRow, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.DataTable, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.ForeignKeyConstraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingRelated(System.Linq.Expressions.Expression<System.Func<System.Data.UniqueConstraint, object>> expression);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTable(string tableName);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTables(System.Collections.Generic.IEnumerable<string> tableNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> ExcludingTables(params string[] tableNames);
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> IgnoringUnmatchedColumns();
+        FluentAssertions.Data.IDataEquivalencyAssertionOptions<T> UsingRowMatchMode(FluentAssertions.Data.RowMatchMode rowMatchMode);
+    }
+    public enum RowMatchMode
+    {
+        Index = 0,
+        PrimaryKey = 1,
+    }
+}
 namespace FluentAssertions.Equivalency
 {
     public class AssertionRuleEquivalencyStep<TSubject> : FluentAssertions.Equivalency.IEquivalencyStep
@@ -605,6 +701,18 @@ namespace FluentAssertions.Equivalency
         public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
         public override string ToString() { }
     }
+    public class ConstraintCollectionEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ConstraintCollectionEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class ConstraintEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public ConstraintEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
     public class ConversionSelector
     {
         public ConversionSelector() { }
@@ -619,6 +727,42 @@ namespace FluentAssertions.Equivalency
     {
         Ignore = 0,
         ThrowException = 1,
+    }
+    public class DataColumnEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataColumnEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataRelationEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataRelationEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataRowCollectionEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataRowCollectionEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataRowEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataRowEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataSetEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataSetEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+    }
+    public class DataTableEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public DataTableEquivalencyStep() { }
+        public bool CanHandle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
+        public bool Handle(FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator parent, FluentAssertions.Equivalency.IEquivalencyAssertionOptions config) { }
     }
     public class DictionaryEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {

--- a/Tests/Benchmarks/Benchmarks.csproj
+++ b/Tests/Benchmarks/Benchmarks.csproj
@@ -12,4 +12,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Data.DataSetExtensions" />
+  </ItemGroup>
 </Project>

--- a/Tests/Benchmarks/Benchmarks.csproj
+++ b/Tests/Benchmarks/Benchmarks.csproj
@@ -11,6 +11,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="Bogus" Version="31.0.3" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Tests/Benchmarks/LargeDataTableEquivalency.cs
+++ b/Tests/Benchmarks/LargeDataTableEquivalency.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Data;
+using System.Linq;
+
+using BenchmarkDotNet.Attributes;
+
+using Bogus;
+
+using FluentAssertions;
+using FluentAssertions.Data;
+
+namespace Benchmarks
+{
+    [MemoryDiagnoser]
+    public class LargeDataTableEquivalencyBenchmarks
+    {
+        private DataTable dataTable1;
+        private DataTable dataTable2;
+
+        [Params(10, 100, 1_000, 10_000, 100_000, 1_000_000)]
+        public int RowCount { get; set; }
+
+        [GlobalSetup]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0055:Fix formatting", Justification = "Big long list of one-liners")]
+        public void GlobalSetup()
+        {
+            dataTable1 = CreateDataTable();
+            dataTable2 = CreateDataTable();
+
+            object[] rowData = new object[dataTable1.Columns.Count];
+
+            var faker = new Faker();
+
+            faker.Random = new Randomizer(localSeed: 1);
+
+            for (int i = 0; i < RowCount; i++)
+            {
+                for (int j = 0; j < dataTable1.Columns.Count; j++)
+                {
+                    var column = dataTable1.Columns[j];
+
+                    switch (Type.GetTypeCode(column.DataType))
+                    {
+                        case TypeCode.Empty:
+                        case TypeCode.DBNull: rowData[j] = null; break;
+                        case TypeCode.Boolean: rowData[j] = faker.Random.Bool(); break;
+                        case TypeCode.Char: rowData[j] = faker.Lorem.Letter().Single(); break;
+                        case TypeCode.SByte: rowData[j] = faker.Random.SByte(); break;
+                        case TypeCode.Byte: rowData[j] = faker.Random.Byte(); break;
+                        case TypeCode.Int16: rowData[j] = faker.Random.Short(); break;
+                        case TypeCode.UInt16: rowData[j] = faker.Random.UShort(); break;
+                        case TypeCode.Int32: rowData[j] = faker.Random.Int(); break;
+                        case TypeCode.UInt32: rowData[j] = faker.Random.UInt(); break;
+                        case TypeCode.Int64: rowData[j] = faker.Random.Long(); break;
+                        case TypeCode.UInt64: rowData[j] = faker.Random.ULong(); break;
+                        case TypeCode.Single: rowData[j] = faker.Random.Float(); break;
+                        case TypeCode.Double: rowData[j] = faker.Random.Double(); break;
+                        case TypeCode.Decimal: rowData[j] = faker.Random.Decimal(); break;
+                        case TypeCode.DateTime: rowData[j] = faker.Date.Between(DateTime.UtcNow.AddDays(-30), DateTime.UtcNow.AddDays(+30)); break;
+                        case TypeCode.String: rowData[j] = faker.Lorem.Lines(1); break;
+
+                        default:
+                        {
+                            if (column.DataType == typeof(TimeSpan))
+                                rowData[j] = faker.Date.Future() - faker.Date.Future();
+                            else if (column.DataType == typeof(Guid))
+                                rowData[j] = faker.Random.Guid();
+                            else
+                                throw new Exception("Unable to populate column of type " + column.DataType);
+
+                            break;
+                        }
+                    }
+                }
+
+                dataTable1.Rows.Add(rowData);
+                dataTable2.Rows.Add(rowData);
+            }
+        }
+
+        private static DataTable CreateDataTable()
+        {
+            var table = new DataTable("Test");
+
+            table.Columns.Add("A", typeof(bool));
+            table.Columns.Add("B", typeof(char));
+            table.Columns.Add("C", typeof(sbyte));
+            table.Columns.Add("D", typeof(byte));
+            table.Columns.Add("E", typeof(short));
+            table.Columns.Add("F", typeof(ushort));
+            table.Columns.Add("G", typeof(int));
+            table.Columns.Add("H", typeof(uint));
+            table.Columns.Add("I", typeof(long));
+            table.Columns.Add("J", typeof(ulong));
+            table.Columns.Add("K", typeof(float));
+            table.Columns.Add("L", typeof(double));
+            table.Columns.Add("M", typeof(decimal));
+            table.Columns.Add("N", typeof(DateTime));
+            table.Columns.Add("O", typeof(string));
+            table.Columns.Add("P", typeof(TimeSpan));
+            table.Columns.Add("Q", typeof(Guid));
+
+            return table;
+        }
+
+        [Benchmark]
+        public AndConstraint<DataTableAssertions<DataTable>> BeEquivalentTo() => dataTable1.Should().BeEquivalentTo(dataTable2);
+    }
+}

--- a/Tests/Benchmarks/Program.cs
+++ b/Tests/Benchmarks/Program.cs
@@ -6,7 +6,7 @@ namespace Benchmarks
     {
         public static void Main()
         {
-            _ = BenchmarkRunner.Run<LargeObjectGraphBenchmarks>();
+            _ = BenchmarkRunner.Run<LargeDataTableEquivalencyBenchmarks>();
         }
     }
 }

--- a/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
+++ b/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
@@ -1,0 +1,195 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Bogus;
+
+using FluentAssertions.Equivalency;
+using FluentAssertions.Equivalency.Tracing;
+using FluentAssertions.Execution;
+
+namespace Benchmarks
+{
+    [SimpleJob(RunStrategy.Throughput, warmupCount: 3, targetCount: 20)]
+    public class UsersOfGetClosedGenericInterfaces
+    {
+        private const int ValueCount = 100_000;
+
+        private object[] values;
+
+        private GenericDictionaryEquivalencyStep dictionaryStep;
+        private GenericEnumerableEquivalencyStep enumerableStep;
+
+        private IEquivalencyValidationContext context;
+        private IEquivalencyAssertionOptions config;
+
+        private class Context : IEquivalencyValidationContext
+        {
+            public INode CurrentNode => throw new NotImplementedException();
+
+            public Type CompileTimeType { get; set; }
+            public Type RuntimeType { get; set; }
+
+            public object Expectation { get; set; }
+
+            public object Subject { get; set; }
+
+            public Reason Reason => throw new NotImplementedException();
+
+            public Tracer Tracer => throw new NotImplementedException();
+
+            public IEquivalencyValidationContext AsCollectionItem<T>(string index, object subject, T expectation) => throw new NotImplementedException();
+            public IEquivalencyValidationContext AsDictionaryItem<TKey, TExpectation>(TKey key, object subject, TExpectation expectation) => throw new NotImplementedException();
+            public IEquivalencyValidationContext AsNestedMember(IMember expectationMember, IMember matchingSubjectMember) => throw new NotImplementedException();
+            public IEquivalencyValidationContext Clone() => throw new NotImplementedException();
+        }
+
+        private class Config : IEquivalencyAssertionOptions
+        {
+            public IEnumerable<IMemberSelectionRule> SelectionRules => throw new NotImplementedException();
+
+            public IEnumerable<IMemberMatchingRule> MatchingRules => throw new NotImplementedException();
+
+            public bool IsRecursive => throw new NotImplementedException();
+
+            public bool AllowInfiniteRecursion => throw new NotImplementedException();
+
+            public CyclicReferenceHandling CyclicReferenceHandling => throw new NotImplementedException();
+
+            public OrderingRuleCollection OrderingRules => throw new NotImplementedException();
+
+            public ConversionSelector ConversionSelector => throw new NotImplementedException();
+
+            public EnumEquivalencyHandling EnumEquivalencyHandling => throw new NotImplementedException();
+
+            public IEnumerable<IEquivalencyStep> UserEquivalencySteps => throw new NotImplementedException();
+
+            public bool UseRuntimeTyping => false;
+
+            public bool IncludeProperties => throw new NotImplementedException();
+
+            public bool IncludeFields => throw new NotImplementedException();
+
+            public ITraceWriter TraceWriter => throw new NotImplementedException();
+
+            public EqualityStrategy GetEqualityStrategy(Type type) => throw new NotImplementedException();
+        }
+
+        [Params(typeof(DBNull), typeof(bool), typeof(char), typeof(sbyte), typeof(byte), typeof(short), typeof(ushort),
+            typeof(int), typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal), typeof(DateTime),
+            typeof(string), typeof(TimeSpan), typeof(Guid), typeof(Dictionary<int, int>), typeof(IEnumerable<int>))]
+        public Type DataType { get; set; }
+
+        [GlobalSetup]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0055:Fix formatting", Justification = "Big long list of one-liners")]
+        public void GlobalSetup()
+        {
+            dictionaryStep = new GenericDictionaryEquivalencyStep();
+            enumerableStep = new GenericEnumerableEquivalencyStep();
+
+            values = new object[ValueCount];
+
+            var faker = new Faker();
+
+            faker.Random = new Randomizer(localSeed: 1);
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                switch (Type.GetTypeCode(DataType))
+                {
+                    case TypeCode.DBNull:
+                        values[i] = DBNull.Value;
+                        break;
+                    case TypeCode.Boolean:
+                        values[i] = faker.Random.Bool();
+                        break;
+                    case TypeCode.Char:
+                        values[i] = faker.Lorem.Letter().Single();
+                        break;
+                    case TypeCode.SByte:
+                        values[i] = faker.Random.SByte();
+                        break;
+                    case TypeCode.Byte:
+                        values[i] = faker.Random.Byte();
+                        break;
+                    case TypeCode.Int16:
+                        values[i] = faker.Random.Short();
+                        break;
+                    case TypeCode.UInt16:
+                        values[i] = faker.Random.UShort();
+                        break;
+                    case TypeCode.Int32:
+                        values[i] = faker.Random.Int();
+                        break;
+                    case TypeCode.UInt32:
+                        values[i] = faker.Random.UInt();
+                        break;
+                    case TypeCode.Int64:
+                        values[i] = faker.Random.Long();
+                        break;
+                    case TypeCode.UInt64:
+                        values[i] = faker.Random.ULong();
+                        break;
+                    case TypeCode.Single:
+                        values[i] = faker.Random.Float();
+                        break;
+                    case TypeCode.Double:
+                        values[i] = faker.Random.Double();
+                        break;
+                    case TypeCode.Decimal:
+                        values[i] = faker.Random.Decimal();
+                        break;
+                    case TypeCode.DateTime:
+                        values[i] = faker.Date.Between(DateTime.UtcNow.AddDays(-30), DateTime.UtcNow.AddDays(+30));
+                        break;
+                    case TypeCode.String:
+                        values[i] = faker.Lorem.Lines(1);
+                        break;
+
+                    default:
+                    {
+                        if (DataType == typeof(TimeSpan))
+                            values[i] = faker.Date.Future() - faker.Date.Future();
+                        else if (DataType == typeof(Guid))
+                            values[i] = faker.Random.Guid();
+                        else if (DataType == typeof(Dictionary<int, int>))
+                            values[i] = new Dictionary<int, int>() { { faker.Random.Int(), faker.Random.Int() } };
+                        else if (DataType == typeof(IEnumerable<int>))
+                            values[i] = new int[] { faker.Random.Int(), faker.Random.Int() };
+                        else
+                            throw new Exception("Unable to populate data of type " + DataType);
+
+                        break;
+                    }
+                }
+            }
+
+            context = new Context() { RuntimeType = DataType, CompileTimeType = DataType, Expectation = values[0] };
+            config = new Config();
+        }
+
+        [Benchmark]
+        public void GenericDictionaryEquivalencyStep_CanHandle()
+        {
+            for (int i = 0; i < values.Length; i++)
+            {
+                context.Subject = values[i];
+
+                dictionaryStep.CanHandle(context, config);
+            }
+        }
+
+        [Benchmark]
+        public void GenericEnumerableEquivalencyStep_CanHandle()
+        {
+            for (int i = 0; i < values.Length; i++)
+            {
+                context.Subject = values[i];
+
+                enumerableStep.CanHandle(context, config);
+            }
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataColumn.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataColumn.cs
@@ -1,0 +1,714 @@
+﻿using System;
+using System.Data;
+
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs
+{
+    /// <summary>
+    /// DataColumnEquivalency specs.
+    /// </summary>
+    public partial class DataEquivalencySpecs
+    {
+        public class DataColumnEquivalencySpecs : DataEquivalencySpecs
+        {
+            [Fact]
+            public void When_DataColumns_are_identical_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                // Act & Assert
+                dataTable1.RowIDColumn.Should().BeEquivalentTo(dataTable2.RowIDColumn);
+            }
+
+            [Fact]
+            public void When_DataColumns_are_both_null_it_should_succeed()
+            {
+                // Act & Assert
+                ((DataColumn)null).Should().BeEquivalentTo(null);
+            }
+
+            [Fact]
+            public void When_DataColumn_is_null_and_isnt_expected_to_be_it_should_fail()
+            {
+                // Arrange
+                var dataSet = CreateDummyDataSet<TypedDataSet>();
+
+                var dataTable = dataSet.TypedDataTable1;
+
+                // Act
+                Action action = () => ((DataColumn)null).Should().BeEquivalentTo(dataTable.RowIDColumn);
+
+                // Assert
+                action.Should().Throw<XunitException>().WithMessage(
+                    "Expected *of type DataColumn*to be non-null, but found null*");
+            }
+
+            [Fact]
+            public void When_DataColumn_is_expected_to_be_null_and_isnt_it_should_fail()
+            {
+                // Arrange
+                var dataSet = CreateDummyDataSet<TypedDataSet>();
+
+                var dataTable = dataSet.TypedDataTable1;
+
+                // Act
+                Action action = () => dataTable.RowIDColumn.Should().BeEquivalentTo(null);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DataColumn_has_changes_but_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.Unique = true;
+                dataColumn2.Caption = "Test";
+
+                // Act & Assert
+                dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+                    .ExcludingColumn(dataColumn2));
+            }
+
+            [Fact]
+            public void When_DataColumn_has_changes_but_is_excluded_it_should_succeed_when_compared_via_DataTable()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataTable2.DecimalColumn.Unique = true;
+                dataTable2.DecimalColumn.Caption = "Test";
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                    .ExcludingColumn(dataTable2.DecimalColumn)
+                    .ExcludingRelated((DataTable dataTable) => dataTable.Constraints));
+            }
+
+            [Fact]
+            public void When_DataColumn_has_changes_but_is_excluded_it_should_succeed_when_compared_via_DataSet()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataTable2.DecimalColumn.Unique = true;
+                dataTable2.DecimalColumn.Caption = "Test";
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options
+                    .ExcludingColumn(dataTable2.DecimalColumn)
+                    .ExcludingRelated((DataTable dataTable) => dataTable.Constraints));
+            }
+
+            [Fact]
+            public void When_ColumnName_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.ColumnName += "different";
+
+                // Act
+                Action action = () => dataColumn1.Should().BeEquivalentTo(dataColumn2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_ColumnName_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.ColumnName += "different";
+
+                // Act & Assert
+                dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+                    .Excluding(dataColumn => dataColumn.ColumnName)
+                    .Excluding(dataColumn => dataColumn.Caption));
+            }
+
+            [Fact]
+            public void When_AllowDBNull_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.AllowDBNull = !dataColumn2.AllowDBNull;
+
+                // Act
+                Action action = () => dataColumn1.Should().BeEquivalentTo(dataColumn2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_AllowDBNull_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.AllowDBNull = !dataColumn2.AllowDBNull;
+
+                // Act & Assert
+                dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+                    .Excluding(dataColumn => dataColumn.AllowDBNull));
+            }
+
+            [Fact]
+            public void When_AutoIncrement_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.AutoIncrement = !dataColumn2.AutoIncrement;
+
+                // Act
+                Action action = () => dataColumn1.Should().BeEquivalentTo(dataColumn2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_AutoIncrement_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.AutoIncrement = !dataColumn2.AutoIncrement;
+
+                // Act & Assert
+                dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+                    .Excluding(dataColumn => dataColumn.AutoIncrement));
+            }
+
+            [Fact]
+            public void When_AutoIncrementSeed_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.AutoIncrementSeed++;
+
+                // Act
+                Action action = () => dataColumn1.Should().BeEquivalentTo(dataColumn2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_AutoIncrementSeed_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.AutoIncrementSeed++;
+
+                // Act & Assert
+                dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+                    .Excluding(dataColumn => dataColumn.AutoIncrementSeed));
+            }
+
+            [Fact]
+            public void When_AutoIncrementStep_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.AutoIncrementStep++;
+
+                // Act
+                Action action = () => dataColumn1.Should().BeEquivalentTo(dataColumn2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_AutoIncrementStep_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.AutoIncrementStep++;
+
+                // Act & Assert
+                dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+                    .Excluding(dataColumn => dataColumn.AutoIncrementStep));
+            }
+
+            [Fact]
+            public void When_Caption_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.Caption += "different";
+
+                // Act
+                Action action = () => dataColumn1.Should().BeEquivalentTo(dataColumn2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Caption_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.Caption += "different";
+
+                // Act & Assert
+                dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+                    .Excluding(dataColumn => dataColumn.Caption));
+            }
+
+            [Fact]
+            public void When_DataType_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>(includeDummyData: false);
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable2.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable2.DecimalColumn;
+
+                dataColumn2.DataType = typeof(double);
+
+                // Act
+                Action action = () => dataColumn1.Should().BeEquivalentTo(dataColumn2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DataType_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>(includeDummyData: false);
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable2.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable2.DecimalColumn;
+
+                dataColumn2.DataType = typeof(double);
+
+                // Act & Assert
+                dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+                    .Excluding(dataColumn => dataColumn.DataType));
+            }
+
+            [Fact]
+            public void When_DateTimeMode_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>(includeDummyData: false);
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable2.DateTimeColumn;
+                var dataColumn2 = dataSet2.TypedDataTable2.DateTimeColumn;
+
+                dataColumn2.DateTimeMode =
+                    dataColumn2.DateTimeMode == DataSetDateTime.Local
+                    ? DataSetDateTime.Utc
+                    : DataSetDateTime.Local;
+
+                // Act
+                Action action = () => dataColumn1.Should().BeEquivalentTo(dataColumn2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DateTimeMode_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>(includeDummyData: false);
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable2.DateTimeColumn;
+                var dataColumn2 = dataSet2.TypedDataTable2.DateTimeColumn;
+
+                dataColumn2.DateTimeMode =
+                    dataColumn2.DateTimeMode == DataSetDateTime.Local
+                    ? DataSetDateTime.Utc
+                    : DataSetDateTime.Local;
+
+                // Act & Assert
+                dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+                    .Excluding(dataColumn => dataColumn.DateTimeMode));
+            }
+
+            [Fact]
+            public void When_DefaultValue_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.DefaultValue = 10M;
+
+                // Act
+                Action action = () => dataColumn1.Should().BeEquivalentTo(dataColumn2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DefaultValue_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.DefaultValue = 10M;
+
+                // Act & Assert
+                dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+                    .Excluding(dataColumn => dataColumn.DefaultValue));
+            }
+
+            [Fact]
+            public void When_Expression_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.Expression = "RowID";
+
+                // Act
+                Action action = () =>
+                    dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+                        .Excluding(dataColumn => dataColumn.ReadOnly));
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Expression_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.Expression = "RowID";
+
+                // Act & Assert
+                dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+                    .Excluding(dataColumn => dataColumn.Expression)
+                    .Excluding(dataColumn => dataColumn.ReadOnly));
+            }
+
+            [Fact]
+            public void When_MaxLength_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.StringColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.StringColumn;
+
+                dataColumn2.MaxLength = 250;
+
+                // Act
+                Action action = () => dataColumn1.Should().BeEquivalentTo(dataColumn2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_MaxLength_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.StringColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.StringColumn;
+
+                dataColumn2.MaxLength = 250;
+
+                // Act & Assert
+                dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+                    .Excluding(dataColumn => dataColumn.MaxLength));
+            }
+
+            [Fact]
+            public void When_Namespace_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.Namespace += "different";
+
+                // Act
+                Action action = () => dataColumn1.Should().BeEquivalentTo(dataColumn2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Namespace_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.Namespace += "different";
+
+                // Act & Assert
+                dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+                    .Excluding(dataColumn => dataColumn.Namespace));
+            }
+
+            [Fact]
+            public void When_Prefix_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.Prefix += "different";
+
+                // Act
+                Action action = () => dataColumn1.Should().BeEquivalentTo(dataColumn2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Prefix_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.Prefix += "different";
+
+                // Act & Assert
+                dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+                    .Excluding(dataColumn => dataColumn.Prefix));
+            }
+
+            [Fact]
+            public void When_ReadOnly_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.ReadOnly = !dataColumn2.ReadOnly;
+
+                // Act
+                Action action = () => dataColumn1.Should().BeEquivalentTo(dataColumn2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_ReadOnly_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.ReadOnly = !dataColumn2.ReadOnly;
+
+                // Act & Assert
+                dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+                    .Excluding(dataColumn => dataColumn.ReadOnly));
+            }
+
+            [Fact]
+            public void When_Unique_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.Unique = !dataColumn2.Unique;
+
+                // Act
+                Action action = () => dataColumn1.Should().BeEquivalentTo(dataColumn2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Unique_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataColumn1 = dataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = dataSet2.TypedDataTable1.DecimalColumn;
+
+                dataColumn2.Unique = !dataColumn2.Unique;
+
+                // Act & Assert
+                dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options
+                    .Excluding(dataColumn => dataColumn.Unique));
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_ExtendedProperties_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataColumn1 = typedDataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = typedDataSet2.TypedDataTable1.DecimalColumn;
+
+                ApplyChange(dataColumn2.ExtendedProperties, changeType);
+
+                // Act
+                Action action = () => dataColumn1.Should().BeEquivalentTo(dataColumn2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_ExtendedProperties_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataColumn1 = typedDataSet1.TypedDataTable1.DecimalColumn;
+                var dataColumn2 = typedDataSet2.TypedDataTable1.DecimalColumn;
+
+                ApplyChange(dataColumn2.ExtendedProperties, changeType);
+
+                // Act & Assert
+                dataColumn1.Should().BeEquivalentTo(dataColumn2, options => options.Excluding(dataColumn => dataColumn.ExtendedProperties));
+            }
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataRelation.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataRelation.cs
@@ -1,0 +1,262 @@
+﻿using System;
+using System.Data;
+
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs
+{
+    /// <summary>
+    /// DataRelationEquivalency specs.
+    /// </summary>
+    public partial class DataEquivalencySpecs
+    {
+        public class DataRelationEquivalencySpecs : DataEquivalencySpecs
+        {
+            [Fact]
+            public void When_RelationName_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataSet2.Relations[0].RelationName += "different";
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_RelationName_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataSet2.Relations[0].RelationName += "different";
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(
+                    dataTable2,
+                    options => options
+                    .ExcludingRelated((DataRelation dataRelation) => dataRelation.RelationName));
+            }
+
+            [Fact]
+            public void When_Nested_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataSet2.Relations[0].Nested = !dataSet2.Relations[0].Nested;
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Nested_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataSet2.Relations[0].Nested = !dataSet2.Relations[0].Nested;
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(
+                    dataTable2,
+                    options => options
+                    .ExcludingRelated((DataRelation dataRelation) => dataRelation.Nested));
+            }
+
+            [Fact]
+            public void When_DataSet_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataSet2.DataSetName += "different";
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.DataSet));
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DataSet_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>(identicalTables: true);
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataSet2.DataSetName += "different";
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(
+                    dataTable2,
+                    options => options
+                    .Excluding(dataTable => dataTable.DataSet)
+                    .ExcludingRelated((DataRelation dataRelation) => dataRelation.DataSet));
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_ExtendedProperties_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                ApplyChange(dataTable2.ChildRelations[0].ExtendedProperties, changeType);
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_ExtendedProperties_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                ApplyChange(dataTable2.ChildRelations[0].ExtendedProperties, changeType);
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                    .ExcludingRelated((DataRelation dataRelation) => dataRelation.ExtendedProperties));
+            }
+
+            [Fact]
+            public void When_ParentColumns_do_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable2;
+                var dataTable2 = dataSet2.TypedDataTable2;
+
+                dataSet2.TypedDataTable1.RowIDColumn.ColumnName += "different";
+
+                // Act
+                Action action = () =>
+                    dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                        .Excluding(dataTable => dataTable.ChildRelations)
+                        .Excluding(dataTable => dataTable.Constraints));
+
+                // Assert
+                action.Should().Throw<XunitException>().Which.Message.Should().Contain(dataSet2.TypedDataTable1.Columns[0].ColumnName);
+            }
+
+            [Fact]
+            public void When_ParentColumns_do_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable2;
+                var dataTable2 = dataSet2.TypedDataTable2;
+
+                dataSet2.TypedDataTable1.RowIDColumn.ColumnName += "different";
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                    .Excluding(dataTable => dataTable.ChildRelations)
+                    .Excluding(dataTable => dataTable.Constraints)
+                    .ExcludingRelated((DataRelation dataRelation) => dataRelation.ParentColumns)
+                    .ExcludingRelated((DataRelation dataRelation) => dataRelation.ParentKeyConstraint)
+                    .ExcludingRelated((DataRelation dataRelation) => dataRelation.ChildKeyConstraint));
+            }
+
+            [Fact]
+            public void When_ChildColumns_do_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataSet2.TypedDataTable2.ForeignRowIDColumn.ColumnName += "different";
+
+                // Act
+                Action action = () =>
+                    dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                        .Excluding(dataTable => dataTable.ParentRelations)
+                        .Excluding(dataTable => dataTable.Constraints));
+
+                // Assert
+                action.Should().Throw<XunitException>().Which.Message.Should().Contain(dataSet2.TypedDataTable1.Columns[0].ColumnName);
+            }
+
+            [Fact]
+            public void When_ChildColumns_do_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataSet2.TypedDataTable2.ForeignRowIDColumn.ColumnName += "different";
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                    .Excluding(dataTable => dataTable.ParentRelations)
+                    .Excluding(dataTable => dataTable.Constraints)
+                    .ExcludingRelated((DataRelation dataRelation) => dataRelation.ChildColumns)
+                    .ExcludingRelated((DataRelation dataRelation) => dataRelation.ParentKeyConstraint)
+                    .ExcludingRelated((DataRelation dataRelation) => dataRelation.ChildKeyConstraint));
+            }
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataRow.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataRow.cs
@@ -1,0 +1,339 @@
+﻿using System;
+using System.Data;
+
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs
+{
+    /// <summary>
+    /// DataRowEquivalency specs.
+    /// </summary>
+    public partial class DataEquivalencySpecs
+    {
+        public class DataRowEquivalencySpecs
+        {
+            [Fact]
+            public void When_DataRows_are_identical_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                // Act & Assert
+                dataTable1[0].Should().BeEquivalentTo(dataTable2[0]);
+            }
+
+            [Fact]
+            public void When_DataRows_are_both_null_it_should_succeed()
+            {
+                // Act & Assert
+                ((DataRow)null).Should().BeEquivalentTo(null);
+            }
+
+            [Fact]
+            public void When_DataRow_is_null_and_isnt_expected_to_be_it_should_fail()
+            {
+                // Arrange
+                var dataSet = CreateDummyDataSet<TypedDataSet>();
+
+                var dataTable = dataSet.TypedDataTable1;
+
+                // Act
+                Action action = () => ((DataRow)null).Should().BeEquivalentTo(dataTable[0]);
+
+                // Assert
+                action.Should().Throw<XunitException>().WithMessage(
+                    "Expected *of type DataRow*to be non-null, but found null*");
+            }
+
+            [Fact]
+            public void When_DataRow_is_expected_to_be_null_and_isnt_it_should_fail()
+            {
+                // Arrange
+                var dataSet = CreateDummyDataSet<TypedDataSet>();
+
+                var dataTable = dataSet.TypedDataTable1;
+
+                // Act
+                Action action = () => dataTable[0].Should().BeEquivalentTo(null);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DataRow_subject_is_deleted_and_RowState_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable2;
+                var dataTable2 = dataSet2.TypedDataTable2;
+
+                var dataRow1 = dataTable1[0];
+                var dataRow2 = dataTable2[0];
+
+                dataRow1.Delete();
+
+                // Act & Assert
+                dataRow1.Should().BeEquivalentTo(dataRow2, config => config
+                    .Excluding(row => row.RowState));
+            }
+
+            [Fact]
+            public void When_DataRow_expectation_is_deleted_and_RowState_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable2;
+                var dataTable2 = dataSet2.TypedDataTable2;
+
+                var dataRow1 = dataTable1[0];
+                var dataRow2 = dataTable2[0];
+
+                dataRow2.Delete();
+
+                // Act & Assert
+                dataRow1.Should().BeEquivalentTo(dataRow2, config => config
+                    .Excluding(row => row.RowState));
+            }
+
+            [Fact]
+            public void When_DataRow_is_deleted_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable2;
+                var dataTable2 = dataSet2.TypedDataTable2;
+
+                var dataRow1 = dataTable1[0];
+                var dataRow2 = dataTable2[0];
+
+                dataRow1.Delete();
+                dataRow2.Delete();
+
+                // Act & Assert
+                dataRow1.Should().BeEquivalentTo(dataRow2);
+            }
+
+            [Fact]
+            public void When_DataRow_is_modified_and_original_data_differs_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable2;
+                var dataTable2 = dataSet2.TypedDataTable2;
+
+                var dataRow1 = dataTable1[0];
+                var dataRow2 = dataTable2[0];
+
+                dataRow1.Decimal++;
+                dataTable1.AcceptChanges();
+                dataRow1.Decimal--;
+
+                dataRow2.Decimal--;
+                dataTable2.AcceptChanges();
+                dataRow2.Decimal++;
+
+                // Act
+                Action action = () => dataRow1.Should().BeEquivalentTo(dataRow2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DataRow_is_modified_and_original_data_differs_and_original_data_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable2;
+                var dataTable2 = dataSet2.TypedDataTable2;
+
+                var dataRow1 = dataTable1[0];
+                var dataRow2 = dataTable2[0];
+
+                dataRow1.Decimal++;
+                dataTable1.AcceptChanges();
+                dataRow1.Decimal--;
+
+                dataRow2.Decimal--;
+                dataTable2.AcceptChanges();
+                dataRow2.Decimal++;
+
+                // Act & Assert
+                dataRow1.Should().BeEquivalentTo(dataRow2, config => config
+                    .ExcludingOriginalData());
+            }
+
+            [Fact]
+            public void When_DataRow_type_does_not_match_and_AllowMismatchedType_not_enabled_it_should_fail()
+            {
+                // Arrange
+                var dataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
+                var dataSet2 = new TypedDataSetSubclass(dataSet);
+
+                var dataTable = dataSet.TypedDataTable1;
+                var dataTableOfMismatchedType = dataSet2.TypedDataTable2;
+
+                dataSet2.Tables.Remove(dataTable.TableName);
+                dataTableOfMismatchedType.TableName = dataTable.TableName;
+
+                // Act
+                Action action = () => dataTable[0].Should().BeEquivalentTo(dataTableOfMismatchedType[0]);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DataRow_type_does_not_match_and_AllowMismatchedType_is_enabled_it_should_succeed()
+            {
+                // Arrange
+                var dataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
+                var dataSet2 = new TypedDataSetSubclass(dataSet);
+
+                var dataTable = dataSet.TypedDataTable1;
+                var dataTableOfMismatchedType = dataSet2.TypedDataTable2;
+
+                dataSet2.Tables.Remove(dataTable.TableName);
+                dataTableOfMismatchedType.TableName = dataTable.TableName;
+
+                // Act & Assert
+                dataTable[0].Should().BeEquivalentTo(dataTableOfMismatchedType[0], options => options.AllowingMismatchedTypes());
+            }
+
+            [Fact]
+            public void When_HasErrors_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataRow1 = dataSet1.TypedDataTable1[0];
+                var dataRow2 = dataSet2.TypedDataTable1[0];
+
+                dataRow2.RowError = "Manually added error";
+
+                // Act
+                Action action = () => dataRow1.Should().BeEquivalentTo(dataRow2);
+
+                // Assert
+                action.Should().Throw<XunitException>().Which.Message.Should().Contain("HasErrors");
+            }
+
+            [Fact]
+            public void When_HasErrors_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataRow1 = dataSet1.TypedDataTable1[0];
+                var dataRow2 = dataSet2.TypedDataTable1[0];
+
+                dataRow2.RowError = "Manually added error";
+
+                // Act & Assert
+                dataRow1.Should().BeEquivalentTo(dataRow2, config => config.Excluding(dataRow => dataRow.HasErrors));
+            }
+
+            [Fact]
+            public void When_RowState_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataRow1 = dataSet1.TypedDataTable1[0];
+                var dataRow2 = dataSet2.TypedDataTable1[0];
+
+                dataRow1.DateTime = DateTime.UtcNow;
+                dataRow2.DateTime = dataRow1.DateTime;
+
+                dataSet2.AcceptChanges();
+
+                // Act
+                Action action = () => dataRow1.Should().BeEquivalentTo(dataRow2);
+
+                // Assert
+                action.Should().Throw<XunitException>().Which.Message.Should().Contain("RowState");
+            }
+
+            [Fact]
+            public void When_RowState_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataRow1 = dataSet1.TypedDataTable1[0];
+                var dataRow2 = dataSet2.TypedDataTable1[0];
+
+                dataRow1.DateTime = DateTime.UtcNow;
+                dataRow2.DateTime = dataRow1.DateTime;
+
+                dataSet2.AcceptChanges();
+
+                // Act & Assert
+                dataRow1.Should().BeEquivalentTo(dataRow2, config => config.Excluding(dataRow => dataRow.RowState));
+            }
+
+            [Fact]
+            public void When_data_does_not_match_and_column_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataRow1 = dataSet1.TypedDataTable1[0];
+                var dataRow2 = dataSet2.TypedDataTable1[0];
+
+                dataRow2.String = Guid.NewGuid().ToString();
+                dataSet2.AcceptChanges();
+
+                // Act
+                Action action = () => dataRow1.Should().BeEquivalentTo(dataRow2);
+
+                // Assert
+                action.Should().Throw<XunitException>().Which.Message.Should().Contain(dataRow2.String);
+            }
+
+            [Fact]
+            public void When_data_does_not_match_and_column_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataRow1 = dataSet1.TypedDataTable1[0];
+                var dataRow2 = dataSet2.TypedDataTable1[0];
+
+                dataRow2.DateTime = DateTime.UtcNow;
+                dataSet2.AcceptChanges();
+
+                // Act & Assert
+                dataRow1.Should().BeEquivalentTo(dataRow2, config => config.ExcludingColumn(dataSet2.TypedDataTable1.DateTimeColumn));
+            }
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataSet.Typed.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataSet.Typed.cs
@@ -1,0 +1,550 @@
+﻿using System;
+using System.Data;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs
+{
+    /// <summary>
+    /// DataSetEquivalency specs for typed data sets.
+    /// </summary>
+    public partial class DataEquivalencySpecs
+    {
+        public class TypedDataSetEquivalencySpecs : DataEquivalencySpecs
+        {
+            [Fact]
+            public void When_DataSets_are_identical_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2);
+            }
+
+            [Fact]
+            public void When_DataSets_are_both_null_it_should_succeed()
+            {
+                // Act & Assert
+                ((TypedDataSet)null).Should().BeEquivalentTo(null);
+            }
+
+            [Fact]
+            public void When_DataSet_is_null_and_isnt_expected_to_be_it_should_fail()
+            {
+                // Arrange
+                var dataSet = CreateDummyDataSet<TypedDataSet>();
+
+                // Act
+                Action action = () => ((TypedDataSet)null).Should().BeEquivalentTo(dataSet);
+
+                // Assert
+                action.Should().Throw<XunitException>().WithMessage(
+                    "Expected *of type DataSet*to be non-null, but found null*");
+            }
+
+            [Fact]
+            public void When_DataSet_is_expected_to_be_null_and_isnt_it_should_fail()
+            {
+                // Arrange
+                var dataSet = CreateDummyDataSet<TypedDataSet>();
+
+                // Act
+                Action action = () => dataSet.Should().BeEquivalentTo(null);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DataSet_type_does_not_match_and_AllowMismatchedType_not_enabled_it_should_fail()
+            {
+                // Arrange
+                var dataSet = CreateDummyDataSet<TypedDataSet>();
+
+                var dataSetOfMismatchedType = new TypedDataSetSubclass(dataSet);
+
+                // Act
+                Action action = () => dataSet.Should().BeEquivalentTo(dataSetOfMismatchedType);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DataSet_type_does_not_match_and_AllowMismatchedType_is_enabled_it_should_succeed()
+            {
+                // Arrange
+                var dataSet = CreateDummyDataSet<TypedDataSet>();
+
+                var dataSetOfMismatchedType = new TypedDataSetSubclass(dataSet);
+
+                // Act & Assert
+                dataSet.Should().BeEquivalentTo(dataSetOfMismatchedType, options => options.AllowingMismatchedTypes());
+            }
+
+            [Fact]
+            public void When_DataSetName_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.DataSetName += "different";
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DataSetName_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.DataSetName += "different";
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options
+                    .Excluding(dataSet => dataSet.DataSetName)
+                    .ExcludingRelated((DataRelation dataRelation) => dataRelation.DataSet));
+            }
+
+            [Fact]
+            public void When_CaseSensitive_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.CaseSensitive = !dataSet2.CaseSensitive;
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_CaseSensitive_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.CaseSensitive = !dataSet2.CaseSensitive;
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options.Excluding(dataSet => dataSet.CaseSensitive));
+            }
+
+            [Fact]
+            public void When_EnforceConstraints_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.EnforceConstraints = !dataSet2.EnforceConstraints;
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_EnforceConstraints_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.EnforceConstraints = !dataSet2.EnforceConstraints;
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options.Excluding(dataSet => dataSet.EnforceConstraints));
+            }
+
+            [Fact]
+            public void When_HasErrors_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.TypedDataTable1.Rows[0].RowError = "Manually added error";
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2, config => config.ExcludingTables("TypedDataTable1"));
+
+                // Assert
+                action.Should().Throw<XunitException>().Which.Message.Should().Contain("HasErrors");
+            }
+
+            [Fact]
+            public void When_HasErrors_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.TypedDataTable1.Rows[0].RowError = "Manually added error";
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, config => config.Excluding(dataSet => dataSet.HasErrors).ExcludingTables("TypedDataTable1"));
+            }
+
+            [Fact]
+            public void When_Locale_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.Locale = new CultureInfo("fr-CA");
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Locale_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.Locale = new CultureInfo("fr-CA");
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options.Excluding(dataSet => dataSet.Locale));
+            }
+
+            [Fact]
+            public void When_Namespace_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.Namespace += "different";
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Namespace_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.Namespace += "different";
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options
+                    .Excluding(dataSet => dataSet.Namespace)
+                    .ExcludingRelated((DataTable dataTable) => dataTable.Namespace)
+                    .ExcludingRelated((DataColumn dataColumn) => dataColumn.Namespace));
+            }
+
+            [Fact]
+            public void When_Prefix_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.Prefix += "different";
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Prefix_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.Prefix += "different";
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options.Excluding(dataSet => dataSet.Prefix));
+            }
+
+            [Fact]
+            public void When_RemotingFormat_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.RemotingFormat =
+                    (dataSet2.RemotingFormat == SerializationFormat.Binary)
+                    ? SerializationFormat.Xml
+                    : SerializationFormat.Binary;
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_RemotingFormat_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.RemotingFormat =
+                    (dataSet2.RemotingFormat == SerializationFormat.Binary)
+                    ? SerializationFormat.Xml
+                    : SerializationFormat.Binary;
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options
+                    .Excluding(dataSet => dataSet.RemotingFormat)
+                    .ExcludingRelated((DataTable dataTable) => dataTable.RemotingFormat));
+            }
+
+            [Fact]
+            public void When_SchemaSerializationMode_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.SchemaSerializationMode =
+                    (dataSet2.SchemaSerializationMode == SchemaSerializationMode.ExcludeSchema)
+                    ? SchemaSerializationMode.IncludeSchema
+                    : SchemaSerializationMode.ExcludeSchema;
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_SchemaSerializationMode_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.SchemaSerializationMode =
+                    (dataSet2.SchemaSerializationMode == SchemaSerializationMode.ExcludeSchema)
+                    ? SchemaSerializationMode.IncludeSchema
+                    : SchemaSerializationMode.ExcludeSchema;
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options.Excluding(dataSet => dataSet.SchemaSerializationMode));
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_ExtendedProperties_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                ApplyChange(dataSet2.ExtendedProperties, changeType);
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_ExtendedProperties_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                ApplyChange(dataSet2.ExtendedProperties, changeType);
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options.Excluding(dataSet => dataSet.ExtendedProperties));
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            [SuppressMessage("Style", "IDE0010:Add missing cases", Justification = "All enum values are accounted for.")]
+            public void When_Relations_does_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                switch (changeType)
+                {
+                    case ChangeType.Added:
+                        dataSet1.Relations.RemoveAt(0);
+                        break;
+
+                    case ChangeType.Changed:
+                        dataSet2.Relations[0].RelationName += "different";
+                        break;
+
+                    case ChangeType.Removed:
+                        dataSet2.Relations.RemoveAt(0);
+                        break;
+                }
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            [SuppressMessage("Style", "IDE0010:Add missing cases", Justification = "All enum values are accounted for.")]
+            public void When_Relations_does_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                switch (changeType)
+                {
+                    case ChangeType.Added:
+                        dataSet1.Relations.RemoveAt(0);
+                        break;
+
+                    case ChangeType.Changed:
+                        dataSet2.Relations[0].RelationName += "different";
+                        break;
+
+                    case ChangeType.Removed:
+                        dataSet2.Relations.RemoveAt(0);
+                        break;
+                }
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options
+                    .Excluding(dataSet => dataSet.Relations)
+                    .ExcludingRelated((DataTable dataTable) => dataTable.ParentRelations)
+                    .ExcludingRelated((DataTable dataTable) => dataTable.ChildRelations));
+            }
+
+            [Fact]
+            public void When_Tables_are_the_same_but_in_a_different_order_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1, swapTableOrder: true);
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2);
+            }
+
+            [Fact]
+            public void When_Tables_count_does_not_match_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1, swapTableOrder: true);
+
+                dataSet2.Tables.Add(new DataTable("ThirdWheel"));
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>().Which.Message.Should().Contain("to contain " + dataSet2.Tables.Count);
+            }
+
+            [Fact]
+            public void When_Tables_count_matches_but_tables_are_different_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1, swapTableOrder: true);
+
+                dataSet2.TypedDataTable2.TableName = "DifferentTableName";
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Tables_contain_different_data_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1, swapTableOrder: true);
+
+                dataSet2.TypedDataTable2[0].Guid = Guid.NewGuid();
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataSet.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataSet.cs
@@ -1,0 +1,620 @@
+﻿using System;
+using System.Data;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs
+{
+    /// <summary>
+    /// DataSetEquivalency specs.
+    /// </summary>
+    public partial class DataEquivalencySpecs
+    {
+        public class DataSetEquivalencySpecs : DataEquivalencySpecs
+        {
+            [Fact]
+            public void When_DataSets_are_identical_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2);
+            }
+
+            [Fact]
+            public void When_DataSets_are_both_null_it_should_succeed()
+            {
+                // Act & Assert
+                ((DataSet)null).Should().BeEquivalentTo(null);
+            }
+
+            [Fact]
+            public void When_DataSet_is_null_and_isnt_expected_to_be_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet = CreateDummyDataSet<TypedDataSet>();
+
+                var dataSet = typedDataSet.ToUntypedDataSet();
+
+                // Act
+                Action action = () => ((DataSet)null).Should().BeEquivalentTo(dataSet);
+
+                // Assert
+                action.Should().Throw<XunitException>().WithMessage(
+                    "Expected *of type DataSet*to be non-null, but found null*");
+            }
+
+            [Fact]
+            public void When_DataSet_is_expected_to_be_null_and_isnt_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet = CreateDummyDataSet<TypedDataSet>();
+
+                var dataSet = typedDataSet.ToUntypedDataSet();
+
+                // Act
+                Action action = () => dataSet.Should().BeEquivalentTo(null);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DataSet_type_does_not_match_and_AllowMismatchedType_not_enabled_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet = CreateDummyDataSet<TypedDataSet>();
+
+                var dataSet = typedDataSet.ToUntypedDataSet();
+
+                var dataSetOfMismatchedType = new TypedDataSetSubclass(typedDataSet);
+
+                // Act
+                Action action = () => dataSet.Should().BeEquivalentTo(dataSetOfMismatchedType);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DataSet_type_does_not_match_and_AllowMismatchedType_is_enabled_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet = CreateDummyDataSet<TypedDataSet>();
+
+                var dataSet = typedDataSet.ToUntypedDataSet();
+
+                var dataSetOfMismatchedType = new TypedDataSetSubclass(typedDataSet);
+
+                // Act & Assert
+                dataSet.Should().BeEquivalentTo(dataSetOfMismatchedType, options => options
+                    .AllowingMismatchedTypes()
+                    .Excluding(dataSet => dataSet.SchemaSerializationMode));
+            }
+
+            [Fact]
+            public void When_DataSetName_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.DataSetName += "different";
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DataSetName_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.DataSetName += "different";
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options
+                    .Excluding(dataSet => dataSet.DataSetName)
+                    .ExcludingRelated((DataRelation dataRelation) => dataRelation.DataSet));
+            }
+
+            [Fact]
+            public void When_CaseSensitive_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.CaseSensitive = !typedDataSet2.CaseSensitive;
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_CaseSensitive_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.CaseSensitive = !typedDataSet2.CaseSensitive;
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options.Excluding(dataSet => dataSet.CaseSensitive));
+            }
+
+            [Fact]
+            public void When_EnforceConstraints_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.EnforceConstraints = !typedDataSet2.EnforceConstraints;
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_EnforceConstraints_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.EnforceConstraints = !typedDataSet2.EnforceConstraints;
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options.Excluding(dataSet => dataSet.EnforceConstraints));
+            }
+
+            [Fact]
+            public void When_HasErrors_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.TypedDataTable1.Rows[0].RowError = "Manually added error";
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2, config => config.ExcludingTables("TypedDataTable1"));
+
+                // Assert
+                action.Should().Throw<XunitException>().Which.Message.Should().Contain("HasErrors");
+            }
+
+            [Fact]
+            public void When_HasErrors_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.TypedDataTable1.Rows[0].RowError = "Manually added error";
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, config => config.Excluding(dataSet => dataSet.HasErrors).ExcludingTables("TypedDataTable1"));
+            }
+
+            [Fact]
+            public void When_Locale_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.Locale = new CultureInfo("fr-CA");
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Locale_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.Locale = new CultureInfo("fr-CA");
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options.Excluding(dataSet => dataSet.Locale));
+            }
+
+            [Fact]
+            public void When_Namespace_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.Namespace += "different";
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Namespace_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.Namespace += "different";
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options
+                    .Excluding(dataSet => dataSet.Namespace)
+                    .ExcludingRelated((DataTable dataTable) => dataTable.Namespace)
+                    .ExcludingRelated((DataColumn dataColumn) => dataColumn.Namespace));
+            }
+
+            [Fact]
+            public void When_Prefix_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.Prefix += "different";
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Prefix_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.Prefix += "different";
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options.Excluding(dataSet => dataSet.Prefix));
+            }
+
+            [Fact]
+            public void When_RemotingFormat_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.RemotingFormat =
+                    (typedDataSet2.RemotingFormat == SerializationFormat.Binary)
+                    ? SerializationFormat.Xml
+                    : SerializationFormat.Binary;
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_RemotingFormat_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.RemotingFormat =
+                    (typedDataSet2.RemotingFormat == SerializationFormat.Binary)
+                    ? SerializationFormat.Xml
+                    : SerializationFormat.Binary;
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options
+                    .Excluding(dataSet => dataSet.RemotingFormat)
+                    .ExcludingRelated((DataTable dataTable) => dataTable.RemotingFormat));
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_ExtendedProperties_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                ApplyChange(typedDataSet2.ExtendedProperties, changeType);
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_ExtendedProperties_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                ApplyChange(typedDataSet2.ExtendedProperties, changeType);
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options.Excluding(dataSet => dataSet.ExtendedProperties));
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            [SuppressMessage("Style", "IDE0010:Add missing cases", Justification = "All enum values are accounted for.")]
+            public void When_Relations_does_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+            {
+                // Arrange
+                TypedDataSetSubclass typedDataSet1;
+                TypedDataSetSubclass typedDataSet2;
+
+                if (changeType == ChangeType.Changed)
+                {
+                    typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                    typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                    typedDataSet2.Relations[0].RelationName += "different";
+                }
+                else
+                {
+                    var doesNotHaveRelation = CreateDummyDataSet<TypedDataSetSubclass>(includeRelation: false);
+                    var hasRelation = new TypedDataSetSubclass(doesNotHaveRelation);
+
+                    AddRelation(hasRelation);
+
+                    if (changeType == ChangeType.Added)
+                    {
+                        typedDataSet1 = doesNotHaveRelation;
+                        typedDataSet2 = hasRelation;
+                    }
+                    else
+                    {
+                        typedDataSet1 = hasRelation;
+                        typedDataSet2 = doesNotHaveRelation;
+                    }
+                }
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            [SuppressMessage("Style", "IDE0010:Add missing cases", Justification = "All enum values are accounted for.")]
+            public void When_Relations_does_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
+            {
+                // Arrange
+                TypedDataSetSubclass typedDataSet1;
+                TypedDataSetSubclass typedDataSet2;
+
+                if (changeType == ChangeType.Changed)
+                {
+                    typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                    typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                    typedDataSet2.Relations[0].RelationName += "different";
+                }
+                else
+                {
+                    var doesNotHaveRelation = CreateDummyDataSet<TypedDataSetSubclass>(includeRelation: false);
+                    var hasRelation = new TypedDataSetSubclass(doesNotHaveRelation);
+
+                    AddRelation(hasRelation);
+
+                    if (changeType == ChangeType.Added)
+                    {
+                        typedDataSet1 = doesNotHaveRelation;
+                        typedDataSet2 = hasRelation;
+                    }
+                    else
+                    {
+                        typedDataSet1 = hasRelation;
+                        typedDataSet2 = doesNotHaveRelation;
+                    }
+                }
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2, options => options
+                    .Excluding(dataSet => dataSet.Relations)
+                    .ExcludingRelated((DataTable dataTable) => dataTable.Constraints)
+                    .ExcludingRelated((DataTable dataTable) => dataTable.ParentRelations)
+                    .ExcludingRelated((DataTable dataTable) => dataTable.ChildRelations)
+                    .ExcludingRelated((DataColumn dataColumn) => dataColumn.Unique));
+            }
+
+            [Fact]
+            public void When_Tables_are_the_same_but_in_a_different_order_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1, swapTableOrder: true);
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act & Assert
+                dataSet1.Should().BeEquivalentTo(dataSet2);
+            }
+
+            [Fact]
+            public void When_Tables_count_does_not_match_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1, swapTableOrder: true);
+
+                typedDataSet2.Tables.Add(new DataTable("ThirdWheel"));
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>().Which.Message.Should().Contain("to contain " + dataSet2.Tables.Count);
+            }
+
+            [Fact]
+            public void When_Tables_count_matches_but_tables_are_different_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1, swapTableOrder: true);
+
+                typedDataSet2.TypedDataTable2.TableName = "DifferentTableName";
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Tables_contain_different_data_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1, swapTableOrder: true);
+
+                typedDataSet2.TypedDataTable2[0].Guid = Guid.NewGuid();
+
+                var dataSet1 = typedDataSet1.ToUntypedDataSet();
+                var dataSet2 = typedDataSet2.ToUntypedDataSet();
+
+                // Act
+                Action action = () => dataSet1.Should().BeEquivalentTo(dataSet2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataTable.Typed.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataTable.Typed.cs
@@ -1,0 +1,672 @@
+﻿using System;
+using System.Collections;
+using System.Data;
+using System.Globalization;
+using System.Linq;
+
+using FluentAssertions.Data;
+
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs
+{
+    /// <summary>
+    /// DataTableEquivalency specs for typed data tables.
+    /// </summary>
+    public partial class DataEquivalencySpecs
+    {
+        public class TypedDataTableEquivalencySpecs : DataEquivalencySpecs
+        {
+            [Fact]
+            public void When_DataTables_are_identical_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2);
+            }
+
+            [Fact]
+            public void When_DataTables_are_both_null_it_should_succeed()
+            {
+                // Act & Assert
+                ((TypedDataTable1)null).Should().BeEquivalentTo(null);
+            }
+
+            [Fact]
+            public void When_DataTable_is_null_and_isnt_expected_to_be_it_should_fail()
+            {
+                // Arrange
+                var dataSet = CreateDummyDataSet<TypedDataSet>();
+
+                var dataTable = dataSet.TypedDataTable1;
+
+                // Act
+                Action action = () => ((TypedDataTable1)null).Should().BeEquivalentTo(dataTable);
+
+                // Assert
+                action.Should().Throw<XunitException>().WithMessage(
+                    "Expected *of type DataTable*to be non-null, but found null*");
+            }
+
+            [Fact]
+            public void When_DataTable_is_expected_to_be_null_and_isnt_it_should_fail()
+            {
+                // Arrange
+                var dataSet = CreateDummyDataSet<TypedDataSet>();
+
+                var dataTable = dataSet.TypedDataTable1;
+
+                // Act
+                Action action = () => dataTable.Should().BeEquivalentTo(null);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DataTable_type_does_not_match_and_AllowMismatchedType_not_enabled_it_should_fail()
+            {
+                // Arrange
+                var dataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
+                var dataSet2 = new TypedDataSetSubclass(dataSet);
+
+                var dataTable = dataSet.TypedDataTable1;
+                var dataTableOfMismatchedType = dataSet2.TypedDataTable2;
+
+                dataSet2.Tables.Remove(dataTable.TableName);
+                dataTableOfMismatchedType.TableName = dataTable.TableName;
+
+                // Act
+                Action action = () => dataTable.Should().BeEquivalentTo(dataTableOfMismatchedType);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DataTable_type_does_not_match_and_AllowMismatchedType_is_enabled_it_should_succeed()
+            {
+                // Arrange
+                var dataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
+                var dataSet2 = new TypedDataSetSubclass(dataSet);
+
+                var dataTable = dataSet.TypedDataTable1;
+                var dataTableOfMismatchedType = dataSet2.TypedDataTable2;
+
+                dataSet2.Tables.Remove(dataTable.TableName);
+                dataTableOfMismatchedType.TableName = dataTable.TableName;
+
+                dataTableOfMismatchedType.Rows.Clear();
+
+                foreach (var row in dataTable)
+                {
+                    dataTableOfMismatchedType.ImportRow(row);
+                }
+
+                foreach (var col in dataTableOfMismatchedType.Columns.Cast<DataColumn>())
+                {
+                    col.ExtendedProperties.Clear();
+
+                    foreach (var property in dataTable.Columns[col.ColumnName].ExtendedProperties.Cast<DictionaryEntry>())
+                    {
+                        col.ExtendedProperties.Add(property.Key, property.Value);
+                    }
+                }
+
+                dataTableOfMismatchedType.AcceptChanges();
+
+                // Act & Assert
+                dataTable.Should().BeEquivalentTo(dataTableOfMismatchedType, options => options.AllowingMismatchedTypes());
+            }
+
+            [Fact]
+            public void When_TableName_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataTable2.TableName += "different";
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_TableName_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>(identicalTables: true);
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataTable2.TableName += "different";
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(
+                    dataTable2,
+                    options => options
+                    .Excluding(dataTable => dataTable.TableName)
+                    .ExcludingRelated((DataColumn dataColumn) => dataColumn.Table)
+                    .ExcludingRelated((Constraint constraint) => constraint.Table));
+            }
+
+            [Fact]
+            public void When_CaseSensitive_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.CaseSensitive = !dataSet2.CaseSensitive;
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_CaseSensitive_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.CaseSensitive = !dataSet2.CaseSensitive;
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.CaseSensitive));
+            }
+
+            [Fact]
+            public void When_DisplayExpression_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataTable2.DisplayExpression = dataTable2.StringColumn.ColumnName;
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DisplayExpression_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataTable2.DisplayExpression = dataTable2.StringColumn.ColumnName;
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.DisplayExpression));
+            }
+
+            [Fact]
+            public void When_HasErrors_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataTable2.Rows[0].RowError = "Manually added error";
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>().Which.Message.Should().Contain("HasErrors");
+            }
+
+            [Fact]
+            public void When_HasErrors_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataTable2.Rows[0].RowError = "Manually added error";
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, config => config
+                    .Excluding(dataTable => dataTable.HasErrors)
+                    .ExcludingRelated((DataRow dataRow) => dataRow.HasErrors));
+            }
+
+            [Fact]
+            public void When_Locale_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.Locale = new CultureInfo("fr-CA");
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Locale_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.Locale = new CultureInfo("fr-CA");
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.Locale));
+            }
+
+            [Fact]
+            public void When_Namespace_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.Namespace += "different";
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Namespace_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.Namespace += "different";
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                    .Excluding(dataTable => dataTable.Namespace)
+                    .ExcludingRelated((DataColumn dataColumn) => dataColumn.Namespace));
+            }
+
+            [Fact]
+            public void When_Prefix_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataTable2.Prefix += "different";
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Prefix_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                dataTable2.Prefix += "different";
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.Prefix));
+            }
+
+            [Fact]
+            public void When_RemotingFormat_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.RemotingFormat =
+                    (dataSet2.RemotingFormat == SerializationFormat.Binary)
+                    ? SerializationFormat.Xml
+                    : SerializationFormat.Binary;
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_RemotingFormat_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                dataSet2.RemotingFormat =
+                    (dataSet2.RemotingFormat == SerializationFormat.Binary)
+                    ? SerializationFormat.Xml
+                    : SerializationFormat.Binary;
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.RemotingFormat));
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_Columns_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                ApplyChange(dataTable2.Columns, changeType);
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_Columns_do_not_match_and_Columns_and_Rows_are_excluded_it_should_succeed(ChangeType changeType)
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                ApplyChange(dataTable2.Columns, changeType);
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                    .Excluding(dataTable => dataTable.Columns)
+                    .Excluding(dataTable => dataTable.Rows));
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_ExtendedProperties_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                ApplyChange(dataTable2.ExtendedProperties, changeType);
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_ExtendedProperties_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                ApplyChange(dataTable2.ExtendedProperties, changeType);
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.ExtendedProperties));
+            }
+
+            [Fact]
+            public void When_PrimaryKey_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable2;
+                var dataTable2 = dataSet2.TypedDataTable2;
+
+                dataTable2.PrimaryKey = dataTable2.Columns.Cast<DataColumn>().Skip(2).ToArray();
+                dataTable2.Columns[0].Unique = true;
+
+                // Act
+                Action action = () =>
+                    dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                        .Excluding(dataTable => dataTable.Constraints));
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_PrimaryKey_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                for (int i = 2; i < dataSet1.TypedDataTable2.Columns.Count; i++)
+                {
+                    dataSet1.TypedDataTable2.Columns[i].AllowDBNull = false;
+                }
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable2;
+                var dataTable2 = dataSet2.TypedDataTable2;
+
+                dataTable2.PrimaryKey = dataTable2.Columns.Cast<DataColumn>().Skip(2).ToArray();
+                dataTable2.Columns[0].Unique = true;
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                    .Excluding(dataTable => dataTable.PrimaryKey)
+                    .Excluding(dataTable => dataTable.Constraints));
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_Constraints_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                ApplyChange(dataTable2.Constraints, dataTable2.DecimalColumn, changeType);
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_Constraints_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                ApplyChange(dataTable2.Constraints, dataTable2.DecimalColumn, changeType);
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                    .Excluding(dataTable => dataTable.Constraints)
+                    .ExcludingRelated((DataColumn dataColumn) => dataColumn.Unique));
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypesWithAcceptChangesValues))]
+            public void When_Rows_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType, bool acceptChanges)
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                ApplyChange(dataTable2.Rows, dataTable2, changeType);
+
+                if (acceptChanges)
+                {
+                    dataTable2.AcceptChanges();
+                }
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypesWithAcceptChangesValues))]
+            public void When_Rows_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType, bool acceptChanges)
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                ApplyChange(dataTable2.Rows, dataTable2, changeType);
+
+                if (acceptChanges)
+                {
+                    dataTable2.AcceptChanges();
+                }
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.Rows));
+            }
+
+            [Fact]
+            public void When_data_matches_in_different_order_and_RowMatchMode_is_PrimaryKey_it_should_succeed()
+            {
+                // Arrange
+                var dataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var dataSet2 = new TypedDataSetSubclass(dataSet1, randomizeRowOrder: true);
+
+                var dataTable1 = dataSet1.TypedDataTable1;
+                var dataTable2 = dataSet2.TypedDataTable1;
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.UsingRowMatchMode(RowMatchMode.PrimaryKey));
+            }
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataTable.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataTable.cs
@@ -1,0 +1,707 @@
+﻿using System;
+using System.Data;
+using System.Globalization;
+using System.Linq;
+
+using FluentAssertions.Data;
+
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs
+{
+    /// <summary>
+    /// DataTableEquivalency specs.
+    /// </summary>
+    public partial class DataEquivalencySpecs
+    {
+        public class DataTableEquivalencySpecs : DataEquivalencySpecs
+        {
+            [Fact]
+            public void When_DataTables_are_identical_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2);
+            }
+
+            [Fact]
+            public void When_DataTables_are_both_null_it_should_succeed()
+            {
+                // Act & Assert
+                ((DataTable)null).Should().BeEquivalentTo(null);
+            }
+
+            [Fact]
+            public void When_DataTable_is_null_and_isnt_expected_to_be_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet = CreateDummyDataSet<TypedDataSet>();
+
+                var dataTable = typedDataSet.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                // Act
+                Action action = () => ((DataTable)null).Should().BeEquivalentTo(dataTable);
+
+                // Assert
+                action.Should().Throw<XunitException>().WithMessage(
+                    "Expected *of type DataTable*to be non-null, but found null*");
+            }
+
+            [Fact]
+            public void When_DataTable_is_expected_to_be_null_and_isnt_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet = CreateDummyDataSet<TypedDataSet>();
+
+                var dataTable = typedDataSet.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                // Act
+                Action action = () => dataTable.Should().BeEquivalentTo(null);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DataTable_type_does_not_match_and_AllowMismatchedType_not_enabled_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet);
+
+                var dataTable = typedDataSet.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTableOfMismatchedType = typedDataSet2.TypedDataTable1;
+
+                // Act
+                Action action = () => dataTable.Should().BeEquivalentTo(dataTableOfMismatchedType);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DataTable_type_does_not_match_and_AllowMismatchedType_is_enabled_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet = CreateDummyDataSet<TypedDataSet>(identicalTables: true);
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet);
+
+                var dataTable = typedDataSet.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTableOfMismatchedType = typedDataSet2.TypedDataTable1;
+
+                // Act & Assert
+                dataTable.Should().BeEquivalentTo(dataTableOfMismatchedType, options => options.AllowingMismatchedTypes());
+            }
+
+            [Fact]
+            public void When_TableName_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                dataTable2.TableName += "different";
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_TableName_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>(identicalTables: true);
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                dataTable2.TableName += "different";
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(
+                    dataTable2,
+                    options => options
+                    .Excluding(dataTable => dataTable.TableName)
+                    .ExcludingRelated((DataColumn dataColumn) => dataColumn.Table)
+                    .ExcludingRelated((Constraint constraint) => constraint.Table));
+            }
+
+            [Fact]
+            public void When_CaseSensitive_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.CaseSensitive = !typedDataSet2.CaseSensitive;
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_CaseSensitive_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.CaseSensitive = !typedDataSet2.CaseSensitive;
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.CaseSensitive));
+            }
+
+            [Fact]
+            public void When_DisplayExpression_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                dataTable2.DisplayExpression = typedDataSet2.TypedDataTable1.StringColumn.ColumnName;
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_DisplayExpression_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                dataTable2.DisplayExpression = typedDataSet2.TypedDataTable1.StringColumn.ColumnName;
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.DisplayExpression));
+            }
+
+            [Fact]
+            public void When_HasErrors_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                dataTable2.Rows[0].RowError = "Manually added error";
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>().Which.Message.Should().Contain("HasErrors");
+            }
+
+            [Fact]
+            public void When_HasErrors_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                dataTable2.Rows[0].RowError = "Manually added error";
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, config => config
+                    .Excluding(dataTable => dataTable.HasErrors)
+                    .ExcludingRelated((DataRow dataRow) => dataRow.HasErrors));
+            }
+
+            [Fact]
+            public void When_Locale_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.Locale = new CultureInfo("fr-CA");
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Locale_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.Locale = new CultureInfo("fr-CA");
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.Locale));
+            }
+
+            [Fact]
+            public void When_Namespace_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.Namespace += "different";
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Namespace_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.Namespace += "different";
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                    .Excluding(dataTable => dataTable.Namespace)
+                    .ExcludingRelated((DataColumn dataColumn) => dataColumn.Namespace));
+            }
+
+            [Fact]
+            public void When_Prefix_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                dataTable2.Prefix += "different";
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_Prefix_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                dataTable2.Prefix += "different";
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.Prefix));
+            }
+
+            [Fact]
+            public void When_RemotingFormat_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.RemotingFormat =
+                    (typedDataSet2.RemotingFormat == SerializationFormat.Binary)
+                    ? SerializationFormat.Xml
+                    : SerializationFormat.Binary;
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_RemotingFormat_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                typedDataSet2.RemotingFormat =
+                    (typedDataSet2.RemotingFormat == SerializationFormat.Binary)
+                    ? SerializationFormat.Xml
+                    : SerializationFormat.Binary;
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                // LAST ONE
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.RemotingFormat));
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_Columns_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                ApplyChange(dataTable2.Columns, changeType);
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_Columns_do_not_match_and_Columns_and_Rows_are_excluded_it_should_succeed(ChangeType changeType)
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                ApplyChange(dataTable2.Columns, changeType);
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                    .Excluding(dataTable => dataTable.Columns)
+                    .Excluding(dataTable => dataTable.Rows));
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_ExtendedProperties_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                ApplyChange(dataTable2.ExtendedProperties, changeType);
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_ExtendedProperties_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                ApplyChange(dataTable2.ExtendedProperties, changeType);
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.ExtendedProperties));
+            }
+
+            [Fact]
+            public void When_PrimaryKey_does_not_match_and_property_is_not_excluded_it_should_fail()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable2"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable2"];
+
+                dataTable2.PrimaryKey = dataTable2.Columns.Cast<DataColumn>().Skip(2).ToArray();
+                dataTable2.Columns[0].Unique = true;
+
+                // Act
+                Action action = () =>
+                    dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                        .Excluding(dataTable => dataTable.Constraints));
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void When_PrimaryKey_does_not_match_and_property_is_excluded_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                for (int i = 2; i < typedDataSet1.TypedDataTable2.Columns.Count; i++)
+                {
+                    typedDataSet1.TypedDataTable2.Columns[i].AllowDBNull = false;
+                }
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable2"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable2"];
+
+                dataTable2.PrimaryKey = dataTable2.Columns.Cast<DataColumn>().Skip(2).ToArray();
+                dataTable2.Columns[0].Unique = true;
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                    .Excluding(dataTable => dataTable.PrimaryKey)
+                    .Excluding(dataTable => dataTable.Constraints));
+            }
+
+            public enum NumberOfColumnsInConstraintDifference
+            {
+                SingleColumn,
+                MultipleColumns,
+            }
+
+            [Theory]
+            [InlineData(NumberOfColumnsInConstraintDifference.SingleColumn)]
+            [InlineData(NumberOfColumnsInConstraintDifference.MultipleColumns)]
+            public void When_columns_for_constraint_do_not_match_message_should_list_all_columns_involved(NumberOfColumnsInConstraintDifference difference)
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable2"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable2"];
+
+                int differenceCount =
+                    difference switch
+                    {
+                        NumberOfColumnsInConstraintDifference.SingleColumn => 1,
+                        NumberOfColumnsInConstraintDifference.MultipleColumns => 2,
+
+                        _ => throw new Exception("Sanity failure")
+                    };
+
+                var dataTable1ColumnsForConstraint = dataTable1.Columns.OfType<DataColumn>()
+                    .Take(dataTable1.Columns.Count - differenceCount)
+                    .ToArray();
+
+                var dataTable2ColumnsForConstraint = dataTable2.Columns.OfType<DataColumn>()
+                    .Skip(differenceCount)
+                    .ToArray();
+
+                const string ConstraintName = "TestSubjectConstraint";
+
+                dataTable1.Constraints.Add(new UniqueConstraint(ConstraintName, dataTable1ColumnsForConstraint));
+                dataTable2.Constraints.Add(new UniqueConstraint(ConstraintName, dataTable2ColumnsForConstraint));
+
+                var missingColumnNames = dataTable2ColumnsForConstraint.Select(col => col.ColumnName)
+                    .Except(dataTable1ColumnsForConstraint.Select(col => col.ColumnName));
+                var extraColumnNames = dataTable1ColumnsForConstraint.Select(col => col.ColumnName)
+                    .Except(dataTable2ColumnsForConstraint.Select(col => col.ColumnName));
+
+                string columnsNoun = differenceCount == 1
+                    ? "column"
+                    : "columns";
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>().WithMessage(
+                    $"Expected *{ConstraintName}* to include {columnsNoun} {string.Join("*", missingColumnNames)}*" +
+                    $"Did not expect *{ConstraintName}* to include {columnsNoun} {string.Join("*", extraColumnNames)}*");
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_Constraints_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType)
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable2"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable2"];
+
+                ApplyChange(dataTable2.Constraints, dataTable2.Columns["Decimal"], changeType);
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypes))]
+            public void When_Constraints_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType)
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable2"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable2"];
+
+                ApplyChange(dataTable2.Constraints, dataTable2.Columns["Decimal"], changeType);
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options
+                    .Excluding(dataTable => dataTable.Constraints)
+                    .ExcludingRelated((DataColumn dataColumn) => dataColumn.Unique));
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypesWithAcceptChangesValues))]
+            public void When_Rows_do_not_match_and_property_is_not_excluded_it_should_fail(ChangeType changeType, bool acceptChanges)
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                ApplyChange(dataTable2.Rows, dataTable2, changeType);
+
+                if (acceptChanges)
+                {
+                    dataTable2.AcceptChanges();
+                }
+
+                // Act
+                Action action = () => dataTable1.Should().BeEquivalentTo(dataTable2);
+
+                // Assert
+                action.Should().Throw<XunitException>();
+            }
+
+            [Theory]
+            [MemberData(nameof(AllChangeTypesWithAcceptChangesValues))]
+            public void When_Rows_do_not_match_and_property_is_excluded_it_should_succeed(ChangeType changeType, bool acceptChanges)
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                ApplyChange(dataTable2.Rows, dataTable2, changeType);
+
+                if (acceptChanges)
+                {
+                    dataTable2.AcceptChanges();
+                }
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.Excluding(dataTable => dataTable.Rows));
+            }
+
+            [Fact]
+            public void When_data_matches_in_different_order_and_RowMatchMode_is_PrimaryKey_it_should_succeed()
+            {
+                // Arrange
+                var typedDataSet1 = CreateDummyDataSet<TypedDataSetSubclass>();
+
+                var typedDataSet2 = new TypedDataSetSubclass(typedDataSet1, randomizeRowOrder: true);
+
+                var dataTable1 = typedDataSet1.ToUntypedDataSet().Tables["TypedDataTable1"];
+                var dataTable2 = typedDataSet2.ToUntypedDataSet().Tables["TypedDataTable1"];
+
+                // Act & Assert
+                dataTable1.Should().BeEquivalentTo(dataTable2, options => options.UsingRowMatchMode(RowMatchMode.PrimaryKey));
+            }
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.cs
@@ -1,0 +1,655 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace FluentAssertions.Specs
+{
+    /// <summary>
+    /// Class containing specs related to System.Data, including many common declarations and methods.
+    /// </summary>
+    public partial class DataEquivalencySpecs
+    {
+        // Non-static member to avoid getting flagged as a "static holder type". This
+        // type is inherited by the specialized specs classes it contains.
+        public int Dummy { get; set; }
+
+        #region Subject Types
+        /*
+
+        NB: TypedDataTable1 and TypedDataTable2 intentionally have the same schema. This allows testing of
+            Should().BeEquivalentTo(options => options.AllowMismatchedTypes).
+
+        */
+
+        public class TypedDataRow1 : DataRow
+        {
+            private readonly TypedDataTable1 ownerTable;
+
+            public TypedDataRow1(DataRowBuilder rowBuilder)
+                : base(rowBuilder)
+            {
+                ownerTable = (TypedDataTable1)Table;
+            }
+
+            public int RowID
+            {
+                get => (int)this[ownerTable.RowIDColumn];
+                set => this[ownerTable.RowIDColumn] = value;
+            }
+
+            public decimal Decimal
+            {
+                get => (decimal)this[ownerTable.DecimalColumn];
+                set => this[ownerTable.DecimalColumn] = value;
+            }
+
+            public string String
+            {
+                get => (string)this[ownerTable.StringColumn];
+                set => this[ownerTable.StringColumn] = value;
+            }
+
+            public Guid Guid
+            {
+                get => (Guid)this[ownerTable.GuidColumn];
+                set => this[ownerTable.GuidColumn] = value;
+            }
+
+            public DateTime DateTime
+            {
+                get => (DateTime)this[ownerTable.DateTimeColumn];
+                set => this[ownerTable.DateTimeColumn] = value;
+            }
+
+            public int? ForeignRowID
+            {
+                get => IsNull(ownerTable.ForeignRowIDColumn) ? null : (int?)this[ownerTable.ForeignRowIDColumn];
+                set => this[ownerTable.ForeignRowIDColumn] = value;
+            }
+        }
+
+        [SuppressMessage("Microsoft.StyleCop.CSharp.Naming", "SA1306", Justification = "DataColumn accessors are named after the columns.")]
+        [SuppressMessage("Microsoft.StyleCop.CSharp.Naming", "SA1516", Justification = "DataColumn accessors are grouped in a block of lines.")]
+        public class TypedDataTable1 : TypedTableBase<TypedDataRow1>
+        {
+            public TypedDataTable1()
+            {
+                TableName = "TypedDataTable1";
+
+                Columns.Add(new DataColumn("RowID", typeof(int)));
+                Columns.Add(new DataColumn("Decimal", typeof(decimal)));
+                Columns.Add(new DataColumn("String", typeof(string)));
+                Columns.Add(new DataColumn("Guid", typeof(Guid)));
+                Columns.Add(new DataColumn("DateTime", typeof(DateTime)));
+                Columns.Add(new DataColumn("ForeignRowID", typeof(int)));
+
+                PrimaryKey = new[] { RowIDColumn };
+
+                Constraints.Add(new UniqueConstraint(GuidColumn));
+            }
+
+            protected override DataRow NewRowFromBuilder(DataRowBuilder builder)
+            {
+                return new TypedDataRow1(builder);
+            }
+
+            public new TypedDataRow1 NewRow()
+            {
+                return (TypedDataRow1)base.NewRow();
+            }
+
+            public TypedDataRow1 this[int index]
+            {
+                get => (TypedDataRow1)Rows[index];
+            }
+
+            public DataColumn RowIDColumn => Columns["RowID"];
+            public DataColumn DecimalColumn => Columns["Decimal"];
+            public DataColumn StringColumn => Columns["String"];
+            public DataColumn GuidColumn => Columns["Guid"];
+            public DataColumn DateTimeColumn => Columns["DateTime"];
+            public DataColumn ForeignRowIDColumn => Columns["ForeignRowID"];
+        }
+
+        public class TypedDataRow2 : DataRow
+        {
+            private readonly TypedDataTable2 ownerTable;
+
+            public TypedDataRow2(DataRowBuilder rowBuilder)
+                : base(rowBuilder)
+            {
+                ownerTable = (TypedDataTable2)Table;
+            }
+
+            public int RowID
+            {
+                get => (int)this[ownerTable.RowIDColumn];
+                set => this[ownerTable.RowIDColumn] = value;
+            }
+
+            public decimal Decimal
+            {
+                get => (decimal)this[ownerTable.DecimalColumn];
+                set => this[ownerTable.DecimalColumn] = value;
+            }
+
+            public string String
+            {
+                get => (string)this[ownerTable.StringColumn];
+                set => this[ownerTable.StringColumn] = value;
+            }
+
+            public Guid Guid
+            {
+                get => (Guid)this[ownerTable.GuidColumn];
+                set => this[ownerTable.GuidColumn] = value;
+            }
+
+            public DateTime DateTime
+            {
+                get => (DateTime)this[ownerTable.DateTimeColumn];
+                set => this[ownerTable.DateTimeColumn] = value;
+            }
+
+            public int? ForeignRowID
+            {
+                get => IsNull(ownerTable.ForeignRowIDColumn) ? null : (int?)this[ownerTable.ForeignRowIDColumn];
+                set => this[ownerTable.ForeignRowIDColumn] = value;
+            }
+        }
+
+        [SuppressMessage("Microsoft.StyleCop.CSharp.Naming", "SA1306", Justification = "DataColumn accessors are named after the columns.")]
+        [SuppressMessage("Microsoft.StyleCop.CSharp.Naming", "SA1516", Justification = "DataColumn accessors are grouped in a block of lines.")]
+        public class TypedDataTable2 : TypedTableBase<TypedDataRow2>
+        {
+            public TypedDataTable2()
+            {
+                TableName = "TypedDataTable2";
+
+                Columns.Add(new DataColumn("RowID", typeof(int)));
+                Columns.Add(new DataColumn("Decimal", typeof(decimal)));
+                Columns.Add(new DataColumn("String", typeof(string)));
+                Columns.Add(new DataColumn("Guid", typeof(Guid)));
+                Columns.Add(new DataColumn("DateTime", typeof(DateTime)));
+                Columns.Add(new DataColumn("ForeignRowID", typeof(int)));
+
+                PrimaryKey = new[] { RowIDColumn };
+
+                Constraints.Add(new UniqueConstraint(GuidColumn));
+            }
+
+            protected override DataRow NewRowFromBuilder(DataRowBuilder builder)
+            {
+                return new TypedDataRow2(builder);
+            }
+
+            public new TypedDataRow2 NewRow()
+            {
+                return (TypedDataRow2)base.NewRow();
+            }
+
+            public TypedDataRow2 this[int index]
+            {
+                get => (TypedDataRow2)Rows[index];
+            }
+
+            public DataColumn RowIDColumn => Columns["RowID"];
+            public DataColumn DecimalColumn => Columns["Decimal"];
+            public DataColumn StringColumn => Columns["String"];
+            public DataColumn GuidColumn => Columns["Guid"];
+            public DataColumn DateTimeColumn => Columns["DateTime"];
+            public DataColumn ForeignRowIDColumn => Columns["ForeignRowID"];
+        }
+
+        [SuppressMessage("Microsoft.StyleCop.CSharp.Naming", "SA1516", Justification = "DataTable accessors are grouped in a block of lines.")]
+        public class TypedDataSet : DataSet
+        {
+            public override SchemaSerializationMode SchemaSerializationMode { get; set; }
+
+            public TypedDataSet()
+                : this(swapTableOrder: false)
+            {
+            }
+
+            public TypedDataSet(bool swapTableOrder = false)
+            {
+                if (swapTableOrder)
+                {
+                    Tables.Add(new TypedDataTable2());
+                    Tables.Add(new TypedDataTable1());
+                }
+                else
+                {
+                    Tables.Add(new TypedDataTable1());
+                    Tables.Add(new TypedDataTable2());
+                }
+            }
+
+            public TypedDataTable1 TypedDataTable1 => (TypedDataTable1)Tables["TypedDataTable1"];
+            public TypedDataTable2 TypedDataTable2 => (TypedDataTable2)Tables["TypedDataTable2"];
+
+            public DataSet ToUntypedDataSet()
+            {
+                var dataSet = new DataSet();
+
+                dataSet.DataSetName = DataSetName;
+                dataSet.CaseSensitive = CaseSensitive;
+                dataSet.EnforceConstraints = EnforceConstraints;
+                dataSet.Locale = Locale;
+                dataSet.Namespace = Namespace;
+                dataSet.Prefix = Prefix;
+                dataSet.RemotingFormat = RemotingFormat;
+
+                foreach (var typedTable in Tables.Cast<DataTable>())
+                {
+                    var dataTable = new DataTable();
+
+                    dataTable.TableName = typedTable.TableName;
+                    dataTable.DisplayExpression = typedTable.DisplayExpression;
+                    dataTable.MinimumCapacity = typedTable.MinimumCapacity;
+                    dataTable.Namespace = typedTable.Namespace;
+                    dataTable.Prefix = typedTable.Prefix;
+                    dataTable.RemotingFormat = typedTable.RemotingFormat;
+
+                    foreach (var column in typedTable.Columns.Cast<DataColumn>())
+                    {
+                        var dataColumn = new DataColumn();
+
+                        dataColumn.ColumnName = column.ColumnName;
+                        dataColumn.AllowDBNull = column.AllowDBNull;
+                        dataColumn.AutoIncrement = column.AutoIncrement;
+                        dataColumn.AutoIncrementSeed = column.AutoIncrementSeed;
+                        dataColumn.AutoIncrementStep = column.AutoIncrementStep;
+                        dataColumn.Caption = column.Caption;
+                        dataColumn.ColumnMapping = column.ColumnMapping;
+                        dataColumn.DataType = column.DataType;
+                        dataColumn.DateTimeMode = column.DateTimeMode;
+                        dataColumn.DefaultValue = column.DefaultValue;
+                        dataColumn.Expression = column.Expression;
+                        dataColumn.MaxLength = column.MaxLength;
+                        dataColumn.Namespace = column.Namespace;
+                        dataColumn.Prefix = column.Prefix;
+                        dataColumn.ReadOnly = column.ReadOnly;
+
+                        foreach (var property in column.ExtendedProperties.Cast<DictionaryEntry>())
+                        {
+                            dataColumn.ExtendedProperties.Add(property.Key, property.Value);
+                        }
+
+                        dataTable.Columns.Add(dataColumn);
+                    }
+
+                    foreach (var row in typedTable.Rows.Cast<DataRow>())
+                    {
+                        dataTable.ImportRow(row);
+                    }
+
+                    dataTable.PrimaryKey = typedTable.PrimaryKey
+                        .Select(col => dataTable.Columns[col.ColumnName])
+                        .ToArray();
+
+                    foreach (var property in typedTable.ExtendedProperties.Cast<DictionaryEntry>())
+                    {
+                        dataTable.ExtendedProperties.Add(property.Key, property.Value);
+                    }
+
+                    foreach (var constraint in typedTable.Constraints.Cast<Constraint>())
+                    {
+                        if (!Relations.Cast<DataRelation>().Any(rel =>
+                            (rel.ChildKeyConstraint == constraint) ||
+                            (rel.ParentKeyConstraint == constraint)))
+                        {
+                            if (constraint is UniqueConstraint uniqueConstraint)
+                            {
+                                if (!uniqueConstraint.IsPrimaryKey)
+                                {
+                                    dataTable.Constraints.Add(new UniqueConstraint(
+                                        name: uniqueConstraint.ConstraintName,
+                                        column: dataTable.Columns[uniqueConstraint.Columns.Single().ColumnName]));
+                                }
+                            }
+                            else
+                            {
+                                throw new Exception($"Don't know how to clone a constraint of type {constraint.GetType()}");
+                            }
+                        }
+                    }
+
+                    dataSet.Tables.Add(dataTable);
+                }
+
+                foreach (var property in ExtendedProperties.Cast<DictionaryEntry>())
+                {
+                    dataSet.ExtendedProperties.Add(property.Key, property.Value);
+                }
+
+                foreach (var relation in Relations.Cast<DataRelation>())
+                {
+                    // NB: In the context of the unit test, this is assuming that there is only one column in a relation.
+                    var dataRelation = new DataRelation(
+                        relation.RelationName,
+                        parentColumn: dataSet.Tables[relation.ParentTable.TableName].Columns[relation.ParentColumns.Single().ColumnName],
+                        childColumn: dataSet.Tables[relation.ChildTable.TableName].Columns[relation.ChildColumns.Single().ColumnName]);
+
+                    foreach (var property in relation.ExtendedProperties.Cast<DictionaryEntry>())
+                    {
+                        dataRelation.ExtendedProperties.Add(property.Key, property.Value);
+                    }
+
+                    dataSet.Relations.Add(dataRelation);
+                }
+
+                return dataSet;
+            }
+        }
+
+        public class TypedDataSetSubclass : TypedDataSet
+        {
+            public TypedDataSetSubclass()
+            {
+            }
+
+            public TypedDataSetSubclass(TypedDataSet copyFrom, bool swapTableOrder = false, bool randomizeRowOrder = false)
+                : base(swapTableOrder)
+            {
+                DataSetName = copyFrom.DataSetName;
+                CaseSensitive = copyFrom.CaseSensitive;
+                EnforceConstraints = copyFrom.EnforceConstraints;
+                Locale = copyFrom.Locale;
+                Namespace = copyFrom.Namespace;
+                Prefix = copyFrom.Prefix;
+                RemotingFormat = copyFrom.RemotingFormat;
+                SchemaSerializationMode = copyFrom.SchemaSerializationMode;
+
+                CopyTable<TypedDataTable1, TypedDataRow1>(
+                    from: copyFrom.TypedDataTable1,
+                    to: TypedDataTable1,
+                    randomizeRowOrder);
+
+                CopyTable<TypedDataTable2, TypedDataRow2>(
+                    from: copyFrom.TypedDataTable2,
+                    to: TypedDataTable2,
+                    randomizeRowOrder);
+
+                foreach (var property in copyFrom.ExtendedProperties.Cast<DictionaryEntry>())
+                {
+                    ExtendedProperties.Add(property.Key, property.Value);
+                }
+
+                foreach (var copyFromRelation in copyFrom.Relations.Cast<DataRelation>())
+                {
+                    // NB: In the context of the unit test, this is assuming that there is only one column in a relation.
+                    var relation = new DataRelation(
+                        copyFromRelation.RelationName,
+                        parentColumn: Tables[copyFromRelation.ParentTable.TableName].Columns[copyFromRelation.ParentColumns.Single().ColumnName],
+                        childColumn: Tables[copyFromRelation.ChildTable.TableName].Columns[copyFromRelation.ChildColumns.Single().ColumnName]);
+
+                    foreach (var property in copyFromRelation.ExtendedProperties.Cast<DictionaryEntry>())
+                    {
+                        relation.ExtendedProperties.Add(property.Key, property.Value);
+                    }
+
+                    Relations.Add(relation);
+                }
+            }
+
+            private void CopyTable<TDataTable, TDataRow>(TDataTable from, TDataTable to, bool randomizeRowOrder)
+                where TDataTable : DataTable, IEnumerable<TDataRow>
+                where TDataRow : DataRow
+            {
+                if (randomizeRowOrder)
+                {
+                    foreach (var row in from.OrderBy(row => Guid.NewGuid()))
+                    {
+                        to.ImportRow(row);
+                    }
+                }
+                else
+                {
+                    foreach (var row in from)
+                    {
+                        to.ImportRow(row);
+                    }
+                }
+
+                foreach (var property in from.ExtendedProperties.Cast<DictionaryEntry>())
+                {
+                    to.ExtendedProperties.Add(property.Key, property.Value);
+                }
+
+                foreach (var column in to.Columns.Cast<DataColumn>())
+                {
+                    foreach (var property in from.Columns[column.ColumnName].ExtendedProperties.Cast<DictionaryEntry>())
+                    {
+                        column.ExtendedProperties.Add(property.Key, property.Value);
+                    }
+                }
+            }
+        }
+        #endregion
+
+        private static readonly Random Random = new Random();
+
+        private static TDataSet CreateDummyDataSet<TDataSet>(bool identicalTables = false, bool includeDummyData = true, bool includeRelation = true)
+            where TDataSet : TypedDataSet, new()
+        {
+            var ret = new TDataSet();
+
+            foreach (var dataColumn in ret.TypedDataTable1.Columns.Cast<DataColumn>())
+            {
+                AddExtendedProperties(dataColumn.ExtendedProperties);
+            }
+
+            if (includeDummyData)
+            {
+                InsertDummyRows(ret.TypedDataTable1);
+            }
+
+            AddExtendedProperties(ret.TypedDataTable1.ExtendedProperties);
+
+            if (identicalTables)
+            {
+                foreach (var dataColumn in ret.TypedDataTable2.Columns.Cast<DataColumn>())
+                {
+                    foreach (var property in ret.TypedDataTable1.ExtendedProperties.Cast<DictionaryEntry>())
+                    {
+                        dataColumn.ExtendedProperties.Add(property.Key, property.Value);
+                    }
+                }
+
+                foreach (var row in ret.TypedDataTable1.Cast<DataRow>())
+                {
+                    ret.TypedDataTable2.ImportRow(row);
+                }
+
+                foreach (var property in ret.TypedDataTable1.ExtendedProperties.Cast<DictionaryEntry>())
+                {
+                    ret.TypedDataTable2.ExtendedProperties.Add(property.Key, property.Value);
+                }
+            }
+            else
+            {
+                foreach (var dataColumn in ret.TypedDataTable2.Columns.Cast<DataColumn>())
+                {
+                    AddExtendedProperties(dataColumn.ExtendedProperties);
+                }
+
+                if (includeDummyData)
+                {
+                    InsertDummyRows(ret.TypedDataTable2, ret.TypedDataTable1);
+                }
+
+                if (includeRelation)
+                {
+                    AddRelation(ret);
+                }
+
+                AddExtendedProperties(ret.TypedDataTable2.ExtendedProperties);
+            }
+
+            AddExtendedProperties(ret.ExtendedProperties);
+
+            return ret;
+        }
+
+        private static void AddRelation(TypedDataSet dataSet)
+        {
+            var relation = new DataRelation("TestRelation", dataSet.TypedDataTable1.RowIDColumn, dataSet.TypedDataTable2.ForeignRowIDColumn);
+
+            AddExtendedProperties(relation.ExtendedProperties);
+
+            dataSet.Relations.Add(relation);
+        }
+
+        private static void AddExtendedProperties(PropertyCollection extendedProperties)
+        {
+            extendedProperties.Add(Guid.NewGuid(), Guid.NewGuid());
+            extendedProperties.Add(Guid.NewGuid(), Guid.NewGuid().ToString());
+            extendedProperties.Add(Guid.NewGuid().ToString(), Guid.NewGuid());
+        }
+
+        private static void InsertDummyRows(DataTable table, DataTable foreignRows = null)
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                InsertDummyRow(table, foreignRows?.Rows[i]);
+            }
+
+            table.AcceptChanges();
+        }
+
+        private static void InsertDummyRow(DataTable table, DataRow foreignRow = null)
+        {
+            var row = table.NewRow();
+
+            foreach (var column in table.Columns.OfType<DataColumn>())
+            {
+                if (column.ColumnName.StartsWith("Foreign", StringComparison.Ordinal))
+                {
+                    row[column] = foreignRow?[column.ColumnName.Substring(7)] ?? DBNull.Value;
+                }
+                else
+                {
+                    row[column] = GetDummyValueOfType(column.DataType);
+                }
+            }
+
+            table.Rows.Add(row);
+        }
+
+        [SuppressMessage("Style", "IDE0010:Add missing cases", Justification = "TypedDataTable test types have a limited set of columns.")]
+        private static object GetDummyValueOfType(Type dataType)
+        {
+            switch (Type.GetTypeCode(dataType))
+            {
+                case TypeCode.Int32:
+                    return Random.Next();
+                case TypeCode.DateTime:
+                    return DateTime.MinValue.AddTicks((Random.Next() & 0x7FFFFFFF) * 1469337835L).AddTicks((Random.Next() & 0x7FFFFFFF) * 1469337835L / 2147483648);
+                case TypeCode.Decimal:
+                    return new decimal(Random.NextDouble());
+                case TypeCode.String:
+                    return Guid.NewGuid().ToString();
+
+                default:
+                    if (dataType == typeof(Guid))
+                    {
+                        return Guid.NewGuid();
+                    }
+
+                    throw new Exception($"Don't know how to generate dummy value of type {dataType}");
+            }
+        }
+
+        public enum ChangeType
+        {
+            Added,
+            Changed,
+            Removed,
+        }
+
+        public static IEnumerable<object[]> AllChangeTypes
+            => Enum.GetValues(typeof(ChangeType)).Cast<ChangeType>().Select(t => new object[] { t });
+
+        public static IEnumerable<object[]> AllChangeTypesWithAcceptChangesValues
+            => Enum.GetValues(typeof(ChangeType)).Cast<ChangeType>().Join(
+                new[] { true, false },
+                changeType => true,
+                acceptChanges => true,
+                (changeType, acceptChanges) => new object[] { changeType, acceptChanges });
+
+        [SuppressMessage("Style", "IDE0010:Add missing cases", Justification = "Every enum value is covered")]
+        private static void ApplyChange(DataColumnCollection columns, ChangeType changeType)
+        {
+            switch (changeType)
+            {
+                case ChangeType.Added:
+                    columns.Add("Test", typeof(int));
+                    break;
+                case ChangeType.Changed:
+                    columns[1].ColumnName += "different";
+                    break;
+                case ChangeType.Removed:
+                    columns.RemoveAt(1);
+                    break;
+            }
+        }
+
+        [SuppressMessage("Style", "IDE0010:Add missing cases", Justification = "Every enum value is covered")]
+        private static void ApplyChange(PropertyCollection extendedProperties, ChangeType changeType)
+        {
+            switch (changeType)
+            {
+                case ChangeType.Added:
+                    extendedProperties[Guid.NewGuid()] = Guid.NewGuid();
+                    break;
+                case ChangeType.Changed:
+                    extendedProperties[extendedProperties.Keys.Cast<object>().First()] = Guid.NewGuid();
+                    break;
+                case ChangeType.Removed:
+                    extendedProperties.Remove(extendedProperties.Keys.Cast<object>().First());
+                    break;
+            }
+        }
+
+        [SuppressMessage("Style", "IDE0010:Add missing cases", Justification = "Every enum value is covered")]
+        private static void ApplyChange(ConstraintCollection constraints, DataColumn columnForNewConstraint, ChangeType changeType)
+        {
+            switch (changeType)
+            {
+                case ChangeType.Added:
+                    constraints.Add(
+                        new UniqueConstraint(
+                            "Test",
+                            columnForNewConstraint));
+                    break;
+                case ChangeType.Changed:
+                    constraints[1].ConstraintName += "different";
+                    break;
+                case ChangeType.Removed:
+                    constraints.RemoveAt(1);
+                    break;
+            }
+        }
+
+        [SuppressMessage("Style", "IDE0010:Add missing cases", Justification = "Every enum value is covered")]
+        private static void ApplyChange(DataRowCollection rows, DataTable dataTable, ChangeType changeType)
+        {
+            switch (changeType)
+            {
+                case ChangeType.Added:
+                    InsertDummyRow(dataTable);
+                    break;
+                case ChangeType.Changed:
+                    rows[1]["String"] += "different";
+                    break;
+                case ChangeType.Removed:
+                    rows.RemoveAt(0);
+                    break;
+            }
+        }
+    }
+}

--- a/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
+++ b/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
@@ -57,6 +57,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.StaFact" Version="1.0.37" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">

--- a/Tests/FluentAssertions.Specs/Formatting/EnumerableExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/EnumerableExtensionsSpecs.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+
+using FluentAssertions.Formatting;
+
+using Xunit;
+
+namespace FluentAssertions.Specs
+{
+    public class EnumerableExtensionsSpecs
+    {
+        public static IEnumerable<object[]> JoinUsingWritingStyleTestCases
+        {
+            get
+            {
+                yield return new object[] { new object[0], "" };
+                yield return new object[] { new object[] { "test" }, "test" };
+                yield return new object[] { new object[] { "test", "test2" }, "test and test2" };
+                yield return new object[] { new object[] { "test", "test2", "test3" }, "test, test2 and test3" };
+                yield return new object[] { new object[] { "test", "test2", "test3", "test4" }, "test, test2, test3 and test4" };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(JoinUsingWritingStyleTestCases))]
+        public void JoinUsingWritingStyle_should_format_correctly(IEnumerable<object> input, string expectation)
+        {
+            // Act
+            var result = input.JoinUsingWritingStyle();
+
+            // Assert
+            result.Should().Be(expectation);
+        }
+    }
+}

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -57,6 +57,8 @@ sidebar:
         url: /guids
       - title: Enums
         url: /enums
+      - title: System.Data
+        url: /data
       - title: Exceptions
         url: /exceptions
       - title: Object graph comparison

--- a/docs/_pages/data.md
+++ b/docs/_pages/data.md
@@ -1,0 +1,173 @@
+---
+title: System.Data
+permalink: /data/
+layout: single
+classes: wide
+sidebar:
+  nav: "sidebar"
+---
+
+Fluent Assertions can be used to assert equivalence of System.Data types such as `DataSet` and `DataTable`.
+
+## Basic Assertions
+
+As with other reference types, you can assert a value of any of the core System.Data types to be null or not null:
+
+```csharp
+DataSet result = ...;
+
+result.Should().NotBeNull();
+```
+
+You can also assert that two `DataSet` objects contain equivalent configuration and data, which, by default, will compare the rows contained by `DataTable` objects by their index within the collection.
+Like this:
+
+```csharp
+var expected = GetExpectedDataSet();
+var actual = GetActualDataSet();
+
+actual.Should().BeEquivalentTo(expected);
+```
+
+The `BeEquivalentTo` test can be applied to `DataTable`, `DataColumn` and `DataRow` objects as well:
+
+```csharp
+actual.Tables["First"].Should().BeEquivalentTo(expected.Tables["First"]);
+```
+
+Chaining additional assertions is supported as well.
+
+```csharp
+dataTable.Should().HaveColumns("FirstName", "LastName")
+    .And.Should().HaveRowCount(3);
+```
+
+## `DataSet` Assertions
+
+The following assertions are available on `DataSet` objects:
+
+* `.Should().HaveTableCount(n)`: Asserts that the `DataSet`'s `Tables` collection has the expected number of members.
+* `.Should().HaveTable(tableName)`, `.Should().HaveTables(tableName, tableName, ...)`: Asserts that the `DataSet`'s `Tables` collection contains at least tables with the specified names. Additional tables are ignored.
+* `.Should().BeEquivalentTo(dataSet)`: Performs a deep equivalency comparison between the subject and the expectation.
+
+## `DataTable` Assertions
+
+The following assertions are available on `DataTable` objects:
+
+* `.Should().HaveColumn(columnName)`, `.Should().HaveColumns(columnName, columnName, ...)`: Asserts that the `DataTable`'s `Columns` collection contains at least columns with the specified names. Additional columns are ignored.
+* `.Should().HaveRowCount(n)`: Asserts that the `DataTable`'s `Rows` collection has the expected number of elements.
+* `.Should().BeEquivalentTo(dataTable)`: Performs a deep equivalency comparison between the subject and the expectation.
+
+When comparing the rows of a `DataTable`, by default the rows are matched by their index in the `Rows` collection. But, if the subject and expectation tables contain equivalent `PrimaryKey` values, then it is possible to match the rows by their primary key field data, irrespective of the row order within the `Rows` collection. See "Equivalency Assertion Options" below for how to configure this.
+
+## `DataColumn` Assertions
+
+The following assertions are available on `DataColumn` objects:
+
+* `.Should().BeEquivalentTo(dataColumn)`: Performs a deep equivalency comparison between the subject and the expectation.
+
+## `DataRow` Assertions
+
+The following assertions are available on `DataRow` objects:
+
+* `.Should().HaveColumn(columnName)`, `.Should().HaveColumns(columnName, columnName, ...)`: Asserts that the `DataTable`'s `Columns` collection contains at least columns with the specified names. Additional columns are ignored.
+* `.Should().BeEquivalentTo(dataRow)`: Performs a deep equivalency comparison between the subject and the expectation. This includes comparing field values, for which the defined columns must match.
+
+When checking the equivalency of two `DataRow` objects, by default the `RowState` must match. But, if this is overridden using equivalency assertion options (`.Excluding(row => row.RowState)`), two `DataRow` objects with differing `RowState`s can still be considered equivalent based on their field values. FluentAssertions automatically determines which _version_ of field values to use in the subject and the expectation separately.
+
+* For `DataRowState.Unchanged`, field values for `DataRowVersion.Current` are used.
+* For `DataRowState.Added`, field values for `DataRowVersion.Current` are used.
+* For `DataRowState.Deleted`, field values for `DataRowVersion.Original` are used.
+* For `DataRowState.Modified`, field values for `DataRowVersion.Current` are used.
+
+In addition, if both the subject and the expectation are in the `DataRowState.Modified` state, then the `DataRowVersion.Original` values are also compared, separately from the `DataRowVersion.Current` values. This can be disabled using the `.ExcludingOriginalData()` equivalency assertion option.
+
+## Equivalency Assertion Options
+
+When checking equivalency, the operation can be fine-tuned by configuring the options provided to an optional configuration callback in the `.BeEquivalentTo` method.
+
+In addition to standard equivalency assertion options, which are applied recursively to all subjects found in the object graph, the following options are available that are specific to equivalency tests for supported `System.Data` types:
+
+* `.AllowingMismatchedTypes()`: Allows objects with equivalent data to be considered equivalent, even if their data types do not match. See "Typed `DataSet`, `DataTable`, `DataRow` objects" below.
+* `.IgnoringUnmatchedColumns()`: Allows tables to be equivalent if one table has columns that the other does not. The column definitions and row data for these columns is ignored.
+* `.UsingRowMatchMode(Index | PrimaryKey)`: Specifies the manner in which rows in two `DataTable`s should be matched up for equivalency testing.
+* `.ExcludingOriginalData()`: Specifies that when comparing two `DataRow` objects whose `RowState` is both `Modified`, only the `Current` value of fields should be compared, ignoring any differences in the `Original` versions of those fields.
+* `.Excluding(x => x.Member)`: Excludes the specified member of the subject type from comparison. This method can only be used to select members accessible from the subject type directly.
+* `.ExcludingRelated((DataRelation x) => x.Member)`:
+* `.ExcludingRelated((DataTable x) => x.Member)`:
+* `.ExcludingRelated((DataColumn x) => x.Member)`:
+* `.ExcludingRelated((DataRow x) => x.Member)`:
+* `.ExcludingRelated((DataConstraint x) => x.Member)`: Excludes the specified member of a related System.Data type from comparison. This is to handle the case where a change to one object within a `DataSet` causes corresponding changes automatically in other places. For instance, setting `Unique` to `true` in a `DataColumn` has a side-effect of adding a new `UniqueConstraint` to the `Constraints` collection of the containing `DataTable`.
+* `.ExcludingTable(tableName)`, `.ExcludingTables(tableName, tableName, ...)`: Excludes tables with the specified name(s) from comparison.
+* `.ExcludingColumnInAllTables(columnName)`, `.ExcludingColumnsInAllTables(columnName, columnName, ...)`: Excludes all columns in any table within the `DataSet` with the specified name(s) from comparison.
+* `.ExcludingColumn(tableName, columnName)`, `.ExcludingColumns(tableName, columnName, columnName, ...)`: Excludes the specified column(s) in tables with a specific name within the `DataSet`s from comparison.
+* `.ExcludingColumn(dataColumn)`, `.ExcludingColumns(dataColumn, dataColumn, ...`): Excludes the specified column(s) in tables with names matching the owner `DataTable` of the supplied `DataColumn` object(s) from comparison. This method is supplied because with typed `DataTable` objects, it is a common pattern that accessors for `DataColumn` objects are provided.
+
+These configuration methods follow a fluent initialization pattern; they return the same options object they were called on, so that configuration can be chained in a single expression.
+
+See the "Examples" section for some uses of equivalency options.
+
+## Typed `DataSet`, `DataTable`, `DataRow` objects
+
+If some of your `DataSet`, `DataTable` or `DataRow` objects are _typed_ objects (e.g. `DataTable` classes that inherit from `TypedTableBase<TRow>`), by default, equivalency tests will fail if the data types do not also match. If you want to compare typed objects with untyped objects that otherwise contain equivalent data, then the option `AllowingMismatchedTypes` can be used:
+
+```csharp
+DataSet expected = GetExpectedDataSet();
+EmployeeData actual = service.GetEmployeeData();
+
+actual.Should().BeEquivalentTo(expected, options => options.AllowingMismatchedTypes());
+```
+
+Apart from the default check for matching types, whether a `DataSet`, `DataTable` or `DataRow` is a vanilla object or an instance of a custom subtype is irrelevant for the purposes of comparison.
+
+## Examples:
+
+Asserting that a `DataTable` has certain columns:
+
+```csharp
+var table = GetDataTable();
+
+MyTypedTableType templateTable = GetExpectedDataTable();
+
+table.Should().HaveColumn("FirstName");
+
+table.Should().HaveColumns(templateTable.FirstNameColumn, templateTable.LastNameColumn);
+```
+
+Excluding tables and columns from equivalency tests:
+
+> You can exclude a column from consideration by name across all tables in a `DataSet`, or from a specific `DataTable`.
+
+```csharp
+var expected = GetExpectedDataSet();
+var actual = GetActualDataSet();
+
+actual.Should().BeEquivalentTo(expected, options => options
+    .ExcludingTable("Employees")
+    .ExcludingColumnInAllTables("EmployeeID")
+    .ExcludingColumn(tableName: "Employees", columnName: "Address"));
+```
+
+Excluding fields from types other than the subject:
+
+> `DataSet` objects have a hierarchy of objects representing the data and many interrelations between these objects. For instance, setting `Unique` to `true` in a `DataColumn` has a side-effect of adding a new `UniqueConstraint` to the `Constraints` collection of the containing `DataTable`. As such, to eliminate side-effects it may be necessary to ignore additional properties of types related to the subject. To support this, a method `ExcludingRelated` can be used that allows members to be selected on any related type.
+
+```csharp
+var expected = GetExpectedDataSet();
+var actual = GetActualDataSet();
+
+actual.Should().BeEquivalentTo(expected, options => options
+    .Excluding(dataSet => dataSet.DataSetName)
+    .ExcludingRelated((DataRelation relation) => relation.DataSet);
+```
+
+Matching the rows of `DataTable`s by their primary key values:
+
+> When comparing the rows of a `DataTable`, by default, rows are expected to be occur at the same indices. If a `DataTable` has a `PrimaryKey` set, then it is possible to instead match rows by their primary key, irrespective of the order in which they occur.
+
+```csharp
+var expected = GetExpectedDataTable();
+var actual = GetActualDataTable(0;
+
+actual.Should().BeEquivalentTo(expected, options => options.UsingRowMatchMode(RowMatchMode.PrimaryKey));
+```

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -21,6 +21,7 @@ sidebar:
 * Added nullable overload for `Be` and `NotBe` methods of `DateTimeAssertions` and `DateTimeOffsetAssertions` - [#1427](https://github.com/fluentassertions/fluentassertions/issues/1427).
 * Added overload of `Enumerating` extension method to be able to force the enumeration of an object member -[#1433](https://github.com/fluentassertions/fluentassertions/pull/1433)
 * Add overloads of `MatchRegex` and `NotMatchRegex` that take `System.Text.RegularExpressions.Regex` -[#1436](https://github.com/fluentassertions/fluentassertions/pull/1436)
+* Added support for equivalency tests on System.Data types (`DataSet`, `DataTable`, `DataColumn`, `DataRow`, `DataRelation`, `Constraint`) - [#1419](https://github.com/fluentassertions/fluentassertions/pull/1419).
 
 **Fixes**
 * Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)


### PR DESCRIPTION
I tried asserting equivalency on `DataSet` objects and the results were .. dissatisfying. :-)

This PR:

- Adds equivalency steps for `DataSet` and related types.
- Registers these steps in `GetDefaultSteps` in `EquivalencyStepCollection.cs`.
- Adds new overloads of `.Should()` in `AssertionExtensions.cs` drive by new subclasses of `ReferenceTypeAssertions<>`.
- Adds comprehensive unit testing of the new functionality.
- Adds documentation of the new functionality for the web site.
- Updates the ApprovedApi files to include the newly-added API surface.
- Adds mention of the new feature to the release notes on the Releases page.

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).