### PR TITLE
Add overloads of MatchRegex and NotMatchRegex that take System.Text.RegularExpressions.Regex

### DIFF
--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -315,32 +315,19 @@ namespace FluentAssertions.Primitives
         {
             Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");
 
-            if (regularExpression.Length == 0)
-            {
-                throw new ArgumentException("Cannot match string against an empty string. Provide a regex pattern or use the BeEmpty method.", nameof(regularExpression));
-            }
-
-            Execute.Assertion
-                .ForCondition(!(Subject is null))
-                .UsingLineBreaks
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:string} to match regex {0}{reason}, but it was <null>.", regularExpression);
-
+            Regex regex;
             try
             {
-                Execute.Assertion
-                .ForCondition(Regex.IsMatch(Subject, regularExpression))
-                .BecauseOf(because, becauseArgs)
-                .UsingLineBreaks
-                .FailWith("Expected {context:string} to match regex {0}{reason}, but {1} does not match.", regularExpression, Subject);
+                regex = new Regex(regularExpression);
             }
             catch (ArgumentException)
             {
-                Execute.Assertion
-                    .FailWith("Cannot match {context:string} against {0} because it is not a valid regular expression.", regularExpression);
+                Execute.Assertion.FailWith("Cannot match {context:string} against {0} because it is not a valid regular expression.",
+                    regularExpression);
+                return new AndConstraint<TAssertions>((TAssertions)this);
             }
 
-            return new AndConstraint<TAssertions>((TAssertions)this);
+            return MatchRegex(regex, because, becauseArgs);
         }
 
         /// <summary>
@@ -372,19 +359,11 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} to match regex {0}{reason}, but it was <null>.", regexStr);
 
-            try
-            {
-                Execute.Assertion
+            Execute.Assertion
                 .ForCondition(regularExpression.IsMatch(Subject))
                 .BecauseOf(because, becauseArgs)
                 .UsingLineBreaks
                 .FailWith("Expected {context:string} to match regex {0}{reason}, but {1} does not match.", regexStr, Subject);
-            }
-            catch (ArgumentException)
-            {
-                Execute.Assertion
-                    .FailWith("Cannot match {context:string} against {0} because it is not a valid regular expression.", regexStr);
-            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -406,32 +385,19 @@ namespace FluentAssertions.Primitives
         {
             Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>. Provide a regex pattern or use the NotBeNull method.");
 
-            if (regularExpression.Length == 0)
-            {
-                throw new ArgumentException("Cannot match string against an empty regex pattern. Provide a regex pattern or use the NotBeEmpty method.", nameof(regularExpression));
-            }
-
-            Execute.Assertion
-                .ForCondition(!(Subject is null))
-                .UsingLineBreaks
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:string} to not match regex {0}{reason}, but it was <null>.", regularExpression);
-
+            Regex regex;
             try
             {
-                Execute.Assertion
-                    .ForCondition(!Regex.IsMatch(Subject, regularExpression))
-                    .BecauseOf(because, becauseArgs)
-                    .UsingLineBreaks
-                    .FailWith("Did not expect {context:string} to match regex {0}{reason}, but {1} matches.", regularExpression, Subject);
+                regex = new Regex(regularExpression);
             }
             catch (ArgumentException)
             {
                 Execute.Assertion.FailWith("Cannot match {context:string} against {0} because it is not a valid regular expression.",
                     regularExpression);
+                return new AndConstraint<TAssertions>((TAssertions)this);
             }
 
-            return new AndConstraint<TAssertions>((TAssertions)this);
+            return NotMatchRegex(regex, because, becauseArgs);
         }
 
         /// <summary>
@@ -463,19 +429,11 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} to not match regex {0}{reason}, but it was <null>.", regexStr);
 
