### PR TITLE
Improve XML assertion messages

### DIFF
--- a/Src/FluentAssertions/Xml/Equivalency/XmlReaderValidator.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/XmlReaderValidator.cs
@@ -56,7 +56,7 @@ namespace FluentAssertions.Xml.Equivalency
                 Failure failure = null;
 
 #pragma warning disable IDE0010 // The default case handles the many missing cases
-                switch (subjectIterator.NodeType)
+                switch (expectationIterator.NodeType)
 #pragma warning restore IDE0010
                 {
                     case XmlNodeType.Element:
@@ -68,11 +68,11 @@ namespace FluentAssertions.Xml.Equivalency
 
                         // starting new element, add local name to location stack
                         // to build XPath info
-                        currentNode = currentNode.Push(subjectIterator.LocalName);
+                        currentNode = currentNode.Push(expectationIterator.LocalName);
 
                         failure = ValidateAttributes();
 
-                        if (subjectIterator.IsEmptyElement)
+                        if (expectationIterator.IsEmptyElement)
                         {
                             // The element is already complete. (We will NOT get an EndElement node.)
                             // Update node information.
@@ -95,7 +95,6 @@ namespace FluentAssertions.Xml.Equivalency
                         // No need to verify end element, if it doesn't match
                         // the start element it isn't valid XML, so the parser
                         // would handle that.
-                        // TODO Doing so, that error message may be misleading.
                         currentNode.Pop();
                         currentNode = currentNode.Parent;
                         break;
@@ -106,7 +105,7 @@ namespace FluentAssertions.Xml.Equivalency
 
                     default:
                         throw new NotSupportedException(
-                            $"{subjectIterator.NodeType} found at {currentNode.GetXPath()} is not supported for equivalency comparison.");
+                            $"{expectationIterator.NodeType} found at {currentNode.GetXPath()} is not supported for equivalency comparison.");
                 }
 
                 if (failure != null)

--- a/Src/FluentAssertions/Xml/XAttributeAssertions.cs
+++ b/Src/FluentAssertions/Xml/XAttributeAssertions.cs
@@ -35,7 +35,7 @@ namespace FluentAssertions.Xml
             Execute.Assertion
                 .ForCondition(Subject.Name == expected.Name && Subject.Value == expected.Value)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected XML attribute to be {0}{reason}, but found {1}.", expected, Subject);
+                .FailWith("Expected {context} to be {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<XAttributeAssertions>(this);
         }
@@ -57,7 +57,7 @@ namespace FluentAssertions.Xml
             Execute.Assertion
                 .ForCondition(!(Subject.Name == unexpected.Name && Subject.Value == unexpected.Value))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect XML attribute to be {0}{reason}.", unexpected);
+                .FailWith("Did not expect {context} to be {0}{reason}.", unexpected);
 
             return new AndConstraint<XAttributeAssertions>(this);
         }
@@ -78,7 +78,7 @@ namespace FluentAssertions.Xml
             Execute.Assertion
                 .ForCondition(Subject.Value == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected XML attribute '{0}' to have value {1}{reason}, but found {2}.",
+                .FailWith("Expected {context} \"{0}\" to have value {1}{reason}, but found {2}.",
                     Subject.Name, expected, Subject.Value);
 
             return new AndConstraint<XAttributeAssertions>(this);

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -41,7 +41,7 @@ namespace FluentAssertions.Xml
             Execute.Assertion
                 .ForCondition(Equals(Subject, expected))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected XML document to be {0}{reason}, but found {1}.", expected, Subject);
+                .FailWith("Expected {context:subject} to be {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<XDocumentAssertions>(this);
         }
@@ -63,7 +63,7 @@ namespace FluentAssertions.Xml
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(!Equals(Subject, unexpected))
-                .FailWith("Did not expect XML document to be {0}{reason}.", unexpected);
+                .FailWith("Did not expect {context:subject} to be {0}{reason}.", unexpected);
 
             return new AndConstraint<XDocumentAssertions>(this);
         }
@@ -164,8 +164,9 @@ namespace FluentAssertions.Xml
             Execute.Assertion
                 .ForCondition((root != null) && (root.Name == expected))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected XML document to have root element \"" + expected.ToString().EscapePlaceholders() + "\"{reason}" +
-                          ", but found {0}.", Subject);
+                .FailWith(
+                    "Expected {context:subject} to have root element {0}{reason}, but found {1}.",
+                    expected.ToString(), Subject);
 
             return new AndWhichConstraint<XDocumentAssertions, XElement>(this, root);
         }
@@ -218,20 +219,20 @@ namespace FluentAssertions.Xml
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected),
                     "Cannot assert the document has an element if the element name is <null>*");
 
-            string expectedText = expected.ToString().EscapePlaceholders();
-
             Execute.Assertion
                 .ForCondition(Subject.Root != null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected XML document {0} to have root element with child \"" + expectedText + "\"{reason}" +
-                          ", but XML document has no Root element.", Subject);
+                .FailWith(
+                    "Expected {context:subject} to have root element with child {0}{reason}, but it has no root element.",
+                    expected.ToString());
 
             XElement xElement = Subject.Root.Element(expected);
             Execute.Assertion
                 .ForCondition(xElement != null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected XML document {0} to have root element with child \"" + expectedText + "\"{reason}" +
-                          ", but no such child element was found.", Subject);
+                .FailWith(
+                    "Expected {context:subject} to have root element with child {0}{reason}, but no such child element was found.",
+                    expected.ToString());
 
             return new AndWhichConstraint<XDocumentAssertions, XElement>(this, xElement);
         }

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -40,7 +40,7 @@ namespace FluentAssertions.Xml
             Execute.Assertion
                 .ForCondition(XNode.DeepEquals(Subject, expected))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected XML element to be {0}{reason}, but found {1}.", expected, Subject);
+                .FailWith("Expected {context:subject} to be {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<XElementAssertions>(this);
         }
@@ -63,7 +63,7 @@ namespace FluentAssertions.Xml
             Execute.Assertion
                 .ForCondition((Subject is null && !(unexpected is null)) || !XNode.DeepEquals(Subject, unexpected))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected XML element not to be {0}{reason}.", unexpected);
+                .FailWith("Expected {context:subject} not to be {0}{reason}.", unexpected);
 
             return new AndConstraint<XElementAssertions>(this);
         }
@@ -81,7 +81,8 @@ namespace FluentAssertions.Xml
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<XElementAssertions> BeEquivalentTo(XElement expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<XElementAssertions> BeEquivalentTo(XElement expected, string because = "",
+            params object[] becauseArgs)
         {
             using (XmlReader subjectReader = Subject.CreateReader())
             using (XmlReader expectedReader = expected.CreateReader())
@@ -106,7 +107,8 @@ namespace FluentAssertions.Xml
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<XElementAssertions> NotBeEquivalentTo(XElement unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<XElementAssertions> NotBeEquivalentTo(XElement unexpected, string because = "",
+            params object[] becauseArgs)
         {
             using (XmlReader subjectReader = Subject.CreateReader())
             using (XmlReader otherReader = unexpected.CreateReader())
@@ -134,7 +136,8 @@ namespace FluentAssertions.Xml
             Execute.Assertion
                 .ForCondition(Subject.Value == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected XML element '{0}' to have value {1}{reason}, but found {2}.",
+                .FailWith(
+                    "Expected {context:subject} '{0}' to have value {1}{reason}, but found {2}.",
                     Subject.Name, expected, Subject.Value);
 
             return new AndConstraint<XElementAssertions>(this);
@@ -176,20 +179,22 @@ namespace FluentAssertions.Xml
             params object[] becauseArgs)
         {
             XAttribute attribute = Subject.Attribute(expectedName);
-            string expectedText = expectedName.ToString().EscapePlaceholders();
+            string expectedText = expectedName.ToString();
 
             Execute.Assertion
                 .ForCondition(attribute != null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
-                    "Expected XML element to have attribute \"" + expectedText + "\" with value {0}{reason}, but found no such attribute in {1}",
-                    expectedValue, Subject);
+                    "Expected {context:subject} to have attribute {0} with value {1}{reason},"
+                    + " but found no such attribute in {2}",
+                    expectedText, expectedValue, Subject);
 
             Execute.Assertion
                 .ForCondition(attribute.Value == expectedValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
-                    "Expected XML attribute \"" + expectedText + "\" to have value {0}{reason}, but found {1}.", expectedValue, attribute.Value);
+                    "Expected attribute {0} in {context:subject} to have value {1}{reason}, but found {2}.",
+                    expectedText, expectedValue, attribute.Value);
 
             return new AndConstraint<XElementAssertions>(this);
         }
@@ -206,7 +211,8 @@ namespace FluentAssertions.Xml
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndWhichConstraint<XElementAssertions, XElement> HaveElement(string expected, string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<XElementAssertions, XElement> HaveElement(string expected, string because = "",
+            params object[] becauseArgs)
         {
             return HaveElement(XNamespace.None + expected, because, becauseArgs);
         }
@@ -223,14 +229,16 @@ namespace FluentAssertions.Xml
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndWhichConstraint<XElementAssertions, XElement> HaveElement(XName expected, string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<XElementAssertions, XElement> HaveElement(XName expected, string because = "",
+            params object[] becauseArgs)
         {
             XElement xElement = Subject.Element(expected);
             Execute.Assertion
                 .ForCondition(xElement != null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected XML element {0} to have child element \"" + expected.ToString().EscapePlaceholders() + "\"{reason}" +
-                        ", but no such child element was found.", Subject);
+                .FailWith(
+                    "Expected {context:subject} to have child element {0}{reason}, but no such child element was found.",
+                    expected.ToString().EscapePlaceholders());
 
             return new AndWhichConstraint<XElementAssertions, XElement>(this, xElement);
         }

--- a/Src/FluentAssertions/Xml/XmlElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XmlElementAssertions.cs
@@ -13,8 +13,7 @@ namespace FluentAssertions.Xml
     public class XmlElementAssertions : XmlNodeAssertions<XmlElement, XmlElementAssertions>
     {
         /// <summary>
-        /// Initialized a new instance of the <see cref="XmlElementAssertions"/>
-        /// class.
+        /// Initializes a new instance of the <see cref="XmlElementAssertions"/> class.
         /// </summary>
         /// <param name="xmlElement"></param>
         public XmlElementAssertions(XmlElement xmlElement)
@@ -34,13 +33,15 @@ namespace FluentAssertions.Xml
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<XmlElementAssertions> HaveInnerText(string expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<XmlElementAssertions> HaveInnerText(string expected, string because = "",
+            params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.InnerText == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected XML element {0} to have value {1}{reason}, but found {2}.",
-                    Subject.Name, expected, Subject.InnerText);
+                .FailWith(
+                    "Expected {context:subject} to have value {0}{reason}, but found {1}.",
+                    expected, Subject.InnerText);
 
             return new AndConstraint<XmlElementAssertions>(this);
         }
@@ -59,7 +60,8 @@ namespace FluentAssertions.Xml
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<XmlElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because = "", params object[] becauseArgs)
+        public AndConstraint<XmlElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because = "",
+            params object[] becauseArgs)
         {
             return HaveAttributeWithNamespace(expectedName, string.Empty, expectedValue, because, becauseArgs);
         }
@@ -87,14 +89,14 @@ namespace FluentAssertions.Xml
             XmlAttribute attribute = Subject.Attributes[expectedName, expectedNamespace];
 
             string expectedFormattedName =
-                (string.IsNullOrEmpty(expectedNamespace) ? string.Empty : "{" + expectedNamespace + "}")
+                (string.IsNullOrEmpty(expectedNamespace) ? string.Empty : $"{{{expectedNamespace}}}")
                 + expectedName;
 
             Execute.Assertion
                 .ForCondition(attribute != null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
-                    "Expected XML element to have attribute {0}"
+                    "Expected {context:subject} to have attribute {0}"
                     + " with value {1}{reason}, but found no such attribute in {2}",
                     expectedFormattedName, expectedValue, Subject);
 
@@ -102,7 +104,7 @@ namespace FluentAssertions.Xml
                 .ForCondition(attribute.Value == expectedValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
-                    "Expected XML attribute {0} to have value {1}{reason}, but found {2}.",
+                    "Expected attribute {0} in {context:subject} to have value {1}{reason}, but found {2}.",
                     expectedFormattedName, expectedValue, attribute.Value);
 
             return new AndConstraint<XmlElementAssertions>(this);
@@ -150,15 +152,15 @@ namespace FluentAssertions.Xml
             XmlElement element = Subject[expectedName, expectedNamespace];
 
             string expectedFormattedName =
-                (string.IsNullOrEmpty(expectedNamespace) ? string.Empty : "{" + expectedNamespace + "}")
+                (string.IsNullOrEmpty(expectedNamespace) ? string.Empty : $"{{{expectedNamespace}}}")
                 + expectedName;
 
             Execute.Assertion
                 .ForCondition(element != null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected XML element {0} to have child element \"" +
-                    expectedFormattedName.EscapePlaceholders() + "\"{reason}" +
-                        ", but no such child element was found.", Subject);
+                .FailWith(
+                    "Expected {context:subject} to have child element {0}{reason}, but no such child element was found.",
+                    expectedFormattedName.EscapePlaceholders());
 
             return new AndWhichConstraint<XmlElementAssertions, XmlElement>(this, element);
         }

--- a/Tests/FluentAssertions.Specs/Xml/XAttributeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XAttributeAssertionSpecs.cs
@@ -28,19 +28,16 @@ namespace FluentAssertions.Specs
         public void When_asserting_an_xml_attribute_is_equal_to_a_different_xml_attribute_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var attribute = new XAttribute("name", "value");
-            var otherXAttribute = new XAttribute("name2", "value");
+            var theAttribute = new XAttribute("name", "value");
+            var otherAttribute = new XAttribute("name2", "value");
 
             // Act
             Action act = () =>
-                attribute.Should().Be(otherXAttribute, "because we want to test the failure {0}", "message");
+                theAttribute.Should().Be(otherAttribute, "because we want to test the failure {0}", "message");
 
             // Assert
-            string expectedMessage = string.Format("Expected XML attribute to be {0}" +
-                " because we want to test the failure message," +
-                    " but found {1}.", otherXAttribute, attribute);
-
-            act.Should().Throw<XunitException>().WithMessage(expectedMessage);
+            act.Should().Throw<XunitException>().WithMessage(
+                $"Expected theAttribute to be {otherAttribute} because we want to test the failure message, but found {theAttribute}.");
         }
 
         [Fact]
@@ -62,33 +59,32 @@ namespace FluentAssertions.Specs
         public void When_asserting_an_xml_attribute_is_not_equal_to_the_same_xml_attribute_it_should_throw()
         {
             // Arrange
-            var attribute = new XAttribute("name", "value");
-            var sameXAttribute = attribute;
+            var theAttribute = new XAttribute("name", "value");
+            var sameXAttribute = theAttribute;
 
             // Act
             Action act = () =>
-                attribute.Should().NotBe(sameXAttribute);
+                theAttribute.Should().NotBe(sameXAttribute);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect theAttribute to be name=\"value\".");
         }
 
         [Fact]
         public void When_asserting_an_xml_attribute_is_not_equal_to_the_same_xml_attribute_it_should_throw_with_descriptive_message()
         {
             // Arrange
-            var attribute = new XAttribute("name", "value");
-            var sameXAttribute = attribute;
+            var theAttribute = new XAttribute("name", "value");
+            var sameAttribute = theAttribute;
 
             // Act
             Action act = () =>
-                attribute.Should().NotBe(sameXAttribute, "because we want to test the failure {0}", "message");
+                theAttribute.Should().NotBe(sameAttribute, "because we want to test the failure {0}", "message");
 
             // Assert
-            string expectedMessage = string.Format("Did not expect XML attribute to be {0}" +
-                " because we want to test the failure message.", sameXAttribute);
-
-            act.Should().Throw<XunitException>().WithMessage(expectedMessage);
+            act.Should().Throw<XunitException>().WithMessage(
+                $"Did not expect theAttribute to be {sameAttribute} because we want to test the failure message.");
         }
 
         #endregion
