### PR TITLE
Fix #1427 Add `DateTime.Should().Be(DateTime?)` and `DateTimeOffset.Should().Be(DateTimeOffset?)` overloads

### DIFF
--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -79,9 +79,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> Be(DateTime? expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(
-                    (!Subject.HasValue && !expected.HasValue) ||
-                    (Subject.HasValue && expected.HasValue && (Subject.Value == expected)))
+                .ForCondition(Subject == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} to be {0}{reason}, but found {1}.",
                     expected, Subject ?? default(DateTime?));

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -80,8 +80,8 @@ namespace FluentAssertions.Primitives
         {
             Execute.Assertion
                 .ForCondition(
-                    (!Subject.HasValue && !expected.HasValue)
-                    || (Subject.HasValue && expected.HasValue && (Subject.Value == expected)))
+                    (!Subject.HasValue && !expected.HasValue) ||
+                    (Subject.HasValue && expected.HasValue && (Subject.Value == expected)))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} to be {0}{reason}, but found {1}.",
                     expected, Subject ?? default(DateTime?));
@@ -127,8 +127,8 @@ namespace FluentAssertions.Primitives
         {
             Execute.Assertion
                 .ForCondition(
-                    (!Subject.HasValue == unexpected.HasValue)
-                    || (Subject.HasValue && unexpected.HasValue && Subject.Value != unexpected))
+                    (!Subject.HasValue == unexpected.HasValue) ||
+                    (Subject.HasValue && unexpected.HasValue && Subject.Value != unexpected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} not to be {0}{reason}, but it is.", unexpected);
 

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -66,6 +66,30 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
+        /// Asserts that the current <see cref="DateTime"/> is exactly equal to the <paramref name="expected"/> value.
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> Be(DateTime? expected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(
+                    (!Subject.HasValue && !expected.HasValue)
+                    || (Subject.HasValue && expected.HasValue && (Subject.Value == expected)))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:date and time} to be {0}{reason}, but found {1}.",
+                    expected, Subject ?? default(DateTime?));
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
         /// Asserts that the current <see cref="DateTime"/> or <see cref="DateTime"/> is not equal to the <paramref name="unexpected"/> value.
         /// </summary>
         /// <param name="unexpected">The unexpected value</param>
@@ -81,6 +105,30 @@ namespace FluentAssertions.Primitives
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue || (Subject.Value != unexpected))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:date and time} not to be {0}{reason}, but it is.", unexpected);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="DateTime"/> or <see cref="DateTime"/> is not equal to the <paramref name="unexpected"/> value.
+        /// </summary>
+        /// <param name="unexpected">The unexpected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotBe(DateTime? unexpected, string because = "",
+            params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(
+                    (!Subject.HasValue == unexpected.HasValue)
+                    || (Subject.HasValue && unexpected.HasValue && Subject.Value != unexpected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} not to be {0}{reason}, but it is.", unexpected);
 

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -82,9 +82,7 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(
-                    (!Subject.HasValue && !expected.HasValue) ||
-                    (Subject.HasValue && expected.HasValue && (Subject.Value == expected)))
+                .ForCondition(Subject == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be {0}{reason}, but it was {1}.",
                     expected, Subject ?? default(DateTimeOffset?));

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -68,6 +68,31 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
+        /// Asserts that the current <see cref="DateTimeOffset"/> is exactly equal to the <paramref name="expected"/> value.
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> Be(DateTimeOffset? expected, string because = "",
+            params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(
+                    (!Subject.HasValue && !expected.HasValue)
+                    || (Subject.HasValue && expected.HasValue && (Subject.Value == expected)))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:the date and time} to be {0}{reason}, but it was {1}.",
+                    expected, Subject ?? default(DateTimeOffset?));
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
         /// Asserts that the current <see cref="DateTimeOffset"/> is not equal to the <paramref name="unexpected"/> value.
         /// </summary>
         /// <param name="unexpected">The unexpected value</param>
