### PR TITLE
Introduce new overload of Enumerating() (#1431)

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -205,9 +205,26 @@ namespace FluentAssertions
             return () => ForceEnumeration(enumerable);
         }
 
+        /// <summary>
+        /// Forces enumerating a collection of the provided <paramref name="subject"/>.
+        /// Should be used to assert that a method that uses the <c>yield</c> keyword throws a particular exception.
+        /// </summary>
+        public static Action Enumerating<T, TResult>(this T subject, Func<T, IEnumerable<TResult>> enumerable)
+        {
+            return () => ForceEnumeration(subject, enumerable);
+        }
+
         private static void ForceEnumeration(Func<IEnumerable> enumerable)
         {
             foreach (object _ in enumerable())
+            {
+                // Do nothing
+            }
+        }
+
+        private static void ForceEnumeration<T>(T subject, Func<T, IEnumerable> enumerable)
+        {
+            foreach (object _ in enumerable(subject))
             {
                 // Do nothing
             }

--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -209,6 +209,8 @@ namespace FluentAssertions
         /// Forces enumerating a collection of the provided <paramref name="subject"/>.
         /// Should be used to assert that a method that uses the <c>yield</c> keyword throws a particular exception.
         /// </summary>
+        /// <param name="subject">The object that exposes the method or property.</param>
+        /// <param name="enumerable">A reference to the method or property to force enumeration of.</param>
         public static Action Enumerating<T, TResult>(this T subject, Func<T, IEnumerable<TResult>> enumerable)
         {
             return () => ForceEnumeration(subject, enumerable);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -28,6 +28,7 @@ namespace FluentAssertions
         public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask<TResult>> action) { }
         public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
         public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static System.Action Enumerating<T, TResult>(this T subject, System.Func<T, System.Collections.Generic.IEnumerable<TResult>> enumerable) { }
         public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
         public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -28,6 +28,7 @@ namespace FluentAssertions
         public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask<TResult>> action) { }
         public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
         public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static System.Action Enumerating<T, TResult>(this T subject, System.Func<T, System.Collections.Generic.IEnumerable<TResult>> enumerable) { }
         public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
         public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -28,6 +28,7 @@ namespace FluentAssertions
         public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask<TResult>> action) { }
         public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
         public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static System.Action Enumerating<T, TResult>(this T subject, System.Func<T, System.Collections.Generic.IEnumerable<TResult>> enumerable) { }
         public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
         public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -28,6 +28,7 @@ namespace FluentAssertions
         public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask<TResult>> action) { }
         public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
         public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static System.Action Enumerating<T, TResult>(this T subject, System.Func<T, System.Collections.Generic.IEnumerable<TResult>> enumerable) { }
         public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
         public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -28,6 +28,7 @@ namespace FluentAssertions
         public static System.Func<System.Threading.Tasks.Task<TResult>> Awaiting<T, TResult>(this T subject, System.Func<T, System.Threading.Tasks.ValueTask<TResult>> action) { }
         public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
         public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
+        public static System.Action Enumerating<T, TResult>(this T subject, System.Func<T, System.Collections.Generic.IEnumerable<TResult>> enumerable) { }
         public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
         public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }

--- a/Tests/FluentAssertions.Specs/Extensions/FluentActionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Extensions/FluentActionsSpecs.cs
@@ -56,10 +56,10 @@ namespace FluentAssertions.Specs
         public void Enumerating_works_with_enumerable_func()
         {
             // Arrange
-            var testee = new Example();
+            var actual = new Example();
 
             // Act / Assert
-            testee.Enumerating(x => x.DoSomething()).Should().Throw<InvalidOperationException>();
+            actual.Enumerating(x => x.DoSomething()).Should().Throw<InvalidOperationException>();
         }
 
         private class Example

--- a/Tests/FluentAssertions.Specs/Extensions/FluentActionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Extensions/FluentActionsSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using static FluentAssertions.FluentActions;
@@ -49,6 +50,36 @@ namespace FluentAssertions.Specs
         {
             // Arrange / Act / Assert
             Enumerating(() => ThrowsAfterFirst(0)).Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void Enumerating_works_with_enumerable_func()
+        {
+            // Arrange
+            var testee = new Example();
+
+            // Act / Assert
+            testee.Enumerating(x => x.DoSomething()).Should().Throw<InvalidOperationException>();
+        }
+
+        private class Example
+        {
+            public IEnumerable<int> DoSomething()
+            {
+                var range = Enumerable.Range(0, 10);
+
+                return range.Select(Twice);
+            }
+
+            private int Twice(int arg)
+            {
+                if (arg == 5)
+                {
+                    throw new InvalidOperationException();
+                }
+
+                return 2 * arg;
+            }
         }
 
         private static void Throws()

--- a/docs/_pages/exceptions.md
+++ b/docs/_pages/exceptions.md
@@ -83,6 +83,12 @@ func.Enumerating().Should().Throw<ArgumentException>();
 
 You do have to use the `Func<T>` type instead of `Action<T>` then.
 
+Or you can do it like this:
+
+```csharp
+obj.Enumerating(x => x.SomeMethodThatUsesYield("blah")).Should().Throw<ArgumentException>();
+```
+
 The exception throwing API follows the same rules as the `try`...`catch`...construction does.
 In other words, if you're expecting a certain exception to be (not) thrown, and a more specific exception is thrown instead, it would still satisfy the assertion.
 So throwing an `ApplicationException` when an `Exception` was expected will not fail the assertion.

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -18,6 +18,7 @@ sidebar:
 * Changed `StringAssertions.StartWith`, `StringAssertions.EndWith` and their `EquivalentOf` versions to allow empty strings - [#1413](https://github.com/fluentassertions/fluentassertions/pull/1413).
 * The equivalency assertions will now include the type of the member and whether it involves a field or property - [#1379](https://github.com/fluentassertions/fluentassertions/pull/1379)
 * Changed AttributeBasedFormatter to allow custom formatter selection based on the parent type - [#1418](https://github.com/fluentassertions/fluentassertions/pull/1418).
+* Added overload of `Enumerating` extension method to be able to force the enumeration of an object member -[#1433](https://github.com/fluentassertions/fluentassertions/pull/1433)
 
 **Fixes**
 * Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).