### PR TITLE
Remove unnecessary Lazy wrapping of CallerIdentity

### DIFF
--- a/Src/FluentAssertions/Data/DataColumnAssertions.cs
+++ b/Src/FluentAssertions/Data/DataColumnAssertions.cs
@@ -115,9 +115,7 @@ namespace FluentAssertions.Data
 
             IDataEquivalencyAssertionOptions<DataColumn> options = config(AssertionOptions.CloneDefaults<DataColumn, DataEquivalencyAssertionOptions<DataColumn>>());
 
-            var callerIdentity = new Lazy<string>(CallerIdentifier.DetermineCallerIdentity);
-
-            var context = new EquivalencyValidationContext(Node.From<DataColumn>(() => callerIdentity.Value))
+            var context = new EquivalencyValidationContext(Node.From<DataColumn>(() => CallerIdentifier.DetermineCallerIdentity()))
             {
                 Subject = Subject,
                 Expectation = expectation,

--- a/Src/FluentAssertions/Data/DataRowAssertions.cs
+++ b/Src/FluentAssertions/Data/DataRowAssertions.cs
@@ -180,9 +180,7 @@ namespace FluentAssertions.Data
 
             IDataEquivalencyAssertionOptions<DataRow> options = config(AssertionOptions.CloneDefaults<DataRow, DataEquivalencyAssertionOptions<DataRow>>());
 
-            var callerIdentity = new Lazy<string>(CallerIdentifier.DetermineCallerIdentity);
-
-            var context = new EquivalencyValidationContext(Node.From<DataRow>(() => callerIdentity.Value))
+            var context = new EquivalencyValidationContext(Node.From<DataRow>(() => CallerIdentifier.DetermineCallerIdentity()))
             {
                 Subject = Subject,
                 Expectation = expectation,

--- a/Src/FluentAssertions/Data/DataSetAssertions.cs
+++ b/Src/FluentAssertions/Data/DataSetAssertions.cs
@@ -232,9 +232,7 @@ namespace FluentAssertions.Data
 
             IDataEquivalencyAssertionOptions<DataSet> options = config(AssertionOptions.CloneDefaults<DataSet, DataEquivalencyAssertionOptions<DataSet>>());
 
-            var callerIdentity = new Lazy<string>(CallerIdentifier.DetermineCallerIdentity);
-
-            var context = new EquivalencyValidationContext(Node.From<DataSet>(() => callerIdentity.Value))
+            var context = new EquivalencyValidationContext(Node.From<DataSet>(() => CallerIdentifier.DetermineCallerIdentity()))
             {
                 Subject = Subject,
                 Expectation = expectation,

--- a/Src/FluentAssertions/Data/DataTableAssertions.cs
+++ b/Src/FluentAssertions/Data/DataTableAssertions.cs
@@ -245,9 +245,7 @@ namespace FluentAssertions.Data
 
             IDataEquivalencyAssertionOptions<DataTable> options = config(AssertionOptions.CloneDefaults<DataTable, DataEquivalencyAssertionOptions<DataTable>>());
 
-            var callerIdentity = new Lazy<string>(CallerIdentifier.DetermineCallerIdentity);
-
-            var context = new EquivalencyValidationContext(Node.From<DataTable>(() => callerIdentity.Value))
+            var context = new EquivalencyValidationContext(Node.From<DataTable>(() => CallerIdentifier.DetermineCallerIdentity()))
             {
                 Subject = Subject,
                 Expectation = expectation,


### PR DESCRIPTION
In no other `BeEquivalentTo` methods we wrap the call to `DetermineCallerIdentity` in a `Lazy<T>`.

I ran the example in `LargeDataTableEquivalencyBenchmarks` and `DetermineCallerIdentity` was not hit, so I don't really the purpose of wrapping it.