@@ -83,6 +108,29 @@ namespace FluentAssertions.Primitives
         {
             Execute.Assertion
                 .ForCondition(!Subject.HasValue || (Subject.Value != unexpected))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Did not expect {context:the date and time} to be {0}{reason}, but it was.", unexpected);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="DateTimeOffset"/> is not equal to the <paramref name="unexpected"/> value.
+        /// </summary>
+        /// <param name="unexpected">The unexpected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotBe(DateTimeOffset? unexpected, string because = "",
+            params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition((!Subject.HasValue == unexpected.HasValue)
+                    || (Subject.HasValue && unexpected.HasValue && Subject.Value != unexpected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:the date and time} to be {0}{reason}, but it was.", unexpected);
 

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -83,8 +83,8 @@ namespace FluentAssertions.Primitives
         {
             Execute.Assertion
                 .ForCondition(
-                    (!Subject.HasValue && !expected.HasValue)
-                    || (Subject.HasValue && expected.HasValue && (Subject.Value == expected)))
+                    (!Subject.HasValue && !expected.HasValue) ||
+                    (Subject.HasValue && expected.HasValue && (Subject.Value == expected)))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be {0}{reason}, but it was {1}.",
                     expected, Subject ?? default(DateTimeOffset?));
@@ -129,8 +129,8 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition((!Subject.HasValue == unexpected.HasValue)
-                    || (Subject.HasValue && unexpected.HasValue && Subject.Value != unexpected))
+                .ForCondition((!Subject.HasValue == unexpected.HasValue) ||
+                (Subject.HasValue && unexpected.HasValue && Subject.Value != unexpected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:the date and time} to be {0}{reason}, but it was.", unexpected);
 

--- a/Src/FluentAssertions/Primitives/NullableDateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateTimeAssertions.cs
@@ -106,26 +106,5 @@ namespace FluentAssertions.Primitives
         {
             return NotHaveValue(because, becauseArgs);
         }
-
-        /// <summary>
-        /// Asserts that the value is equal to the specified <paramref name="expected"/> value.
-        /// </summary>
-        /// <param name="expected">The expected value</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-        /// </param>
-        public AndConstraint<TAssertions> Be(DateTime? expected, string because = "", params object[] becauseArgs)
-        {
-            Execute.Assertion
-                .ForCondition(Subject == expected)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {0}{reason}, but found {1}.", expected, Subject);
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
     }
 }

--- a/Src/FluentAssertions/Primitives/NullableDateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateTimeOffsetAssertions.cs
@@ -107,27 +107,5 @@ namespace FluentAssertions.Primitives
         {
             return NotHaveValue(because, becauseArgs);
         }
-
-        /// <summary>
-        /// Asserts that the value is equal to the specified <paramref name="expected"/> value.
-        /// </summary>
-        /// <param name="expected">The expected value</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-        /// </param>
-        public AndConstraint<TAssertions> Be(DateTimeOffset? expected, string because = "",
-            params object[] becauseArgs)
-        {
-            Execute.Assertion
-                .ForCondition(Subject == expected)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:the date and time} to be {0}{reason}, but it was {1}.", expected, Subject);
-
-            return new AndConstraint<TAssertions>((TAssertions)this);
-        }
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -1495,6 +1495,7 @@ namespace FluentAssertions.Primitives
         public DateTimeAssertions(System.DateTime? value) { }
         public System.DateTime? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
@@ -1518,6 +1519,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTime? unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
@@ -1541,6 +1543,7 @@ namespace FluentAssertions.Primitives
         public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
         public System.DateTimeOffset? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -1564,6 +1567,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTimeOffset? unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