@@ -113,29 +109,30 @@ namespace FluentAssertions.Specs
         public void When_asserting_a_non_null_xml_attribute_is_null_it_should_fail()
         {
             // Arrange
-            var attribute = new XAttribute("name", "value");
+            var theAttribute = new XAttribute("name", "value");
 
             // Act
             Action act = () =>
-                attribute.Should().BeNull();
+                theAttribute.Should().BeNull();
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theAttribute to be <null>, but found name=\"value\".");
         }
 
         [Fact]
         public void When_asserting_a_non_null_xml_attribute_is_null_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var attribute = new XAttribute("name", "value");
+            var theAttribute = new XAttribute("name", "value");
 
             // Act
             Action act = () =>
-                attribute.Should().BeNull("because we want to test the failure {0}", "message");
+                theAttribute.Should().BeNull("because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                $"Expected attribute to be <null> because we want to test the failure message, but found {attribute}.");
+                $"Expected theAttribute to be <null> because we want to test the failure message, but found {theAttribute}.");
         }
 
         [Fact]
@@ -156,29 +153,30 @@ namespace FluentAssertions.Specs
         public void When_asserting_a_null_xml_attribute_is_not_null_it_should_fail()
         {
             // Arrange
-            XAttribute attribute = null;
+            XAttribute theAttribute = null;
 
             // Act
             Action act = () =>
-                attribute.Should().NotBeNull();
+                theAttribute.Should().NotBeNull();
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theAttribute not to be <null>.");
         }
 
         [Fact]
         public void When_asserting_a_null_xml_attribute_is_not_null_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            XAttribute attribute = null;
+            XAttribute theAttribute = null;
 
             // Act
             Action act = () =>
-                attribute.Should().NotBeNull("because we want to test the failure {0}", "message");
+                theAttribute.Should().NotBeNull("because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected attribute not to be <null> because we want to test the failure message.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theAttribute not to be <null> because we want to test the failure message.");
         }
 
         #endregion
