### PR TITLE
Cleanup (and C# 9.0 features)

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -28,7 +28,7 @@ namespace FluentAssertions
     [DebuggerNonUserCode]
     public static class AssertionExtensions
     {
-        private static readonly AggregateExceptionExtractor Extractor = new AggregateExceptionExtractor();
+        private static readonly AggregateExceptionExtractor Extractor = new();
 
         /// <summary>
         /// Invokes the specified action on a subject so that you can chain it

--- a/Src/FluentAssertions/AssertionOptions.cs
+++ b/Src/FluentAssertions/AssertionOptions.cs
@@ -9,7 +9,7 @@ namespace FluentAssertions
     /// </summary>
     public static class AssertionOptions
     {
-        private static EquivalencyAssertionOptions defaults = new EquivalencyAssertionOptions();
+        private static EquivalencyAssertionOptions defaults = new();
 
         static AssertionOptions()
         {

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -33,7 +33,7 @@ namespace FluentAssertions
 
                 int searchStart = allStackFrames.Length - 1;
 
-                if (StartStackSearchAfterStackFrame.Value != null)
+                if (StartStackSearchAfterStackFrame.Value is not null)
                 {
                     searchStart = Array.FindLastIndex(
                         allStackFrames,
@@ -55,7 +55,7 @@ namespace FluentAssertions
 
                     logger(frame.ToString());
 
-                    if (frame.GetMethod() is object
+                    if (frame.GetMethod() is not null
                         && !IsDynamic(frame)
                         && !IsDotNet(frame)
                         && !IsCustomAssertion(frame))
@@ -174,7 +174,7 @@ namespace FluentAssertions
             int column = frame.GetFileColumnNumber();
             string line = GetSourceCodeLineFrom(frame);
 
-            if ((line != null) && (column != 0) && (line.Length > 0))
+            if ((line is not null) && (column != 0) && (line.Length > 0))
             {
                 string statement = line.Substring(Math.Min(column - 1, line.Length - 1));
 
@@ -214,7 +214,7 @@ namespace FluentAssertions
                 string line;
                 int currentLine = 1;
 
-                while ((line = reader.ReadLine()) != null && currentLine < expectedLineNumber)
+                while ((line = reader.ReadLine()) is not null && currentLine < expectedLineNumber)
                 {
                     currentLine++;
                 }

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -25,7 +25,7 @@ namespace FluentAssertions
 
             try
             {
-                StackTrace stack = new StackTrace(fNeedFileInfo: true);
+                var stack = new StackTrace(fNeedFileInfo: true);
 
                 var allStackFrames = stack.GetFrames()
                     .Where(frame => !IsCompilerServices(frame))
@@ -108,7 +108,7 @@ namespace FluentAssertions
             }
         }
 
-        private static readonly AsyncLocal<StackFrameReference> StartStackSearchAfterStackFrame = new AsyncLocal<StackFrameReference>();
+        private static readonly AsyncLocal<StackFrameReference> StartStackSearchAfterStackFrame = new();
 
         internal static IDisposable OverrideStackSearchUsingCurrentScope()
         {
@@ -210,7 +210,7 @@ namespace FluentAssertions
 
             try
             {
-                using StreamReader reader = new StreamReader(File.OpenRead(fileName));
+                using var reader = new StreamReader(File.OpenRead(fileName));
                 string line;
                 int currentLine = 1;
 

--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -790,7 +790,7 @@ namespace FluentAssertions.Collections
             int index = 0;
             foreach (object item in Subject)
             {
-                if (!(item is T))
+                if (item is not T)
                 {
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)

--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -592,7 +592,7 @@ namespace FluentAssertions.Collections
         /// and the result is equal.
         /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
         /// </remarks>
-        /// <param name="expectation">An <see cref="IEnumerable{T}"/> with the expected elements.</param>
+        /// <param name="expectation">The expected element.</param>
         /// <param name="config">
         /// A reference to the <see cref="EquivalencyAssertionOptions{TSubject}"/> configuration object that can be used
         /// to influence the way the object graphs are compared. You can also provide an alternative instance of the
@@ -664,6 +664,7 @@ namespace FluentAssertions.Collections
         /// and the result is equal.
         /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
         /// </remarks>
+        /// <param name="unexpected">The unexpected element.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -686,6 +687,7 @@ namespace FluentAssertions.Collections
         /// and the result is equal.
         /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
         /// </remarks>
+        /// <param name="unexpected">The unexpected element.</param>
         /// <param name="config">
         /// A reference to the <see cref="EquivalencyAssertionOptions{TSubject}"/> configuration object that can be used
         /// to influence the way the object graphs are compared. You can also provide an alternative instance of the

--- a/Src/FluentAssertions/Collections/CollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/CollectionAssertions.cs
@@ -36,7 +36,7 @@ namespace FluentAssertions.Collections
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:collection} to be empty{reason}, ")
-                .ForCondition(!ReferenceEquals(Subject, null))
+                .ForCondition(Subject is not null)
                 .FailWith("but found {0}.", Subject)
                 .Then
                 .Given(() => Subject.Cast<object>())
@@ -60,7 +60,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -89,7 +89,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> BeNullOrEmpty(string because = "", params object[] becauseArgs)
         {
-            var nullOrEmpty = ReferenceEquals(Subject, null) || !Subject.Cast<object>().Any();
+            var nullOrEmpty = Subject is null || !Subject.Cast<object>().Any();
 
             Execute.Assertion.ForCondition(nullOrEmpty)
                 .BecauseOf(because, becauseArgs)
@@ -128,7 +128,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -173,7 +173,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -240,7 +240,7 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(equalityComparison, nameof(equalityComparison));
 
-            bool subjectIsNull = ReferenceEquals(Subject, null);
+            bool subjectIsNull = Subject is null;
             bool expectationIsNull = expectation is null;
             if (subjectIsNull && expectationIsNull)
             {
@@ -281,7 +281,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> NotEqual(IEnumerable unexpected, string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -492,7 +492,7 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot verify inequivalence against a <null> collection.");
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -535,7 +535,7 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot verify inequivalence against a <null> collection.");
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -611,7 +611,7 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(config, nameof(config));
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -706,7 +706,7 @@ namespace FluentAssertions.Collections
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject != null)
+                .ForCondition(Subject is not null)
                 .FailWith("Expected {context:collection} not to contain equivalent of {0}{reason}, but collection is <null>.", unexpected);
 
             EquivalencyAssertionOptions<TExpectation> options = config(AssertionOptions.CloneDefaults<TExpectation>());
@@ -777,7 +777,7 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> ContainItemsAssignableTo<T>(string because = "", params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -826,7 +826,7 @@ namespace FluentAssertions.Collections
                     nameof(expected));
             }
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -896,7 +896,7 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot verify ordered containment against a <null> collection.");
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -1100,7 +1100,7 @@ namespace FluentAssertions.Collections
         {
             string sortOrder = (expectedOrder == SortOrder.Ascending) ? "ascending" : "descending";
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -1216,7 +1216,7 @@ namespace FluentAssertions.Collections
         {
             string sortOrder = (order == SortOrder.Ascending) ? "ascending" : "descending";
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -1261,7 +1261,7 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(expectedSuperset, nameof(expectedSuperset), "Cannot verify a subset against a <null> collection.");
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -1301,7 +1301,7 @@ namespace FluentAssertions.Collections
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null))
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Cannot assert a <null> collection against a subset.");
 
@@ -1343,7 +1343,7 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot verify count against a <null> collection.");
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -1381,7 +1381,7 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot verify count against a <null> collection.");
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -1428,7 +1428,7 @@ namespace FluentAssertions.Collections
         public AndWhichConstraint<TAssertions, object> HaveElementAt(int index, object element, string because = "",
             params object[] becauseArgs)
         {
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -1480,7 +1480,7 @@ namespace FluentAssertions.Collections
                     nameof(unexpected));
             }
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -1537,7 +1537,7 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot verify intersection against a <null> collection.");
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -1576,7 +1576,7 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot verify intersection against a <null> collection.");
 
-            if (ReferenceEquals(Subject, null))
+            if (Subject is null)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
@@ -1833,7 +1833,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected type to be {0}{reason}, ", typeof(T).FullName)
                 .Given(() => Subject.Cast<object>())
-                .ForCondition(subject => subject.All(x => x != null))
+                .ForCondition(subject => subject.All(x => x is not null))
                 .FailWith("but found a null element.")
                 .Then
                 .ForCondition(subject => subject.All(x => typeof(T).IsAssignableFrom(GetType(x))))
@@ -1863,7 +1863,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected type to be {0}{reason}, ", expectedType.FullName)
                 .Given(() => Subject.Cast<object>())
-                .ForCondition(subject => subject.All(x => x != null))
+                .ForCondition(subject => subject.All(x => x is not null))
                 .FailWith("but found a null element.")
                 .Then
                 .ForCondition(subject => subject.All(x => expectedType.IsAssignableFrom(GetType(x))))
@@ -1891,7 +1891,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected type to be {0}{reason}, ", typeof(T).FullName)
                 .Given(() => Subject.Cast<object>())
-                .ForCondition(subject => subject.All(x => x != null))
+                .ForCondition(subject => subject.All(x => x is not null))
                 .FailWith("but found a null element.")
                 .Then
                 .ForCondition(subject => subject.All(x => typeof(T) == GetType(x)))
@@ -1921,7 +1921,7 @@ namespace FluentAssertions.Collections
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected type to be {0}{reason}, ", expectedType.FullName)
                 .Given(() => Subject.Cast<object>())
-                .ForCondition(subject => subject.All(x => x != null))
+                .ForCondition(subject => subject.All(x => x is not null))
                 .FailWith("but found a null element.")
                 .Then
                 .ForCondition(subject => subject.All(x => expectedType == GetType(x)))

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -496,7 +496,7 @@ namespace FluentAssertions.Collections
                 "Cannot assert collection ordering without specifying a property.");
 
             return Execute.Assertion
-                .ForCondition(!(Subject is null))
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} to be ordered by {0}{reason} but found <null>.",
                     propertyExpression.GetMemberPath());

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -537,6 +537,7 @@ namespace FluentAssertions.Collections
         /// items in the collection are structurally equal.
         /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
         /// </remarks>
+        /// <param name="expectation">The expected element.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -561,6 +562,7 @@ namespace FluentAssertions.Collections
         /// items in the collection are structurally equal.
         /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
         /// </remarks>
+        /// <param name="expectation">The expected element.</param>
         /// <param name="config">
         /// A reference to the <see cref="EquivalencyAssertionOptions{TExpectation}"/> configuration object that can be used
         /// to influence the way the object graphs are compared. You can also provide an alternative instance of the

--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -728,7 +728,7 @@ namespace FluentAssertions.Collections
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:collection} to satisfy all inspectors{reason}, ")
-                .ForCondition(!(Subject is null))
+                .ForCondition(Subject is not null)
                 .FailWith("but collection is <null>.")
                 .Then
                 .ForCondition(Subject.Any())

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -334,7 +334,7 @@ namespace FluentAssertions.Collections
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .FailWith("Expected {context:collection} to contain a match of {0}{reason}, but found <null>.", wildcardPattern)
                 .Then
                 .ForCondition(ContainsMatch(wildcardPattern))
@@ -388,7 +388,7 @@ namespace FluentAssertions.Collections
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .FailWith("Did not expect {context:collection} to contain a match of {0}{reason}, but found <null>.", wildcardPattern)
                 .Then
                 .ForCondition(NotContainsMatch(wildcardPattern))

--- a/Src/FluentAssertions/Common/Configuration.cs
+++ b/Src/FluentAssertions/Common/Configuration.cs
@@ -52,7 +52,7 @@ namespace FluentAssertions.Common
 
         private ValueFormatterDetectionMode DetermineFormatterDetectionMode()
         {
-            if (ValueFormatterAssembly != null)
+            if (ValueFormatterAssembly is not null)
             {
                 return ValueFormatterDetectionMode.Specific;
             }

--- a/Src/FluentAssertions/Common/Configuration.cs
+++ b/Src/FluentAssertions/Common/Configuration.cs
@@ -7,7 +7,7 @@ namespace FluentAssertions.Common
     {
         #region Private Definitions
 
-        private readonly object propertiesAccessLock = new object();
+        private readonly object propertiesAccessLock = new();
         private readonly IConfigurationStore store;
         private string valueFormatterAssembly;
         private ValueFormatterDetectionMode? valueFormatterDetectionMode;

--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -14,7 +14,7 @@ namespace FluentAssertions.Common
 
             MemberInfo memberInfo = AttemptToGetMemberInfoFromExpression(expression);
 
-            if (!(memberInfo is PropertyInfo propertyInfo))
+            if (memberInfo is not PropertyInfo propertyInfo)
             {
                 throw new ArgumentException("Cannot use <" + expression.Body + "> when a property expression is expected.",
                     nameof(expression));
@@ -79,7 +79,7 @@ namespace FluentAssertions.Common
 
                     case ExpressionType.Call:
                         var methodCallExpression = (MethodCallExpression)node;
-                        if (methodCallExpression.Method.Name != "get_Item" || methodCallExpression.Arguments.Count != 1 || !(methodCallExpression.Arguments[0] is ConstantExpression))
+                        if (methodCallExpression.Method.Name != "get_Item" || methodCallExpression.Arguments.Count != 1 || methodCallExpression.Arguments[0] is not ConstantExpression)
                         {
                             throw new ArgumentException(GetUnsupportedExpressionMessage(expression.Body), nameof(expression));
                         }

--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -41,7 +41,7 @@ namespace FluentAssertions.Common
             var declaringTypes = new List<Type>();
             Expression node = expression;
 
-            while (node != null)
+            while (node is not null)
             {
 #pragma warning disable IDE0010 // System.Linq.Expressions.ExpressionType has many members we do not care about
                 switch (node.NodeType)

--- a/Src/FluentAssertions/Common/InternalObjectExtensions.cs
+++ b/Src/FluentAssertions/Common/InternalObjectExtensions.cs
@@ -63,23 +63,22 @@ namespace FluentAssertions.Common
 
         private static bool IsNumericType(this object obj)
         {
-            switch (obj)
+            return obj switch
             {
-                case int _:
-                case long _:
-                case float _:
-                case double _:
-                case decimal _:
-                case sbyte _:
-                case byte _:
-                case short _:
-                case ushort _:
-                case uint _:
-                case ulong _:
-                    return true;
-                default:
-                    return false;
-            }
+                int or
+                long or
+                float or
+                double or
+                decimal or
+                sbyte or
+                byte or
+                short or
+                ushort or
+                uint or
+                ulong
+                  => true,
+                _ => false,
+            };
         }
     }
 }

--- a/Src/FluentAssertions/Common/Services.cs
+++ b/Src/FluentAssertions/Common/Services.cs
@@ -8,7 +8,7 @@ namespace FluentAssertions.Common
     /// </summary>
     public static class Services
     {
-        private static readonly object Lockable = new object();
+        private static readonly object Lockable = new();
         private static Configuration configuration;
 
         static Services()

--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -114,11 +114,12 @@ namespace FluentAssertions.Common
         /// <summary>
         /// Counts the number of times a substring appears within a string by using the specified <see cref="StringComparison"/>.
         /// </summary>
+        /// <param name="str">The string to search in.</param>
         /// <param name="substring">The substring to search for.</param>
         /// <param name="comparisonType">The <see cref="StringComparison"/> option to use for comparison.</param>
-        public static int CountSubstring(this string @this, string substring, StringComparison comparisonType)
+        public static int CountSubstring(this string str, string substring, StringComparison comparisonType)
         {
-            string actual = @this ?? string.Empty;
+            string actual = str ?? string.Empty;
             string search = substring ?? string.Empty;
 
             int count = 0;

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -461,7 +461,7 @@ namespace FluentAssertions.Common
             bool IsNamespacePrefix() => type.Namespace?.StartsWith(@namespace, StringComparison.Ordinal) == true;
         }
 
-        private static readonly Dictionary<Type, string> DefaultDictionary = new Dictionary<Type, string>
+        private static readonly Dictionary<Type, string> DefaultDictionary = new()
         {
             { typeof(int), "int" },
             { typeof(uint), "uint" },

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -153,7 +153,7 @@ namespace FluentAssertions.Common
             MethodInfo method = type
                 .GetMethod("Equals", new[] { typeof(object) });
 
-            return method != null
+            return method is not null
                    && method.GetBaseDefinition().DeclaringType != method.DeclaringType;
         }
 
@@ -294,7 +294,7 @@ namespace FluentAssertions.Common
         private static bool HasNonPrivateGetter(PropertyInfo propertyInfo)
         {
             MethodInfo getMethod = propertyInfo.GetGetMethod(nonPublic: true);
-            return getMethod != null && !getMethod.IsPrivate && !getMethod.IsFamily;
+            return getMethod is not null && !getMethod.IsPrivate && !getMethod.IsFamily;
         }
 
         /// <summary>
@@ -333,7 +333,7 @@ namespace FluentAssertions.Common
 
         public static bool HasMethod(this Type type, string methodName, IEnumerable<Type> parameterTypes)
         {
-            return type.GetMethod(methodName, parameterTypes) != null;
+            return type.GetMethod(methodName, parameterTypes) is not null;
         }
 
         public static MethodInfo GetParameterlessMethod(this Type type, string methodName)
@@ -343,7 +343,7 @@ namespace FluentAssertions.Common
 
         public static bool HasParameterlessMethod(this Type type, string methodName)
         {
-            return type.GetParameterlessMethod(methodName) != null;
+            return type.GetParameterlessMethod(methodName) is not null;
         }
 
         public static PropertyInfo GetPropertyByName(this Type type, string propertyName)
@@ -357,7 +357,7 @@ namespace FluentAssertions.Common
             bool hasSetter = type.GetMethods(AllMembersFlag)
                 .SingleOrDefault(m =>
                     m.Name == string.Format("{0}.set_{1}", interfaceType.FullName, propertyName) &&
-                    m.GetParameters().Length == 1) != null;
+                    m.GetParameters().Length == 1) is not null;
 
             return hasGetter || hasSetter;
         }
@@ -437,7 +437,7 @@ namespace FluentAssertions.Common
 
             // check subject and its base types against definition
             for (Type baseType = type;
-                baseType != null;
+                baseType is not null;
                 baseType = baseType.BaseType)
             {
                 if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == definition)

--- a/Src/FluentAssertions/Data/DataColumnAssertions.cs
+++ b/Src/FluentAssertions/Data/DataColumnAssertions.cs
@@ -113,7 +113,7 @@ namespace FluentAssertions.Data
         {
             Guard.ThrowIfArgumentIsNull(config, nameof(config));
 
-            var options = config(AssertionOptions.CloneDefaults<DataColumn, DataEquivalencyAssertionOptions<DataColumn>>());
+            IDataEquivalencyAssertionOptions<DataColumn> options = config(AssertionOptions.CloneDefaults<DataColumn, DataEquivalencyAssertionOptions<DataColumn>>());
 
             var callerIdentity = new Lazy<string>(CallerIdentifier.DetermineCallerIdentity);
 

--- a/Src/FluentAssertions/Data/DataColumnAssertions.cs
+++ b/Src/FluentAssertions/Data/DataColumnAssertions.cs
@@ -26,7 +26,7 @@ namespace FluentAssertions.Data
         /// </summary>
         /// <remarks>
         /// Data columns are equivalent when the following members have the same values:
-        /// 
+        ///
         /// <list type="bullet">
         ///   <item><description>AllowDBNull</description></item>
         ///   <item><description>AutoIncrement</description></item>
@@ -68,7 +68,7 @@ namespace FluentAssertions.Data
         /// </summary>
         /// <remarks>
         /// Data columns are equivalent when the following members have the same values:
-        /// 
+        ///
         /// <list type="bullet">
         ///   <item><description>AllowDBNull</description></item>
         ///   <item><description>AutoIncrement</description></item>
@@ -87,10 +87,10 @@ namespace FluentAssertions.Data
         ///   <item><description>ReadOnly</description></item>
         ///   <item><description>Unique</description></item>
         /// </list>
-        /// 
+        ///
         /// Testing of any property can be overridden using the <paramref name="config"/> callback. Exclude specific properties using
         /// <see cref="IDataEquivalencyAssertionOptions{T}.Excluding(System.Linq.Expressions.Expression{Func{T, object}})"/>.
-        /// 
+        ///
         /// If <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingColumn(DataColumn)"/> or a related function is
         /// used and the exclusion matches the subject <see cref="DataColumn"/>, then the equivalency test will never
         /// fail.

--- a/Src/FluentAssertions/Data/DataEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Data/DataEquivalencyAssertionOptions.cs
@@ -13,9 +13,9 @@ namespace FluentAssertions.Data
     internal class DataEquivalencyAssertionOptions<T> : EquivalencyAssertionOptions<T>, IDataEquivalencyAssertionOptions<T>
 #pragma warning restore CA1812
     {
-        private readonly HashSet<string> excludeTableNames = new HashSet<string>();
-        private readonly HashSet<string> excludeColumnNames = new HashSet<string>();
-        private readonly Dictionary<string, HashSet<string>> excludeColumnNamesByTableName = new Dictionary<string, HashSet<string>>();
+        private readonly HashSet<string> excludeTableNames = new();
+        private readonly HashSet<string> excludeColumnNames = new();
+        private readonly Dictionary<string, HashSet<string>> excludeColumnNamesByTableName = new();
 
         private bool allowMismatchedTypes;
         private bool ignoreUnmatchedColumns;

--- a/Src/FluentAssertions/Data/DataRowAssertions.cs
+++ b/Src/FluentAssertions/Data/DataRowAssertions.cs
@@ -178,7 +178,7 @@ namespace FluentAssertions.Data
         {
             Guard.ThrowIfArgumentIsNull(config, nameof(config));
 
-            var options = config(AssertionOptions.CloneDefaults<DataRow, DataEquivalencyAssertionOptions<DataRow>>());
+            IDataEquivalencyAssertionOptions<DataRow> options = config(AssertionOptions.CloneDefaults<DataRow, DataEquivalencyAssertionOptions<DataRow>>());
 
             var callerIdentity = new Lazy<string>(CallerIdentifier.DetermineCallerIdentity);
 

--- a/Src/FluentAssertions/Data/DataRowAssertions.cs
+++ b/Src/FluentAssertions/Data/DataRowAssertions.cs
@@ -105,12 +105,12 @@ namespace FluentAssertions.Data
         /// <remarks>
         /// Data rows are equivalent when they contain identical field data for the row they represent, and
         /// the following members have the same values:
-        /// 
+        ///
         /// <list type="bullet">
         ///   <item><description>HasErrors</description></item>
         ///   <item><description>RowState</description></item>
         /// </list>
-        /// 
+        ///
         /// The <see cref="DataRow"/> objects must be of the same type; if two <see cref="DataRow"/> objects
         /// are equivalent in all ways, except that one is part of a typed <see cref="DataTable"/> and is of a subclass
         /// of <see cref="DataRow"/>, then by default, they will not be considered equivalent. This can be overridden
@@ -140,16 +140,16 @@ namespace FluentAssertions.Data
         /// <remarks>
         /// Data rows are equivalent when they contain identical field data for the row they represent, and
         /// the following members have the same values:
-        /// 
+        ///
         /// <list type="bullet">
         ///   <item><description>HasErrors</description></item>
         ///   <item><description>RowState</description></item>
         /// </list>
-        /// 
+        ///
         /// The <see cref="DataRow"/> objects must be of the same type; if two <see cref="DataRow"/> objects
         /// are equivalent in all ways, except that one is part of a typed <see cref="DataTable"/> and is of a subclass
         /// of <see cref="DataRow"/>, then by default, they will not be considered equivalent.
-        /// 
+        ///
         /// This, as well as testing of any property can be overridden using the <paramref name="config"/> callback.
         /// By calling <see cref="IDataEquivalencyAssertionOptions{T}.AllowingMismatchedTypes"/>, two <see cref="DataRow"/>
         /// objects of differing types can be considered equivalent. Exclude specific properties using
@@ -157,7 +157,7 @@ namespace FluentAssertions.Data
         /// Exclude columns of the data table (which also excludes the related field data in <see cref="DataRow"/>
         /// objects) using <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingColumn(DataColumn)"/> or a related function.
         /// </remarks>
-        /// 
+        ///
         /// You can use <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingRelated(System.Linq.Expressions.Expression{Func{DataTable, object}})"/>
         /// and related functions to exclude properties on other related System.Data types.
         /// <param name="expectation">A <see cref="DataColumn"/> with the expected configuration.</param>

--- a/Src/FluentAssertions/Data/DataSetAssertions.cs
+++ b/Src/FluentAssertions/Data/DataSetAssertions.cs
@@ -230,7 +230,7 @@ namespace FluentAssertions.Data
         {
             Guard.ThrowIfArgumentIsNull(config, nameof(config));
 
-            var options = config(AssertionOptions.CloneDefaults<DataSet, DataEquivalencyAssertionOptions<DataSet>>());
+            IDataEquivalencyAssertionOptions<DataSet> options = config(AssertionOptions.CloneDefaults<DataSet, DataEquivalencyAssertionOptions<DataSet>>());
 
             var callerIdentity = new Lazy<string>(CallerIdentifier.DetermineCallerIdentity);
 

--- a/Src/FluentAssertions/Data/DataSetAssertions.cs
+++ b/Src/FluentAssertions/Data/DataSetAssertions.cs
@@ -135,7 +135,7 @@ namespace FluentAssertions.Data
         /// <remarks>
         /// Data sets are equivalent when their <see cref="DataSet.Tables"/> and <see cref="DataSet.ExtendedProperties"/>
         /// collections are equivalent and the following members have the same values:
-        /// 
+        ///
         /// <list type="bullet">
         ///   <item><description>DataSetName</description></item>
         ///   <item><description>CaseSensitive</description></item>
@@ -147,7 +147,7 @@ namespace FluentAssertions.Data
         ///   <item><description>RemotingFormat</description></item>
         ///   <item><description>SchemaSerializationMode</description></item>
         /// </list>
-        /// 
+        ///
         /// The <see cref="DataSet"/> objects must be of the same type; if two <see cref="DataSet"/> objects
         /// are equivalent in all ways, except that one is a custom subclass of <see cref="DataSet"/> (e.g. to provide
         /// typed accessors for <see cref="DataTable"/> values contained by the <see cref="DataSet"/>), then by default,
@@ -178,7 +178,7 @@ namespace FluentAssertions.Data
         /// <remarks>
         /// Data sets are equivalent when their <see cref="DataSet.Tables"/> and <see cref="DataSet.ExtendedProperties"/>
         /// collections are equivalent and the following members have the same values:
-        /// 
+        ///
         /// <list type="bullet">
         ///   <item><description>DataSetName</description></item>
         ///   <item><description>CaseSensitive</description></item>
@@ -190,12 +190,12 @@ namespace FluentAssertions.Data
         ///   <item><description>RemotingFormat</description></item>
         ///   <item><description>SchemaSerializationMode</description></item>
         /// </list>
-        /// 
+        ///
         /// The <see cref="DataSet"/> objects must be of the same type; if two <see cref="DataSet"/> objects
         /// are equivalent in all ways, except that one is a custom subclass of <see cref="DataSet"/> (e.g. to provide
         /// typed accessors for <see cref="DataTable"/> values contained by the <see cref="DataSet"/>), then by default,
         /// they will not be considered equivalent.
-        /// 
+        ///
         /// This, as well as testing of any property can be overridden using the <paramref name="config"/> callback.
         /// By calling <see cref="IDataEquivalencyAssertionOptions{T}.AllowingMismatchedTypes"/>, two <see cref="DataSet"/>
         /// objects of differing types can be considered equivalent. This setting applies to all types recursively tested
@@ -208,7 +208,7 @@ namespace FluentAssertions.Data
         /// or a related function. The <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingColumnInAllTables(string)"/> method
         /// can be used to exclude columns across all <see cref="DataTable"/> objects in the <see cref="DataSet"/> that share
         /// the same name.
-        /// 
+        ///
         /// You can use <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingRelated(System.Linq.Expressions.Expression{Func{DataTable, object}})"/>
         /// and related functions to exclude properties on other related System.Data types.
         /// </remarks>

--- a/Src/FluentAssertions/Data/DataTableAssertions.cs
+++ b/Src/FluentAssertions/Data/DataTableAssertions.cs
@@ -134,7 +134,7 @@ namespace FluentAssertions.Data
         /// </summary>
         /// <remarks>
         /// Data tables are equivalent when the following members have the same values:
-        /// 
+        ///
         /// <list type="bullet">
         ///   <item><description>TableName</description></item>
         ///   <item><description>CaseSensitive</description></item>
@@ -145,9 +145,9 @@ namespace FluentAssertions.Data
         ///   <item><description>Prefix</description></item>
         ///   <item><description>RemotingFormat</description></item>
         /// </list>
-        /// 
+        ///
         /// In addition, the following collections must contain equivalent data:
-        /// 
+        ///
         /// <list type="type=bullet">
         ///   <item><description>ChildRelations</description></item>
         ///   <item><description>Columns</description></item>
@@ -157,7 +157,7 @@ namespace FluentAssertions.Data
         ///   <item><description>PrimaryKey</description></item>
         ///   <item><description>Rows</description></item>
         /// </list>
-        /// 
+        ///
         /// The <see cref="DataTable"/> objects must be of the same type; if two <see cref="DataTable"/> objects
         /// are equivalent in all ways, except that one is a typed <see cref="DataTable"/> that is a subclass
         /// of <see cref="DataTable"/>, then by default, they will not be considered equivalent. This can be overridden
@@ -186,7 +186,7 @@ namespace FluentAssertions.Data
         /// </summary>
         /// <remarks>
         /// Data tables are equivalent when the following members have the same values:
-        /// 
+        ///
         /// <list type="bullet">
         ///   <item><description>TableName</description></item>
         ///   <item><description>CaseSensitive</description></item>
@@ -197,9 +197,9 @@ namespace FluentAssertions.Data
         ///   <item><description>Prefix</description></item>
         ///   <item><description>RemotingFormat</description></item>
         /// </list>
-        /// 
+        ///
         /// In addition, the following collections must contain equivalent data:
-        /// 
+        ///
         /// <list type="type=bullet">
         ///   <item><description>ChildRelations</description></item>
         ///   <item><description>Columns</description></item>
@@ -209,11 +209,11 @@ namespace FluentAssertions.Data
         ///   <item><description>PrimaryKey</description></item>
         ///   <item><description>Rows</description></item>
         /// </list>
-        /// 
+        ///
         /// The <see cref="DataTable"/> objects must be of the same type; if two <see cref="DataTable"/> objects
         /// are equivalent in all ways, except that one is a typed <see cref="DataTable"/> that is a subclass
         /// of <see cref="DataTable"/>, then by default, they will not be considered equivalent.
-        /// 
+        ///
         /// This, as well as testing of any property can be overridden using the <paramref name="config"/> callback.
         /// By calling <see cref="IDataEquivalencyAssertionOptions{T}.AllowingMismatchedTypes"/>, two <see cref="DataTable"/>
         /// objects of differing types can be considered equivalent. Exclude specific properties using
@@ -221,7 +221,7 @@ namespace FluentAssertions.Data
         /// Exclude columns of the data table using <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingColumn(DataColumn)"/>
         /// or a related function -- this excludes both the <see cref="DataColumn"/> objects in <see cref="DataTable.Columns"/>
         /// and associated field data in <see cref="DataRow"/> objects within the <see cref="DataTable"/>.
-        /// 
+        ///
         /// You can use <see cref="IDataEquivalencyAssertionOptions{T}.ExcludingRelated(System.Linq.Expressions.Expression{Func{DataTable, object}})"/>
         /// and related functions to exclude properties on other related System.Data types.
         /// </remarks>

--- a/Src/FluentAssertions/Data/DataTableAssertions.cs
+++ b/Src/FluentAssertions/Data/DataTableAssertions.cs
@@ -243,7 +243,7 @@ namespace FluentAssertions.Data
         {
             Guard.ThrowIfArgumentIsNull(config, nameof(config));
 
-            var options = config(AssertionOptions.CloneDefaults<DataTable, DataEquivalencyAssertionOptions<DataTable>>());
+            IDataEquivalencyAssertionOptions<DataTable> options = config(AssertionOptions.CloneDefaults<DataTable, DataEquivalencyAssertionOptions<DataTable>>());
 
             var callerIdentity = new Lazy<string>(CallerIdentifier.DetermineCallerIdentity);
 

--- a/Src/FluentAssertions/Equivalency/AssertionContext.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionContext.cs
@@ -24,7 +24,7 @@ namespace FluentAssertions.Equivalency
 
         internal static AssertionContext<TSubject> CreateFromEquivalencyValidationContext(IEquivalencyValidationContext context)
         {
-            TSubject expectation = (context.Expectation != null) ? (TSubject)context.Expectation : default;
+            TSubject expectation = (context.Expectation is not null) ? (TSubject)context.Expectation : default;
 
             return new AssertionContext<TSubject>(
                 context.CurrentNode,

--- a/Src/FluentAssertions/Equivalency/AssertionResultSet.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionResultSet.cs
@@ -9,7 +9,7 @@ namespace FluentAssertions.Equivalency
     /// </summary>
     internal class AssertionResultSet
     {
-        private readonly Dictionary<object, string[]> set = new Dictionary<object, string[]>();
+        private readonly Dictionary<object, string[]> set = new();
 
         /// <summary>
         /// Adds the failures (if any) resulting from executing an assertion within a

--- a/Src/FluentAssertions/Equivalency/AssertionRuleEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionRuleEquivalencyStep.cs
@@ -11,7 +11,7 @@ namespace FluentAssertions.Equivalency
         private readonly Func<IObjectInfo, bool> predicate;
         private readonly string description;
         private readonly Action<IAssertionContext<TSubject>> assertion;
-        private readonly AutoConversionStep converter = new AutoConversionStep();
+        private readonly AutoConversionStep converter = new();
 
         public AssertionRuleEquivalencyStep(
             Expression<Func<IObjectInfo, bool>> predicate,

--- a/Src/FluentAssertions/Equivalency/ConstraintCollectionEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/ConstraintCollectionEquivalencyStep.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Data;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 using FluentAssertions.Execution;
@@ -14,10 +13,9 @@ namespace FluentAssertions.Equivalency
             return typeof(ConstraintCollection).IsAssignableFrom(config.GetExpectationType(context.RuntimeType, context.CompileTimeType));
         }
 
-        [SuppressMessage("Style", "IDE0038:Use pattern matching", Justification = "Would decrease code clarity")]
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
         {
-            if (!(context.Subject is ConstraintCollection))
+            if (context.Subject is not ConstraintCollection)
             {
                 AssertionScope.Current
                     .FailWith("Expected a value of type ConstraintCollection at {context:Constraints}, but found {0}", context.Subject.GetType());

--- a/Src/FluentAssertions/Equivalency/ConstraintCollectionEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/ConstraintCollectionEquivalencyStep.cs
@@ -1,4 +1,5 @@
-﻿using System.Data;
+﻿using System.Collections.Generic;
+using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
@@ -29,21 +30,21 @@ namespace FluentAssertions.Equivalency
                 var subjectConstraints = subject.Cast<Constraint>().ToDictionary(constraint => constraint.ConstraintName);
                 var expectationConstraints = expectation.Cast<Constraint>().ToDictionary(constraint => constraint.ConstraintName);
 
-                var constraintNames = subjectConstraints.Keys.Union(expectationConstraints.Keys);
+                IEnumerable<string> constraintNames = subjectConstraints.Keys.Union(expectationConstraints.Keys);
 
                 foreach (var constraintName in constraintNames)
                 {
                     AssertionScope.Current
-                        .ForCondition(subjectConstraints.TryGetValue(constraintName, out var subjectConstraint))
+                        .ForCondition(subjectConstraints.TryGetValue(constraintName, out Constraint subjectConstraint))
                         .FailWith("Expected constraint named {0} in {context:Constraints collection}{reason}, but did not find one", constraintName);
 
                     AssertionScope.Current
-                        .ForCondition(expectationConstraints.TryGetValue(constraintName, out var expectationConstraint))
+                        .ForCondition(expectationConstraints.TryGetValue(constraintName, out Constraint expectationConstraint))
                         .FailWith("Found unexpected constraint named {0} in {context:Constraints collection}", constraintName);
 
                     if ((subjectConstraint != null) && (expectationConstraint != null))
                     {
-                        var nestedContext = context.AsCollectionItem(
+                        IEquivalencyValidationContext nestedContext = context.AsCollectionItem(
                             constraintName,
                             subjectConstraint,
                             expectationConstraint);

--- a/Src/FluentAssertions/Equivalency/ConstraintCollectionEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/ConstraintCollectionEquivalencyStep.cs
@@ -42,14 +42,14 @@ namespace FluentAssertions.Equivalency
                         .ForCondition(expectationConstraints.TryGetValue(constraintName, out Constraint expectationConstraint))
                         .FailWith("Found unexpected constraint named {0} in {context:Constraints collection}", constraintName);
 
-                    if ((subjectConstraint != null) && (expectationConstraint != null))
+                    if ((subjectConstraint is not null) && (expectationConstraint is not null))
                     {
                         IEquivalencyValidationContext nestedContext = context.AsCollectionItem(
                             constraintName,
                             subjectConstraint,
                             expectationConstraint);
 
-                        if (nestedContext != null)
+                        if (nestedContext is not null)
                         {
                             parent.AssertEqualityUsing(nestedContext);
                         }

--- a/Src/FluentAssertions/Equivalency/ConstraintEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/ConstraintEquivalencyStep.cs
@@ -15,10 +15,9 @@ namespace FluentAssertions.Equivalency
             return typeof(Constraint).IsAssignableFrom(config.GetExpectationType(context.RuntimeType, context.CompileTimeType));
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0038:Use pattern matching", Justification = "Would decrease code clarity")]
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
         {
-            if (!(context.Subject is Constraint))
+            if (context.Subject is not Constraint)
             {
                 AssertionScope.Current
                     .FailWith("Expected {context:constraint} to be a value of type Constraint, but found {0}", context.Subject.GetType());

--- a/Src/FluentAssertions/Equivalency/ConstraintEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/ConstraintEquivalencyStep.cs
@@ -82,12 +82,12 @@ namespace FluentAssertions.Equivalency
             {
                 IMember matchingMember = FindMatchFor(expectationMember, context, config);
 
-                if (matchingMember != null)
+                if (matchingMember is not null)
                 {
                     IEquivalencyValidationContext nestedContext =
                         context.AsNestedMember(expectationMember, matchingMember);
 
-                    if (nestedContext != null)
+                    if (nestedContext is not null)
                     {
                         parent.AssertEqualityUsing(nestedContext);
                     }
@@ -233,7 +233,7 @@ namespace FluentAssertions.Equivalency
             IEnumerable<IMember> query =
                 from rule in config.MatchingRules
                 let match = rule.Match(selectedMemberInfo, context.Subject, context.CurrentNode, config)
-                where match != null
+                where match is not null
                 select match;
 
             return query.FirstOrDefault();

--- a/Src/FluentAssertions/Equivalency/ConstraintEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/ConstraintEquivalencyStep.cs
@@ -78,9 +78,9 @@ namespace FluentAssertions.Equivalency
                     .FailWith("Expected {context:constraint} to be associated with a Table with TableName of {0}{reason}, but found {1}", expectation.Table.TableName, subject.Table.TableName);
             }
 
-            if (selectedMembers.TryGetValue("ExtendedProperties", out var expectationMember))
+            if (selectedMembers.TryGetValue("ExtendedProperties", out IMember expectationMember))
             {
-                var matchingMember = FindMatchFor(expectationMember, context, config);
+                IMember matchingMember = FindMatchFor(expectationMember, context, config);
 
                 if (matchingMember != null)
                 {

--- a/Src/FluentAssertions/Equivalency/ConversionSelector.cs
+++ b/Src/FluentAssertions/Equivalency/ConversionSelector.cs
@@ -25,8 +25,8 @@ namespace FluentAssertions.Equivalency
             }
         }
 
-        private List<ConversionSelectorRule> inclusions = new List<ConversionSelectorRule>();
-        private List<ConversionSelectorRule> exclusions = new List<ConversionSelectorRule>();
+        private List<ConversionSelectorRule> inclusions = new();
+        private List<ConversionSelectorRule> exclusions = new();
 
         public void IncludeAll()
         {
@@ -65,7 +65,7 @@ namespace FluentAssertions.Equivalency
                 return "Without automatic conversion.";
             }
 
-            StringBuilder descriptionBuilder = new StringBuilder();
+            var descriptionBuilder = new StringBuilder();
 
             foreach (ConversionSelectorRule inclusion in inclusions)
             {

--- a/Src/FluentAssertions/Equivalency/CyclicReferenceDetector.cs
+++ b/Src/FluentAssertions/Equivalency/CyclicReferenceDetector.cs
@@ -13,7 +13,7 @@ namespace FluentAssertions.Equivalency
         #region Private Definitions
 
         private readonly CyclicReferenceHandling handling;
-        private HashSet<ObjectReference> observedReferences = new HashSet<ObjectReference>();
+        private HashSet<ObjectReference> observedReferences = new();
 
         #endregion
 

--- a/Src/FluentAssertions/Equivalency/DataColumnEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataColumnEquivalencyStep.cs
@@ -20,18 +20,18 @@ namespace FluentAssertions.Equivalency
             var subject = context.Subject as DataColumn;
             var expectation = context.Expectation as DataColumn;
 
-            if (expectation == null)
+            if (expectation is null)
             {
-                if (subject != null)
+                if (subject is not null)
                 {
                     AssertionScope.Current.FailWith("Expected {context:DataColumn} value to be null, but found {0}", subject);
                 }
             }
             else
             {
-                if (subject == null)
+                if (subject is null)
                 {
-                    if (context.Subject == null)
+                    if (context.Subject is null)
                     {
                         AssertionScope.Current.FailWith("Expected {context:DataColumn} to be non-null, but found null");
                     }
@@ -57,9 +57,9 @@ namespace FluentAssertions.Equivalency
             var dataTableConfig = config as DataEquivalencyAssertionOptions<DataTable>;
             var dataColumnConfig = config as DataEquivalencyAssertionOptions<DataColumn>;
 
-            if (((dataSetConfig != null) && dataSetConfig.ShouldExcludeColumn(subject))
-             || ((dataTableConfig != null) && dataTableConfig.ShouldExcludeColumn(subject))
-             || ((dataColumnConfig != null) && dataColumnConfig.ShouldExcludeColumn(subject)))
+            if (((dataSetConfig is not null) && dataSetConfig.ShouldExcludeColumn(subject))
+             || ((dataTableConfig is not null) && dataTableConfig.ShouldExcludeColumn(subject))
+             || ((dataColumnConfig is not null) && dataColumnConfig.ShouldExcludeColumn(subject)))
             {
                 compareColumn = false;
             }
@@ -80,12 +80,12 @@ namespace FluentAssertions.Equivalency
         {
             IMember matchingMember = FindMatchFor(expectationMember, context, config);
 
-            if (matchingMember != null)
+            if (matchingMember is not null)
             {
                 IEquivalencyValidationContext nestedContext =
                             context.AsNestedMember(expectationMember, matchingMember);
 
-                if (nestedContext != null)
+                if (nestedContext is not null)
                 {
                     parent.AssertEqualityUsing(nestedContext);
                 }
@@ -97,7 +97,7 @@ namespace FluentAssertions.Equivalency
             IEnumerable<IMember> query =
                 from rule in config.MatchingRules
                 let match = rule.Match(selectedMemberInfo, context.Subject, context.CurrentNode, config)
-                where match != null
+                where match is not null
                 select match;
 
             return query.FirstOrDefault();

--- a/Src/FluentAssertions/Equivalency/DataColumnEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataColumnEquivalencyStep.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Data;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 using FluentAssertions.Data;
@@ -14,7 +15,7 @@ namespace FluentAssertions.Equivalency
             return typeof(DataColumn).IsAssignableFrom(config.GetExpectationType(context.RuntimeType, context.CompileTimeType));
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
+        [SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
         {
             var subject = context.Subject as DataColumn;

--- a/Src/FluentAssertions/Equivalency/DataColumnEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataColumnEquivalencyStep.cs
@@ -66,7 +66,7 @@ namespace FluentAssertions.Equivalency
 
             if (compareColumn)
             {
-                foreach (var expectationMember in GetMembersFromExpectation(context, config))
+                foreach (IMember expectationMember in GetMembersFromExpectation(context, config))
                 {
                     if (expectationMember.Name != nameof(subject.Table))
                     {
@@ -78,7 +78,7 @@ namespace FluentAssertions.Equivalency
 
         private static void CompareMember(IMember expectationMember, IEquivalencyValidator parent, IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
         {
-            var matchingMember = FindMatchFor(expectationMember, context, config);
+            IMember matchingMember = FindMatchFor(expectationMember, context, config);
 
             if (matchingMember != null)
             {

--- a/Src/FluentAssertions/Equivalency/DataRelationEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRelationEquivalencyStep.cs
@@ -47,7 +47,7 @@ namespace FluentAssertions.Equivalency
 
                     CompareScalarProperties(subject, expectation, selectedMembers);
 
-                    CompareCollections(context, parent, config, expectation, selectedMembers);
+                    CompareCollections(context, parent, config, selectedMembers);
 
                     CompareRelationConstraints(context, parent, config, subject, expectation, selectedMembers);
                 }
@@ -83,9 +83,9 @@ namespace FluentAssertions.Equivalency
             }
         }
 
-        private static void CompareCollections(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config, DataRelation expectation, Dictionary<string, IMember> selectedMembers)
+        private static void CompareCollections(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config, Dictionary<string, IMember> selectedMembers)
         {
-            if (selectedMembers.TryGetValue(nameof(expectation.ExtendedProperties), out IMember expectationMember))
+            if (selectedMembers.TryGetValue(nameof(DataRelation.ExtendedProperties), out IMember expectationMember))
             {
                 IMember matchingMember = FindMatchFor(expectationMember, context, config);
 

--- a/Src/FluentAssertions/Equivalency/DataRelationEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRelationEquivalencyStep.cs
@@ -20,18 +20,18 @@ namespace FluentAssertions.Equivalency
             var subject = context.Subject as DataRelation;
             var expectation = context.Expectation as DataRelation;
 
-            if (expectation == null)
+            if (expectation is null)
             {
-                if (subject != null)
+                if (subject is not null)
                 {
                     AssertionScope.Current.FailWith("Expected {context:DataRelation} to be null, but found {0}", subject);
                 }
             }
             else
             {
-                if (subject == null)
+                if (subject is null)
                 {
-                    if (context.Subject == null)
+                    if (context.Subject is null)
                     {
                         AssertionScope.Current.FailWith("Expected {context:DataRelation} value to be non-null, but found null");
                     }
@@ -89,12 +89,12 @@ namespace FluentAssertions.Equivalency
             {
                 IMember matchingMember = FindMatchFor(expectationMember, context, config);
 
-                if (matchingMember != null)
+                if (matchingMember is not null)
                 {
                     IEquivalencyValidationContext nestedContext =
                             context.AsNestedMember(expectationMember, matchingMember);
 
-                    if (nestedContext != null)
+                    if (nestedContext is not null)
                     {
                         parent.AssertEqualityUsing(nestedContext);
                     }
@@ -197,7 +197,7 @@ namespace FluentAssertions.Equivalency
 
                 IEquivalencyValidationContext nestedContext = context.AsNestedMember(expectationMember, subjectMember);
 
-                if (nestedContext != null)
+                if (nestedContext is not null)
                 {
                     parent.AssertEqualityUsing(nestedContext);
                 }
@@ -209,7 +209,7 @@ namespace FluentAssertions.Equivalency
             IEnumerable<IMember> query =
                 from rule in config.MatchingRules
                 let match = rule.Match(selectedMemberInfo, context.Subject, context.CurrentNode, config)
-                where match != null
+                where match is not null
                 select match;
 
             return query.FirstOrDefault();

--- a/Src/FluentAssertions/Equivalency/DataRelationEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRelationEquivalencyStep.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 using FluentAssertions.Execution;
@@ -14,7 +15,7 @@ namespace FluentAssertions.Equivalency
             return typeof(DataRelation).IsAssignableFrom(config.GetExpectationType(context.RuntimeType, context.CompileTimeType));
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
+        [SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
         {
             var subject = context.Subject as DataRelation;

--- a/Src/FluentAssertions/Equivalency/DataRelationEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRelationEquivalencyStep.cs
@@ -85,9 +85,9 @@ namespace FluentAssertions.Equivalency
 
         private static void CompareCollections(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config, DataRelation expectation, Dictionary<string, IMember> selectedMembers)
         {
-            if (selectedMembers.TryGetValue(nameof(expectation.ExtendedProperties), out var expectationMember))
+            if (selectedMembers.TryGetValue(nameof(expectation.ExtendedProperties), out IMember expectationMember))
             {
-                var matchingMember = FindMatchFor(expectationMember, context, config);
+                IMember matchingMember = FindMatchFor(expectationMember, context, config);
 
                 if (matchingMember != null)
                 {
@@ -148,8 +148,8 @@ namespace FluentAssertions.Equivalency
 
         private static void CompareDataRelationColumns(DataRelation subject, DataRelation expectation, Func<DataRelation, DataColumn[]> getColumns)
         {
-            var subjectColumns = getColumns(subject);
-            var expectationColumns = getColumns(expectation);
+            DataColumn[] subjectColumns = getColumns(subject);
+            DataColumn[] expectationColumns = getColumns(expectation);
 
             // These column references are in different tables in different data sets that _should_ be equivalent
             // to one another.
@@ -161,8 +161,8 @@ namespace FluentAssertions.Equivalency
             {
                 for (int i = 0; i < expectationColumns.Length; i++)
                 {
-                    var subjectColumn = subjectColumns[i];
-                    var expectationColumn = expectationColumns[i];
+                    DataColumn subjectColumn = subjectColumns[i];
+                    DataColumn expectationColumn = expectationColumns[i];
 
                     bool columnsAreEquivalent =
                         (subjectColumn.Table.TableName == expectationColumn.Table.TableName) &&
@@ -181,8 +181,8 @@ namespace FluentAssertions.Equivalency
 
         private static void CompareDataRelationTable(DataRelation subject, DataRelation expectation, Func<DataRelation, DataTable> getOtherTable)
         {
-            var subjectTable = getOtherTable(subject);
-            var expectationTable = getOtherTable(expectation);
+            DataTable subjectTable = getOtherTable(subject);
+            DataTable expectationTable = getOtherTable(expectation);
 
             AssertionScope.Current
                 .ForCondition(subjectTable.TableName == expectationTable.TableName)
@@ -191,11 +191,11 @@ namespace FluentAssertions.Equivalency
 
         private static void CompareDataRelationKeyConstraint(IEquivalencyValidator parent, IEquivalencyValidationContext context, IEquivalencyAssertionOptions config, Dictionary<string, IMember> selectedMembers, string relationDirection)
         {
-            if (selectedMembers.TryGetValue(relationDirection + "KeyConstraint", out var expectationMember))
+            if (selectedMembers.TryGetValue(relationDirection + "KeyConstraint", out IMember expectationMember))
             {
-                var subjectMember = FindMatchFor(expectationMember, context, config);
+                IMember subjectMember = FindMatchFor(expectationMember, context, config);
 
-                var nestedContext = context.AsNestedMember(expectationMember, subjectMember);
+                IEquivalencyValidationContext nestedContext = context.AsNestedMember(expectationMember, subjectMember);
 
                 if (nestedContext != null)
                 {

--- a/Src/FluentAssertions/Equivalency/DataRowCollectionEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRowCollectionEquivalencyStep.cs
@@ -14,10 +14,9 @@ namespace FluentAssertions.Equivalency
             return typeof(DataRowCollection).IsAssignableFrom(config.GetExpectationType(context.RuntimeType, context.CompileTimeType));
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0038:Use pattern matching", Justification = "Would decrease code clarity")]
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
         {
-            if (!(context.Subject is DataRowCollection))
+            if (context.Subject is not DataRowCollection)
             {
                 AssertionScope.Current
                     .FailWith("Expected {context:value} to be of type DataRowCollection, but found {0}", context.Subject.GetType());

--- a/Src/FluentAssertions/Equivalency/DataRowCollectionEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRowCollectionEquivalencyStep.cs
@@ -70,7 +70,7 @@ namespace FluentAssertions.Equivalency
                     subject[i],
                     expectation[i]);
 
-                if (nestedContext != null)
+                if (nestedContext is not null)
                 {
                     parent.AssertEqualityUsing(nestedContext);
                 }
@@ -104,7 +104,7 @@ namespace FluentAssertions.Equivalency
         {
             Type[] primaryKeyTypes = null;
 
-            if ((table.PrimaryKey == null) || (table.PrimaryKey.Length == 0))
+            if ((table.PrimaryKey is null) || (table.PrimaryKey.Length == 0))
             {
                 AssertionScope.Current
                     .FailWith("Table '{0}' containing {1} {context:DataRowCollection} does not have a primary key. RowMatchMode.PrimaryKey cannot be applied.", table.TableName, comparisonTerm);
@@ -126,7 +126,7 @@ namespace FluentAssertions.Equivalency
         {
             bool matchingTypes = false;
 
-            if ((subjectPrimaryKeyTypes != null) && (expectationPrimaryKeyTypes != null))
+            if ((subjectPrimaryKeyTypes is not null) && (expectationPrimaryKeyTypes is not null))
             {
                 matchingTypes = subjectPrimaryKeyTypes.Length == expectationPrimaryKeyTypes.Length;
 
@@ -171,7 +171,7 @@ namespace FluentAssertions.Equivalency
                         subjectRow,
                         expectationRow);
 
-                    if (nestedContext != null)
+                    if (nestedContext is not null)
                     {
                         parent.AssertEqualityUsing(nestedContext);
                     }
@@ -204,7 +204,7 @@ namespace FluentAssertions.Equivalency
 
             public bool Equals(CompoundKey other)
             {
-                if (other == null)
+                if (other is null)
                 {
                     return false;
                 }

--- a/Src/FluentAssertions/Equivalency/DataRowCollectionEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRowCollectionEquivalencyStep.cs
@@ -65,7 +65,7 @@ namespace FluentAssertions.Equivalency
         {
             for (int i = 0; i < expectation.Count; i++)
             {
-                var nestedContext = context.AsCollectionItem(
+                IEquivalencyValidationContext nestedContext = context.AsCollectionItem(
                     i.ToString(),
                     subject[i],
                     expectation[i]);
@@ -153,11 +153,11 @@ namespace FluentAssertions.Equivalency
             var expectationRowByKey = expectation.Cast<DataRow>()
                 .ToDictionary(row => ExtractPrimaryKey(row));
 
-            foreach (var subjectRow in subject.Cast<DataRow>())
+            foreach (DataRow subjectRow in subject.Cast<DataRow>())
             {
-                var key = ExtractPrimaryKey(subjectRow);
+                CompoundKey key = ExtractPrimaryKey(subjectRow);
 
-                if (!expectationRowByKey.TryGetValue(key, out var expectationRow))
+                if (!expectationRowByKey.TryGetValue(key, out DataRow expectationRow))
                 {
                     AssertionScope.Current
                         .FailWith("Found unexpected row in {context:DataRowCollection} with key {0}", key);
@@ -166,7 +166,7 @@ namespace FluentAssertions.Equivalency
                 {
                     expectationRowByKey.Remove(key);
 
-                    var nestedContext = context.AsCollectionItem(
+                    IEquivalencyValidationContext nestedContext = context.AsCollectionItem(
                         key.ToString(),
                         subjectRow,
                         expectationRow);
@@ -247,7 +247,7 @@ namespace FluentAssertions.Equivalency
 
         private static CompoundKey ExtractPrimaryKey(DataRow row)
         {
-            var primaryKey = row.Table.PrimaryKey;
+            DataColumn[] primaryKey = row.Table.PrimaryKey;
 
             var values = new object[primaryKey.Length];
 

--- a/Src/FluentAssertions/Equivalency/DataRowEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRowEquivalencyStep.cs
@@ -48,9 +48,9 @@ namespace FluentAssertions.Equivalency
                     var dataTableConfig = config as DataEquivalencyAssertionOptions<DataTable>;
                     var dataRowConfig = config as DataEquivalencyAssertionOptions<DataRow>;
 
-                    if (((dataSetConfig is null) || !dataSetConfig.AllowMismatchedTypes)
-                     && ((dataTableConfig is null) || !dataTableConfig.AllowMismatchedTypes)
-                     && ((dataRowConfig is null) || !dataRowConfig.AllowMismatchedTypes))
+                    if (dataSetConfig?.AllowMismatchedTypes != true
+                     && dataTableConfig?.AllowMismatchedTypes != true
+                     && dataRowConfig?.AllowMismatchedTypes != true)
                     {
                         AssertionScope.Current
                             .ForCondition(subject.GetType() == expectation.GetType())

--- a/Src/FluentAssertions/Equivalency/DataRowEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRowEquivalencyStep.cs
@@ -199,10 +199,11 @@ namespace FluentAssertions.Equivalency
                     });
                 }
 
-                selectedMembers = new SelectedDataRowMembers();
-
-                selectedMembers.HasErrors = members.Any(m => m.Name == nameof(DataRow.HasErrors));
-                selectedMembers.RowState = members.Any(m => m.Name == nameof(DataRow.RowState));
+                selectedMembers = new SelectedDataRowMembers
+                {
+                    HasErrors = members.Any(m => m.Name == nameof(DataRow.HasErrors)),
+                    RowState = members.Any(m => m.Name == nameof(DataRow.RowState))
+                };
 
                 SelectedMembersCache.TryAdd(cacheKey, selectedMembers);
             }

--- a/Src/FluentAssertions/Equivalency/DataRowEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRowEquivalencyStep.cs
@@ -22,18 +22,18 @@ namespace FluentAssertions.Equivalency
             var subject = context.Subject as DataRow;
             var expectation = context.Expectation as DataRow;
 
-            if (expectation == null)
+            if (expectation is null)
             {
-                if (subject != null)
+                if (subject is not null)
                 {
                     AssertionScope.Current.FailWith("Expected {context:DataRow} value to be null, but found {0}", subject);
                 }
             }
             else
             {
-                if (subject == null)
+                if (subject is null)
                 {
-                    if (context.Subject == null)
+                    if (context.Subject is null)
                     {
                         AssertionScope.Current.FailWith("Expected {context:DataRow} to be non-null, but found null");
                     }
@@ -48,9 +48,9 @@ namespace FluentAssertions.Equivalency
                     var dataTableConfig = config as DataEquivalencyAssertionOptions<DataTable>;
                     var dataRowConfig = config as DataEquivalencyAssertionOptions<DataRow>;
 
-                    if (((dataSetConfig == null) || !dataSetConfig.AllowMismatchedTypes)
-                     && ((dataTableConfig == null) || !dataTableConfig.AllowMismatchedTypes)
-                     && ((dataRowConfig == null) || !dataRowConfig.AllowMismatchedTypes))
+                    if (((dataSetConfig is null) || !dataSetConfig.AllowMismatchedTypes)
+                     && ((dataTableConfig is null) || !dataTableConfig.AllowMismatchedTypes)
+                     && ((dataRowConfig is null) || !dataRowConfig.AllowMismatchedTypes))
                     {
                         AssertionScope.Current
                             .ForCondition(subject.GetType() == expectation.GetType())
@@ -96,9 +96,9 @@ namespace FluentAssertions.Equivalency
                 .Select(col => col.ColumnName);
 
             bool ignoreUnmatchedColumns =
-                ((dataSetConfig != null) && dataSetConfig.IgnoreUnmatchedColumns) ||
-                ((dataTableConfig != null) && dataTableConfig.IgnoreUnmatchedColumns) ||
-                ((dataRowConfig != null) && dataRowConfig.IgnoreUnmatchedColumns);
+                ((dataSetConfig is not null) && dataSetConfig.IgnoreUnmatchedColumns) ||
+                ((dataTableConfig is not null) && dataTableConfig.IgnoreUnmatchedColumns) ||
+                ((dataRowConfig is not null) && dataRowConfig.IgnoreUnmatchedColumns);
 
             DataRowVersion subjectVersion =
                 (subject.RowState == DataRowState.Deleted)
@@ -112,9 +112,9 @@ namespace FluentAssertions.Equivalency
 
             bool compareOriginalVersions = (subject.RowState == DataRowState.Modified) && (expectation.RowState == DataRowState.Modified);
 
-            if (((dataSetConfig != null) && dataSetConfig.ExcludeOriginalData)
-             || ((dataTableConfig != null) && dataTableConfig.ExcludeOriginalData)
-             || ((dataRowConfig != null) && dataRowConfig.ExcludeOriginalData))
+            if (((dataSetConfig is not null) && dataSetConfig.ExcludeOriginalData)
+             || ((dataTableConfig is not null) && dataTableConfig.ExcludeOriginalData)
+             || ((dataRowConfig is not null) && dataRowConfig.ExcludeOriginalData))
             {
                 compareOriginalVersions = false;
             }
@@ -124,9 +124,9 @@ namespace FluentAssertions.Equivalency
                 DataColumn expectationColumn = expectation.Table.Columns[columnName];
                 DataColumn subjectColumn = subject.Table.Columns[columnName];
 
-                if (((dataSetConfig != null) && dataSetConfig.ShouldExcludeColumn(subjectColumn))
-                 || ((dataTableConfig != null) && dataTableConfig.ShouldExcludeColumn(subjectColumn))
-                 || ((dataRowConfig != null) && dataRowConfig.ShouldExcludeColumn(subjectColumn)))
+                if (((dataSetConfig is not null) && dataSetConfig.ShouldExcludeColumn(subjectColumn))
+                 || ((dataTableConfig is not null) && dataTableConfig.ShouldExcludeColumn(subjectColumn))
+                 || ((dataRowConfig is not null) && dataRowConfig.ShouldExcludeColumn(subjectColumn)))
                 {
                     continue;
                 }
@@ -134,15 +134,15 @@ namespace FluentAssertions.Equivalency
                 if (!ignoreUnmatchedColumns)
                 {
                     AssertionScope.Current
-                        .ForCondition(subjectColumn != null)
+                        .ForCondition(subjectColumn is not null)
                         .FailWith("Expected {context:DataRow} to have column '{0}'{reason}, but found none", columnName);
 
                     AssertionScope.Current
-                        .ForCondition(expectationColumn != null)
+                        .ForCondition(expectationColumn is not null)
                         .FailWith("Found unexpected column '{0}' in {context:DataRow}", columnName);
                 }
 
-                if ((subjectColumn != null) && (expectationColumn != null))
+                if ((subjectColumn is not null) && (expectationColumn is not null))
                 {
                     CompareFieldValue(context, parent, subject, expectation, subjectColumn, subjectVersion, expectationColumn, expectationVersion);
 
@@ -163,7 +163,7 @@ namespace FluentAssertions.Equivalency
                 subject[subjectColumn, subjectVersion],
                 expectation[expectationColumn, expectationVersion]);
 
-            if (nestedContext != null)
+            if (nestedContext is not null)
             {
                 parent.AssertEqualityUsing(nestedContext);
             }

--- a/Src/FluentAssertions/Equivalency/DataRowEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRowEquivalencyStep.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 using FluentAssertions.Data;
@@ -16,7 +17,7 @@ namespace FluentAssertions.Equivalency
             return typeof(DataRow).IsAssignableFrom(config.GetExpectationType(context.RuntimeType, context.CompileTimeType));
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
+        [SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
         {
             var subject = context.Subject as DataRow;

--- a/Src/FluentAssertions/Equivalency/DataSetEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataSetEquivalencyStep.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Data;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 using FluentAssertions.Data;
@@ -14,7 +15,7 @@ namespace FluentAssertions.Equivalency
             return typeof(DataSet).IsAssignableFrom(config.GetExpectationType(context.RuntimeType, context.CompileTimeType));
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
+        [SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
         {
             var subject = context.Subject as DataSet;

--- a/Src/FluentAssertions/Equivalency/DataSetEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataSetEquivalencyStep.cs
@@ -20,18 +20,18 @@ namespace FluentAssertions.Equivalency
             var subject = context.Subject as DataSet;
             var expectation = context.Expectation as DataSet;
 
-            if (expectation == null)
+            if (expectation is null)
             {
-                if (subject != null)
+                if (subject is not null)
                 {
                     AssertionScope.Current.FailWith("Expected {context:DataSet} value to be null, but found {0}", subject);
                 }
             }
             else
             {
-                if (subject == null)
+                if (subject is null)
                 {
-                    if (context.Subject == null)
+                    if (context.Subject is null)
                     {
                         AssertionScope.Current.FailWith("Expected {context:DataSet} to be non-null, but found null");
                     }
@@ -44,7 +44,7 @@ namespace FluentAssertions.Equivalency
                 {
                     var dataConfig = config as DataEquivalencyAssertionOptions<DataSet>;
 
-                    if ((dataConfig == null) || !dataConfig.AllowMismatchedTypes)
+                    if ((dataConfig is null) || !dataConfig.AllowMismatchedTypes)
                     {
                         AssertionScope.Current
                             .ForCondition(subject.GetType() == expectation.GetType())
@@ -148,12 +148,12 @@ namespace FluentAssertions.Equivalency
                 {
                     IMember matchingMember = FindMatchFor(expectationMember, context, config);
 
-                    if (matchingMember != null)
+                    if (matchingMember is not null)
                     {
                         IEquivalencyValidationContext nestedContext =
                                 context.AsNestedMember(expectationMember, matchingMember);
 
-                        if (nestedContext != null)
+                        if (nestedContext is not null)
                         {
                             parent.AssertEqualityUsing(nestedContext);
                         }
@@ -170,7 +170,7 @@ namespace FluentAssertions.Equivalency
                     .ForCondition(subject.Tables.Count == expectation.Tables.Count)
                     .FailWith("Expected {context:DataSet} to contain {0}, but found {1} table(s)", expectation.Tables.Count, subject.Tables.Count);
 
-                if (dataConfig != null)
+                if (dataConfig is not null)
                 {
                     bool excludeCaseSensitive = !selectedMembers.ContainsKey(nameof(DataSet.CaseSensitive));
                     bool excludeLocale = !selectedMembers.ContainsKey(nameof(DataSet.Locale));
@@ -193,7 +193,7 @@ namespace FluentAssertions.Equivalency
 
                 foreach (string tableName in expectationTableNames.Union(subjectTableNames))
                 {
-                    if ((dataConfig != null) && dataConfig.ExcludeTableNames.Contains(tableName))
+                    if ((dataConfig is not null) && dataConfig.ExcludeTableNames.Contains(tableName))
                     {
                         continue;
                     }
@@ -202,11 +202,11 @@ namespace FluentAssertions.Equivalency
                     DataTable subjectTable = subject.Tables[tableName];
 
                     AssertionScope.Current
-                        .ForCondition(subjectTable != null)
+                        .ForCondition(subjectTable is not null)
                         .FailWith("Expected {context:DataSet} to contain table '{0}'{reason}, but did not find it", tableName);
 
                     AssertionScope.Current
-                        .ForCondition(expectationTable != null)
+                        .ForCondition(expectationTable is not null)
                         .FailWith("Found unexpected table '{0}' in DataSet", tableName);
 
                     IEquivalencyValidationContext nestedContext = context.AsCollectionItem(
@@ -214,7 +214,7 @@ namespace FluentAssertions.Equivalency
                         subjectTable,
                         expectationTable);
 
-                    if (nestedContext != null)
+                    if (nestedContext is not null)
                     {
                         parent.AssertEqualityUsing(nestedContext);
                     }
@@ -227,7 +227,7 @@ namespace FluentAssertions.Equivalency
             IEnumerable<IMember> query =
                 from rule in config.MatchingRules
                 let match = rule.Match(selectedMemberInfo, context.Subject, context.CurrentNode, config)
-                where match != null
+                where match is not null
                 select match;
 
             return query.FirstOrDefault();

--- a/Src/FluentAssertions/Equivalency/DataSetEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataSetEquivalencyStep.cs
@@ -144,9 +144,9 @@ namespace FluentAssertions.Equivalency
         {
             foreach (var collectionName in new[] { nameof(expectation.ExtendedProperties), nameof(expectation.Relations) })
             {
-                if (selectedMembers.TryGetValue(collectionName, out var expectationMember))
+                if (selectedMembers.TryGetValue(collectionName, out IMember expectationMember))
                 {
-                    var matchingMember = FindMatchFor(expectationMember, context, config);
+                    IMember matchingMember = FindMatchFor(expectationMember, context, config);
 
                     if (matchingMember != null)
                     {
@@ -186,9 +186,9 @@ namespace FluentAssertions.Equivalency
                     }
                 }
 
-                var expectationTableNames = expectation.Tables.OfType<DataTable>()
+                IEnumerable<string> expectationTableNames = expectation.Tables.OfType<DataTable>()
                     .Select(table => table.TableName);
-                var subjectTableNames = subject.Tables.OfType<DataTable>()
+                IEnumerable<string> subjectTableNames = subject.Tables.OfType<DataTable>()
                     .Select(table => table.TableName);
 
                 foreach (string tableName in expectationTableNames.Union(subjectTableNames))
@@ -198,8 +198,8 @@ namespace FluentAssertions.Equivalency
                         continue;
                     }
 
-                    var expectationTable = expectation.Tables[tableName];
-                    var subjectTable = subject.Tables[tableName];
+                    DataTable expectationTable = expectation.Tables[tableName];
+                    DataTable subjectTable = subject.Tables[tableName];
 
                     AssertionScope.Current
                         .ForCondition(subjectTable != null)
@@ -209,7 +209,7 @@ namespace FluentAssertions.Equivalency
                         .ForCondition(expectationTable != null)
                         .FailWith("Found unexpected table '{0}' in DataSet", tableName);
 
-                    var nestedContext = context.AsCollectionItem(
+                    IEquivalencyValidationContext nestedContext = context.AsCollectionItem(
                         tableName,
                         subjectTable,
                         expectationTable);

--- a/Src/FluentAssertions/Equivalency/DataSetEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataSetEquivalencyStep.cs
@@ -44,7 +44,7 @@ namespace FluentAssertions.Equivalency
                 {
                     var dataConfig = config as DataEquivalencyAssertionOptions<DataSet>;
 
-                    if ((dataConfig is null) || !dataConfig.AllowMismatchedTypes)
+                    if (dataConfig?.AllowMismatchedTypes != true)
                     {
                         AssertionScope.Current
                             .ForCondition(subject.GetType() == expectation.GetType())

--- a/Src/FluentAssertions/Equivalency/DataSetEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataSetEquivalencyStep.cs
@@ -135,14 +135,14 @@ namespace FluentAssertions.Equivalency
         {
             // Note: The collections here are listed in the XML documentation for the DataSet.BeEquivalentTo extension
             // method in DataSetAssertions.cs. If this ever needs to change, keep them in sync.
-            CompareExtendedProperties(context, parent, config, expectation, selectedMembers);
+            CompareExtendedProperties(context, parent, config, selectedMembers);
 
             CompareTables(context, parent, subject, expectation, dataConfig, selectedMembers);
         }
 
-        private static void CompareExtendedProperties(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config, DataSet expectation, Dictionary<string, IMember> selectedMembers)
+        private static void CompareExtendedProperties(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config, Dictionary<string, IMember> selectedMembers)
         {
-            foreach (var collectionName in new[] { nameof(expectation.ExtendedProperties), nameof(expectation.Relations) })
+            foreach (var collectionName in new[] { nameof(DataSet.ExtendedProperties), nameof(DataSet.Relations) })
             {
                 if (selectedMembers.TryGetValue(collectionName, out IMember expectationMember))
                 {

--- a/Src/FluentAssertions/Equivalency/DataTableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataTableEquivalencyStep.cs
@@ -20,18 +20,18 @@ namespace FluentAssertions.Equivalency
             var subject = context.Subject as DataTable;
             var expectation = context.Expectation as DataTable;
 
-            if (expectation == null)
+            if (expectation is null)
             {
-                if (subject != null)
+                if (subject is not null)
                 {
                     AssertionScope.Current.FailWith("Expected {context:DataTable} value to be null, but found {0}", subject);
                 }
             }
             else
             {
-                if (subject == null)
+                if (subject is null)
                 {
-                    if (context.Subject == null)
+                    if (context.Subject is null)
                     {
                         AssertionScope.Current.FailWith("Expected {context:DataTable} to be non-null, but found null");
                     }
@@ -45,8 +45,8 @@ namespace FluentAssertions.Equivalency
                     var dataSetConfig = config as DataEquivalencyAssertionOptions<DataSet>;
                     var dataTableConfig = config as DataEquivalencyAssertionOptions<DataTable>;
 
-                    if (((dataSetConfig == null) || !dataSetConfig.AllowMismatchedTypes)
-                     && ((dataTableConfig == null) || !dataTableConfig.AllowMismatchedTypes))
+                    if (((dataSetConfig is null) || !dataSetConfig.AllowMismatchedTypes)
+                     && ((dataTableConfig is null) || !dataTableConfig.AllowMismatchedTypes))
                     {
                         AssertionScope.Current
                             .ForCondition(subject.GetType() == expectation.GetType())
@@ -147,12 +147,12 @@ namespace FluentAssertions.Equivalency
                 {
                     IMember matchingMember = FindMatchFor(expectationMember, context, config);
 
-                    if (matchingMember != null)
+                    if (matchingMember is not null)
                     {
                         IEquivalencyValidationContext nestedContext =
                                 context.AsNestedMember(expectationMember, matchingMember);
 
-                        if (nestedContext != null)
+                        if (nestedContext is not null)
                         {
                             parent.AssertEqualityUsing(nestedContext);
                         }
@@ -166,7 +166,7 @@ namespace FluentAssertions.Equivalency
             IEnumerable<IMember> query =
                 from rule in config.MatchingRules
                 let match = rule.Match(selectedMemberInfo, context.Subject, context.CurrentNode, config)
-                where match != null
+                where match is not null
                 select match;
 
             return query.FirstOrDefault();

--- a/Src/FluentAssertions/Equivalency/DataTableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataTableEquivalencyStep.cs
@@ -45,8 +45,8 @@ namespace FluentAssertions.Equivalency
                     var dataSetConfig = config as DataEquivalencyAssertionOptions<DataSet>;
                     var dataTableConfig = config as DataEquivalencyAssertionOptions<DataTable>;
 
-                    if (((dataSetConfig is null) || !dataSetConfig.AllowMismatchedTypes)
-                     && ((dataTableConfig is null) || !dataTableConfig.AllowMismatchedTypes))
+                    if (dataSetConfig?.AllowMismatchedTypes != true
+                     && dataTableConfig?.AllowMismatchedTypes != true)
                     {
                         AssertionScope.Current
                             .ForCondition(subject.GetType() == expectation.GetType())

--- a/Src/FluentAssertions/Equivalency/DataTableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataTableEquivalencyStep.cs
@@ -58,7 +58,7 @@ namespace FluentAssertions.Equivalency
 
                     CompareScalarProperties(subject, expectation, selectedMembers);
 
-                    CompareCollections(context, parent, config, expectation, selectedMembers);
+                    CompareCollections(context, parent, config, selectedMembers);
                 }
             }
 
@@ -126,19 +126,19 @@ namespace FluentAssertions.Equivalency
             }
         }
 
-        private static void CompareCollections(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config, DataTable expectation, Dictionary<string, IMember> selectedMembers)
+        private static void CompareCollections(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config, Dictionary<string, IMember> selectedMembers)
         {
             // Note: The collections here are listed in the XML documentation for the DataTable.BeEquivalentTo extension
             // method in DataTableAssertions.cs. If this ever needs to change, keep them in sync.
             var collectionNames = new[]
             {
-                nameof(expectation.ChildRelations),
-                nameof(expectation.Columns),
-                nameof(expectation.Constraints),
-                nameof(expectation.ExtendedProperties),
-                nameof(expectation.ParentRelations),
-                nameof(expectation.PrimaryKey),
-                nameof(expectation.Rows),
+                nameof(DataTable.ChildRelations),
+                nameof(DataTable.Columns),
+                nameof(DataTable.Constraints),
+                nameof(DataTable.ExtendedProperties),
+                nameof(DataTable.ParentRelations),
+                nameof(DataTable.PrimaryKey),
+                nameof(DataTable.Rows),
             };
 
             foreach (var collectionName in collectionNames)

--- a/Src/FluentAssertions/Equivalency/DataTableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataTableEquivalencyStep.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Data;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 using FluentAssertions.Data;
@@ -14,7 +15,7 @@ namespace FluentAssertions.Equivalency
             return typeof(DataTable).IsAssignableFrom(config.GetExpectationType(context.RuntimeType, context.CompileTimeType));
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
+        [SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "The code is easier to read without it.")]
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
         {
             var subject = context.Subject as DataTable;

--- a/Src/FluentAssertions/Equivalency/DataTableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataTableEquivalencyStep.cs
@@ -143,9 +143,9 @@ namespace FluentAssertions.Equivalency
 
             foreach (var collectionName in collectionNames)
             {
-                if (selectedMembers.TryGetValue(collectionName, out var expectationMember))
+                if (selectedMembers.TryGetValue(collectionName, out IMember expectationMember))
                 {
-                    var matchingMember = FindMatchFor(expectationMember, context, config);
+                    IMember matchingMember = FindMatchFor(expectationMember, context, config);
 
                     if (matchingMember != null)
                     {

--- a/Src/FluentAssertions/Equivalency/DictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DictionaryEquivalencyStep.cs
@@ -33,7 +33,7 @@ namespace FluentAssertions.Equivalency
 
             if (PreconditionsAreMet(expectation, subject))
             {
-                if (expectation != null)
+                if (expectation is not null)
                 {
                     foreach (object key in expectation.Keys)
                     {
@@ -64,14 +64,14 @@ namespace FluentAssertions.Equivalency
         private static bool AssertEitherIsNotNull(IDictionary expectation, IDictionary subject)
         {
             return AssertionScope.Current
-                .ForCondition(((expectation is null) && (subject is null)) || (expectation != null))
+                .ForCondition(((expectation is null) && (subject is null)) || (expectation is not null))
                 .FailWith("Expected {context:subject} to be {0}{reason}, but found {1}.", null, subject);
         }
 
         private static bool AssertIsDictionary(IDictionary subject)
         {
             return AssertionScope.Current
-                .ForCondition(subject != null)
+                .ForCondition(subject is not null)
                 .FailWith("Expected {context:subject} to be a dictionary, but it is not.");
         }
 

--- a/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
+++ b/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
@@ -107,7 +107,7 @@ namespace FluentAssertions.Equivalency
 
         private static decimal? ExtractDecimal(object o)
         {
-            return o != null ? Convert.ToDecimal(o, CultureInfo.InvariantCulture) : (decimal?)null;
+            return o is not null ? Convert.ToDecimal(o, CultureInfo.InvariantCulture) : (decimal?)null;
         }
     }
 }

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyStep.cs
@@ -47,7 +47,7 @@ namespace FluentAssertions.Equivalency
         private static bool AssertSubjectIsCollection(object subject)
         {
             bool conditionMet = AssertionScope.Current
-                .ForCondition(!(subject is null))
+                .ForCondition(subject is not null)
                 .FailWith("Expected a collection, but {context:Subject} is <null>.");
 
             if (conditionMet)
@@ -67,7 +67,7 @@ namespace FluentAssertions.Equivalency
 
         internal static object[] ToArray(object value)
         {
-            return !(value is null) ? ((IEnumerable)value).Cast<object>().ToArray() : null;
+            return value is not null ? ((IEnumerable)value).Cast<object>().ToArray() : null;
         }
     }
 }

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
@@ -50,7 +50,7 @@ namespace FluentAssertions.Equivalency
         private static bool AssertIsNotNull(object expectation, object[] subject)
         {
             return AssertionScope.Current
-                .ForCondition(!(expectation is null))
+                .ForCondition(expectation is not null)
                 .FailWith("Expected {context:subject} to be <null>, but found {0}.", new object[] { subject });
         }
 

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
@@ -47,12 +47,12 @@ namespace FluentAssertions.Equivalency
         {
             get
             {
-                if (Expectation != null)
+                if (Expectation is not null)
                 {
                     return Expectation.GetType();
                 }
 
-                if (CurrentNode != null)
+                if (CurrentNode is not null)
                 {
                     return CurrentNode.Type;
                 }

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -35,7 +35,7 @@ namespace FluentAssertions.Equivalency
 
             AssertEqualityUsing(context);
 
-            if (context.TraceWriter != null)
+            if (context.TraceWriter is not null)
             {
                 scope.AddReportable("trace", context.TraceWriter.ToString());
             }

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -17,7 +17,7 @@ namespace FluentAssertions.Equivalency
 
         private readonly IEquivalencyAssertionOptions config;
 
-        private readonly Dictionary<Type, bool> isComplexTypeMap = new Dictionary<Type, bool>();
+        private readonly Dictionary<Type, bool> isComplexTypeMap = new();
 
         #endregion
 

--- a/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
@@ -62,14 +62,14 @@ namespace FluentAssertions.Equivalency
         private static bool AssertSubjectIsNotNull(object subject)
         {
             return AssertionScope.Current
-                .ForCondition(!(subject is null))
+                .ForCondition(subject is not null)
                 .FailWith("Expected {context:Subject} not to be {0}{reason}.", new object[] { null });
         }
 
         private static bool AssertExpectationIsNotNull(object subject, object expectation)
         {
             return AssertionScope.Current
-                .ForCondition(!(expectation is null))
+                .ForCondition(expectation is not null)
                 .FailWith("Expected {context:Subject} to be {0}{reason}, but found {1}.", null, subject);
         }
 

--- a/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
@@ -21,7 +21,7 @@ namespace FluentAssertions.Equivalency
         {
             Type expectationType = config.GetExpectationType(context.RuntimeType, context.CompileTimeType);
 
-            return context.Expectation != null && GetIDictionaryInterfaces(expectationType).Any();
+            return context.Expectation is not null && GetIDictionaryInterfaces(expectationType).Any();
         }
 
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent,

--- a/Src/FluentAssertions/Equivalency/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericEnumerableEquivalencyStep.cs
@@ -79,7 +79,7 @@ namespace FluentAssertions.Equivalency
         private static bool AssertSubjectIsCollection(object subject)
         {
             bool conditionMet = AssertionScope.Current
-                .ForCondition(!(subject is null))
+                .ForCondition(subject is not null)
                 .FailWith("Expected {context:subject} not to be {0}.", new object[] { null });
 
             if (conditionMet)

--- a/Src/FluentAssertions/Equivalency/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericEnumerableEquivalencyStep.cs
@@ -22,7 +22,7 @@ namespace FluentAssertions.Equivalency
         {
             Type expectationType = config.GetExpectationType(context.RuntimeType, context.CompileTimeType);
 
-            return (context.Expectation != null) && IsGenericCollection(expectationType);
+            return (context.Expectation is not null) && IsGenericCollection(expectationType);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Equivalency/IMemberMatchingRule.cs
+++ b/Src/FluentAssertions/Equivalency/IMemberMatchingRule.cs
@@ -21,6 +21,7 @@ namespace FluentAssertions.Equivalency
         /// <param name="subject">
         /// The subject object for which a matching member must be returned. Can never be <c>null</c>.
         /// </param>
+        /// <param name="parent"></param>
         /// <param name="options"></param>
         /// <returns>
         /// Returns the <see cref="IMember"/> of the property with which to compare the subject with, or <c>null</c>

--- a/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
@@ -16,13 +16,13 @@ namespace FluentAssertions.Equivalency.Matching
             if (config.IncludeProperties)
             {
                 PropertyInfo propertyInfo = subject.GetType().FindProperty(expectedMember.Name, expectedMember.Type);
-                subjectMember = (propertyInfo != null) && !propertyInfo.IsIndexer() ? (IMember)new Property(propertyInfo, parent) : null;
+                subjectMember = (propertyInfo is not null) && !propertyInfo.IsIndexer() ? (IMember)new Property(propertyInfo, parent) : null;
             }
 
             if ((subjectMember is null) && config.IncludeFields)
             {
                 FieldInfo fieldInfo = subject.GetType().FindField(expectedMember.Name, expectedMember.Type);
-                subjectMember = (fieldInfo != null) ? (IMember)new Field(fieldInfo, parent) : null;
+                subjectMember = (fieldInfo is not null) ? (IMember)new Field(fieldInfo, parent) : null;
             }
 
             if ((subjectMember is null || !config.UseRuntimeTyping) && ExpectationImplementsMemberExplicitly(subject, expectedMember))

--- a/Src/FluentAssertions/Equivalency/Matching/TryMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/TryMatchByNameRule.cs
@@ -11,13 +11,13 @@ namespace FluentAssertions.Equivalency.Matching
         public IMember Match(IMember expectedMember, object subject, INode parent, IEquivalencyAssertionOptions config)
         {
             PropertyInfo property = subject.GetType().FindProperty(expectedMember.Name, expectedMember.Type);
-            if ((property != null) && !property.IsIndexer())
+            if ((property is not null) && !property.IsIndexer())
             {
                 return new Property(property, parent);
             }
 
             FieldInfo field = subject.GetType().FindField(expectedMember.Name, expectedMember.Type);
-            return (field != null) ? (IMember)new Field(field, parent) : null;
+            return (field is not null) ? (IMember)new Field(field, parent) : null;
         }
 
         /// <inheritdoc />

--- a/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
@@ -122,7 +122,7 @@ namespace FluentAssertions.Equivalency
             var indices = new List<int>();
 
             Digit digit = this;
-            while (digit != null)
+            while (digit is not null)
             {
                 indices.Add(digit.index);
                 digit = digit.nextDigit;

--- a/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/MultiDimensionalArrayEquivalencyStep.cs
@@ -69,7 +69,7 @@ namespace FluentAssertions.Equivalency
         private static bool IsArray(object type)
         {
             return AssertionScope.Current
-                .ForCondition(!(type is null))
+                .ForCondition(type is not null)
                 .FailWith("Cannot compare a multi-dimensional array to <null>.")
                 .Then
                 .ForCondition(type is Array)

--- a/Src/FluentAssertions/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Equivalency/Node.cs
@@ -77,7 +77,7 @@ namespace FluentAssertions.Equivalency
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
+            if (obj is null)
             {
                 return false;
             }

--- a/Src/FluentAssertions/Equivalency/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/ObjectReference.cs
@@ -31,12 +31,8 @@ namespace FluentAssertions.Equivalency
         /// <filterpriority>2</filterpriority>
         public override bool Equals(object obj)
         {
-            if (!(obj is ObjectReference other))
-            {
-                return false;
-            }
-
-            return ReferenceEquals(@object, other.@object) && IsParentOrChildOf(other);
+            return obj is ObjectReference other
+                && ReferenceEquals(@object, other.@object) && IsParentOrChildOf(other);
         }
 
         private string[] GetPathElements() => pathElements
@@ -71,6 +67,6 @@ namespace FluentAssertions.Equivalency
             return $"{{\"{path}\", {@object}}}";
         }
 
-        public bool IsComplexType => isComplexType ?? (!(@object is null) && !@object.GetType().OverridesEquals());
+        public bool IsComplexType => isComplexType ?? (@object is not null && !@object.GetType().OverridesEquals());
     }
 }

--- a/Src/FluentAssertions/Equivalency/OrderingRuleCollection.cs
+++ b/Src/FluentAssertions/Equivalency/OrderingRuleCollection.cs
@@ -10,7 +10,7 @@ namespace FluentAssertions.Equivalency
     /// </summary>
     public class OrderingRuleCollection : IEnumerable<IOrderingRule>
     {
-        private readonly List<IOrderingRule> rules = new List<IOrderingRule>();
+        private readonly List<IOrderingRule> rules = new();
 
         /// <summary>
         /// Initializes a new collection of ordering rules.

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -21,29 +21,29 @@ namespace FluentAssertions.Equivalency
     {
         #region Private Definitions
 
-        private readonly ConcurrentDictionary<Type, bool> hasValueSemanticsMap = new ConcurrentDictionary<Type, bool>();
+        private readonly ConcurrentDictionary<Type, bool> hasValueSemanticsMap = new();
 
-        private readonly List<Type> referenceTypes = new List<Type>();
+        private readonly List<Type> referenceTypes = new();
 
-        private readonly List<Type> valueTypes = new List<Type>();
+        private readonly List<Type> valueTypes = new();
 
         private readonly Func<Type, EqualityStrategy> getDefaultEqualityStrategy;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private readonly List<IMemberSelectionRule> selectionRules = new List<IMemberSelectionRule>();
+        private readonly List<IMemberSelectionRule> selectionRules = new();
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private readonly List<IMemberMatchingRule> matchingRules = new List<IMemberMatchingRule>();
+        private readonly List<IMemberMatchingRule> matchingRules = new();
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private readonly List<IEquivalencyStep> userEquivalencySteps = new List<IEquivalencyStep>();
+        private readonly List<IEquivalencyStep> userEquivalencySteps = new();
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private CyclicReferenceHandling cyclicReferenceHandling = CyclicReferenceHandling.ThrowException;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
 #pragma warning disable CA1051, SA1401 // TODO: fix in 6.0
-        protected readonly OrderingRuleCollection orderingRules = new OrderingRuleCollection();
+        protected readonly OrderingRuleCollection orderingRules = new();
 #pragma warning restore SA1401, CA1051
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -132,7 +132,7 @@ namespace FluentAssertions.Equivalency
         /// </summary>
         IEnumerable<IEquivalencyStep> IEquivalencyAssertionOptions.UserEquivalencySteps => userEquivalencySteps;
 
-        public ConversionSelector ConversionSelector { get; } = new ConversionSelector();
+        public ConversionSelector ConversionSelector { get; } = new();
 
         /// <summary>
         /// Gets an ordered collection of rules that determine whether or not the order of collections is important. By
@@ -632,7 +632,7 @@ namespace FluentAssertions.Equivalency
         /// <filterpriority>2</filterpriority>
         public override string ToString()
         {
-            StringBuilder builder = new StringBuilder();
+            var builder = new StringBuilder();
 
             builder.Append("- Use ")
                 .Append(useRuntimeTyping ? "runtime" : "declared")

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -183,7 +183,7 @@ namespace FluentAssertions.Equivalency
             }
             else
             {
-                if (getDefaultEqualityStrategy != null)
+                if (getDefaultEqualityStrategy is not null)
                 {
                     strategy = getDefaultEqualityStrategy(type);
                 }

--- a/Src/FluentAssertions/Equivalency/StringEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/StringEqualityEquivalencyStep.cs
@@ -14,7 +14,7 @@ namespace FluentAssertions.Equivalency
         {
             Type expectationType = config.GetExpectationType(context.RuntimeType, context.CompileTimeType);
 
-            return (expectationType != null) && (expectationType == typeof(string));
+            return (expectationType is not null) && (expectationType == typeof(string));
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Equivalency/StructuralEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/StructuralEqualityEquivalencyStep.cs
@@ -54,12 +54,12 @@ namespace FluentAssertions.Equivalency
         private static void AssertMemberEquality(IEquivalencyValidationContext context, IEquivalencyValidator parent, IMember selectedMember, IEquivalencyAssertionOptions config)
         {
             IMember matchingMember = FindMatchFor(selectedMember, context, config);
-            if (matchingMember != null)
+            if (matchingMember is not null)
             {
                 IEquivalencyValidationContext nestedContext =
                     context.AsNestedMember(selectedMember, matchingMember);
 
-                if (nestedContext != null)
+                if (nestedContext is not null)
                 {
                     parent.AssertEqualityUsing(nestedContext);
                 }
@@ -71,7 +71,7 @@ namespace FluentAssertions.Equivalency
             IEnumerable<IMember> query =
                 from rule in config.MatchingRules
                 let match = rule.Match(selectedMember, context.Subject, context.CurrentNode, config)
-                where match != null
+                where match is not null
                 select match;
 
             return query.FirstOrDefault();

--- a/Src/FluentAssertions/Equivalency/StructuralEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/StructuralEqualityEquivalencyStep.cs
@@ -18,14 +18,14 @@ namespace FluentAssertions.Equivalency
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent, IEquivalencyAssertionOptions config)
         {
             bool expectationIsNotNull = AssertionScope.Current
-                .ForCondition(!(context.Expectation is null))
+                .ForCondition(context.Expectation is not null)
                 .BecauseOf(context.Reason)
                 .FailWith(
                     "Expected {context:subject} to be <null>{reason}, but found {0}.",
                     context.Subject);
 
             bool subjectIsNotNull = AssertionScope.Current
-                .ForCondition(!(context.Subject is null))
+                .ForCondition(context.Subject is not null)
                 .BecauseOf(context.Reason)
                 .FailWith(
                     "Expected {context:object} to be {0}{reason}, but found {1}.",

--- a/Src/FluentAssertions/Equivalency/Tracing/StringBuilderTraceWriter.cs
+++ b/Src/FluentAssertions/Equivalency/Tracing/StringBuilderTraceWriter.cs
@@ -5,7 +5,7 @@ namespace FluentAssertions.Equivalency.Tracing
 {
     public class StringBuilderTraceWriter : ITraceWriter
     {
-        private readonly StringBuilder builder = new StringBuilder();
+        private readonly StringBuilder builder = new();
         private int depth = 1;
 
         public void AddSingle(string trace)

--- a/Src/FluentAssertions/Equivalency/Tracing/Tracer.cs
+++ b/Src/FluentAssertions/Equivalency/Tracing/Tracer.cs
@@ -37,7 +37,7 @@ namespace FluentAssertions.Equivalency.Tracing
         /// </remarks>
         public IDisposable WriteBlock(GetTraceMessage getTraceMessage)
         {
-            if (traceWriter != null)
+            if (traceWriter is not null)
             {
                 return traceWriter.AddBlock(getTraceMessage(currentNode));
             }
@@ -47,6 +47,6 @@ namespace FluentAssertions.Equivalency.Tracing
             }
         }
 
-        public override string ToString() => (traceWriter != null) ? traceWriter.ToString() : string.Empty;
+        public override string ToString() => (traceWriter is not null) ? traceWriter.ToString() : string.Empty;
     }
 }

--- a/Src/FluentAssertions/EquivalencyStepCollection.cs
+++ b/Src/FluentAssertions/EquivalencyStepCollection.cs
@@ -52,7 +52,7 @@ namespace FluentAssertions
             int insertIndex = Math.Max(steps.Count - 1, 0);
 
             IEquivalencyStep predecessor = steps.LastOrDefault(s => s is TPredecessor);
-            if (predecessor != null)
+            if (predecessor is not null)
             {
                 insertIndex = Math.Min(insertIndex, steps.LastIndexOf(predecessor) + 1);
             }
@@ -78,7 +78,7 @@ namespace FluentAssertions
             int insertIndex = Math.Max(steps.Count - 1, 0);
 
             IEquivalencyStep equalityStep = steps.LastOrDefault(s => s is TSuccessor);
-            if (equalityStep != null)
+            if (equalityStep is not null)
             {
                 insertIndex = steps.LastIndexOf(equalityStep);
             }

--- a/Src/FluentAssertions/EventRaisingExtensions.cs
+++ b/Src/FluentAssertions/EventRaisingExtensions.cs
@@ -143,7 +143,7 @@ namespace FluentAssertions
                 Execute
                     .Assertion
                     .FailWith("Expected at least one event with arguments matching {0}, but found none.",
-                    string.Join(" | ", predicates.Where(p => p != null).Select(p => p.Body.ToString())));
+                    string.Join(" | ", predicates.Where(p => p is not null).Select(p => p.Body.ToString())));
             }
 
             return new FilteredEventRecording(eventRecording, eventsMatchingPredicate);

--- a/Src/FluentAssertions/Events/EventHandlerFactory.cs
+++ b/Src/FluentAssertions/Events/EventHandlerFactory.cs
@@ -129,7 +129,7 @@ namespace FluentAssertions.Events
             }
 
             MethodInfo invoke = d.GetMethod("Invoke");
-            return invoke != null;
+            return invoke is not null;
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Events/EventRecorder.cs
+++ b/Src/FluentAssertions/Events/EventRecorder.cs
@@ -60,7 +60,7 @@ namespace FluentAssertions.Events
 
         public void Dispose()
         {
-            if (cleanup != null)
+            if (cleanup is not null)
             {
                 cleanup?.Invoke();
                 cleanup = null;

--- a/Src/FluentAssertions/Events/EventRecorder.cs
+++ b/Src/FluentAssertions/Events/EventRecorder.cs
@@ -51,7 +51,7 @@ namespace FluentAssertions.Events
 
             cleanup = () =>
             {
-                if (!(subject.Target is null))
+                if (subject.Target is not null)
                 {
                     eventInfo.RemoveEventHandler(subject.Target, handler);
                 }

--- a/Src/FluentAssertions/Events/EventRecorder.cs
+++ b/Src/FluentAssertions/Events/EventRecorder.cs
@@ -15,8 +15,8 @@ namespace FluentAssertions.Events
     internal sealed class EventRecorder : IEventRecording, IDisposable
     {
         private readonly Func<DateTime> utcNow;
-        private readonly BlockingCollection<RecordedEvent> raisedEvents = new BlockingCollection<RecordedEvent>();
-        private readonly object lockable = new object();
+        private readonly BlockingCollection<RecordedEvent> raisedEvents = new();
+        private readonly object lockable = new();
         private Action cleanup;
 
         /// <summary>

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -53,7 +53,7 @@ namespace FluentAssertions.Execution
         {
             SetCurrentAssertionScope(this);
 
-            if (parent != null)
+            if (parent is not null)
             {
                 contextData.Add(parent.contextData);
                 Context = parent.Context;
@@ -247,7 +247,7 @@ namespace FluentAssertions.Execution
                 {
                     string result = failReasonFunc();
 
-                    if (expectation != null)
+                    if (expectation is not null)
                     {
                         result = expectation() + result;
                     }
@@ -352,7 +352,7 @@ namespace FluentAssertions.Execution
         {
             SetCurrentAssertionScope(parent);
 
-            if (parent != null)
+            if (parent is not null)
             {
                 foreach (string failureMessage in assertionStrategy.FailureMessages)
                 {

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -17,12 +17,12 @@ namespace FluentAssertions.Execution
         #region Private Definitions
 
         private readonly IAssertionStrategy assertionStrategy;
-        private readonly ContextDataItems contextData = new ContextDataItems();
+        private readonly ContextDataItems contextData = new();
 
         private Func<string> reason;
         private bool useLineBreaks;
 
-        private static readonly AsyncLocal<AssertionScope> CurrentScope = new AsyncLocal<AssertionScope>();
+        private static readonly AsyncLocal<AssertionScope> CurrentScope = new();
         private AssertionScope parent;
         private Func<string> expectation;
         private string fallbackIdentifier = "object";

--- a/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
@@ -9,7 +9,7 @@ namespace FluentAssertions.Execution
 {
     internal class CollectingAssertionStrategy : IAssertionStrategy
     {
-        private readonly List<string> failureMessages = new List<string>();
+        private readonly List<string> failureMessages = new();
 
         /// <summary>
         /// Returns the messages for the assertion failures that happened until now.

--- a/Src/FluentAssertions/Execution/ContextDataItems.cs
+++ b/Src/FluentAssertions/Execution/ContextDataItems.cs
@@ -9,7 +9,7 @@ namespace FluentAssertions.Execution
     /// </summary>
     internal class ContextDataItems
     {
-        private readonly List<DataItem> items = new List<DataItem>();
+        private readonly List<DataItem> items = new();
 
         public IDictionary<string, object> GetReportable()
         {

--- a/Src/FluentAssertions/Execution/ContextDataItems.cs
+++ b/Src/FluentAssertions/Execution/ContextDataItems.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Execution
         public string AsStringOrDefault(string key)
         {
             DataItem item = items.SingleOrDefault(i => i.Key == key);
-            if (item != null)
+            if (item is not null)
             {
                 if (item.RequiresFormatting)
                 {

--- a/Src/FluentAssertions/Execution/GivenSelectorExtensions.cs
+++ b/Src/FluentAssertions/Execution/GivenSelectorExtensions.cs
@@ -11,7 +11,7 @@ namespace FluentAssertions.Execution
             this GivenSelector<IEnumerable<T>> givenSelector)
         {
             return givenSelector
-                .ForCondition(items => !(items is null))
+                .ForCondition(items => items is not null)
                 .FailWith("but found collection is <null>.");
         }
 

--- a/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
+++ b/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
@@ -31,7 +31,7 @@ namespace FluentAssertions.Execution
                     .GetAssemblies()
                     .FirstOrDefault(a => a.FullName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
 
-                return assembly != null;
+                return assembly is not null;
             }
         }
 

--- a/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
+++ b/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
@@ -9,7 +9,7 @@ namespace FluentAssertions.Execution
     {
         #region Private Definitions
 
-        private static readonly Dictionary<string, ITestFramework> Frameworks = new Dictionary<string, ITestFramework>(StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<string, ITestFramework> Frameworks = new(StringComparer.OrdinalIgnoreCase)
         {
             ["mspec"] = new MSpecFramework(),
             ["nspec3"] = new NSpecFramework(),

--- a/Src/FluentAssertions/Execution/XUnit2TestFramework.cs
+++ b/Src/FluentAssertions/Execution/XUnit2TestFramework.cs
@@ -15,7 +15,7 @@ namespace FluentAssertions.Execution
                 {
                     assembly = Assembly.Load(new AssemblyName("xunit.assert"));
 
-                    return assembly != null;
+                    return assembly is not null;
                 }
                 catch
                 {

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -76,7 +76,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
-    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.1">
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -26,7 +26,7 @@
     <PackageIcon>FluentAssertions.png</PackageIcon>
     <PackageReleaseNotes>See https://fluentassertions.com/releases/</PackageReleaseNotes>
     <Copyright>Copyright Dennis Doomen 2010-2020</Copyright>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -84,7 +84,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.321">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
@@ -25,7 +25,7 @@ namespace FluentAssertions.Formatting
         /// </returns>
         public bool CanHandle(object value)
         {
-            return IsScanningEnabled && (value != null) && (GetFormatter(value) != null);
+            return IsScanningEnabled && (value is not null) && (GetFormatter(value) is not null);
         }
 
         private static bool IsScanningEnabled
@@ -55,7 +55,7 @@ namespace FluentAssertions.Formatting
 
                 valueType = valueType.BaseType;
             }
-            while (valueType != null);
+            while (valueType is not null);
 
             return null;
         }
@@ -83,7 +83,7 @@ namespace FluentAssertions.Formatting
         {
             var query =
                 from type in Services.Reflector.GetAllTypesFromAppDomain(Applicable)
-                where type != null
+                where type is not null
                 from method in type.GetMethods(BindingFlags.Static | BindingFlags.Public)
                 where method.IsStatic
                 where method.ReturnType == typeof(string)

--- a/Src/FluentAssertions/Formatting/ExceptionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ExceptionValueFormatter.cs
@@ -25,7 +25,7 @@ namespace FluentAssertions.Formatting
             var builder = new StringBuilder();
             builder.AppendFormat("{0} with message \"{1}\"\n", exception.GetType().FullName, exception.Message);
 
-            if (exception.StackTrace != null)
+            if (exception.StackTrace is not null)
             {
                 foreach (string line in exception.StackTrace.Split(new[] { Environment.NewLine }, StringSplitOptions.None))
                 {

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -14,9 +14,9 @@ namespace FluentAssertions.Formatting
     {
         #region Private Definitions
 
-        private static readonly List<IValueFormatter> CustomFormatters = new List<IValueFormatter>();
+        private static readonly List<IValueFormatter> CustomFormatters = new();
 
-        private static readonly List<IValueFormatter> DefaultFormatters = new List<IValueFormatter>
+        private static readonly List<IValueFormatter> DefaultFormatters = new()
         {
             new XmlNodeFormatter(),
             new AttributeBasedFormatter(),

--- a/Src/FluentAssertions/Formatting/XDocumentValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XDocumentValueFormatter.cs
@@ -14,7 +14,7 @@ namespace FluentAssertions.Formatting
         {
             var document = (XDocument)value;
 
-            return (document.Root != null)
+            return (document.Root is not null)
                 ? formatChild("root", document.Root)
                 : FormatDocumentWithoutRoot();
         }

--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -675,7 +675,7 @@ namespace FluentAssertions
             }
 
             Execute.Assertion
-                .ForCondition(parent.Subject != null)
+                .ForCondition(parent.Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
@@ -718,7 +718,7 @@ namespace FluentAssertions
             }
 
             bool succeeded = Execute.Assertion
-                .ForCondition(expectedValue != null)
+                .ForCondition(expectedValue is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was {2}.", expectedValue, precision, parent.Subject);
 
@@ -802,7 +802,7 @@ namespace FluentAssertions
             }
 
             Execute.Assertion
-                .ForCondition(parent.Subject != null)
+                .ForCondition(parent.Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
@@ -845,7 +845,7 @@ namespace FluentAssertions
             }
 
             bool succeeded = Execute.Assertion
-                .ForCondition(expectedValue != null)
+                .ForCondition(expectedValue is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was {2}.", expectedValue, precision, parent.Subject);
 
@@ -929,7 +929,7 @@ namespace FluentAssertions
             }
 
             Execute.Assertion
-                .ForCondition(parent.Subject != null)
+                .ForCondition(parent.Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
@@ -972,7 +972,7 @@ namespace FluentAssertions
             }
 
             bool succeeded = Execute.Assertion
-                .ForCondition(expectedValue != null)
+                .ForCondition(expectedValue is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was {2}.", expectedValue, precision, parent.Subject);
 
@@ -1061,7 +1061,7 @@ namespace FluentAssertions
                 throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
             }
 
-            if (parent.Subject != null)
+            if (parent.Subject is not null)
             {
                 var nonNullableAssertions = new NumericAssertions<float>((float)parent.Subject);
                 nonNullableAssertions.NotBeApproximately(unexpectedValue, precision, because, becauseArgs);
@@ -1103,7 +1103,7 @@ namespace FluentAssertions
             }
 
             bool succeeded = Execute.Assertion
-                .ForCondition(parent.Subject != null && unexpectedValue != null)
+                .ForCondition(parent.Subject is not null && unexpectedValue is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to not approximate {0} +/- {1}{reason}, but it was {2}.", unexpectedValue, precision, parent.Subject);
 
@@ -1186,7 +1186,7 @@ namespace FluentAssertions
                 throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
             }
 
-            if (parent.Subject != null)
+            if (parent.Subject is not null)
             {
                 var nonNullableAssertions = new NumericAssertions<double>((double)parent.Subject);
                 nonNullableAssertions.NotBeApproximately(unexpectedValue, precision, because, becauseArgs);
@@ -1228,7 +1228,7 @@ namespace FluentAssertions
             }
 
             bool succeeded = Execute.Assertion
-                .ForCondition(parent.Subject != null && unexpectedValue != null)
+                .ForCondition(parent.Subject is not null && unexpectedValue is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to not approximate {0} +/- {1}{reason}, but it was {2}.", unexpectedValue, precision, parent.Subject);
 
@@ -1311,7 +1311,7 @@ namespace FluentAssertions
                 throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
             }
 
-            if (parent.Subject != null)
+            if (parent.Subject is not null)
             {
                 var nonNullableAssertions = new NumericAssertions<decimal>((decimal)parent.Subject);
                 NotBeApproximately(nonNullableAssertions, unexpectedValue, precision, because, becauseArgs);
@@ -1353,7 +1353,7 @@ namespace FluentAssertions
             }
 
             bool succeeded = Execute.Assertion
-                .ForCondition(parent.Subject != null && unexpectedValue != null)
+                .ForCondition(parent.Subject is not null && unexpectedValue is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to not approximate {0} +/- {1}{reason}, but it was {2}.", unexpectedValue, precision, parent.Subject);
 

--- a/Src/FluentAssertions/ObjectAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ObjectAssertionsExtensions.cs
@@ -16,6 +16,7 @@ namespace FluentAssertions
         /// Asserts that an object can be serialized and deserialized using the binary serializer and that it stills retains
         /// the values of all members.
         /// </summary>
+        /// <param name="assertions"></param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -33,6 +34,13 @@ namespace FluentAssertions
         /// Asserts that an object can be serialized and deserialized using the binary serializer and that it stills retains
         /// the values of all members.
         /// </summary>
+        /// <param name="assertions"></param>
+        /// <param name="options">
+        /// A reference to the <see cref="EquivalencyAssertionOptions{TExpectation}"/> configuration object that can be used
+        /// to influence the way the object graphs are compared. You can also provide an alternative instance of the
+        /// <see cref="EquivalencyAssertionOptions{TExpectation}"/> class. The global defaults are determined by the
+        /// <see cref="AssertionOptions"/> class.
+        /// </param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -72,6 +80,7 @@ namespace FluentAssertions
         /// Asserts that an object can be serialized and deserialized using the data contract serializer and that it stills retains
         /// the values of all members.
         /// </summary>
+        /// <param name="assertions"></param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -89,6 +98,13 @@ namespace FluentAssertions
         /// Asserts that an object can be serialized and deserialized using the data contract serializer and that it stills retains
         /// the values of all members.
         /// </summary>
+        /// <param name="assertions"></param>
+        /// <param name="options">
+        /// A reference to the <see cref="EquivalencyAssertionOptions{TExpectation}"/> configuration object that can be used
+        /// to influence the way the object graphs are compared. You can also provide an alternative instance of the
+        /// <see cref="EquivalencyAssertionOptions{TExpectation}"/> class. The global defaults are determined by the
+        /// <see cref="AssertionOptions"/> class.
+        /// </param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -171,6 +187,7 @@ namespace FluentAssertions
         /// Asserts that an object can be serialized and deserialized using the XML serializer and that it stills retains
         /// the values of all members.
         /// </summary>
+        /// <param name="assertions"></param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.

--- a/Src/FluentAssertions/Primitives/EnumAssertions.cs
+++ b/Src/FluentAssertions/Primitives/EnumAssertions.cs
@@ -45,7 +45,7 @@ namespace FluentAssertions.Primitives
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(!(Subject is null))
+                .ForCondition(Subject is not null)
                 .FailWith("Expected type to be {0}{reason}, but found <null>.", expectedFlag.GetType())
                 .Then
                 .ForCondition(Subject.GetType() == expectedFlag.GetType())
@@ -74,7 +74,7 @@ namespace FluentAssertions.Primitives
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(!(Subject is null))
+                .ForCondition(Subject is not null)
                 .FailWith("Expected type to be {0}{reason}, but found <null>.", unexpectedFlag.GetType())
                 .Then
                 .ForCondition(Subject.GetType() == unexpectedFlag.GetType())

--- a/Src/FluentAssertions/Primitives/ObjectAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ObjectAssertions.cs
@@ -83,6 +83,7 @@ namespace FluentAssertions.Primitives
         /// items in the collection are structurally equal.
         /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
         /// </remarks>
+        /// <param name="expectation">The expected element.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -105,6 +106,7 @@ namespace FluentAssertions.Primitives
         /// The type of a collection property is ignored as long as the collection implements <see cref="IEnumerable{T}"/> and all
         /// items in the collection are structurally equal.
         /// </remarks>
+        /// <param name="expectation">The expected element.</param>
         /// <param name="config">
         /// A reference to the <see cref="EquivalencyAssertionOptions{TSubject}"/> configuration object that can be used
         /// to influence the way the object graphs are compared. You can also provide an alternative instance of the
@@ -151,6 +153,7 @@ namespace FluentAssertions.Primitives
         /// items in the collection are structurally equal.
         /// Notice that actual behavior is determined by the global defaults managed by <see cref="AssertionOptions"/>.
         /// </remarks>
+        /// <param name="unexpected">The unexpected element.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -175,6 +178,7 @@ namespace FluentAssertions.Primitives
         /// The type of a collection property is ignored as long as the collection implements <see cref="IEnumerable{T}"/> and all
         /// items in the collection are structurally equal.
         /// </remarks>
+        /// <param name="unexpected">The unexpected element.</param>
         /// <param name="config">
         /// A reference to the <see cref="EquivalencyAssertionOptions{TSubject}"/> configuration object that can be used
         /// to influence the way the object graphs are compared. You can also provide an alternative instance of the

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -37,7 +37,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(ReferenceEquals(Subject, null))
+                .ForCondition(Subject is null)
                 .BecauseOf(because, becauseArgs)
                 .WithDefaultIdentifier(Identifier)
                 .FailWith("Expected {context} to be <null>{reason}, but found {0}.", Subject);
@@ -58,7 +58,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null))
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .WithDefaultIdentifier(Identifier)
                 .FailWith("Expected {context} not to be <null>{reason}.");
@@ -152,7 +152,7 @@ namespace FluentAssertions.Primitives
             Guard.ThrowIfArgumentIsNull(expectedType, nameof(expectedType));
 
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null))
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .WithDefaultIdentifier("type")
                 .FailWith("Expected {context} to be {0}{reason}, but found <null>.", expectedType);
@@ -206,7 +206,7 @@ namespace FluentAssertions.Primitives
             Guard.ThrowIfArgumentIsNull(unexpectedType, nameof(unexpectedType));
 
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null))
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .WithDefaultIdentifier("type")
                 .FailWith("Expected {context} not to be {0}{reason}, but found <null>.", unexpectedType);
@@ -270,7 +270,7 @@ namespace FluentAssertions.Primitives
             Guard.ThrowIfArgumentIsNull(type, nameof(type));
 
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null))
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .WithDefaultIdentifier("type")
                 .FailWith("Expected {context} to be assignable to {0}{reason}, but found <null>.", type);
@@ -330,7 +330,7 @@ namespace FluentAssertions.Primitives
             Guard.ThrowIfArgumentIsNull(type, nameof(type));
 
             Execute.Assertion
-                .ForCondition(!ReferenceEquals(Subject, null))
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .WithDefaultIdentifier("type")
                 .FailWith("Expected {context} to not be assignable to {0}{reason}, but found <null>.", type);

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -1072,7 +1072,7 @@ namespace FluentAssertions.Primitives
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .FailWith("Expected {context:string} with length {0}{reason}, but found <null>", expected)
                 .Then
                 .ForCondition(Subject.Length == expected)

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -354,7 +354,7 @@ namespace FluentAssertions.Primitives
             }
 
             Execute.Assertion
-                .ForCondition(!(Subject is null))
+                .ForCondition(Subject is not null)
                 .UsingLineBreaks
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} to match regex {0}{reason}, but it was <null>.", regexStr);
@@ -424,7 +424,7 @@ namespace FluentAssertions.Primitives
             }
 
             Execute.Assertion
-                .ForCondition(!(Subject is null))
+                .ForCondition(Subject is not null)
                 .UsingLineBreaks
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} to not match regex {0}{reason}, but it was <null>.", regexStr);

--- a/Src/FluentAssertions/Primitives/StringValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringValidator.cs
@@ -30,7 +30,7 @@ namespace FluentAssertions.Primitives
 
         public void Validate()
         {
-            if ((Expected != null) || (Subject != null))
+            if ((Expected is not null) || (Subject is not null))
             {
                 if (ValidateAgainstNulls())
                 {

--- a/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
@@ -89,7 +89,7 @@ namespace FluentAssertions.Reflection
             Type foundType = Subject.GetTypes().SingleOrDefault(t => t.Namespace == @namespace && t.Name == name);
 
             Execute.Assertion
-                .ForCondition(foundType != null)
+                .ForCondition(foundType is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected assembly {0} to define type {1}.{2}{reason}, but it does not.",
                     Subject.FullName, @namespace, name);

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -42,7 +42,7 @@ namespace FluentAssertions.Specialized
             TimeSpan timeSpan, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:task} to complete within {0}{reason}, but found <null>.", timeSpan);
 
@@ -89,14 +89,14 @@ namespace FluentAssertions.Specialized
             Type expectedType = typeof(TException);
 
             Execute.Assertion
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context} to throw exactly {0}{reason}, but found <null>.", expectedType);
 
             Exception exception = await InvokeWithInterceptionAsync(Subject);
 
             Execute.Assertion
-                .ForCondition(exception != null)
+                .ForCondition(exception is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but no exception was thrown.", expectedType);
 
@@ -120,7 +120,7 @@ namespace FluentAssertions.Specialized
             where TException : Exception
         {
             Execute.Assertion
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context} to throw {0}{reason}, but found <null>.", typeof(TException));
 
@@ -141,7 +141,7 @@ namespace FluentAssertions.Specialized
         public async Task<AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context} not to throw{reason}, but found <null>.");
 
@@ -171,7 +171,7 @@ namespace FluentAssertions.Specialized
             where TException : Exception
         {
             Execute.Assertion
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context} not to throw{reason}, but found <null>.");
 
@@ -224,7 +224,7 @@ namespace FluentAssertions.Specialized
             }
 
             Execute.Assertion
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context} not to throw any exceptions after {0}{reason}, but found <null>.", waitTime);
 

--- a/Src/FluentAssertions/Specialized/DelegateAssertions.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertions.cs
@@ -39,7 +39,7 @@ namespace FluentAssertions.Specialized
             where TException : Exception
         {
             Execute.Assertion
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context} to throw {0}{reason}, but found <null>.", typeof(TException));
 
@@ -62,7 +62,7 @@ namespace FluentAssertions.Specialized
             where TException : Exception
         {
             Execute.Assertion
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context} not to throw {0}{reason}, but found <null>.", typeof(TException));
 
@@ -84,7 +84,7 @@ namespace FluentAssertions.Specialized
         public AndConstraint<TAssertions> NotThrow(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context} not to throw{reason}, but found <null>.");
 
@@ -114,7 +114,7 @@ namespace FluentAssertions.Specialized
             where TException : Exception
         {
             Execute.Assertion
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context} to throw exactly {0}{reason}, but found <null>.", typeof(TException));
 
@@ -124,7 +124,7 @@ namespace FluentAssertions.Specialized
             Type expectedType = typeof(TException);
 
             Execute.Assertion
-                .ForCondition(exception != null)
+                .ForCondition(exception is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {0}{reason}, but no exception was thrown.", expectedType);
 
@@ -159,7 +159,7 @@ namespace FluentAssertions.Specialized
         public AndConstraint<TAssertions> NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context} not to throw after {0}{reason}, but found <null>.", waitTime);
 

--- a/Src/FluentAssertions/Specialized/DelegateAssertionsBase.cs
+++ b/Src/FluentAssertions/Specialized/DelegateAssertionsBase.cs
@@ -35,7 +35,7 @@ namespace FluentAssertions.Specialized
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected a <{0}> to be thrown{reason}, ", typeof(TException))
-                .ForCondition(exception != null)
+                .ForCondition(exception is not null)
                 .FailWith("but no exception was thrown.")
                 .Then
                 .ForCondition(expectedExceptions.Any())

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -22,7 +22,7 @@ namespace FluentAssertions.Specialized
     {
         #region Private Definitions
 
-        private static readonly ExceptionMessageAssertion OuterMessageAssertion = new ExceptionMessageAssertion();
+        private static readonly ExceptionMessageAssertion OuterMessageAssertion = new();
 
         #endregion
 

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -91,10 +91,10 @@ namespace FluentAssertions.Specialized
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected inner {0}{reason}, but ", typeof(TInnerException))
-                .ForCondition(Subject != null)
+                .ForCondition(Subject is not null)
                 .FailWith("no exception was thrown.")
                 .Then
-                .ForCondition(Subject.Any(e => e.InnerException != null))
+                .ForCondition(Subject.Any(e => e.InnerException is not null))
                 .FailWith("the thrown exception has no inner exception.")
                 .Then
                 .ClearExpectation();

--- a/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
@@ -43,7 +43,7 @@ namespace FluentAssertions.Specialized
                 elapsed = execution.ElapsedTime;
             }
 
-            if (execution.Exception != null)
+            if (execution.Exception is not null)
             {
                 // rethrow captured exception
                 throw execution.Exception;

--- a/Src/FluentAssertions/Specialized/FunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/FunctionAssertions.cs
@@ -41,7 +41,7 @@ namespace FluentAssertions.Specialized
         public new AndWhichConstraint<FunctionAssertions<T>, T> NotThrow(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-               .ForCondition(Subject is object)
+               .ForCondition(Subject is not null)
                .BecauseOf(because, becauseArgs)
                .FailWith("Expected {context} not to throw{reason}, but found <null>.");
 
@@ -75,7 +75,7 @@ namespace FluentAssertions.Specialized
         public new AndWhichConstraint<FunctionAssertions<T>, T> NotThrowAfter(TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context} not to throw any exceptions after {0}{reason}, but found <null>.", waitTime);
 

--- a/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
@@ -33,7 +33,7 @@ namespace FluentAssertions.Specialized
             TimeSpan timeSpan, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context} to complete within {0}{reason}, but found <null>.", timeSpan);
 
@@ -70,7 +70,7 @@ namespace FluentAssertions.Specialized
         public new async Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAsync(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context} not to throw{reason}, but found <null>.");
 
@@ -123,7 +123,7 @@ namespace FluentAssertions.Specialized
             }
 
             Execute.Assertion
-                .ForCondition(Subject is object)
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context} not to throw any exceptions after {0}{reason}, but found <null>.", waitTime);
 

--- a/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertions.cs
+++ b/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertions.cs
@@ -52,7 +52,7 @@ namespace FluentAssertions.Specialized
             object[] failArgs)
         {
             Execute.Assertion
-                .ForCondition(subject is object)
+                .ForCondition(subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(failMessage1, failArgs);
 

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -208,6 +208,7 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the selected methods have specified <paramref name="accessModifier"/>.
         /// </summary>
+        /// <param name="accessModifier">The expected access modifier.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -231,6 +232,7 @@ namespace FluentAssertions.Types
         /// <summary>
         /// Asserts that the selected methods don't have specified <paramref name="accessModifier"/>
         /// </summary>
+        /// <param name="accessModifier">The expected access modifier.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -43,7 +43,7 @@ namespace FluentAssertions.Types
                 selectedProperties = selectedProperties.Where(property =>
                 {
                     MethodInfo getter = property.GetGetMethod(nonPublic: true);
-                    return (getter != null) && (getter.IsPublic || getter.IsAssembly);
+                    return (getter is not null) && (getter.IsPublic || getter.IsAssembly);
                 });
 
                 return this;

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -219,7 +219,7 @@ namespace FluentAssertions.Types
         /// </param>
         public AndConstraint<TypeAssertions> NotBe(Type unexpected, string because = "", params object[] becauseArgs)
         {
-            string nameOfUnexpectedType = (unexpected != null) ? $"[{unexpected.AssemblyQualifiedName}]" : "<null>";
+            string nameOfUnexpectedType = (unexpected is not null) ? $"[{unexpected.AssemblyQualifiedName}]" : "<null>";
 
             Execute.Assertion
                 .ForCondition(Subject != unexpected)
@@ -784,14 +784,14 @@ namespace FluentAssertions.Types
 
             string propertyInfoDescription = string.Empty;
 
-            if (propertyInfo != null)
+            if (propertyInfo is not null)
             {
                 propertyInfoDescription = PropertyInfoAssertions.GetDescriptionFor(propertyInfo);
             }
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(propertyInfo != null)
+                .ForCondition(propertyInfo is not null)
                 .FailWith($"Expected {propertyType.Name} {Subject.FullName}.{name} to exist{{reason}}, but it does not.")
                 .Then
                 .ForCondition(propertyInfo.PropertyType == propertyType)
@@ -835,7 +835,7 @@ namespace FluentAssertions.Types
 
             string propertyInfoDescription = string.Empty;
 
-            if (propertyInfo != null)
+            if (propertyInfo is not null)
             {
                 propertyInfoDescription = PropertyInfoAssertions.GetDescriptionFor(propertyInfo);
             }
@@ -1054,12 +1054,12 @@ namespace FluentAssertions.Types
 
             string propertyInfoDescription = string.Empty;
 
-            if (propertyInfo != null)
+            if (propertyInfo is not null)
             {
                 propertyInfoDescription = PropertyInfoAssertions.GetDescriptionFor(propertyInfo);
             }
 
-            Execute.Assertion.ForCondition(propertyInfo != null)
+            Execute.Assertion.ForCondition(propertyInfo is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(string.Format("Expected {0} {1}[{2}] to exist{{reason}}, but it does not.",
                     indexerType.Name, Subject.FullName,
@@ -1113,7 +1113,7 @@ namespace FluentAssertions.Types
         {
             MethodInfo methodInfo = Subject.GetMethod(name, parameterTypes);
 
-            Execute.Assertion.ForCondition(methodInfo != null)
+            Execute.Assertion.ForCondition(methodInfo is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(string.Format("Expected method {0}.{1}({2}) to exist{{reason}}, but it does not.",
                     Subject.FullName, name,
@@ -1141,7 +1141,7 @@ namespace FluentAssertions.Types
 
             string methodInfoDescription = string.Empty;
 
-            if (methodInfo != null)
+            if (methodInfo is not null)
             {
                 methodInfoDescription = MethodInfoAssertions.GetDescriptionFor(methodInfo);
             }
@@ -1169,7 +1169,7 @@ namespace FluentAssertions.Types
         {
             ConstructorInfo constructorInfo = Subject.GetConstructor(parameterTypes);
 
-            Execute.Assertion.ForCondition(constructorInfo != null)
+            Execute.Assertion.ForCondition(constructorInfo is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(string.Format("Expected constructor {0}({1}) to exist{{reason}}, but it does not.",
                     Subject.FullName,
@@ -1317,7 +1317,7 @@ namespace FluentAssertions.Types
         {
             MethodInfo methodInfo = Subject.GetImplicitConversionOperator(sourceType, targetType);
 
-            Execute.Assertion.ForCondition(methodInfo != null)
+            Execute.Assertion.ForCondition(methodInfo is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(string.Format("Expected public static implicit {0}({1}) to exist{{reason}}, but it does not.",
                     targetType.FullName, sourceType.FullName));
@@ -1399,7 +1399,7 @@ namespace FluentAssertions.Types
         {
             MethodInfo methodInfo = Subject.GetExplicitConversionOperator(sourceType, targetType);
 
-            Execute.Assertion.ForCondition(methodInfo != null)
+            Execute.Assertion.ForCondition(methodInfo is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(string.Format("Expected public static explicit {0}({1}) to exist{{reason}}, but it does not.",
                     targetType.FullName, sourceType.FullName));

--- a/Src/FluentAssertions/Xml/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/Node.cs
@@ -45,7 +45,7 @@ namespace FluentAssertions.Xml.Equivalency
         private IEnumerable<Node> GetPath()
         {
             Node current = this;
-            while (current.Parent != null)
+            while (current.Parent is not null)
             {
                 yield return current;
                 current = current.Parent;

--- a/Src/FluentAssertions/Xml/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/Node.cs
@@ -22,7 +22,7 @@ namespace FluentAssertions.Xml.Equivalency
         {
             var resultBuilder = new StringBuilder();
 
-            foreach (var location in GetPath().Reverse())
+            foreach (Node location in GetPath().Reverse())
             {
                 if (location.count > 1)
                 {

--- a/Src/FluentAssertions/Xml/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/Node.cs
@@ -6,7 +6,7 @@ namespace FluentAssertions.Xml.Equivalency
 {
     internal sealed class Node
     {
-        private readonly List<Node> children = new List<Node>();
+        private readonly List<Node> children = new();
         private readonly string name;
         private int count;
 
@@ -71,7 +71,7 @@ namespace FluentAssertions.Xml.Equivalency
 
         private Node AddChildNode(string name)
         {
-            Node node = new Node(this, name);
+            var node = new Node(this, name);
             children.Add(node);
             return node;
         }

--- a/Src/FluentAssertions/Xml/Equivalency/XmlReaderValidator.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/XmlReaderValidator.cs
@@ -25,7 +25,7 @@ namespace FluentAssertions.Xml.Equivalency
         {
             Failure failure = Validate();
 
-            if (shouldBeEquivalent && failure != null)
+            if (shouldBeEquivalent && failure is not null)
             {
                 assertion.FailWith(failure.FormatString, failure.FormatParams);
             }
@@ -61,7 +61,7 @@ namespace FluentAssertions.Xml.Equivalency
                 {
                     case XmlNodeType.Element:
                         failure = ValidateStartElement();
-                        if (failure != null)
+                        if (failure is not null)
                         {
                             return failure;
                         }
@@ -108,7 +108,7 @@ namespace FluentAssertions.Xml.Equivalency
                             $"{expectationIterator.NodeType} found at {currentNode.GetXPath()} is not supported for equivalency comparison.");
                 }
 
-                if (failure != null)
+                if (failure is not null)
                 {
                     return failure;
                 }

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -162,7 +162,7 @@ namespace FluentAssertions.Xml
             XElement root = Subject.Root;
 
             Execute.Assertion
-                .ForCondition((root != null) && (root.Name == expected))
+                .ForCondition((root is not null) && (root.Name == expected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected {context:subject} to have root element {0}{reason}, but found {1}.",
@@ -220,7 +220,7 @@ namespace FluentAssertions.Xml
                     "Cannot assert the document has an element if the element name is <null>*");
 
             Execute.Assertion
-                .ForCondition(Subject.Root != null)
+                .ForCondition(Subject.Root is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected {context:subject} to have root element with child {0}{reason}, but it has no root element.",
@@ -228,7 +228,7 @@ namespace FluentAssertions.Xml
 
             XElement xElement = Subject.Root.Element(expected);
             Execute.Assertion
-                .ForCondition(xElement != null)
+                .ForCondition(xElement is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected {context:subject} to have root element with child {0}{reason}, but no such child element was found.",

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -61,7 +61,7 @@ namespace FluentAssertions.Xml
         public AndConstraint<XElementAssertions> NotBe(XElement unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition((Subject is null && !(unexpected is null)) || !XNode.DeepEquals(Subject, unexpected))
+                .ForCondition((Subject is null && unexpected is not null) || !XNode.DeepEquals(Subject, unexpected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:subject} not to be {0}{reason}.", unexpected);
 

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -182,7 +182,7 @@ namespace FluentAssertions.Xml
             string expectedText = expectedName.ToString();
 
             Execute.Assertion
-                .ForCondition(attribute != null)
+                .ForCondition(attribute is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected {context:subject} to have attribute {0} with value {1}{reason},"
@@ -234,7 +234,7 @@ namespace FluentAssertions.Xml
         {
             XElement xElement = Subject.Element(expected);
             Execute.Assertion
-                .ForCondition(xElement != null)
+                .ForCondition(xElement is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected {context:subject} to have child element {0}{reason}, but no such child element was found.",

--- a/Src/FluentAssertions/Xml/XmlElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XmlElementAssertions.cs
@@ -68,10 +68,11 @@ namespace FluentAssertions.Xml
 
         /// <summary>
         /// Asserts that the current <see cref="XmlElement"/> has an attribute
-        /// with the specified <paramref name="expectedName"/>, <param name="expectedNamespace"/>
+        /// with the specified <paramref name="expectedName"/>, <paramref name="expectedNamespace"/>
         /// and <paramref name="expectedValue"/>.
         /// </summary>
         /// <param name="expectedName">The name of the expected attribute</param>
+        /// <param name="expectedNamespace">The namespace of the expected attribute</param>
         /// <param name="expectedValue">The value of the expected attribute</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion

--- a/Src/FluentAssertions/Xml/XmlElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XmlElementAssertions.cs
@@ -93,7 +93,7 @@ namespace FluentAssertions.Xml
                 + expectedName;
 
             Execute.Assertion
-                .ForCondition(attribute != null)
+                .ForCondition(attribute is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected {context:subject} to have attribute {0}"
@@ -156,7 +156,7 @@ namespace FluentAssertions.Xml
                 + expectedName;
 
             Execute.Assertion
-                .ForCondition(element != null)
+                .ForCondition(element is not null)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected {context:subject} to have child element {0}{reason}, but no such child element was found.",

--- a/Src/FluentAssertions/Xml/XmlNodeAssertions.cs
+++ b/Src/FluentAssertions/Xml/XmlNodeAssertions.cs
@@ -43,8 +43,8 @@ namespace FluentAssertions.Xml
         /// </param>
         public AndConstraint<TAssertions> BeEquivalentTo(XmlNode expected, string because = "", params object[] becauseArgs)
         {
-            using (XmlNodeReader subjectReader = new XmlNodeReader(Subject))
-            using (XmlNodeReader expectedReader = new XmlNodeReader(expected))
+            using (var subjectReader = new XmlNodeReader(Subject))
+            using (var expectedReader = new XmlNodeReader(expected))
             {
                 var xmlReaderValidator = new XmlReaderValidator(subjectReader, expectedReader, because, becauseArgs);
                 xmlReaderValidator.Validate(shouldBeEquivalent: true);
@@ -67,8 +67,8 @@ namespace FluentAssertions.Xml
         /// </param>
         public AndConstraint<TAssertions> NotBeEquivalentTo(XmlNode unexpected, string because = "", params object[] becauseArgs)
         {
-            using (XmlNodeReader subjectReader = new XmlNodeReader(Subject))
-            using (XmlNodeReader unexpectedReader = new XmlNodeReader(unexpected))
+            using (var subjectReader = new XmlNodeReader(Subject))
+            using (var unexpectedReader = new XmlNodeReader(unexpected))
             {
                 var xmlReaderValidator = new XmlReaderValidator(subjectReader, unexpectedReader, because, becauseArgs);
                 xmlReaderValidator.Validate(shouldBeEquivalent: false);

--- a/Tests/Approval.Tests/ApiApproval.cs
+++ b/Tests/Approval.Tests/ApiApproval.cs
@@ -24,7 +24,7 @@ namespace Approval.Tests
         public void ApproveApi(string projectName, string frameworkVersion)
         {
             string codeBase = Assembly.GetExecutingAssembly().CodeBase;
-            UriBuilder uri = new UriBuilder(new Uri(codeBase));
+            var uri = new UriBuilder(new Uri(codeBase));
             string assemblyPath = Uri.UnescapeDataString(uri.Path);
             var containingDirectory = Path.GetDirectoryName(assemblyPath);
             var configurationName = new DirectoryInfo(containingDirectory).Parent.Name;

--- a/Tests/Benchmarks/Benchmarks.csproj
+++ b/Tests/Benchmarks/Benchmarks.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net47</TargetFramework>
+    <LangVersion>9.0</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Tests/FluentAssertions.Specs/AssertionExtensions.cs
+++ b/Tests/FluentAssertions.Specs/AssertionExtensions.cs
@@ -7,7 +7,7 @@ namespace FluentAssertions.Specs
 {
     internal static class AssertionExtensions
     {
-        private static readonly AggregateExceptionExtractor Extractor = new AggregateExceptionExtractor();
+        private static readonly AggregateExceptionExtractor Extractor = new();
 
         public static NonGenericAsyncFunctionAssertions Should(this Func<Task> action, IClock clock)
         {

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedFactAttributeDiscoverer.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedFactAttributeDiscoverer.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Specs.CultureAwareTesting
             var ctorArgs = factAttribute.GetConstructorArguments().ToArray();
             var cultures = Reflector.ConvertArguments(ctorArgs, new[] { typeof(string[]) }).Cast<string[]>().Single();
 
-            if (cultures == null || cultures.Length == 0)
+            if (cultures is null || cultures.Length == 0)
             {
                 cultures = new[] { "en-US", "fr-FR" };
             }

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedTheoryAttributeDiscoverer.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedTheoryAttributeDiscoverer.cs
@@ -27,7 +27,7 @@ namespace FluentAssertions.Specs.CultureAwareTesting
             var ctorArgs = culturedTheoryAttribute.GetConstructorArguments().ToArray();
             var cultures = Reflector.ConvertArguments(ctorArgs, new[] { typeof(string[]) }).Cast<string[]>().Single();
 
-            if (cultures == null || cultures.Length == 0)
+            if (cultures is null || cultures.Length == 0)
             {
                 cultures = new[] { "en-US", "fr-FR" };
             }

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedXunitTheoryTestCaseRunner.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/CulturedXunitTheoryTestCaseRunner.cs
@@ -48,12 +48,12 @@ namespace FluentAssertions.Specs.CultureAwareTesting
 
         protected override Task BeforeTestCaseFinishedAsync()
         {
-            if (originalUICulture != null)
+            if (originalUICulture is not null)
             {
                 CurrentUICulture = originalUICulture;
             }
 
-            if (originalCulture != null)
+            if (originalCulture is not null)
             {
                 CurrentCulture = originalCulture;
             }

--- a/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
@@ -36,12 +36,8 @@ namespace FluentAssertions.Specs
 
             public override bool Equals(object obj)
             {
-                if (!(obj is SubDummy))
-                {
-                    return false;
-                }
-
-                return Id == ((SubDummy)obj).Id;
+                return obj is SubDummy subDummy
+                    && Id == subDummy.Id;
             }
 
             public override int GetHashCode()

--- a/Tests/FluentAssertions.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
@@ -150,7 +150,7 @@ namespace FluentAssertions.Specs
                 }
 
                 PropertyInfo runtimeProperty = subject.GetType().GetRuntimeProperty(name);
-                return (runtimeProperty != null) ? (IMember)new Property(runtimeProperty, parent) : null;
+                return (runtimeProperty is not null) ? (IMember)new Property(runtimeProperty, parent) : null;
             }
         }
 

--- a/Tests/FluentAssertions.Specs/FakeClock.cs
+++ b/Tests/FluentAssertions.Specs/FakeClock.cs
@@ -13,7 +13,7 @@ namespace FluentAssertions.Specs
     /// </remarks>
     internal class FakeClock : IClock
     {
-        private readonly TaskCompletionSource<bool> delayTask = new TaskCompletionSource<bool>();
+        private readonly TaskCompletionSource<bool> delayTask = new();
 
         private TimeSpan elapsedTime = TimeSpan.Zero;
 

--- a/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
+++ b/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
@@ -65,7 +65,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.321">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
+++ b/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Src\FluentAssertions\FluentAssertions.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
@@ -496,7 +496,7 @@ namespace FluentAssertions.Specs
 
             // Act
             IEnumerable<Type> types = AllTypes.From(assembly)
-                .ThatSatisfy(t => t.GetCustomAttribute<SomeAttribute>() != null);
+                .ThatSatisfy(t => t.GetCustomAttribute<SomeAttribute>() is not null);
 
             // Assert
             types.Should()


### PR DESCRIPTION
To allow more consistent null checks, I upgraded the project to C# 9.0.
So not it's `is null` and `is not null` everywhere except when expressions.

As you've already [tweeted](https://twitter.com/ddoomen/status/1345363681455054851) about Target-typed new expressions I'm introducing them in the code base.