@@ -1646,7 +1650,6 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<TAssertions>
     {
         public NullableDateTimeAssertions(System.DateTime? expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
@@ -1660,7 +1663,6 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<TAssertions>
     {
         public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -1495,6 +1495,7 @@ namespace FluentAssertions.Primitives
         public DateTimeAssertions(System.DateTime? value) { }
         public System.DateTime? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
@@ -1518,6 +1519,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTime? unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
@@ -1541,6 +1543,7 @@ namespace FluentAssertions.Primitives
         public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
         public System.DateTimeOffset? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -1564,6 +1567,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTimeOffset? unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
@@ -1646,7 +1650,6 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<TAssertions>
     {
         public NullableDateTimeAssertions(System.DateTime? expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
@@ -1660,7 +1663,6 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<TAssertions>
     {
         public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -1495,6 +1495,7 @@ namespace FluentAssertions.Primitives
         public DateTimeAssertions(System.DateTime? value) { }
         public System.DateTime? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
@@ -1518,6 +1519,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTime? unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
@@ -1541,6 +1543,7 @@ namespace FluentAssertions.Primitives
         public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
         public System.DateTimeOffset? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -1564,6 +1567,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTimeOffset? unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
@@ -1646,7 +1650,6 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<TAssertions>
     {
         public NullableDateTimeAssertions(System.DateTime? expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
@@ -1660,7 +1663,6 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<TAssertions>
     {
         public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1448,6 +1448,7 @@ namespace FluentAssertions.Primitives
         public DateTimeAssertions(System.DateTime? value) { }
         public System.DateTime? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
@@ -1471,6 +1472,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTime? unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
@@ -1494,6 +1496,7 @@ namespace FluentAssertions.Primitives
         public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
         public System.DateTimeOffset? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -1517,6 +1520,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTimeOffset? unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
@@ -1599,7 +1603,6 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<TAssertions>
     {
         public NullableDateTimeAssertions(System.DateTime? expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
@@ -1613,7 +1616,6 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<TAssertions>
     {
         public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -1495,6 +1495,7 @@ namespace FluentAssertions.Primitives
         public DateTimeAssertions(System.DateTime? value) { }
         public System.DateTime? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTime expected, string because = "", params object[] becauseArgs) { }
@@ -1518,6 +1519,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTime? unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTime unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTime distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
@@ -1541,6 +1543,7 @@ namespace FluentAssertions.Primitives
         public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
         public System.DateTimeOffset? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -1564,6 +1567,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> HaveSecond(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveYear(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(System.DateTimeOffset? unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
@@ -1646,7 +1650,6 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<TAssertions>
     {
         public NullableDateTimeAssertions(System.DateTime? expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
@@ -1660,7 +1663,6 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<TAssertions>
     {
         public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
@@ -140,6 +140,20 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void Should_succeed_when_asserting_datetime_value_is_equal_to_the_same_nullable_value()
+        {
+            // Arrange
+            DateTime dateTime = new DateTime(2016, 06, 04);
+            DateTime? sameDateTime = new DateTime(2016, 06, 04);
+
+            // Act
+            Action act = () => dateTime.Should().Be(sameDateTime);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
         public void When_both_values_are_at_their_minimum_then_it_should_succeed()
         {
             // Arrange
@@ -183,6 +197,21 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void Should_fail_when_asserting_datetime_value_is_equal_to_the_different_nullable_value()
+        {
+            // Arrange
+            DateTime dateTime = new DateTime(2012, 03, 10);
+            DateTime? otherDateTime = new DateTime(2012, 03, 11);
+
+            // Act
+            Action act = () => dateTime.Should().Be(otherDateTime, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected dateTime to be <2012-03-11>*failure message, but found <2012-03-10>.");
+        }
+
+        [Fact]
         public void Should_succeed_when_asserting_datetime_value_is_not_equal_to_a_different_value()
         {
             // Arrange
@@ -197,11 +226,41 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void Should_succeed_when_asserting_datetime_value_is_not_equal_to_a_different_nullable_value()
+        {
+            // Arrange
+            DateTime dateTime = new DateTime(2016, 06, 04);
+            DateTime? otherDateTime = new DateTime(2016, 06, 05);
+
+            // Act
+            Action act = () => dateTime.Should().NotBe(otherDateTime);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
         public void Should_fail_when_asserting_datetime_value_is_not_equal_to_the_same_value()
         {
             // Arrange
             var dateTime = DateTime.SpecifyKind(10.March(2012).At(10, 00), DateTimeKind.Local);
             var sameDateTime = DateTime.SpecifyKind(10.March(2012).At(10, 00), DateTimeKind.Utc);
+
+            // Act
+            Action act =
+                () => dateTime.Should().NotBe(sameDateTime, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected dateTime not to be <2012-03-10 10:00:00> because we want to test the failure message, but it is.");
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_datetime_value_is_not_equal_to_the_same_nullable_value()
+        {
+            // Arrange
+            DateTime dateTime = DateTime.SpecifyKind(10.March(2012).At(10, 00), DateTimeKind.Local);
+            DateTime? sameDateTime = DateTime.SpecifyKind(10.March(2012).At(10, 00), DateTimeKind.Utc);
 
             // Act
             Action act =
@@ -299,7 +358,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected <2016-06-04> because we want to test the failure message, but found <null>.");
+                .WithMessage("Expected nullableDateTime to be <2016-06-04> because we want to test the failure message, but found <null>.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
@@ -140,11 +140,11 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void Should_succeed_when_asserting_datetime_value_is_equal_to_the_same_nullable_value()
+        public void When_datetime_value_is_equal_to_the_same_nullable_value_be_should_succeed()
         {
             // Arrange
-            DateTime dateTime = new DateTime(2016, 06, 04);
-            DateTime? sameDateTime = new DateTime(2016, 06, 04);
+            DateTime dateTime = 4.June(2016);
+            DateTime? sameDateTime = 4.June(2016);
 
             // Act
             Action act = () => dateTime.Should().Be(sameDateTime);
@@ -197,11 +197,11 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void Should_fail_when_asserting_datetime_value_is_equal_to_the_different_nullable_value()
+        public void When_datetime_value_is_equal_to_the_different_nullable_value_be_should_failed()
         {
             // Arrange
-            DateTime dateTime = new DateTime(2012, 03, 10);
-            DateTime? otherDateTime = new DateTime(2012, 03, 11);
+            DateTime dateTime = 10.March(2012);
+            DateTime? otherDateTime = 11.March(2012);
 
             // Act
             Action act = () => dateTime.Should().Be(otherDateTime, "because we want to test the failure {0}", "message");
@@ -226,11 +226,11 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void Should_succeed_when_asserting_datetime_value_is_not_equal_to_a_different_nullable_value()
+        public void When_datetime_value_is_not_equal_to_a_different_nullable_value_notbe_should_succeed()
         {
             // Arrange
-            DateTime dateTime = new DateTime(2016, 06, 04);
-            DateTime? otherDateTime = new DateTime(2016, 06, 05);
+            DateTime dateTime = 4.June(2016);
+            DateTime? otherDateTime = 5.June(2016);
 
             // Act
             Action act = () => dateTime.Should().NotBe(otherDateTime);
@@ -256,7 +256,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void Should_fail_when_asserting_datetime_value_is_not_equal_to_the_same_nullable_value()
+        public void When_datetime_value_is_not_equal_to_the_same_nullable_value_notbe_should_failed()
         {
             // Arrange
             DateTime dateTime = DateTime.SpecifyKind(10.March(2012).At(10, 00), DateTimeKind.Local);

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
@@ -141,11 +141,11 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void Should_succeed_when_asserting_datetimeoffset_value_is_equal_to_the_same_nullable_value()
+        public void When_datetimeoffset_value_is_equal_to_the_same_nullable_value_be_should_succeed()
         {
             // Arrange
-            DateTimeOffset dateTime = new DateTime(2016, 06, 04);
-            DateTimeOffset? sameDateTime = new DateTime(2016, 06, 04);
+            DateTimeOffset dateTime = 4.June(2016);
+            DateTimeOffset? sameDateTime = 4.June(2016);
 
             // Act
             Action act = () => dateTime.Should().Be(sameDateTime);
@@ -198,7 +198,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void Should_fail_when_asserting_datetimeoffset_value_is_equal_to_the_different_nullable_value()
+        public void When_datetimeoffset_value_is_equal_to_the_different_nullable_value_be_should_failed()
         {
             // Arrange
             DateTimeOffset dateTime = 10.March(2012).WithOffset(1.Hours());
@@ -227,11 +227,11 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void Should_succeed_when_asserting_datetimeoffset_value_is_not_equal_to_a_nullable_different_value()
+        public void When_datetimeoffset_value_is_not_equal_to_a_nullable_different_value_notbe_should_succeed()
         {
             // Arrange
-            DateTimeOffset dateTime = new DateTime(2016, 06, 04);
-            DateTimeOffset? otherDateTime = new DateTime(2016, 06, 05);
+            DateTimeOffset dateTime = 4.June(2016);
+            DateTimeOffset? otherDateTime = 5.June(2016);
 
             // Act
             Action act = () => dateTime.Should().NotBe(otherDateTime);
@@ -257,7 +257,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void Should_fail_when_asserting_datetimeoffset_value_is_not_equal_to_the_same_nullable_value()
+        public void When_datetimeoffset_value_is_not_equal_to_the_same_nullable_value_notbe_should_failed()
         {
             // Arrange
             DateTimeOffset dateTime = new DateTimeOffset(10.March(2012), 1.Hours());

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
@@ -141,6 +141,20 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void Should_succeed_when_asserting_datetimeoffset_value_is_equal_to_the_same_nullable_value()
+        {
+            // Arrange
+            DateTimeOffset dateTime = new DateTime(2016, 06, 04);
+            DateTimeOffset? sameDateTime = new DateTime(2016, 06, 04);
+
+            // Act
+            Action act = () => dateTime.Should().Be(sameDateTime);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
         public void When_both_values_are_at_their_minimum_then_it_should_succeed()
         {
             // Arrange
@@ -184,6 +198,21 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void Should_fail_when_asserting_datetimeoffset_value_is_equal_to_the_different_nullable_value()
+        {
+            // Arrange
+            DateTimeOffset dateTime = 10.March(2012).WithOffset(1.Hours());
+            DateTimeOffset? otherDateTime = 11.March(2012).WithOffset(1.Hours());
+
+            // Act
+            Action act = () => dateTime.Should().Be(otherDateTime, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected dateTime to be <2012-03-11 +1h>*failure message, but it was <2012-03-10 +1h>.");
+        }
+
+        [Fact]
         public void Should_succeed_when_asserting_datetimeoffset_value_is_not_equal_to_a_different_value()
         {
             // Arrange
@@ -198,11 +227,41 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void Should_succeed_when_asserting_datetimeoffset_value_is_not_equal_to_a_nullable_different_value()
+        {
+            // Arrange
+            DateTimeOffset dateTime = new DateTime(2016, 06, 04);
+            DateTimeOffset? otherDateTime = new DateTime(2016, 06, 05);
+
+            // Act
+            Action act = () => dateTime.Should().NotBe(otherDateTime);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
         public void Should_fail_when_asserting_datetimeoffset_value_is_not_equal_to_the_same_value()
         {
             // Arrange
             var dateTime = new DateTimeOffset(10.March(2012), 1.Hours());
             var sameDateTime = new DateTimeOffset(10.March(2012), 1.Hours());
+
+            // Act
+            Action act =
+                () => dateTime.Should().NotBe(sameDateTime, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect dateTime to be <2012-03-10 +1h> because we want to test the failure message, but it was.");
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_datetimeoffset_value_is_not_equal_to_the_same_nullable_value()
+        {
+            // Arrange
+            DateTimeOffset dateTime = new DateTimeOffset(10.March(2012), 1.Hours());
+            DateTimeOffset? sameDateTime = new DateTimeOffset(10.March(2012), 1.Hours());
 
             // Act
             Action act =

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -18,6 +18,7 @@ sidebar:
 * Changed `StringAssertions.StartWith`, `StringAssertions.EndWith` and their `EquivalentOf` versions to allow empty strings - [#1413](https://github.com/fluentassertions/fluentassertions/pull/1413).
 * The equivalency assertions will now include the type of the member and whether it involves a field or property - [#1379](https://github.com/fluentassertions/fluentassertions/pull/1379)
 * Changed AttributeBasedFormatter to allow custom formatter selection based on the parent type - [#1418](https://github.com/fluentassertions/fluentassertions/pull/1418).
+* Added nullable overload for `Be` and `NotBe` methods of `DateTimeAssertions` and `DateTimeOffsetAssertions` - [#1427](https://github.com/fluentassertions/fluentassertions/issues/1427).
 
 **Fixes**
 * Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)


### PR DESCRIPTION
## Add `DateTime.Should().Be(DateTime?)` and `DateTimeOffset.Should().Be(DateTimeOffset?)` overloads

Fixes #1427 

To mimic the behavior of NumericAssertions, I have added the cases marked in bold to `DateTimeAssertions` and `DateTimeOffsetAssertions`. Below examples are for Datetime, but same logic was followed for DatetimeOffset.

### subject.Be(expected)

| subject       | expected      | result |
| -------       | --------      | ------ |
| 16/11/2020    | 16/11/2020    | true   |
|**16/11/2020**   | **null**          | **false** |
| null          | 16/11/2020    | false  |
| **null**          | **null**          | **true**   |

### subject.NotBe(expected)

| subject       | expected      | result |
| -------       | --------      | ------ |
| 16/11/2020    | 16/11/2020             | false  |
| **16/11/2020**    | **null**          | **true**   |
| null          | 16/11/2020    | true   |
| **null**          | **null**          | **false**  |


## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).