@@ -203,31 +201,30 @@ namespace FluentAssertions.Specs
         public void When_asserting_attribute_has_a_specific_value_but_it_has_a_different_value_it_should_throw()
         {
             // Arrange
-            var attribute = new XAttribute("age", "36");
+            var theAttribute = new XAttribute("age", "36");
 
             // Act
             Action act = () =>
-                attribute.Should().HaveValue("16");
+                theAttribute.Should().HaveValue("16");
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theAttribute \"age\" to have value \"16\", but found \"36\".");
         }
 
         [Fact]
         public void When_asserting_attribute_has_a_specific_value_but_it_has_a_different_value_it_should_throw_with_descriptive_message()
         {
             // Arrange
-            var attribute = new XAttribute("age", "36");
+            var theAttribute = new XAttribute("age", "36");
 
             // Act
             Action act = () =>
-                attribute.Should().HaveValue("16", "because we want to test the failure {0}", "message");
+                theAttribute.Should().HaveValue("16", "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected XML attribute 'age' to have value \"16\"" +
-                    " because we want to test the failure message" +
-                        ", but found \"36\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theAttribute \"age\" to have value \"16\" because we want to test the failure message, but found \"36\".");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
@@ -1,6 +1,6 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Xml.Linq;
-
 using FluentAssertions.Formatting;
 using Xunit;
 using Xunit.Sdk;
@@ -30,33 +30,37 @@ namespace FluentAssertions.Specs
         public void When_asserting_a_xml_document_is_equal_to_a_different_xml_document_it_should_fail()
         {
             // Arrange
-            var document = new XDocument();
+            var theDocument = new XDocument();
             var otherXDocument = new XDocument();
 
             // Act
             Action act = () =>
-                document.Should().Be(otherXDocument);
+                theDocument.Should().Be(otherXDocument);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theDocument to be [XML document without root element], but found [XML document without root element].");
         }
 
         [Fact]
+        [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
         public void When_asserting_a_null_xml_document_is_equal_to_another_xml_document_it_should_fail()
         {
             // Arrange
-            XDocument document = null;
+            XDocument theDocument = null;
             var otherXDocument = new XDocument();
 
             // Act
             Action act = () =>
-                document.Should().Be(otherXDocument);
+                theDocument.Should().Be(otherXDocument);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theDocument to be [XML document without root element], but found <null>.");
         }
 
         [Fact]
+        [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
         public void When_a_null_xml_document_is_equal_to_a_null_xml_document_it_should_succeed()
         {
             // Arrange
@@ -75,18 +79,16 @@ namespace FluentAssertions.Specs
         public void When_asserting_a_xml_document_is_equal_to_a_different_xml_document_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var document = XDocument.Parse("<configuration></configuration>");
+            var theDocument = XDocument.Parse("<configuration></configuration>");
             var otherXDocument = XDocument.Parse("<data></data>");
 
             // Act
             Action act = () =>
-                document.Should().Be(otherXDocument, "because we want to test the failure {0}", "message");
+                theDocument.Should().Be(otherXDocument, "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected XML document to be <data></data>" +
-                    " because we want to test the failure message," +
-                        " but found <configuration></configuration>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theDocument to be <data*> because we want to test the failure message, but found <configuration*>.");
         }
 
         [Fact]
@@ -108,18 +110,20 @@ namespace FluentAssertions.Specs
         public void When_asserting_a_xml_document_is_not_equal_to_the_same_xml_document_it_should_fail()
         {
             // Arrange
-            var document = new XDocument();
-            var sameXDocument = document;
+            var theDocument = new XDocument();
+            var sameXDocument = theDocument;
 
             // Act
             Action act = () =>
-                document.Should().NotBe(sameXDocument);
+                theDocument.Should().NotBe(sameXDocument);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect theDocument to be [XML document without root element].");
         }
 
         [Fact]
+        [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
         public void When_asserting_a_null_xml_document_is_not_equal_to_some_xml_document_it_should_succeed()
         {
             // Arrange
@@ -135,36 +139,35 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
         public void When_asserting_a_null_xml_document_is_not_equal_to_a_null_xml_document_it_should_fail()
         {
             // Arrange
-            XDocument document = null;
+            XDocument theDocument = null;
             XDocument someXDocument = null;
 
             // Act
             Action act = () =>
-                document.Should().NotBe(someXDocument);
+                theDocument.Should().NotBe(someXDocument);
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect XML document to be <null>.");
+            act.Should().Throw<XunitException>().WithMessage("Did not expect theDocument to be <null>.");
         }
 
         [Fact]
         public void When_asserting_a_xml_document_is_not_equal_to_the_same_xml_document_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var document = XDocument.Parse("<configuration></configuration>");
-            var sameXDocument = document;
+            var theDocument = XDocument.Parse("<configuration></configuration>");
+            var sameXDocument = theDocument;
 
             // Act
             Action act = () =>
-                document.Should().NotBe(sameXDocument, "because we want to test the failure {0}", "message");
+                theDocument.Should().NotBe(sameXDocument, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect XML document to be <configuration></configuration>" +
-                    " because we want to test the failure message.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect theDocument to be <configuration*> because we want to test the failure message.");
         }
 
         #endregion
@@ -204,21 +207,15 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_with_same_structure_it_should_succeed()
         {
-            //-------------------------------------------------------------------------------------------------------------------
             // Arrange
-            //-------------------------------------------------------------------------------------------------------------------
             var document = XDocument.Parse("<parent><child></child></parent>");
             var otherXDocument = XDocument.Parse("<parent><child></child></parent>");
 
-            //-------------------------------------------------------------------------------------------------------------------
             // Act
-            //-------------------------------------------------------------------------------------------------------------------
             Action act = () =>
                 document.Should().BeEquivalentTo(otherXDocument);
 
-            //-------------------------------------------------------------------------------------------------------------------
             // Assert
-            //-------------------------------------------------------------------------------------------------------------------
             act.Should().NotThrow();
         }
 
@@ -226,84 +223,82 @@ namespace FluentAssertions.Specs
         public void When_asserting_a_xml_document_is_equivalent_to_a_xml_document_with_elements_missing_it_should_fail()
         {
             // Arrange
-            var document = XDocument.Parse("<parent><child /><child2 /></parent>");
+            var theDocument = XDocument.Parse("<parent><child /><child2 /></parent>");
             var otherXDocument = XDocument.Parse("<parent><child /></parent>");
 
             // Act
             Action act = () =>
-                document.Should().BeEquivalentTo(otherXDocument);
+                theDocument.Should().BeEquivalentTo(otherXDocument);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected EndElement \"parent\" in theDocument at \"/parent\", but found Element \"child2\".");
         }
 
         [Fact]
         public void When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_with_extra_elements_it_should_fail()
         {
             // Arrange
-            var document = XDocument.Parse("<parent><child /></parent>");
-            var otherXDocument = XDocument.Parse("<parent><child /><child2 /></parent>");
+            var theDocument = XDocument.Parse("<parent><child /></parent>");
+            var expected = XDocument.Parse("<parent><child /><child2 /></parent>");
 
             // Act
             Action act = () =>
-                document.Should().BeEquivalentTo(otherXDocument);
+                theDocument.Should().BeEquivalentTo(expected);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected Element \"child2\" in theDocument at \"/parent\", but found EndElement \"parent\".");
         }
 
         [Fact]
         public void When_asserting_a_xml_document_with_selfclosing_child_is_equivalent_to_a_different_xml_document_with_subchild_child_it_should_fail()
         {
-            //-------------------------------------------------------------------------------------------------------------------
             // Arrange
-            //-------------------------------------------------------------------------------------------------------------------
-            var document = XDocument.Parse("<parent><child /></parent>");
+            var theDocument = XDocument.Parse("<parent><child /></parent>");
             var otherXDocument = XDocument.Parse("<parent><child><child /></child></parent>");
 
-            //-------------------------------------------------------------------------------------------------------------------
             // Act
-            //-------------------------------------------------------------------------------------------------------------------
             Action act = () =>
-                document.Should().BeEquivalentTo(otherXDocument);
+                theDocument.Should().BeEquivalentTo(otherXDocument);
 
-            //-------------------------------------------------------------------------------------------------------------------
             // Assert
-            //-------------------------------------------------------------------------------------------------------------------
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected node of type Element at \"/parent\", but found EndElement.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected Element \"child\" in theDocument at \"/parent\", but found EndElement \"parent\".");
         }
 
         [Fact]
         public void When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_elements_missing_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var document = XDocument.Parse("<parent><child /><child2 /></parent>");
-            var otherXDocument = XDocument.Parse("<parent><child /></parent>");
+            var theDocument = XDocument.Parse("<parent><child /><child2 /></parent>");
+            var expected = XDocument.Parse("<parent><child /></parent>");
 
             // Act
             Action act = () =>
-                document.Should().BeEquivalentTo(otherXDocument, "because we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected node of type EndElement at \"/parent\" because we want to test the failure message, but found Element.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected EndElement \"parent\" in theDocument at \"/parent\" because we want to test the failure message,"
+                + " but found Element \"child2\".");
         }
 
         [Fact]
         public void When_asserting_a_xml_document_is_equivalent_to_a_different_xml_document_with_extra_elements_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var document = XDocument.Parse("<parent><child /></parent>");
-            var otherXDocument = XDocument.Parse("<parent><child /><child2 /></parent>");
+            var theDocument = XDocument.Parse("<parent><child /></parent>");
+            var expected = XDocument.Parse("<parent><child /><child2 /></parent>");
 
             // Act
             Action act = () =>
-                document.Should().BeEquivalentTo(otherXDocument, "because we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected node of type Element at \"/parent\" because we want to test the failure message, but found EndElement.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected Element \"child2\" in theDocument at \"/parent\" because we want to test the failure message,"
+                + " but found EndElement \"parent\".");
         }
 
         [Fact]
@@ -340,92 +335,96 @@ namespace FluentAssertions.Specs
         public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_structure_it_should_fail()
         {
             // Arrange
-            var document = XDocument.Parse("<parent><child /></parent>");
+            var theDocument = XDocument.Parse("<parent><child /></parent>");
             var otherXDocument = XDocument.Parse("<parent><child /></parent>");
 
             // Act
             Action act = () =>
-                document.Should().NotBeEquivalentTo(otherXDocument);
+                theDocument.Should().NotBeEquivalentTo(otherXDocument);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect theDocument to be equivalent, but it is.");
         }
 
         [Fact]
         public void When_asserting_a_xml_document_is_not_equivalent_to_the_same_xml_document_it_should_fail()
         {
             // Arrange
-            var document = new XDocument();
-            var sameXDocument = document;
+            var theDocument = new XDocument();
+            var sameXDocument = theDocument;
 
             // Act
             Action act = () =>
-                document.Should().NotBeEquivalentTo(sameXDocument);
+                theDocument.Should().NotBeEquivalentTo(sameXDocument);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect theDocument to be equivalent, but it is.");
         }
 
         [Fact]
         public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_structure_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var document = XDocument.Parse("<parent><child /></parent>");
-            var otherXDocument = XDocument.Parse("<parent><child /></parent>");
+            var theDocument = XDocument.Parse("<parent><child /></parent>");
+            var otherDocument = XDocument.Parse("<parent><child /></parent>");
 
             // Act
             Action act = () =>
-                document.Should().NotBeEquivalentTo(otherXDocument, "because we want to test the failure {0}", "message");
+                theDocument.Should().NotBeEquivalentTo(otherDocument, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect Xml to be equivalent because we want to test the failure message, but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect theDocument to be equivalent because we want to test the failure message, but it is.");
         }
 
         [Fact]
         public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_contents_but_different_ns_prefixes_it_should_fail()
         {
             // Arrange
-            var document = XDocument.Parse(@"<parent xmlns:ns1=""a""><ns1:child /></parent>");
+            var theDocument = XDocument.Parse(@"<parent xmlns:ns1=""a""><ns1:child /></parent>");
             var otherXDocument = XDocument.Parse(@"<parent xmlns:ns2=""a""><ns2:child /></parent>");
 
             // Act
             Action act = () =>
-                document.Should().NotBeEquivalentTo(otherXDocument, "because we want to test the failure {0}", "message");
+                theDocument.Should().NotBeEquivalentTo(otherXDocument, "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect theDocument to be equivalent because we want to test the failure message, but it is.");
         }
 
         [Fact]
         public void When_asserting_a_xml_document_is_not_equivalent_to_a_different_xml_document_with_same_contents_but_extra_unused_xmlns_declaration_it_should_fail()
         {
             // Arrange
-            var element = XDocument.Parse(@"<xml xmlns:ns1=""a"" />");
-            var otherXElement = XDocument.Parse("<xml />");
+            var theDocument = XDocument.Parse(@"<xml xmlns:ns1=""a"" />");
+            var otherDocument = XDocument.Parse("<xml />");
 
             // Act
             Action act = () =>
-                element.Should().NotBeEquivalentTo(otherXElement);
+                theDocument.Should().NotBeEquivalentTo(otherDocument);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect theDocument to be equivalent, but it is.");
         }
 
         [Fact]
         public void When_asserting_a_xml_document_is_not_equivalent_to_the_same_xml_document_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var document = XDocument.Parse("<parent><child /></parent>");
-            var sameXDocument = document;
+            var theDocument = XDocument.Parse("<parent><child /></parent>");
+            var sameXDocument = theDocument;
 
             // Act
             Action act = () =>
-                document.Should().NotBeEquivalentTo(sameXDocument, "because we want to test the failure {0}", "message");
+                theDocument.Should().NotBeEquivalentTo(sameXDocument, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect Xml to be equivalent because we want to test the failure message, but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect theDocument to be equivalent because we want to test the failure message, but it is.");
         }
 
         [Fact]
@@ -462,80 +461,80 @@ namespace FluentAssertions.Specs
         public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_lacks_attributes_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = XDocument.Parse("<xml><element b=\"1\"/></xml>");
+            var theDocument = XDocument.Parse("<xml><element b=\"1\"/></xml>");
             var expected = XDocument.Parse("<xml><element a=\"b\" b=\"1\"/></xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Expected attribute \"a\" at \"/xml/element\" because we want to test the failure message, but found none.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected attribute \"a\" in theDocument at \"/xml/element\" because we want to test the failure message, but found none.");
         }
 
         [Fact]
         public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_extra_attributes_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = XDocument.Parse("<xml><element a=\"b\"/></xml>");
+            var theDocument = XDocument.Parse("<xml><element a=\"b\"/></xml>");
             var expected = XDocument.Parse("<xml><element/></xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Did not expect to find attribute \"a\" at \"/xml/element\" because we want to test the failure message.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect to find attribute \"a\" in theDocument at \"/xml/element\" because we want to test the failure message.");
         }
 
         [Fact]
         public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = XDocument.Parse("<xml><element a=\"b\"/></xml>");
+            var theDocument = XDocument.Parse("<xml><element a=\"b\"/></xml>");
             var expected = XDocument.Parse("<xml><element a=\"c\"/></xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Expected attribute \"a\" at \"/xml/element\" to have value \"c\" because we want to test the failure message, but found \"b\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected attribute \"a\" in theDocument at \"/xml/element\" to have value \"c\" because we want to test the failure message, but found \"b\".");
         }
 
         [Fact]
         public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = XDocument.Parse("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
+            var theDocument = XDocument.Parse("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
             var expected = XDocument.Parse("<xml><element a=\"b\"/></xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Did not expect to find attribute \"ns:a\" at \"/xml/element\" because we want to test the failure message.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect to find attribute \"ns:a\" in theDocument at \"/xml/element\" because we want to test the failure message.");
         }
 
         [Fact]
         public void When_asserting_an_xml_document_is_equivalent_to_different_xml_document_which_has_different_text_contents_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = XDocument.Parse("<xml>a</xml>");
+            var theDocument = XDocument.Parse("<xml>a</xml>");
             var expected = XDocument.Parse("<xml>b</xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Expected content to be \"b\" at \"/xml\" because we want to test the failure message, but found \"a\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected content to be \"b\" in theDocument at \"/xml\" because we want to test the failure message, but found \"a\".");
         }
 
         [Fact]