-            try
-            {
-                Execute.Assertion
-                    .ForCondition(!regularExpression.IsMatch(Subject))
-                    .BecauseOf(because, becauseArgs)
-                    .UsingLineBreaks
-                    .FailWith("Did not expect {context:string} to match regex {0}{reason}, but {1} matches.", regexStr, Subject);
-            }
-            catch (ArgumentException)
-            {
-                Execute.Assertion.FailWith("Cannot match {context:string} against {0} because it is not a valid regular expression.",
-                    regexStr);
-            }
+            Execute.Assertion
+                .ForCondition(!regularExpression.IsMatch(Subject))
+                .BecauseOf(because, becauseArgs)
+                .UsingLineBreaks
+                .FailWith("Did not expect {context:string} to match regex {0}{reason}, but {1} matches.", regexStr, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -344,6 +344,52 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
+        /// Asserts that a string matches a regular expression.
+        /// </summary>
+        /// <param name="regularExpression">
+        /// The regular expression with which the subject is matched.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> MatchRegex(Regex regularExpression, string because = "", params object[] becauseArgs)
+        {
+            Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");
+
+            var regexStr = regularExpression.ToString();
+            if (regexStr.Length == 0)
+            {
+                throw new ArgumentException("Cannot match string against an empty string. Provide a regex pattern or use the BeEmpty method.", nameof(regularExpression));
+            }
+
+            Execute.Assertion
+                .ForCondition(!(Subject is null))
+                .UsingLineBreaks
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:string} to match regex {0}{reason}, but it was <null>.", regexStr);
+
+            try
+            {
+                Execute.Assertion
+                .ForCondition(regularExpression.IsMatch(Subject))
+                .BecauseOf(because, becauseArgs)
+                .UsingLineBreaks
+                .FailWith("Expected {context:string} to match regex {0}{reason}, but {1} does not match.", regexStr, Subject);
+            }
+            catch (ArgumentException)
+            {
+                Execute.Assertion
+                    .FailWith("Cannot match {context:string} against {0} because it is not a valid regular expression.", regexStr);
+            }
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
         /// Asserts that a string does not match a regular expression.
         /// </summary>
         /// <param name="regularExpression">
@@ -383,6 +429,52 @@ namespace FluentAssertions.Primitives
             {
                 Execute.Assertion.FailWith("Cannot match {context:string} against {0} because it is not a valid regular expression.",
                     regularExpression);
+            }
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that a string does not match a regular expression.
+        /// </summary>
+        /// <param name="regularExpression">
+        /// The regular expression with which the subject is matched.
+        /// </param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotMatchRegex(Regex regularExpression, string because = "", params object[] becauseArgs)
+        {
+            Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>. Provide a regex pattern or use the NotBeNull method.");
+
+            var regexStr = regularExpression.ToString();
+            if (regexStr.Length == 0)
+            {
+                throw new ArgumentException("Cannot match string against an empty regex pattern. Provide a regex pattern or use the NotBeEmpty method.", nameof(regularExpression));
+            }
+
+            Execute.Assertion
+                .ForCondition(!(Subject is null))
+                .UsingLineBreaks
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:string} to not match regex {0}{reason}, but it was <null>.", regexStr);
+
+            try
+            {
+                Execute.Assertion
+                    .ForCondition(!regularExpression.IsMatch(Subject))
+                    .BecauseOf(because, becauseArgs)
+                    .UsingLineBreaks
+                    .FailWith("Did not expect {context:string} to match regex {0}{reason}, but {1} matches.", regexStr, Subject);
+            }
+            catch (ArgumentException)
+            {
+                Execute.Assertion.FailWith("Cannot match {context:string} against {0} because it is not a valid regular expression.",
+                    regexStr);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -1787,6 +1787,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
@@ -1805,6 +1806,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -1787,6 +1787,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
@@ -1805,6 +1806,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -1787,6 +1787,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
@@ -1805,6 +1806,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1740,6 +1740,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
@@ -1758,6 +1759,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -1787,6 +1787,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> MatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> MatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo(string unexpected, string because = "", params object[] becauseArgs) { }
@@ -1805,6 +1806,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotMatchRegex(string regularExpression, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotMatchRegex(System.Text.RegularExpressions.Regex regularExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotStartWith(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotStartWithEquivalentOf(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> StartWith(string expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
 using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
@@ -625,7 +626,7 @@ namespace FluentAssertions.Specs
         #region Match Regex
 
         [Fact]
-        public void When_a_string_matches_a_regular_expression_it_should_not_throw()
+        public void When_a_string_matches_a_regular_expression_string_it_should_not_throw()
         {
             // Arrange
             string subject = "hello world!";
@@ -640,7 +641,7 @@ namespace FluentAssertions.Specs
 
         [Fact]
         [SuppressMessage("ReSharper", "StringLiteralTypo")]
-        public void When_a_string_does_not_match_a_regular_expression_it_should_throw()
+        public void When_a_string_does_not_match_a_regular_expression_string_it_should_throw()
         {
             // Arrange
             string subject = "hello world!";
@@ -654,7 +655,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_a_null_string_is_matched_against_a_regex_it_should_throw_with_a_clear_explanation()
+        public void When_a_null_string_is_matched_against_a_regex_string_it_should_throw_with_a_clear_explanation()
         {
             // Arrange
             string subject = null;
@@ -668,13 +669,13 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_a_string_is_matched_against_a_null_regex_it_should_throw_with_a_clear_explanation()
+        public void When_a_string_is_matched_against_a_null_regex_string_it_should_throw_with_a_clear_explanation()
         {
             // Arrange
             string subject = "hello world!";
 
             // Act
-            Action act = () => subject.Should().MatchRegex(null);
+            Action act = () => subject.Should().MatchRegex((string)null);
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
@@ -683,7 +684,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_a_string_is_matched_against_an_invalid_regex_it_should_throw_with_a_clear_explanation()
+        public void When_a_string_is_matched_against_an_invalid_regex_string_it_should_throw_with_a_clear_explanation()
         {
             // Arrange
             string subject = "hello world!";
@@ -698,7 +699,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_a_string_is_matched_against_an_invalid_regex_it_should_only_have_one_failure_message()
+        public void When_a_string_is_matched_against_an_invalid_regex_string_it_should_only_have_one_failure_message()
         {
             // Arrange
             string subject = "hello world!";
@@ -718,7 +719,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_a_string_is_matched_against_an_empty_regex_it_should_throw_with_a_clear_explanation()
+        public void When_a_string_is_matched_against_an_empty_regex_string_it_should_throw_with_a_clear_explanation()
         {
             // Arrange
             string subject = "hello world";
@@ -732,12 +733,85 @@ namespace FluentAssertions.Specs
                 .And.ParamName.Should().Be("regularExpression");
         }
 
+        [Fact]
+        public void When_a_string_matches_a_regular_expression_it_should_not_throw()
+        {
+            // Arrange
+            string subject = "hello world!";
+
+            // Act
+            // ReSharper disable once StringLiteralTypo
+            Action act = () => subject.Should().MatchRegex(new Regex("h.*\\sworld.$"));
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        [SuppressMessage("ReSharper", "StringLiteralTypo")]
+        public void When_a_string_does_not_match_a_regular_expression_it_should_throw()
+        {
+            // Arrange
+            string subject = "hello world!";
+
+            // Act
+            Action act = () => subject.Should().MatchRegex(new Regex("h.*\\sworld?$"), "that's the universal greeting");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+              .WithMessage("Expected subject to match regex*\"h.*\\sworld?$\" because that's the universal greeting, but*\"hello world!\" does not match.");
+        }
+
+        [Fact]
+        public void When_a_null_string_is_matched_against_a_regex_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            string subject = null;
+
+            // Act
+            Action act = () => subject.Should().MatchRegex(new Regex(".*"), "because it should be a string");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+             .WithMessage("Expected subject to match regex*\".*\" because it should be a string, but it was <null>.");
+        }
+
+        [Fact]
+        public void When_a_string_is_matched_against_a_null_regex_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            string subject = "hello world!";
+
+            // Act
+            Action act = () => subject.Should().MatchRegex((Regex)null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>()
+               .WithMessage("Cannot match string against <null>. Provide a regex pattern or use the BeNull method.*")
+               .And.ParamName.Should().Be("regularExpression");
+        }
+
+        [Fact]
+        public void When_a_string_is_matched_against_an_empty_regex_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            string subject = "hello world";
+
+            // Act
+            Action act = () => subject.Should().MatchRegex(new Regex(string.Empty));
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentException>()
+                .WithMessage("Cannot match string against an empty string. Provide a regex pattern or use the BeEmpty method.*")
+                .And.ParamName.Should().Be("regularExpression");
+        }
+
         #endregion
 
         #region Not Match Regex
 
         [Fact]
-        public void When_a_string_does_not_match_a_regular_expression_and_it_shouldnt_it_should_not_throw()
+        public void When_a_string_does_not_match_a_regular_expression_string_and_it_shouldnt_it_should_not_throw()
         {
             // Arrange
             string subject = "hello world!";
@@ -750,7 +824,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_a_string_matches_a_regular_expression_but_it_shouldnt_it_should_throw()
+        public void When_a_string_matches_a_regular_expression_string_but_it_shouldnt_it_should_throw()
         {
             // Arrange
             string subject = "hello world!";
@@ -764,7 +838,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_a_null_string_is_negatively_matched_against_a_regex_it_should_throw_with_a_clear_explanation()
+        public void When_a_null_string_is_negatively_matched_against_a_regex_string_it_should_throw_with_a_clear_explanation()
         {
             // Arrange
             string subject = null;
@@ -778,13 +852,13 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_a_string_is_negatively_matched_against_a_null_regex_it_should_throw_with_a_clear_explanation()
+        public void When_a_string_is_negatively_matched_against_a_null_regex_string_it_should_throw_with_a_clear_explanation()
         {
             // Arrange
             string subject = "hello world!";
 
             // Act
-            Action act = () => subject.Should().NotMatchRegex(null);
+            Action act = () => subject.Should().NotMatchRegex((string)null);
 
             // Assert
             act.Should().Throw<ArgumentNullException>()
@@ -793,7 +867,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_a_string_is_negatively_matched_against_an_invalid_regex_it_should_throw_with_a_clear_explanation()
+        public void When_a_string_is_negatively_matched_against_an_invalid_regex_string_it_should_throw_with_a_clear_explanation()
         {
             // Arrange
             string subject = "hello world!";
@@ -808,7 +882,7 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_a_string_is_negatively_matched_against_an_invalid_regex_it_only_contain_one_failure_message()
+        public void When_a_string_is_negatively_matched_against_an_invalid_regex_string_it_only_contain_one_failure_message()
         {
             // Arrange
             string subject = "hello world!";
@@ -828,13 +902,84 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_a_string_is_negatively_matched_against_an_empty_regex_it_should_throw_with_a_clear_explanation()
+        public void When_a_string_is_negatively_matched_against_an_empty_regex_string_it_should_throw_with_a_clear_explanation()
         {
             // Arrange
             string subject = "hello world";
 
             // Act
             Action act = () => subject.Should().NotMatchRegex(string.Empty);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentException>()
+                .WithMessage("Cannot match string against an empty regex pattern. Provide a regex pattern or use the NotBeEmpty method.*")
+                .And.ParamName.Should().Be("regularExpression");
+        }
+
+        [Fact]
+        public void When_a_string_does_not_match_a_regular_expression_and_it_shouldnt_it_should_not_throw()
+        {
+            // Arrange
+            string subject = "hello world!";
+
+            // Act
+            Action act = () => subject.Should().NotMatchRegex(new Regex(".*earth.*"));
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_a_string_matches_a_regular_expression_but_it_shouldnt_it_should_throw()
+        {
+            // Arrange
+            string subject = "hello world!";
+
+            // Act
+            Action act = () => subject.Should().NotMatchRegex(new Regex(".*world.*"), "because that's illegal");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+              .WithMessage("Did not expect subject to match regex*\".*world.*\" because that's illegal, but*\"hello world!\" matches.");
+        }
+
+        [Fact]
+        public void When_a_null_string_is_negatively_matched_against_a_regex_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            string subject = null;
+
+            // Act
+            Action act = () => subject.Should().NotMatchRegex(new Regex(".*"), "because it should not be a string");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+             .WithMessage("Expected subject to not match regex*\".*\" because it should not be a string, but it was <null>.");
+        }
+
+        [Fact]
+        public void When_a_string_is_negatively_matched_against_a_null_regex_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            string subject = "hello world!";
+
+            // Act
+            Action act = () => subject.Should().NotMatchRegex((Regex)null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>()
+               .WithMessage("Cannot match string against <null>. Provide a regex pattern or use the NotBeNull method.*")
+               .And.ParamName.Should().Be("regularExpression");
+        }
+
+        [Fact]
+        public void When_a_string_is_negatively_matched_against_an_empty_regex_it_should_throw_with_a_clear_explanation()
+        {
+            // Arrange
+            string subject = "hello world";
+
+            // Act
+            Action act = () => subject.Should().NotMatchRegex(new Regex(string.Empty));
 
             // Assert
             act.Should().ThrowExactly<ArgumentException>()

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -20,7 +20,7 @@ sidebar:
 * Changed AttributeBasedFormatter to allow custom formatter selection based on the parent type - [#1418](https://github.com/fluentassertions/fluentassertions/pull/1418).
 * Added nullable overload for `Be` and `NotBe` methods of `DateTimeAssertions` and `DateTimeOffsetAssertions` - [#1427](https://github.com/fluentassertions/fluentassertions/issues/1427).
 * Added overload of `Enumerating` extension method to be able to force the enumeration of an object member -[#1433](https://github.com/fluentassertions/fluentassertions/pull/1433)
-* add overloads of MatchRegex and NotMatchRegex that take System.Text.RegularExpressions.Regex -[#1436](https://github.com/fluentassertions/fluentassertions/pull/1436)
+* Add overloads of `MatchRegex` and `NotMatchRegex` that take `System.Text.RegularExpressions.Regex` -[#1436](https://github.com/fluentassertions/fluentassertions/pull/1436)
 
 **Fixes**
 * Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -20,6 +20,7 @@ sidebar:
 * Changed AttributeBasedFormatter to allow custom formatter selection based on the parent type - [#1418](https://github.com/fluentassertions/fluentassertions/pull/1418).
 * Added nullable overload for `Be` and `NotBe` methods of `DateTimeAssertions` and `DateTimeOffsetAssertions` - [#1427](https://github.com/fluentassertions/fluentassertions/issues/1427).
 * Added overload of `Enumerating` extension method to be able to force the enumeration of an object member -[#1433](https://github.com/fluentassertions/fluentassertions/pull/1433)
+* add overloads of MatchRegex and NotMatchRegex that take System.Text.RegularExpressions.Regex -[#1436](https://github.com/fluentassertions/fluentassertions/pull/1436)
 
 **Fixes**
 * Guard against negative precision arguments for `BeCloseTo` and `BeApproximately` - [#1386](https://github.com/fluentassertions/fluentassertions/pull/1386)

--- a/docs/_pages/strings.md
+++ b/docs/_pages/strings.md
@@ -87,5 +87,7 @@ And if wildcards aren't enough for you, you can always use some regular expressi
 
 ```csharp
 someString.Should().MatchRegex("h.*\\sworld.$");
+someString.Should().MatchRegex(new System.Text.RegularExpressions.Regex("h.*\\sworld.$"));
+subject.Should().NotMatchRegex(new System.Text.RegularExpressions.Regex(".*earth.*"));
 subject.Should().NotMatchRegex(".*earth.*");
 ```


### PR DESCRIPTION
Visual Studio 2019 supports regex syntax highlighting of `System.Text.RegularExpressions.Regex`.

https://devblogs.microsoft.com/dotnet/visual-studio-2019-net-productivity/#regex-language-support

![image](https://user-images.githubusercontent.com/32071278/99948852-73373980-2dbd-11eb-95a4-445fc54bd4b0.png)

I want overloads of `StringAssertions.MatchRegex` and `StringAssertions.NotMatchRegex` that take System.Text.RegularExpressions.Regex.

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).