### PR TITLE
When a dictionary does not a key, it should report the right path including the reason

### DIFF
--- a/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
@@ -262,7 +262,11 @@ namespace FluentAssertions.Equivalency
                 {
                     if (config.IsRecursive)
                     {
-                        parent.AssertEqualityUsing(context.AsDictionaryItem(key, subjectValue, expectation[key]));
+                        // Run the child assertion without affecting the current context
+                        using (new AssertionScope())
+                        {
+                            parent.AssertEqualityUsing(context.AsDictionaryItem(key, subjectValue, expectation[key]));
+                        }
                     }
                     else
                     {

--- a/Tests/FluentAssertions.Specs/Equivalency/DictionaryEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DictionaryEquivalencySpecs.cs
@@ -1060,6 +1060,30 @@ namespace FluentAssertions.Specs
         }
 
         [Fact]
+        public void When_a_dictionary_is_missing_a_key_it_should_report_the_specific_key()
+        {
+            // Arrange
+            var actual = new Dictionary<string,string>
+            {
+                { "a", "x" },
+                { "b", "x" },
+            };
+
+            var expected = new Dictionary<string,string>
+            {
+                { "a", "x" },
+                { "c", "x" }, // key mismatch
+            };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected actual*Dictionary*key*c*");
+        }
+
+        [Fact]
         public void When_a_nested_dictionary_value_doesnt_match_it_should_throw()
         {
             // Arrange

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 **What's New**
 
 **Fixes**
+* Sometimes `BeEquivalentTo` reported an incorrect message when a dictionary was missing a key - [1454](https://github.com/fluentassertions/fluentassertions/pull/1454)
 
 **Breaking Changes**
 


### PR DESCRIPTION
Sometimes BeEquivalentTo reported an incorrect message when a dictionary was missing a key.

Fixes #145