@@ -619,6 +618,7 @@ namespace FluentAssertions.Specs
         #region BeNull / NotBeNull
 
         [Fact]
+        [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
         public void When_asserting_a_null_xml_document_is_null_it_should_succeed()
         {
             // Arrange
@@ -636,29 +636,30 @@ namespace FluentAssertions.Specs
         public void When_asserting_a_non_null_xml_document_is_null_it_should_fail()
         {
             // Arrange
-            var document = new XDocument();
+            var theDocument = new XDocument();
 
             // Act
             Action act = () =>
-                document.Should().BeNull();
+                theDocument.Should().BeNull();
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theDocument to be <null>, but found [XML document without root element].");
         }
 
         [Fact]
         public void When_asserting_a_non_null_xml_document_is_null_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var document = XDocument.Parse("<configuration></configuration>");
+            var theDocument = XDocument.Parse("<configuration></configuration>");
 
             // Act
             Action act = () =>
-                document.Should().BeNull("because we want to test the failure {0}", "message");
+                theDocument.Should().BeNull("because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected document to be <null> because we want to test the failure message, but found <configuration></configuration>.");
+                "Expected theDocument to be <null> because we want to test the failure message, but found <configuration*>.");
         }
 
         [Fact]
@@ -679,29 +680,29 @@ namespace FluentAssertions.Specs
         public void When_asserting_a_null_xml_document_is_not_null_it_should_fail()
         {
             // Arrange
-            XDocument document = null;
+            XDocument theDocument = null;
 
             // Act
             Action act = () =>
-                document.Should().NotBeNull();
+                theDocument.Should().NotBeNull();
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage("Expected theDocument not to be <null>.");
         }
 
         [Fact]
         public void When_asserting_a_null_xml_document_is_not_null_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            XDocument document = null;
+            XDocument theDocument = null;
 
             // Act
             Action act = () =>
-                document.Should().NotBeNull("because we want to test the failure {0}", "message");
+                theDocument.Should().NotBeNull("because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected document not to be <null> because we want to test the failure message.");
+                "Expected theDocument not to be <null> because we want to test the failure message.");
         }
 
         #endregion
