### PR TITLE
Make new `CloneDefaults` less assuming

### DIFF
--- a/Src/FluentAssertions/AssertionOptions.cs
+++ b/Src/FluentAssertions/AssertionOptions.cs
@@ -21,12 +21,12 @@ namespace FluentAssertions
             return new EquivalencyAssertionOptions<T>(defaults);
         }
 
-        public static TOptions CloneDefaults<T, TOptions>()
+        internal static TOptions CloneDefaults<T, TOptions>(Func<EquivalencyAssertionOptions, TOptions> predicate)
             where TOptions : EquivalencyAssertionOptions<T>
         {
-            return (TOptions)Activator.CreateInstance(
-                typeof(TOptions),
-                defaults);
+            Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
+
+            return predicate(defaults);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Data/DataColumnAssertions.cs
+++ b/Src/FluentAssertions/Data/DataColumnAssertions.cs
@@ -113,7 +113,7 @@ namespace FluentAssertions.Data
         {
             Guard.ThrowIfArgumentIsNull(config, nameof(config));
 
-            IDataEquivalencyAssertionOptions<DataColumn> options = config(AssertionOptions.CloneDefaults<DataColumn, DataEquivalencyAssertionOptions<DataColumn>>());
+            IDataEquivalencyAssertionOptions<DataColumn> options = config(AssertionOptions.CloneDefaults<DataColumn, DataEquivalencyAssertionOptions<DataColumn>>(e => new(e)));
 
             var context = new EquivalencyValidationContext(Node.From<DataColumn>(() => CallerIdentifier.DetermineCallerIdentity()))
             {

--- a/Src/FluentAssertions/Data/DataEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Data/DataEquivalencyAssertionOptions.cs
@@ -9,9 +9,7 @@ using FluentAssertions.Equivalency;
 
 namespace FluentAssertions.Data
 {
-#pragma warning disable CA1812 // Internal class that is apparently never instantiated; this class is instantiated dynamically by AssertionOptions.CloneDefaults
     internal class DataEquivalencyAssertionOptions<T> : EquivalencyAssertionOptions<T>, IDataEquivalencyAssertionOptions<T>
-#pragma warning restore CA1812
     {
         private readonly HashSet<string> excludeTableNames = new();
         private readonly HashSet<string> excludeColumnNames = new();

--- a/Src/FluentAssertions/Data/DataRowAssertions.cs
+++ b/Src/FluentAssertions/Data/DataRowAssertions.cs
@@ -178,7 +178,7 @@ namespace FluentAssertions.Data
         {
             Guard.ThrowIfArgumentIsNull(config, nameof(config));
 
-            IDataEquivalencyAssertionOptions<DataRow> options = config(AssertionOptions.CloneDefaults<DataRow, DataEquivalencyAssertionOptions<DataRow>>());
+            IDataEquivalencyAssertionOptions<DataRow> options = config(AssertionOptions.CloneDefaults<DataRow, DataEquivalencyAssertionOptions<DataRow>>(e => new(e)));
 
             var context = new EquivalencyValidationContext(Node.From<DataRow>(() => CallerIdentifier.DetermineCallerIdentity()))
             {

--- a/Src/FluentAssertions/Data/DataSetAssertions.cs
+++ b/Src/FluentAssertions/Data/DataSetAssertions.cs
@@ -230,7 +230,7 @@ namespace FluentAssertions.Data
         {
             Guard.ThrowIfArgumentIsNull(config, nameof(config));
 
-            IDataEquivalencyAssertionOptions<DataSet> options = config(AssertionOptions.CloneDefaults<DataSet, DataEquivalencyAssertionOptions<DataSet>>());
+            IDataEquivalencyAssertionOptions<DataSet> options = config(AssertionOptions.CloneDefaults<DataSet, DataEquivalencyAssertionOptions<DataSet>>(e => new(e)));
 
             var context = new EquivalencyValidationContext(Node.From<DataSet>(() => CallerIdentifier.DetermineCallerIdentity()))
             {

--- a/Src/FluentAssertions/Data/DataTableAssertions.cs
+++ b/Src/FluentAssertions/Data/DataTableAssertions.cs
@@ -243,7 +243,7 @@ namespace FluentAssertions.Data
         {
             Guard.ThrowIfArgumentIsNull(config, nameof(config));
 
-            IDataEquivalencyAssertionOptions<DataTable> options = config(AssertionOptions.CloneDefaults<DataTable, DataEquivalencyAssertionOptions<DataTable>>());
+            IDataEquivalencyAssertionOptions<DataTable> options = config(AssertionOptions.CloneDefaults<DataTable, DataEquivalencyAssertionOptions<DataTable>>(e => new(e)));
 
             var context = new EquivalencyValidationContext(Node.From<DataTable>(() => CallerIdentifier.DetermineCallerIdentity()))
             {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -111,8 +111,6 @@ namespace FluentAssertions
         public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
-        public static TOptions CloneDefaults<T, TOptions>()
-            where TOptions : FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> { }
     }
     public static class AtLeast
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -111,8 +111,6 @@ namespace FluentAssertions
         public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
-        public static TOptions CloneDefaults<T, TOptions>()
-            where TOptions : FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> { }
     }
     public static class AtLeast
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -111,8 +111,6 @@ namespace FluentAssertions
         public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
-        public static TOptions CloneDefaults<T, TOptions>()
-            where TOptions : FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> { }
     }
     public static class AtLeast
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -110,8 +110,6 @@ namespace FluentAssertions
         public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
-        public static TOptions CloneDefaults<T, TOptions>()
-            where TOptions : FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> { }
     }
     public static class AtLeast
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -111,8 +111,6 @@ namespace FluentAssertions
         public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
-        public static TOptions CloneDefaults<T, TOptions>()
-            where TOptions : FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> { }
     }
     public static class AtLeast
     {


### PR DESCRIPTION
The new `CloneDefaults` added in #1419 _assumes_ that `TOptions` has a constructor that takes an `EquivalencyAssertionOptions`.
Instead of assuming the existence of such a constructor, inject a predicate to make it more type safe.

Two other benefits:
* The compiler now easily sees that `DataEquivalencyAssertionOptions` is constructed.
* It's faster to construct and inject a predicate.

```
|            Method |       Mean |    Error |   StdDev | Ratio |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------ |-----------:|---------:|---------:|------:|-------:|-------:|------:|----------:|
|     CloneDefaults | 1,437.0 ns | 27.29 ns | 29.20 ns |  1.00 | 0.4349 | 0.0038 |     - |   2.68 KB |
| CloneDefaultsFunc |   708.4 ns |  5.20 ns |  4.86 ns |  0.49 | 0.3729 | 0.0038 |     - |    2.3 KB |
```