### PR TITLE
Exclude custom ValueFormatters not returning a string

### DIFF
--- a/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
@@ -77,6 +77,7 @@ namespace FluentAssertions.Formatting
                 where type != null
                 from method in type.GetMethods(BindingFlags.Static | BindingFlags.Public)
                 where method.IsStatic
+                where method.ReturnType == typeof(string)
                 where method.IsDecoratedWithOrInherit<ValueFormatterAttribute>()
                 where method.GetParameters().Length == 1
                 select method;

--- a/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
@@ -664,6 +664,12 @@ namespace FluentAssertions.Specs
         public static class CustomFormatter
         {
             [ValueFormatter]
+            public static int Bar(SomeClassWithCustomFormatter _)
+            {
+                return -1;
+            }
+
+            [ValueFormatter]
             public static string Foo(SomeClassWithCustomFormatter value)
             {
                 return "Property = " + value.Property;


### PR DESCRIPTION
If a method not returning a `string` is decorated with `ValueFormatter` we would throw an `InvalidCastException` when explicitly casting the return value of the `formatter` to `string`.