@@ -728,35 +729,36 @@ namespace FluentAssertions.Specs
         public void When_asserting_document_has_root_element_but_it_does_not_it_should_fail()
         {
             // Arrange
-            var document = XDocument.Parse(
+            var theDocument = XDocument.Parse(
                 @"<parent>
                     <child />
                   </parent>");
 
             // Act
-            Action act = () => document.Should().HaveRoot("unknown");
+            Action act = () => theDocument.Should().HaveRoot("unknown");
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theDocument to have root element \"unknown\", but found <parent>…</parent>.");
         }
 
         [Fact]
         public void When_asserting_document_has_root_element_but_it_does_not_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var document = XDocument.Parse(
+            var theDocument = XDocument.Parse(
                 @"<parent>
                     <child />
                   </parent>");
 
             // Act
             Action act = () =>
-                document.Should().HaveRoot("unknown", "because we want to test the failure message");
+                theDocument.Should().HaveRoot("unknown", "because we want to test the failure message");
 
             // Assert
-            string expectedMessage = string.Format("Expected XML document to have root element \"unknown\"" +
-                " because we want to test the failure message" +
-                    ", but found {0}.", Formatter.ToString(document));
+            string expectedMessage = string.Format("Expected theDocument to have root element \"unknown\"" +
+                                                   " because we want to test the failure message" +
+                                                   ", but found {0}.", Formatter.ToString(theDocument));
 
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }
@@ -765,10 +767,10 @@ namespace FluentAssertions.Specs
         public void When_asserting_a_null_document_has_root_element_it_should_fail()
         {
             // Arrange
-            XDocument document = null;
+            XDocument theDocument = null;
 
             // Act
-            Action act = () => document.Should().HaveRoot("unknown");
+            Action act = () => theDocument.Should().HaveRoot("unknown");
 
             // Assert
             act.Should().Throw<InvalidOperationException>().WithMessage(
@@ -779,13 +781,13 @@ namespace FluentAssertions.Specs
         public void When_asserting_a_document_has_a_null_root_element_it_should_fail()
         {
             // Arrange
-            var document = XDocument.Parse(
+            var theDocument = XDocument.Parse(
                 @"<parent>
                     <child />
                   </parent>");
 
             // Act
-            Action act = () => document.Should().HaveRoot(null);
+            Action act = () => theDocument.Should().HaveRoot(null);
 
             // Assert
             act.Should().Throw<ArgumentNullException>().WithMessage(
@@ -813,39 +815,43 @@ namespace FluentAssertions.Specs
         public void When_asserting_document_has_root_element_with_ns_but_it_does_not_it_should_fail()
         {
             // Arrange
-            var document = XDocument.Parse(
+            var theDocument = XDocument.Parse(
                 @"<parent>
                     <child />
                   </parent>");
 
             // Act
             Action act = () =>
-                document.Should().HaveRoot(XName.Get("unknown", "http://www.example.com/2012/test"));
+                theDocument.Should().HaveRoot(XName.Get("unknown", "http://www.example.com/2012/test"));
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theDocument to have root element \"{http://www.example.com/2012/test}unknown\", but found <parent>…</parent>.");
         }
 
         [Fact]
         public void When_asserting_document_has_root_element_with_ns_but_it_does_not_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var document = XDocument.Parse(
+            var theDocument = XDocument.Parse(
                 @"<parent>
                     <child />
                   </parent>");
 
             // Act
             Action act = () =>
-                document.Should().HaveRoot(XName.Get("unknown", "http://www.example.com/2012/test"), "because we want to test the failure message");
+                theDocument.Should().HaveRoot(XName.Get("unknown", "http://www.example.com/2012/test"),
+                    "because we want to test the failure message");
 
             // Assert
-            string expectedMessage = string.Format("Expected XML document to have root element \"{{http://www.example.com/2012/test}}unknown\"" +
+            string expectedMessage = string.Format(
+                "Expected theDocument to have root element \"{{http://www.example.com/2012/test}}unknown\"" +
                 " because we want to test the failure message" +
-                    ", but found {0}.", Formatter.ToString(document));
+                ", but found {0}.", Formatter.ToString(theDocument));
 
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }
+
         #endregion
 
         #region HaveElement
@@ -870,38 +876,37 @@ namespace FluentAssertions.Specs
         public void When_asserting_document_has_root_with_child_element_but_it_does_not_it_should_fail()
         {
             // Arrange
-            var document = XDocument.Parse(
+            var theDocument = XDocument.Parse(
                 @"<parent>
                     <child />
                   </parent>");
 
             // Act
             Action act = () =>
-                document.Should().HaveElement("unknown");
+                theDocument.Should().HaveElement("unknown");
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theDocument to have root element with child \"unknown\", but no such child element was found.");
         }
 
         [Fact]
         public void When_asserting_document_has_root_with_child_element_but_it_does_not_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var document = XDocument.Parse(
+            var theDocument = XDocument.Parse(
                 @"<parent>
                     <child />
                   </parent>");
 
             // Act
             Action act = () =>
-                document.Should().HaveElement("unknown", "because we want to test the failure message");
+                theDocument.Should().HaveElement("unknown", "because we want to test the failure message");
 
             // Assert
-            string expectedMessage = string.Format("Expected XML document {0} to have root element with child \"unknown\"" +
-                " because we want to test the failure message" +
-                    ", but no such child element was found.", Formatter.ToString(document));
-
-            act.Should().Throw<XunitException>().WithMessage(expectedMessage);
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theDocument to have root element with child \"unknown\" because we want to test the failure message,"
+                + " but no such child element was found.");
         }
 
         [Fact]
@@ -935,29 +940,29 @@ namespace FluentAssertions.Specs
                 document.Should().HaveElement(XName.Get("unknown", "http://www.example.org/2012/test"));
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected document to have root element with child \"{http://www.example.org/2012/test}unknown\","
+                + " but no such child element was found.");
         }
 
         [Fact]
         public void When_asserting_document_has_root_with_child_element_with_ns_but_it_does_not_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var document = XDocument.Parse(
+            var theDocument = XDocument.Parse(
                 @"<parent>
                     <child />
                   </parent>");
 
             // Act
             Action act = () =>
-                document.Should().HaveElement(XName.Get("unknown", "http://www.example.org/2012/test"),
-                "because we want to test the failure message");
+                theDocument.Should().HaveElement(XName.Get("unknown", "http://www.example.org/2012/test"),
+                    "because we want to test the failure message");
 
             // Assert
-            string expectedMessage = string.Format("Expected XML document {0} to have root element with child \"{{http://www.example.org/2012/test}}unknown\"" +
-                " because we want to test the failure message" +
-                    ", but no such child element was found.", Formatter.ToString(document));
-
-            act.Should().Throw<XunitException>().WithMessage(expectedMessage);
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theDocument to have root element with child \"{http://www.example.org/2012/test}unknown\""
+                + " because we want to test the failure message, but no such child element was found.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
@@ -264,7 +264,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected Element \"child\" in theDocument at \"/parent\", but found EndElement \"parent\".");
+                "Expected Element \"child\" in theDocument at \"/parent/child\", but found EndElement \"parent\".");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
@@ -389,7 +389,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected content \"text\" in theElement at \"/parent\" because we want to test the failure message, but found EndElement \"parent\".");
+                "Expected content \"text\" in theElement at \"/parent/child\" because we want to test the failure message, but found EndElement \"parent\".");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Xml.Linq;
-
-using FluentAssertions.Formatting;
 using Xunit;
 using Xunit.Sdk;
 
@@ -15,12 +13,12 @@ namespace FluentAssertions.Specs
         public void When_asserting_an_xml_element_is_equal_to_the_same_xml_element_it_should_succeed()
         {
             // Arrange
-            var element = new XElement("element");
+            var theElement = new XElement("element");
             var sameElement = new XElement("element");
 
             // Act
             Action act = () =>
-                element.Should().Be(sameElement);
+                theElement.Should().Be(sameElement);
 
             // Assert
             act.Should().NotThrow();
@@ -30,51 +28,52 @@ namespace FluentAssertions.Specs
         public void When_asserting_an_xml_element_is_equal_to_a_different_xml_element_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var element = new XElement("element");
+            var theElement = new XElement("element");
             var otherElement = new XElement("other");
 
             // Act
             Action act = () =>
-                element.Should().Be(otherElement, "because we want to test the failure {0}", "message");
+                theElement.Should().Be(otherElement, "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected XML element to be*other*because we want to test the failure message, but found *element*");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to be*other*because we want to test the failure message, but found *element*");
         }
 
         [Fact]
         public void When_asserting_an_xml_element_is_equal_to_an_xml_element_with_a_deep_difference_it_should_fail()
         {
             // Arrange
+            var theElement =
+                new XElement("parent",
+                    new XElement("child",
+                        new XElement("grandChild2")));
             var expected =
                 new XElement("parent",
                     new XElement("child",
                         new XElement("grandChild")));
-            var actual =
-                new XElement("parent",
-                    new XElement("child",
-                        new XElement("grandChild2")));
 
             // Act
-            Action act = () => actual.Should().Be(expected);
+            Action act = () => theElement.Should().Be(expected);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to be <parent>…</parent>, but found <parent>…</parent>.");
         }
 
         [Fact]
         public void When_asserting_the_equality_of_an_xml_element_but_is_null_it_should_throw_appropriately()
         {
             // Arrange
-            XElement actual = null;
+            XElement theElement = null;
             var expected = new XElement("other");
 
             // Act
-            Action act = () => actual.Should().Be(expected);
+            Action act = () => theElement.Should().Be(expected);
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected XML element to be*other*, but found <null>.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to be*other*, but found <null>.");
         }
 
         [Fact]
@@ -116,32 +115,32 @@ namespace FluentAssertions.Specs
         public void When_asserting_an_xml_element_is_not_equal_to_the_same_xml_element_it_should_fail()
         {
             // Arrange
-            var element = new XElement("element");
-            var sameElement = element;
+            var theElement = new XElement("element");
+            var sameElement = theElement;
 
             // Act
             Action act = () =>
-                element.Should().NotBe(sameElement);
+                theElement.Should().NotBe(sameElement);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement not to be <element />.");
         }
 
         [Fact]
         public void When_asserting_an_xml_element_is_not_equal_to_the_same_xml_element_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var element = new XElement("element");
-            var sameElement = element;
+            var theElement = new XElement("element");
+            var sameElement = theElement;
 
             // Act
             Action act = () =>
-                element.Should().NotBe(sameElement, "because we want to test the failure {0}", "message");
+                theElement.Should().NotBe(sameElement, "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected XML element not to be <element />" +
-                    " because we want to test the failure message.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement not to be <element /> because we want to test the failure message.");
         }
 
         [Fact]
@@ -180,30 +179,30 @@ namespace FluentAssertions.Specs
         public void When_asserting_an_xml_element_is_null_but_it_is_not_it_should_fail()
         {
             // Arrange
-            var element = new XElement("element");
+            var theElement = new XElement("element");
 
             // Act
             Action act = () =>
-                element.Should().BeNull();
+                theElement.Should().BeNull();
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to be <null>, but found <element />.");
         }
 
         [Fact]
         public void When_asserting_an_xml_element_is_null_but_it_is_not_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var element = new XElement("element");
+            var theElement = new XElement("element");
 
             // Act
             Action act = () =>
-                element.Should().BeNull("because we want to test the failure {0}", "message");
+                theElement.Should().BeNull("because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected element to be <null> because we want to test the failure message, but found <element />.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to be <null> because we want to test the failure message, but found <element />.");
         }
 
         [Fact]
@@ -224,29 +223,29 @@ namespace FluentAssertions.Specs
         public void When_asserting_a_null_xml_element_is_not_null_it_should_fail()
         {
             // Arrange
-            XElement element = null;
+            XElement theElement = null;
 
             // Act
             Action act = () =>
-                element.Should().NotBeNull();
+                theElement.Should().NotBeNull();
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage("Expected theElement not to be <null>.");
         }
 
         [Fact]
         public void When_asserting_a_null_xml_element_is_not_null_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            XElement element = null;
+            XElement theElement = null;
 
             // Act
             Action act = () =>
-                element.Should().NotBeNull("because we want to test the failure {0}", "message");
+                theElement.Should().NotBeNull("because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected element not to be <null> because we want to test the failure message.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement not to be <null> because we want to test the failure message.");
         }
 
         #endregion
@@ -286,42 +285,30 @@ namespace FluentAssertions.Specs
         [Fact]
         public void When_asserting_an_empty_xml_element_is_equivalent_to_a_different_selfclosing_xml_element_it_should_succeed()
         {
-            //-------------------------------------------------------------------------------------------------------------------
             // Arrange
-            //-------------------------------------------------------------------------------------------------------------------
             var element = XElement.Parse("<parent><child></child></parent>");
             var otherElement = XElement.Parse("<parent><child /></parent>");
 
-            //-------------------------------------------------------------------------------------------------------------------
             // Act
-            //-------------------------------------------------------------------------------------------------------------------
             Action act = () =>
                 element.Should().BeEquivalentTo(otherElement);
 
-            //-------------------------------------------------------------------------------------------------------------------
             // Assert
-            //-------------------------------------------------------------------------------------------------------------------
             act.Should().NotThrow();
         }
 
         [Fact]
         public void When_asserting_a_selfclosing_xml_element_is_equivalent_to_a_different_empty_xml_element_it_should_succeed()
         {
-            //-------------------------------------------------------------------------------------------------------------------
             // Arrange
-            //-------------------------------------------------------------------------------------------------------------------
             var element = XElement.Parse("<parent><child /></parent>");
             var otherElement = XElement.Parse("<parent><child></child></parent>");
 
-            //-------------------------------------------------------------------------------------------------------------------
             // Act
-            //-------------------------------------------------------------------------------------------------------------------
             Action act = () =>
                 element.Should().BeEquivalentTo(otherElement);
 
-            //-------------------------------------------------------------------------------------------------------------------
             // Assert
-            //-------------------------------------------------------------------------------------------------------------------
             act.Should().NotThrow();
         }
 
@@ -329,83 +316,80 @@ namespace FluentAssertions.Specs
         public void When_asserting_a_xml_element_is_equivalent_to_a_xml_element_with_elements_missing_it_should_fail()
         {
             // Arrange
-            var element = XElement.Parse("<parent><child /><child2 /></parent>");
+            var theElement = XElement.Parse("<parent><child /><child2 /></parent>");
             var otherXElement = XElement.Parse("<parent><child /></parent>");
 
             // Act
             Action act = () =>
-                element.Should().BeEquivalentTo(otherXElement);
+                theElement.Should().BeEquivalentTo(otherXElement);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected EndElement \"parent\" in theElement at \"/parent\", but found Element \"child2\".");
         }
 
         [Fact]
         public void When_asserting_a_xml_element_is_equivalent_to_a_different_xml_element_with_extra_elements_it_should_fail()
         {
             // Arrange
-            var element = XElement.Parse("<parent><child /></parent>");
+            var theElement = XElement.Parse("<parent><child /></parent>");
             var otherXElement = XElement.Parse("<parent><child /><child2 /></parent>");
 
             // Act
             Action act = () =>
-                element.Should().BeEquivalentTo(otherXElement);
+                theElement.Should().BeEquivalentTo(otherXElement);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected Element \"child2\" in theElement at \"/parent\", but found EndElement \"parent\".");
         }
 
         [Fact]
         public void When_asserting_a_xml_element_is_equivalent_to_a_different_xml_element_elements_missing_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var element = XElement.Parse("<parent><child /><child2 /></parent>");
+            var theElement = XElement.Parse("<parent><child /><child2 /></parent>");
             var otherXElement = XElement.Parse("<parent><child /></parent>");
 
             // Act
             Action act = () =>
-                element.Should().BeEquivalentTo(otherXElement, "because we want to test the failure {0}", "message");
+                theElement.Should().BeEquivalentTo(otherXElement, "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected node of type EndElement at \"/parent\" because we want to test the failure message, but found Element.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected EndElement \"parent\" in theElement at \"/parent\" because we want to test the failure message, but found Element \"child2\".");
         }
 
         [Fact]
         public void When_asserting_a_xml_element_is_equivalent_to_a_different_xml_element_with_extra_elements_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var element = XElement.Parse("<parent><child /></parent>");
+            var theElement = XElement.Parse("<parent><child /></parent>");
             var otherXElement = XElement.Parse("<parent><child /><child2 /></parent>");
 
             // Act
             Action act = () =>
-                element.Should().BeEquivalentTo(otherXElement, "because we want to test the failure {0}", "message");
+                theElement.Should().BeEquivalentTo(otherXElement, "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected node of type Element at \"/parent\" because we want to test the failure message, but found EndElement.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected Element \"child2\" in theElement at \"/parent\" because we want to test the failure message, but found EndElement \"parent\".");
         }
 
         [Fact]
         public void When_asserting_an_empty_xml_element_is_equivalent_to_a_different_xml_element_with_text_content_it_should_fail()
         {
-            //-------------------------------------------------------------------------------------------------------------------
             // Arrange
-            //-------------------------------------------------------------------------------------------------------------------
-            var element = XElement.Parse("<parent><child /></parent>");
+            var theElement = XElement.Parse("<parent><child /></parent>");
             var otherXElement = XElement.Parse("<parent><child>text</child></parent>");
 
-            //-------------------------------------------------------------------------------------------------------------------
             // Act
-            //-------------------------------------------------------------------------------------------------------------------
             Action act = () =>
-                element.Should().BeEquivalentTo(otherXElement, "because we want to test the failure {0}", "message");
+                theElement.Should().BeEquivalentTo(otherXElement, "because we want to test the failure {0}", "message");
 
-            //-------------------------------------------------------------------------------------------------------------------
             // Assert
-            //-------------------------------------------------------------------------------------------------------------------
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected content \"text\" in theElement at \"/parent\" because we want to test the failure message, but found EndElement \"parent\".");
         }
 
         [Fact]
@@ -442,96 +426,101 @@ namespace FluentAssertions.Specs
         public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_structure_it_should_fail()
         {
             // Arrange
-            var element = XElement.Parse("<parent><child /></parent>");
+            var theElement = XElement.Parse("<parent><child /></parent>");
             var otherXElement = XElement.Parse("<parent><child /></parent>");
 
             // Act
             Action act = () =>
-                element.Should().NotBeEquivalentTo(otherXElement);
+                theElement.Should().NotBeEquivalentTo(otherXElement);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect theElement to be equivalent, but it is.");
         }
 
         [Fact]
         public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_contents_but_different_ns_prefixes_it_should_fail()
         {
             // Arrange
-            var element = XElement.Parse(@"<parent xmlns:ns1=""a""><ns1:child /></parent>");
+            var theElement = XElement.Parse(@"<parent xmlns:ns1=""a""><ns1:child /></parent>");
             var otherXElement = XElement.Parse(@"<parent xmlns:ns2=""a""><ns2:child /></parent>");
 
             // Act
             Action act = () =>
-                element.Should().NotBeEquivalentTo(otherXElement);
+                theElement.Should().NotBeEquivalentTo(otherXElement);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect theElement to be equivalent, but it is.");
         }
 
         [Fact]
         public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_contents_but_extra_unused_xmlns_declaration_it_should_fail()
         {
             // Arrange
-            var element = XElement.Parse(@"<xml xmlns:ns1=""a"" />");
+            var theElement = XElement.Parse(@"<xml xmlns:ns1=""a"" />");
             var otherXElement = XElement.Parse("<xml />");
 
             // Act
             Action act = () =>
-                element.Should().NotBeEquivalentTo(otherXElement);
+                theElement.Should().NotBeEquivalentTo(otherXElement);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect theElement to be equivalent, but it is.");
         }
 
         [Fact]
         public void When_asserting_a_xml_element_is_not_equivalent_to_the_same_xml_element_it_should_fail()
         {
             // Arrange
-            var element = new XElement("element");
-            var sameXElement = element;
+            var theElement = new XElement("element");
+            var sameXElement = theElement;
 
             // Act
             Action act = () =>
-                element.Should().NotBeEquivalentTo(sameXElement);
+                theElement.Should().NotBeEquivalentTo(sameXElement);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect theElement to be equivalent, but it is.");
         }
 
         [Fact]
         public void When_asserting_a_xml_element_is_not_equivalent_to_a_different_xml_element_with_same_structure_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var element = XElement.Parse("<parent><child /></parent>");
