### PR TITLE
Fix Contain, NotContain and OnlyContain to avoid multiple enumeration…

### DIFF
--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -422,15 +422,16 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:collection} to contain {0}{reason}, but found {1}.", expected, Subject);
             }
 
-            if (!Subject.Contains(expected))
+            var collection = Subject.ConvertOrCastToCollection();
+            if (!collection.Contains(expected))
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} {0} to contain {1}{reason}.", Subject, expected);
+                    .FailWith("Expected {context:collection} {0} to contain {1}{reason}.", collection, expected);
             }
 
             return new AndWhichConstraint<TAssertions, T>((TAssertions)this,
-                Subject.Where(
+                collection.Where(
                     item => EqualityComparer<T>.Default.Equals(item, expected)));
         }
 
@@ -498,13 +499,14 @@ namespace FluentAssertions.Collections
 
             Func<T, bool> compiledPredicate = predicate.Compile();
 
+            var collection = Subject.ConvertOrCastToCollection();
             Execute.Assertion
-                .ForCondition(Subject.Any())
+                .ForCondition(collection.Any())
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} to contain only items matching {0}{reason}, but the collection is empty.",
                     predicate.Body);
 
-            IEnumerable<T> mismatchingItems = Subject.Where(item => !compiledPredicate(item));
+            IEnumerable<T> mismatchingItems = collection.Where(item => !compiledPredicate(item));
             if (mismatchingItems.Any())
             {
                 Execute.Assertion
@@ -536,15 +538,16 @@ namespace FluentAssertions.Collections
                     .FailWith("Expected {context:collection} to not contain {0}{reason}, but found <null>.", unexpected);
             }
 
-            if (Subject.Contains(unexpected))
+            var collection = Subject.ConvertOrCastToCollection();
+            if (collection.Contains(unexpected))
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} {0} to not contain {1}{reason}.", Subject, unexpected);
+                    .FailWith("Expected {context:collection} {0} to not contain {1}{reason}.", collection, unexpected);
             }
 
             return new AndWhichConstraint<TAssertions, T>((TAssertions)this,
-                Subject.Where(
+                collection.Where(
                     item => !EqualityComparer<T>.Default.Equals(item, unexpected)));
         }
 

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -184,6 +185,68 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected strings {\"string1\", \"string2\"} to not contain {\"string3\", \"string4\", \"string2\"}, but found {\"string2\"}.");
+        }
+
+        [Fact]
+        public void When_a_collection_does_not_contain_the_expected_item_it_should_not_be_enumerated_twice()
+        {
+            // Arrange
+            var collection = new OneTimeEnumerable<int>(1, 2, 3);
+
+            // Act
+            Action act = () => collection.Should().Contain(4);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection*to contain 4.");
+        }
+
+        [Fact]
+        public void When_a_collection_contains_the_unexpected_item_it_should_not_be_enumerated_twice()
+        {
+            // Arrange
+            var collection = new OneTimeEnumerable<int>(1, 2, 3);
+
+            // Act
+            Action act = () => collection.Should().NotContain(2);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection*to not contain 2.");
+        }
+
+        [Fact]
+        public void When_a_collection_does_not_contain_the_unexpected_items_it_should_not_be_enumerated_twice()
+        {
+            // Arrange
+            var collection = new OneTimeEnumerable<int>(1, 2, 3);
+
+            // Act
+            Action act = () => collection.Should().OnlyContain(i => i > 3);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection to contain only items matching*");
+        }
+
+        private class OneTimeEnumerable<T> : IEnumerable<T>
+        {
+            private readonly IEnumerable<T> items;
+            private int enumerations = 0;
+
+            public OneTimeEnumerable(params T[] items) => this.items = items;
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                if (enumerations++ > 0)
+                {
+                    throw new InvalidOperationException("OneTimeEnumerable can be enumerated one time only");
+                }
+
+                return items.GetEnumerator();
+            }
         }
 
         #endregion

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -17,7 +17,6 @@ sidebar:
 * Added overload of `CollectionAssertions.NotBeEquivalentTo` that takes a `config` parameter` - [#1408](https://github.com/fluentassertions/fluentassertions/pull/1408).
 * Changed `StringAssertions.StartWith`, `StringAssertions.EndWith` and their `EquivalentOf` versions to allow empty strings - [#1413](https://github.com/fluentassertions/fluentassertions/pull/1413).
 * Added `ThenBeInAscendingOrder` and `ThenBeInDescendingOrder` to allow asserting that a subsequence is ordered in ascending or descending order - [#1416](https://github.com/fluentassertions/fluentassertions/pull/1416).
-* Changed `AttributeBasedFormatter` to allow custom formatter selection based on the parent type - [#1418](https://github.com/fluentassertions/fluentassertions/pull/1418).
 
 **Fixes**
 * Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -17,11 +17,13 @@ sidebar:
 * Added overload of `CollectionAssertions.NotBeEquivalentTo` that takes a `config` parameter` - [#1408](https://github.com/fluentassertions/fluentassertions/pull/1408).
 * Changed `StringAssertions.StartWith`, `StringAssertions.EndWith` and their `EquivalentOf` versions to allow empty strings - [#1413](https://github.com/fluentassertions/fluentassertions/pull/1413).
 * Added `ThenBeInAscendingOrder` and `ThenBeInDescendingOrder` to allow asserting that a subsequence is ordered in ascending or descending order - [#1416](https://github.com/fluentassertions/fluentassertions/pull/1416).
+* Changed `AttributeBasedFormatter` to allow custom formatter selection based on the parent type - [#1418](https://github.com/fluentassertions/fluentassertions/pull/1418).
 
 **Fixes**
 * Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)
 * Guard against implicitly or explicitly trying to compare primitive types by members - [#1394](https://github.com/fluentassertions/fluentassertions/pull/1394).
-* Fixed formatting of brackets in expressions passed to ContainSingle(...) - [#1406](https://github.com/fluentassertions/fluentassertions/pull/1406). 
+* Fixed formatting of brackets in expressions passed to ContainSingle(...) - [#1406](https://github.com/fluentassertions/fluentassertions/pull/1406).
+* Fixed `Contain`, `NotContain` and `OnlyContain` to avoid multiple enumerations when the condition is false - [#1421](https://github.com/fluentassertions/fluentassertions/pull/1421).
 
 **Breaking Changes**
 * Made the extension methods under the `FluentAssertions.Common` namespace `internal` -  [#1376](https://github.com/fluentassertions/fluentassertions/pull/1376)


### PR DESCRIPTION
…s when the condition is false

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).

Fixes #327