### PR TITLE
Make public fields properties

### DIFF
--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -15,9 +15,7 @@ namespace FluentAssertions
     /// </summary>
     public static class CallerIdentifier
     {
-#pragma warning disable CA2211, SA1401, SA1307 // TODO: fix in 6.0
-        public static Action<string> logger = _ => { };
-#pragma warning restore SA1307, SA1401, CA2211
+        public static Action<string> Logger { get; set; } = _ => { };
 
         public static string DetermineCallerIdentity()
         {
@@ -53,7 +51,7 @@ namespace FluentAssertions
                 {
                     var frame = allStackFrames[i];
 
-                    logger(frame.ToString());
+                    Logger(frame.ToString());
 
                     if (frame.GetMethod() is not null
                         && !IsDynamic(frame)
@@ -68,7 +66,7 @@ namespace FluentAssertions
             catch (Exception e)
             {
                 // Ignore exceptions, as determination of caller identity is only a nice-to-have
-                logger(e.ToString());
+                Logger(e.ToString());
             }
 
             return caller;
@@ -178,14 +176,14 @@ namespace FluentAssertions
             {
                 string statement = line.Substring(Math.Min(column - 1, line.Length - 1));
 
-                logger(statement);
+                Logger(statement);
 
                 int indexOfShould = statement.IndexOf(".Should", StringComparison.Ordinal);
                 if (indexOfShould != -1)
                 {
                     string candidate = statement.Substring(0, indexOfShould);
 
-                    logger(candidate);
+                    Logger(candidate);
 
                     if (!IsBooleanLiteral(candidate) && !IsNumeric(candidate) && !IsStringLiteral(candidate) &&
                         !UsesNewKeyword(candidate))

--- a/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyAssertionOptions.cs
@@ -69,7 +69,7 @@ namespace FluentAssertions.Equivalency
             Expression<Func<TExpectation, object>> expression)
         {
             string expressionMemberPath = expression.GetMemberPath().ToString();
-            orderingRules.Add(new PathBasedOrderingRule(expressionMemberPath));
+            OrderingRules.Add(new PathBasedOrderingRule(expressionMemberPath));
             return this;
         }
 

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -42,9 +42,7 @@ namespace FluentAssertions.Equivalency
         private CyclicReferenceHandling cyclicReferenceHandling = CyclicReferenceHandling.ThrowException;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-#pragma warning disable CA1051, SA1401 // TODO: fix in 6.0
-        protected readonly OrderingRuleCollection orderingRules = new();
-#pragma warning restore SA1401, CA1051
+        protected OrderingRuleCollection OrderingRules { get; } = new();
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private bool isRecursive;
@@ -65,7 +63,7 @@ namespace FluentAssertions.Equivalency
         {
             AddMatchingRule(new MustMatchByNameRule());
 
-            orderingRules.Add(new ByteArrayOrderingRule());
+            OrderingRules.Add(new ByteArrayOrderingRule());
         }
 
         /// <summary>
@@ -86,7 +84,7 @@ namespace FluentAssertions.Equivalency
             selectionRules.AddRange(defaults.SelectionRules);
             userEquivalencySteps.AddRange(defaults.UserEquivalencySteps);
             matchingRules.AddRange(defaults.MatchingRules);
-            orderingRules = new OrderingRuleCollection(defaults.OrderingRules);
+            OrderingRules = new OrderingRuleCollection(defaults.OrderingRules);
 
             getDefaultEqualityStrategy = defaults.GetEqualityStrategy;
             TraceWriter = defaults.TraceWriter;
@@ -139,7 +137,7 @@ namespace FluentAssertions.Equivalency
         /// default,
         /// ordering is irrelevant.
         /// </summary>
-        OrderingRuleCollection IEquivalencyAssertionOptions.OrderingRules => orderingRules;
+        OrderingRuleCollection IEquivalencyAssertionOptions.OrderingRules => OrderingRules;
 
         /// <summary>
         /// Gets value indicating whether the equality check will include nested collections and complex types.
@@ -468,8 +466,8 @@ namespace FluentAssertions.Equivalency
         /// </summary>
         public TSelf WithStrictOrdering()
         {
-            orderingRules.Clear();
-            orderingRules.Add(new MatchAllOrderingRule());
+            OrderingRules.Clear();
+            OrderingRules.Add(new MatchAllOrderingRule());
             return (TSelf)this;
         }
 
@@ -479,7 +477,7 @@ namespace FluentAssertions.Equivalency
         /// </summary>
         public TSelf WithStrictOrderingFor(Expression<Func<IObjectInfo, bool>> predicate)
         {
-            orderingRules.Add(new PredicateBasedOrderingRule(predicate));
+            OrderingRules.Add(new PredicateBasedOrderingRule(predicate));
             return (TSelf)this;
         }
 
@@ -488,8 +486,8 @@ namespace FluentAssertions.Equivalency
         /// </summary>
         public TSelf WithoutStrictOrdering()
         {
-            orderingRules.Clear();
-            orderingRules.Add(new ByteArrayOrderingRule());
+            OrderingRules.Clear();
+            OrderingRules.Add(new ByteArrayOrderingRule());
             return (TSelf)this;
         }
 
@@ -499,7 +497,7 @@ namespace FluentAssertions.Equivalency
         /// </summary>
         public TSelf WithoutStrictOrderingFor(Expression<Func<IObjectInfo, bool>> predicate)
         {
-            orderingRules.Add(new PredicateBasedOrderingRule(predicate)
+            OrderingRules.Add(new PredicateBasedOrderingRule(predicate)
             {
                 Invert = true
             });
@@ -669,7 +667,7 @@ namespace FluentAssertions.Equivalency
                 builder.Append("- ").AppendLine(step.ToString());
             }
 
-            foreach (IOrderingRule rule in orderingRules)
+            foreach (IOrderingRule rule in OrderingRules)
             {
                 builder.Append("- ").AppendLine(rule.ToString());
             }
@@ -747,7 +745,7 @@ namespace FluentAssertions.Equivalency
 
         private TSelf AddOrderingRule(IOrderingRule orderingRule)
         {
-            orderingRules.Add(orderingRule);
+            OrderingRules.Add(orderingRule);
             return (TSelf)this;
         }
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -129,7 +129,7 @@ namespace FluentAssertions
     }
     public static class CallerIdentifier
     {
-        public static System.Action<string> logger;
+        public static System.Action<string> Logger { get; set; }
         public static string DetermineCallerIdentity() { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -1022,10 +1022,10 @@ namespace FluentAssertions.Equivalency
     public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
     {
-        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
-        protected readonly FluentAssertions.Equivalency.OrderingRuleCollection orderingRules;
         protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -129,7 +129,7 @@ namespace FluentAssertions
     }
     public static class CallerIdentifier
     {
-        public static System.Action<string> logger;
+        public static System.Action<string> Logger { get; set; }
         public static string DetermineCallerIdentity() { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -1022,10 +1022,10 @@ namespace FluentAssertions.Equivalency
     public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
     {
-        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
-        protected readonly FluentAssertions.Equivalency.OrderingRuleCollection orderingRules;
         protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -129,7 +129,7 @@ namespace FluentAssertions
     }
     public static class CallerIdentifier
     {
-        public static System.Action<string> logger;
+        public static System.Action<string> Logger { get; set; }
         public static string DetermineCallerIdentity() { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -1022,10 +1022,10 @@ namespace FluentAssertions.Equivalency
     public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
     {
-        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
-        protected readonly FluentAssertions.Equivalency.OrderingRuleCollection orderingRules;
         protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -128,7 +128,7 @@ namespace FluentAssertions
     }
     public static class CallerIdentifier
     {
-        public static System.Action<string> logger;
+        public static System.Action<string> Logger { get; set; }
         public static string DetermineCallerIdentity() { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1015,10 +1015,10 @@ namespace FluentAssertions.Equivalency
     public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
     {
-        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
-        protected readonly FluentAssertions.Equivalency.OrderingRuleCollection orderingRules;
         protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -129,7 +129,7 @@ namespace FluentAssertions
     }
     public static class CallerIdentifier
     {
-        public static System.Action<string> logger;
+        public static System.Action<string> Logger { get; set; }
         public static string DetermineCallerIdentity() { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -1022,10 +1022,10 @@ namespace FluentAssertions.Equivalency
     public abstract class SelfReferenceEquivalencyAssertionOptions<TSelf> : FluentAssertions.Equivalency.IEquivalencyAssertionOptions
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
     {
-        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
-        protected readonly FluentAssertions.Equivalency.OrderingRuleCollection orderingRules;
         protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
+        [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+        protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
         public FluentAssertions.Equivalency.Tracing.ITraceWriter TraceWriter { get; }
         protected TSelf AddSelectionRule(FluentAssertions.Equivalency.IMemberSelectionRule selectionRule) { }
         public TSelf AllowingInfiniteRecursion() { }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -19,6 +19,7 @@ sidebar:
 
 **Breaking Changes (Extensibility)**
 * Pascal cased `CallerIdentifier.logger` - [#1458](https://github.com/fluentassertions/fluentassertions/pull/1458).
+* Pascal cased `SelfReferenceEquivalencyAssertionOptions.orderingRules` - [#1458](https://github.com/fluentassertions/fluentassertions/pull/1458).
 
 ## 6.0.0 Alpha 2
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -18,6 +18,7 @@ sidebar:
 **Breaking Changes**
 
 **Breaking Changes (Extensibility)**
+* Pascal cased `CallerIdentifier.logger` - [#1458](https://github.com/fluentassertions/fluentassertions/pull/1458).
 
 ## 6.0.0 Alpha 2
 


### PR DESCRIPTION
`CallerIdentifier.logger` and `SelfReferenceEquivalencyAssertionOptions.orderingRules` are public fields.
This PR makes them properties instead and pascal case their names.