+            var theElement = XElement.Parse("<parent><child /></parent>");
             var otherXElement = XElement.Parse("<parent><child /></parent>");
 
             // Act
             Action act = () =>
-                element.Should().NotBeEquivalentTo(otherXElement, "because we want to test the failure {0}", "message");
+                theElement.Should().NotBeEquivalentTo(otherXElement, "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect Xml to be equivalent because we want to test the failure message, but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect theElement to be equivalent because we want to test the failure message, but it is.");
         }
 
         [Fact]
         public void When_asserting_a_xml_element_is_not_equivalent_to_the_same_xml_element_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var element = XElement.Parse("<parent><child /></parent>");
-            var sameXElement = element;
+            var theElement = XElement.Parse("<parent><child /></parent>");
+            var sameXElement = theElement;
 
             // Act
             Action act = () =>
-                element.Should().NotBeEquivalentTo(sameXElement, "because we want to test the failure {0}", "message");
+                theElement.Should().NotBeEquivalentTo(sameXElement, "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect Xml to be equivalent because we want to test the failure message, but it is.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect theElement to be equivalent because we want to test the failure message, but it is.");
         }
 
         [Fact]
-        public void When_asserting_an_xml_element_is_equivalent_to_a_different_xml_element_with_different_namespace_prefix_it_should_succeed()
+        public void
+            When_asserting_an_xml_element_is_equivalent_to_a_different_xml_element_with_different_namespace_prefix_it_should_succeed()
         {
             // Arrange
             var subject = XElement.Parse("<xml xmlns=\"urn:a\"/>");
@@ -564,80 +553,81 @@ namespace FluentAssertions.Specs
         public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_lacks_attributes_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = XElement.Parse("<xml><element b=\"1\"/></xml>");
+            var theElement = XElement.Parse("<xml><element b=\"1\"/></xml>");
             var expected = XElement.Parse("<xml><element a=\"b\" b=\"1\"/></xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theElement.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Expected attribute \"a\" at \"/xml/element\" because we want to test the failure message, but found none.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected attribute \"a\" in theElement at \"/xml/element\" because we want to test the failure message, but found none.");
         }
 
         [Fact]
         public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_extra_attributes_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = XElement.Parse("<xml><element a=\"b\"/></xml>");
+            var theElement = XElement.Parse("<xml><element a=\"b\"/></xml>");
             var expected = XElement.Parse("<xml><element/></xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theElement.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Did not expect to find attribute \"a\" at \"/xml/element\" because we want to test the failure message.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect to find attribute \"a\" in theElement at \"/xml/element\" because we want to test the failure message.");
         }
 
         [Fact]
-        public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = XElement.Parse("<xml><element a=\"b\"/></xml>");
+            var theElement = XElement.Parse("<xml><element a=\"b\"/></xml>");
             var expected = XElement.Parse("<xml><element a=\"c\"/></xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theElement.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Expected attribute \"a\" at \"/xml/element\" to have value \"c\" because we want to test the failure message, but found \"b\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected attribute \"a\" in theElement at \"/xml/element\" to have value \"c\" because we want to test the failure message, but found \"b\".");
         }
 
         [Fact]
         public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = XElement.Parse("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
+            var theElement = XElement.Parse("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
             var expected = XElement.Parse("<xml><element a=\"b\"/></xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theElement.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Did not expect to find attribute \"ns:a\" at \"/xml/element\" because we want to test the failure message.");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect to find attribute \"ns:a\" in theElement at \"/xml/element\" because we want to test the failure message.");
         }
 
         [Fact]
         public void When_asserting_an_xml_element_is_equivalent_to_different_xml_element_which_has_different_text_contents_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = XElement.Parse("<xml>a</xml>");
+            var theElement = XElement.Parse("<xml>a</xml>");
             var expected = XElement.Parse("<xml>b</xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theElement.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Expected content to be \"b\" at \"/xml\" because we want to test the failure message, but found \"a\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected content to be \"b\" in theElement at \"/xml\" because we want to test the failure message, but found \"a\".");
         }
 
         [Fact]
@@ -676,31 +666,30 @@ namespace FluentAssertions.Specs
         public void When_asserting_element_has_a_specific_value_but_it_has_a_different_value_it_should_throw()
         {
             // Arrange
-            var element = XElement.Parse("<user>grega</user>");
+            var theElement = XElement.Parse("<user>grega</user>");
 
             // Act
             Action act = () =>
-                element.Should().HaveValue("stamac");
+                theElement.Should().HaveValue("stamac");
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement 'user' to have value \"stamac\", but found \"grega\".");
         }
 
         [Fact]
         public void When_asserting_element_has_a_specific_value_but_it_has_a_different_value_it_should_throw_with_descriptive_message()
         {
             // Arrange
-            var element = XElement.Parse("<user>grega</user>");
+            var theElement = XElement.Parse("<user>grega</user>");
 
             // Act
             Action act = () =>
-                element.Should().HaveValue("stamac", "because we want to test the failure {0}", "message");
+                theElement.Should().HaveValue("stamac", "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected XML element 'user' to have value \"stamac\"" +
-                    " because we want to test the failure message" +
-                        ", but found \"grega\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement 'user' to have value \"stamac\" because we want to test the failure message, but found \"grega\".");
         }
 
         #endregion
@@ -739,124 +728,128 @@ namespace FluentAssertions.Specs
         public void When_asserting_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail()
         {
             // Arrange
-            var element = XElement.Parse(@"<user name=""martin"" />");
+            var theElement = XElement.Parse(@"<user name=""martin"" />");
 
             // Act
             Action act = () =>
-                element.Should().HaveAttribute("age", "36");
+                theElement.Should().HaveAttribute("age", "36");
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to have attribute \"age\" with value \"36\", but found no such attribute in <user name=\"martin\" />");
         }
 
         [Fact]
         public void When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail()
         {
             // Arrange
-            var element = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+            var theElement = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
 
             // Act
             Action act = () =>
-                element.Should().HaveAttribute(XName.Get("age", "http://www.example.com/2012/test"), "36");
+                theElement.Should().HaveAttribute(XName.Get("age", "http://www.example.com/2012/test"), "36");
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to have attribute \"{http://www.example.com/2012/test}age\" with value \"36\","
+                + " but found no such attribute in <user xmlns:a=\"http://www.example.com/2012/test\" a:name=\"martin\" />");
         }
 
         [Fact]
         public void When_asserting_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var element = XElement.Parse(@"<user name=""martin"" />");
+            var theElement = XElement.Parse(@"<user name=""martin"" />");
 
             // Act
             Action act = () =>
-                element.Should().HaveAttribute("age", "36", "because we want to test the failure {0}", "message");
+                theElement.Should().HaveAttribute("age", "36", "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected XML element to have attribute \"age\" with value \"36\"" +
-                    " because we want to test the failure message" +
-                        ", but found no such attribute in <user name=\"martin\" />");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to have attribute \"age\" with value \"36\" because we want to test the failure message,"
+                + " but found no such attribute in <user name=\"martin\" />");
         }
 
         [Fact]
         public void When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var element = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+            var theElement = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
 
             // Act
             Action act = () =>
-                element.Should().HaveAttribute(XName.Get("age", "http://www.example.com/2012/test"), "36", "because we want to test the failure {0}", "message");
+                theElement.Should().HaveAttribute(XName.Get("age", "http://www.example.com/2012/test"), "36",
+                    "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected XML element to have attribute \"{http://www.example.com/2012/test}age\" with value \"36\"" +
-                    " because we want to test the failure message" +
-                        ", but found no such attribute in <user xmlns:a=\"http://www.example.com/2012/test\" a:name=\"martin\" />");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to have attribute \"{http://www.example.com/2012/test}age\" with value \"36\""
+                + " because we want to test the failure message,"
+                + " but found no such attribute in <user xmlns:a=\"http://www.example.com/2012/test\" a:name=\"martin\" />");
         }
 
         [Fact]
         public void When_asserting_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail()
         {
             // Arrange
-            var element = XElement.Parse(@"<user name=""martin"" />");
+            var theElement = XElement.Parse(@"<user name=""martin"" />");
 
             // Act
             Action act = () =>
-                element.Should().HaveAttribute("name", "dennis");
+                theElement.Should().HaveAttribute("name", "dennis");
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected attribute \"name\" in theElement to have value \"dennis\", but found \"martin\".");
         }
 
         [Fact]
         public void When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail()
         {
             // Arrange
-            var element = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+            var theElement = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
 
             // Act
             Action act = () =>
-                element.Should().HaveAttribute(XName.Get("name", "http://www.example.com/2012/test"), "dennis");
+                theElement.Should().HaveAttribute(XName.Get("name", "http://www.example.com/2012/test"), "dennis");
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected attribute \"{http://www.example.com/2012/test}name\" in theElement to have value \"dennis\", but found \"martin\".");
         }
 
         [Fact]
         public void When_asserting_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var element = XElement.Parse(@"<user name=""martin"" />");
+            var theElement = XElement.Parse(@"<user name=""martin"" />");
 
             // Act
             Action act = () =>
-                element.Should().HaveAttribute("name", "dennis", "because we want to test the failure {0}", "message");
+                theElement.Should().HaveAttribute("name", "dennis", "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected XML attribute \"name\" to have value \"dennis\"" +
-                    " because we want to test the failure message" +
-                        ", but found \"martin\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected attribute \"name\" in theElement to have value \"dennis\""
+                + " because we want to test the failure message, but found \"martin\".");
         }
 
         [Fact]
         public void When_asserting_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var element = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+            var theElement = XElement.Parse(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
 
             // Act
             Action act = () =>
-                element.Should().HaveAttribute(XName.Get("name", "http://www.example.com/2012/test"), "dennis", "because we want to test the failure {0}", "message");
+                theElement.Should().HaveAttribute(XName.Get("name", "http://www.example.com/2012/test"), "dennis",
+                    "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected XML attribute \"{http://www.example.com/2012/test}name\" to have value \"dennis\"" +
-                    " because we want to test the failure message" +
-                        ", but found \"martin\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected attribute \"{http://www.example.com/2012/test}name\" in theElement to have value \"dennis\""
+                + " because we want to test the failure message, but found \"martin\".");
         }
 
         #endregion
@@ -901,76 +894,75 @@ namespace FluentAssertions.Specs
         public void When_asserting_element_has_child_element_but_it_does_not_it_should_fail()
         {
             // Arrange
-            var element = XElement.Parse(
+            var theElement = XElement.Parse(
                 @"<parent>
                     <child />
                   </parent>");
 
             // Act
             Action act = () =>
-                element.Should().HaveElement("unknown");
+                theElement.Should().HaveElement("unknown");
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to have child element \"unknown\", but no such child element was found.");
         }
 
         [Fact]
         public void When_asserting_element_has_child_element_with_ns_but_it_does_not_it_should_fail()
         {
             // Arrange
-            var element = XElement.Parse(
+            var theElement = XElement.Parse(
                 @"<parent>
                     <child />
                   </parent>");
 
             // Act
             Action act = () =>
-                element.Should().HaveElement(XName.Get("unknown", "http://www.example.com/2012/test"));
+                theElement.Should().HaveElement(XName.Get("unknown", "http://www.example.com/2012/test"));
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to have child element \"{{http://www.example.com/2012/test}}unknown\", but no such child element was found.");
         }
 
         [Fact]
         public void When_asserting_element_has_child_element_but_it_does_not_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var element = XElement.Parse(
+            var theElement = XElement.Parse(
                 @"<parent>
                     <child />
                   </parent>");
 
             // Act
             Action act = () =>
-                element.Should().HaveElement("unknown", "because we want to test the failure message");
+                theElement.Should().HaveElement("unknown", "because we want to test the failure message");
 
             // Assert
-            string expectedMessage = string.Format("Expected XML element {0} to have child element \"unknown\"" +
-                " because we want to test the failure message" +
-                    ", but no such child element was found.", Formatter.ToString(element));
-
-            act.Should().Throw<XunitException>().WithMessage(expectedMessage);
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to have child element \"unknown\" because we want to test the failure message,"
+                + " but no such child element was found.");
         }
 
         [Fact]
         public void When_asserting_element_has_child_element_with_ns_but_it_does_not_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var element = XElement.Parse(
+            var theElement = XElement.Parse(
                 @"<parent>
                     <child />
                   </parent>");
 
             // Act
             Action act = () =>
-                element.Should().HaveElement(XName.Get("unknown", "http://www.example.com/2012/test"), "because we want to test the failure message");
+                theElement.Should().HaveElement(XName.Get("unknown", "http://www.example.com/2012/test"),
+                    "because we want to test the failure message");
 
             // Assert
-            string expectedMessage = string.Format("Expected XML element {0} to have child element \"{{http://www.example.com/2012/test}}unknown\"" +
-                " because we want to test the failure message" +
-                    ", but no such child element was found.", Formatter.ToString(element));
-
-            act.Should().Throw<XunitException>().WithMessage(expectedMessage);
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to have child element \"{{http://www.example.com/2012/test}}unknown\""
+                + " because we want to test the failure message, but no such child element was found.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Xml/XmlElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XmlElementAssertionSpecs.cs
@@ -32,6 +32,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().NotThrow();
         }
+
         #endregion
 
         #region HaveValue
@@ -69,22 +70,21 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_asserting_xml_element_has_a_specific_inner_text_but_it_has_a_different_inner_text_it_should_throw_with_descriptive_message()
+        public void
+            When_asserting_xml_element_has_a_specific_inner_text_but_it_has_a_different_inner_text_it_should_throw_with_descriptive_message()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml("<user>grega</user>");
-            var element = xmlDoc.DocumentElement;
+            var document = new XmlDocument();
+            document.LoadXml("<user>grega</user>");
+            var theElement = document.DocumentElement;
 
             // Act
             Action act = () =>
-                element.Should().HaveInnerText("stamac", "because we want to test the failure {0}", "message");
+                theElement.Should().HaveInnerText("stamac", "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected XML element \"user\" to have value \"stamac\"" +
-                    " because we want to test the failure message" +
-                        ", but found \"grega\".");
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to have value \"stamac\" because we want to test the failure message, but found \"grega\".");
         }
 
         #endregion
@@ -140,7 +140,8 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail()
+        public void
+            When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail()
         {
             // Arrange
             var xmlDoc = new XmlDocument();
@@ -156,45 +157,50 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(@"<user name=""martin"" />");
-            var element = xmlDoc.DocumentElement;
+            var document = new XmlDocument();
+            document.LoadXml(@"<user name=""martin"" />");
+            var theElement = document.DocumentElement;
 
             // Act
             Action act = () =>
-                element.Should().HaveAttribute("age", "36", "because we want to test the failure {0}", "message");
+                theElement.Should().HaveAttribute("age", "36", "because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected XML element to have attribute \"age\" with value \"36\"" +
-                    " because we want to test the failure message" +
-                        ", but found no such attribute in <user name=\"martin\"*");
+                .WithMessage("Expected theElement to have attribute \"age\" with value \"36\"" +
+                             " because we want to test the failure message" +
+                             ", but found no such attribute in <user name=\"martin\"*");
         }
 
         [Fact]
-        public void When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
-            var element = xmlDoc.DocumentElement;
+            var document = new XmlDocument();
+            document.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+            var theElement = document.DocumentElement;
 
             // Act
             Action act = () =>
-                element.Should().HaveAttributeWithNamespace("age", "http://www.example.com/2012/test", "36", "because we want to test the failure {0}", "message");
+                theElement.Should().HaveAttributeWithNamespace("age", "http://www.example.com/2012/test", "36",
+                    "because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected XML element to have attribute \"{http://www.example.com/2012/test}age\" with value \"36\"" +
+                .WithMessage(
+                    "Expected theElement to have attribute \"{http://www.example.com/2012/test}age\" with value \"36\"" +
                     " because we want to test the failure message" +
-                        ", but found no such attribute in <user xmlns:a=\"http:…");
+                    ", but found no such attribute in <user xmlns:a=\"http:…");
         }
 
         [Fact]
-        public void When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail()
+        public void
+            When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail()
         {
             // Arrange
             var xmlDoc = new XmlDocument();
@@ -210,7 +216,8 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail()
+        public void
+            When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail()
         {
             // Arrange
             var xmlDoc = new XmlDocument();
@@ -226,41 +233,45 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(@"<user name=""martin"" />");
-            var element = xmlDoc.DocumentElement;
+            var document = new XmlDocument();
+            document.LoadXml(@"<user name=""martin"" />");
+            var theElement = document.DocumentElement;
 
             // Act
             Action act = () =>
-                element.Should().HaveAttribute("name", "dennis", "because we want to test the failure {0}", "message");
+                theElement.Should().HaveAttribute("name", "dennis", "because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected XML attribute \"name\" to have value \"dennis\"" +
-                    " because we want to test the failure message" +
-                        ", but found \"martin\".");
+                .WithMessage("Expected attribute \"name\" in theElement to have value \"dennis\"" +
+                             " because we want to test the failure message" +
+                             ", but found \"martin\".");
         }
 
         [Fact]
-        public void When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
+        public void
+            When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
-            var element = xmlDoc.DocumentElement;
+            var document = new XmlDocument();
+            document.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
+            var theElement = document.DocumentElement;
 
             // Act
             Action act = () =>
-                element.Should().HaveAttributeWithNamespace("name", "http://www.example.com/2012/test", "dennis", "because we want to test the failure {0}", "message");
+                theElement.Should().HaveAttributeWithNamespace("name", "http://www.example.com/2012/test", "dennis",
+                    "because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected XML attribute \"{http://www.example.com/2012/test}name\" to have value \"dennis\"" +
+                .WithMessage(
+                    "Expected attribute \"{http://www.example.com/2012/test}name\" in theElement to have value \"dennis\"" +
                     " because we want to test the failure message" +
-                        ", but found \"martin\".");
+                    ", but found \"martin\".");
         }
 
         #endregion
@@ -347,46 +358,45 @@ namespace FluentAssertions.Specs
         public void When_asserting_xml_element_has_child_element_but_it_does_not_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(
+            var document = new XmlDocument();
+            document.LoadXml(
                 @"<parent>
                     <child />
                   </parent>");
-            var element = xmlDoc.DocumentElement;
+            var theElement = document.DocumentElement;
 
             // Act
             Action act = () =>
-                element.Should().HaveElement("unknown", "because we want to test the failure message");
+                theElement.Should().HaveElement("unknown", "because we want to test the failure message");
 
             // Assert
-            string expectedMessage = string.Format("Expected XML element {0} to have child element \"unknown\"" +
-                " because we want to test the failure message" +
-                    ", but no such child element was found.", Formatter.ToString(element));
-
-            act.Should().Throw<XunitException>().WithMessage(expectedMessage);
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to have child element \"unknown\""
+                + " because we want to test the failure message"
+                + ", but no such child element was found.");
         }
 
         [Fact]
         public void When_asserting_xml_element_has_child_element_with_ns_but_it_does_not_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(
+            var document = new XmlDocument();
+            document.LoadXml(
                 @"<parent>
                     <child />
                   </parent>");
-            var element = xmlDoc.DocumentElement;
+            var theElement = document.DocumentElement;
 
             // Act
             Action act = () =>
-                element.Should().HaveElementWithNamespace("unknown", "http://www.example.com/2012/test", "because we want to test the failure message");
+                theElement.Should().HaveElementWithNamespace("unknown", "http://www.example.com/2012/test",
+                    "because we want to test the failure message");
 
             // Assert
-            string expectedMessage = string.Format("Expected XML element {0} to have child element \"{{http://www.example.com/2012/test}}unknown\"" +
-                " because we want to test the failure message" +
-                    ", but no such child element was found.", Formatter.ToString(element));
-
-            act.Should().Throw<XunitException>().WithMessage(expectedMessage);
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theElement to have child element \"{{http://www.example.com/2012/test}}unknown\""
+                + " because we want to test the failure message"
+                + ", but no such child element was found.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Xml/XmlNodeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XmlNodeAssertionSpecs.cs
@@ -27,53 +27,56 @@ namespace FluentAssertions.Specs
         public void When_asserting_an_xml_node_is_same_as_a_different_xml_node_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var doc = new XmlDocument();
-            doc.LoadXml("<doc/>");
+            var theDocument = new XmlDocument();
+            theDocument.LoadXml("<doc/>");
             var otherNode = new XmlDocument();
             otherNode.LoadXml("<otherDoc/>");
 
             // Act
             Action act = () =>
-                doc.Should().BeSameAs(otherNode, "we want to test the failure {0}", "message");
+                theDocument.Should().BeSameAs(otherNode, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected doc to refer to <otherDoc /> because we want to test the failure message, but found <doc />.");
+                .WithMessage(
+                    "Expected theDocument to refer to <otherDoc /> because we want to test the failure message, but found <doc />.");
         }
 
         [Fact]
         public void When_asserting_an_xml_node_is_same_as_a_different_xml_node_it_should_fail_with_descriptive_message_and_truncate_xml()
         {
             // Arrange
-            var doc = new XmlDocument();
-            doc.LoadXml("<doc>Some very long text that should be truncated.</doc>");
+            var theDocument = new XmlDocument();
+            theDocument.LoadXml("<doc>Some very long text that should be truncated.</doc>");
             var otherNode = new XmlDocument();
             otherNode.LoadXml("<otherDoc/>");
 
             // Act
             Action act = () =>
-                doc.Should().BeSameAs(otherNode, "we want to test the failure {0}", "message");
+                theDocument.Should().BeSameAs(otherNode, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected doc to refer to <otherDoc /> because we want to test the failure message, but found <doc>Some very long….");
+                .WithMessage(
+                    "Expected theDocument to refer to <otherDoc /> because we want to test the failure message, but found <doc>Some very long….");
         }
 
         [Fact]
         public void When_asserting_the_equality_of_an_xml_node_but_is_null_it_should_throw_appropriately()
         {
             // Arrange
-            XmlDocument actual = null;
+            XmlDocument theDocument = null;
             var expected = new XmlDocument();
             expected.LoadXml("<xml/>");
 
             // Act
-            Action act = () => actual.Should().BeSameAs(expected);
+            Action act = () => theDocument.Should().BeSameAs(expected);
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected actual to refer to *xml*, but found <null>.");
+                .WithMessage("Expected theDocument to refer to *xml*, but found <null>.");
         }
+
         #endregion
 
         #region BeNull / NotBeNull
@@ -111,17 +114,17 @@ namespace FluentAssertions.Specs
         public void When_asserting_an_xml_node_is_null_but_it_is_not_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml("<xml/>");
+            var theDocument = new XmlDocument();
+            theDocument.LoadXml("<xml/>");
 
             // Act
             Action act = () =>
-                xmlDoc.Should().BeNull("because we want to test the failure {0}", "message");
+                theDocument.Should().BeNull("because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected xmlDoc to be <null> because we want to test the failure message," +
-                    " but found <xml />.");
+                .WithMessage("Expected theDocument to be <null> because we want to test the failure message," +
+                             " but found <xml />.");
         }
 
         [Fact]
@@ -157,15 +160,15 @@ namespace FluentAssertions.Specs
         public void When_asserting_a_null_xml_node_is_not_null_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            XmlDocument xmlDoc = null;
+            XmlDocument theDocument = null;
 
             // Act
             Action act = () =>
-                xmlDoc.Should().NotBeNull("because we want to test the failure {0}", "message");
+                theDocument.Should().NotBeNull("because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected xmlDoc not to be <null> because we want to test the failure message.");
+                .WithMessage("Expected theDocument not to be <null> because we want to test the failure message.");
         }
 
         #endregion
@@ -207,34 +210,36 @@ namespace FluentAssertions.Specs
         public void When_asserting_an_xml_node_is_not_equivalent_to_same_xml_node_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml>a</xml>");
+            var theDocument = new XmlDocument();
+            theDocument.LoadXml("<xml>a</xml>");
 
             // Act
             Action act = () =>
-                subject.Should().NotBeEquivalentTo(subject, "we want to test the failure {0}", "message");
+                theDocument.Should().NotBeEquivalentTo(theDocument, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Did not expect Xml to be equivalent because we want to test the failure message, but it is.");
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Did not expect theDocument to be equivalent because we want to test the failure message, but it is.");
         }
 
         [Fact]
         public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_with_other_contents_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<subject/>");
+            var theDocument = new XmlDocument();
+            theDocument.LoadXml("<subject/>");
             var expected = new XmlDocument();
             expected.LoadXml("<expected/>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Expected local name of element at \"/\" to be \"expected\" because we want to test the failure message, but found \"subject\".");
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected local name of element in theDocument at \"/\" to be \"expected\" because we want to test the failure message, but found \"subject\".");
         }
 
         [Fact]
@@ -294,180 +299,190 @@ namespace FluentAssertions.Specs
         public void When_asserting_an_xml_node_is_equivalent_to_a_different_XmlDocument_which_differs_on_a_child_element_name_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml><child><subject/></child></xml>");
+            var theDocument = new XmlDocument();
+            theDocument.LoadXml("<xml><child><subject/></child></xml>");
             var expected = new XmlDocument();
             expected.LoadXml("<xml><child><expected/></child></xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Expected local name of element at \"/xml/child\" to be \"expected\" because we want to test the failure message, but found \"subject\".");
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected local name of element in theDocument at \"/xml/child\" to be \"expected\" because we want to test the failure message, but found \"subject\".");
         }
 
         [Fact]
         public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_which_differs_on_a_child_element_namespace_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<a:xml xmlns:a=\"urn:a\"><a:child><a:data/></a:child></a:xml>");
+            var theDocument = new XmlDocument();
+            theDocument.LoadXml("<a:xml xmlns:a=\"urn:a\"><a:child><a:data/></a:child></a:xml>");
             var expected = new XmlDocument();
             expected.LoadXml("<xml xmlns=\"urn:a\"><child><data xmlns=\"urn:b\"/></child></xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Expected namespace of element \"data\" at \"/xml/child\" to be \"urn:b\" because we want to test the failure message, but found \"urn:a\".");
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected namespace of element \"data\" in theDocument at \"/xml/child\" to be \"urn:b\" because we want to test the failure message, but found \"urn:a\".");
         }
 
         [Fact]
         public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_contains_an_unexpected_node_type_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml>data</xml>");
+            var theDocument = new XmlDocument();
+            theDocument.LoadXml("<xml>data</xml>");
             var expected = new XmlDocument();
             expected.LoadXml("<xml><data/></xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Expected node of type Element at \"/xml\" because we want to test the failure message, but found Text.");
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected Element \"data\" in theDocument at \"/xml\" because we want to test the failure message, but found content \"data\".");
         }
 
         [Fact]
         public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_contains_extra_elements_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml><data/></xml>");
+            var theDocument = new XmlDocument();
+            theDocument.LoadXml("<xml><data/></xml>");
             var expected = new XmlDocument();
             expected.LoadXml("<xml/>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Expected end of document because we want to test the failure message, but found \"data\".");
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected end of document in theDocument because we want to test the failure message, but found \"data\".");
         }
 
         [Fact]
         public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_lacks_elements_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml/>");
+            var theDocument = new XmlDocument();
+            theDocument.LoadXml("<xml/>");
             var expected = new XmlDocument();
             expected.LoadXml("<xml><data/></xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Expected \"data\" because we want to test the failure message, but found end of document.");
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected \"data\" in theDocument because we want to test the failure message, but found end of document.");
         }
 
         [Fact]
         public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_lacks_attributes_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml><element b=\"1\"/></xml>");
+            var theDocument = new XmlDocument();
+            theDocument.LoadXml("<xml><element b=\"1\"/></xml>");
             var expected = new XmlDocument();
             expected.LoadXml("<xml><element a=\"b\" b=\"1\"/></xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Expected attribute \"a\" at \"/xml/element\" because we want to test the failure message, but found none.");
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected attribute \"a\" in theDocument at \"/xml/element\" because we want to test the failure message, but found none.");
         }
 
         [Fact]
         public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_extra_attributes_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml><element a=\"b\"/></xml>");
+            var theDocument = new XmlDocument();
+            theDocument.LoadXml("<xml><element a=\"b\"/></xml>");
             var expected = new XmlDocument();
             expected.LoadXml("<xml><element/></xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Did not expect to find attribute \"a\" at \"/xml/element\" because we want to test the failure message.");
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Did not expect to find attribute \"a\" in theDocument at \"/xml/element\" because we want to test the failure message.");
         }
 
         [Fact]
         public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml><element a=\"b\"/></xml>");
+            var theDocument = new XmlDocument();
+            theDocument.LoadXml("<xml><element a=\"b\"/></xml>");
             var expected = new XmlDocument();
             expected.LoadXml("<xml><element a=\"c\"/></xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Expected attribute \"a\" at \"/xml/element\" to have value \"c\" because we want to test the failure message, but found \"b\".");
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected attribute \"a\" in theDocument at \"/xml/element\" to have value \"c\" because we want to test the failure message, but found \"b\".");
         }
 
         [Fact]
         public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
+            var theDocument = new XmlDocument();
+            theDocument.LoadXml("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
             var expected = new XmlDocument();
             expected.LoadXml("<xml><element a=\"b\"/></xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Did not expect to find attribute \"ns:a\" at \"/xml/element\" because we want to test the failure message.");
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Did not expect to find attribute \"ns:a\" in theDocument at \"/xml/element\" because we want to test the failure message.");
         }
 
         [Fact]
         public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_different_text_contents_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml>a</xml>");
+            var theDocument = new XmlDocument();
+            theDocument.LoadXml("<xml>a</xml>");
             var expected = new XmlDocument();
             expected.LoadXml("<xml>b</xml>");
 
             // Act
             Action act = () =>
-                subject.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
+                theDocument.Should().BeEquivalentTo(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().
-                WithMessage("Expected content to be \"b\" at \"/xml\" because we want to test the failure message, but found \"a\".");
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected content to be \"b\" in theDocument at \"/xml\" because we want to test the failure message, but found \"a\".");
         }
 
         [Fact]
@@ -506,11 +521,11 @@ namespace FluentAssertions.Specs
         public void When_asserting_an_xml_node_is_equivalent_that_contains_an_unsupported_node_it_should_throw_a_descriptive_message()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml><![CDATA[Text]]></xml>");
+            var theDocument = new XmlDocument();
+            theDocument.LoadXml("<xml><![CDATA[Text]]></xml>");
 
             // Act
-            Action act = () => subject.Should().BeEquivalentTo(subject);
+            Action act = () => theDocument.Should().BeEquivalentTo(theDocument);
 
             // Assert
             act.Should().Throw<NotSupportedException>()
@@ -518,23 +533,23 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
-        public void When_asserting_an_xml_node_is_equivalent_that_isnt_it_should_include_the_right_location_in_the_descriptive_message()
+        public void
+            When_asserting_an_xml_node_is_equivalent_that_isnt_it_should_include_the_right_location_in_the_descriptive_message()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml><a/><b c=\"d\"/></xml>");
+            var theDocument = new XmlDocument();
+            theDocument.LoadXml("<xml><a/><b c=\"d\"/></xml>");
             var expected = new XmlDocument();
             expected.LoadXml("<xml><a/><b c=\"e\"/></xml>");
 
             // Act
-            Action act = () => subject.Should().BeEquivalentTo(expected);
+            Action act = () => theDocument.Should().BeEquivalentTo(expected);
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected attribute \"c\" at \"/xml/b\" to have value \"e\", but found \"d\".");
+                .WithMessage("Expected attribute \"c\" in theDocument at \"/xml/b\" to have value \"e\", but found \"d\".");
         }
 
         #endregion
-
     }
 }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -27,6 +27,7 @@ sidebar:
 * Guard against implicitly or explicitly trying to compare primitive types by members - [#1394](https://github.com/fluentassertions/fluentassertions/pull/1394).
 * Fixed formatting of brackets in expressions passed to ContainSingle(...) - [#1406](https://github.com/fluentassertions/fluentassertions/pull/1406).
 * Fixed `Contain`, `NotContain` and `OnlyContain` to avoid multiple enumerations when the condition is false - [#1421](https://github.com/fluentassertions/fluentassertions/pull/1421).
+* Added variable name and other useful and consistent information to XML assertions - [#1440](https://github.com/fluentassertions/fluentassertions/pull/1440).
 
 **Breaking Changes**
 * Moved `[Not]HaveFlag` from `ObjectAssertions` to `EnumAssertions` - [#1375](https://github.com/fluentassertions/fluentassertions/pull/1375).


### PR DESCRIPTION
I was triggered by reading #1353 that most XML assertion messages does not include variable name too.

So I've started reworking these assertions to
* include variable name
* provide some useful context information.

While reviewing the texts in the unit tests I found some messages which are misleading because the XmlValidator was following the subject instead of the expectation.

You may want to review the two commits separately.

I'll add changelog when the PR number is available...
Should these two commits result into two statements in the changelog?