### PR TITLE
Bumped most dependencies to the latest and greatest

### DIFF
--- a/Build/_build.csproj
+++ b/Build/_build.csproj
@@ -11,6 +11,6 @@
     <PackageDownload Include="GitVersion.Tool" Version="[5.1.2]" />
     <PackageDownload Include="NSpec" Version="[3.1.0]" />
     <PackageDownload Include="xunit.runner.console" Version="[2.4.1]" />
-    <PackageReference Include="Nuke.Common" Version="0.25.0" />
+    <PackageReference Include="Nuke.Common" Version="5.0.2" />
   </ItemGroup>
 </Project>

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -40,7 +40,7 @@
     <AdditionalFiles Include="BannedSymbols.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" PrivateAssets="all" />
+    <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" PrivateAssets="all" />
     <None Include="..\FluentAssertions.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/Tests/Approval.Tests/Approval.Tests.csproj
+++ b/Tests/Approval.Tests/Approval.Tests.csproj
@@ -5,13 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ApprovalTests" Version="5.4.3" />
+    <PackageReference Include="ApprovalTests" Version="5.4.5" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
   </ItemGroup>
 

--- a/Tests/Benchmarks/Benchmarks.csproj
+++ b/Tests/Benchmarks/Benchmarks.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="Bogus" Version="31.0.3" />
+    <PackageReference Include="Bogus" Version="32.0.2" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
+++ b/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
@@ -29,7 +29,6 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net47'">
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -37,7 +36,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[16.2.0]" />
     <PackageReference Include="xunit.runner.visualstudio" Version="[2.4.1]">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -45,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.0'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -55,6 +53,7 @@
   <ItemGroup>
     <PackageReference Include="Chill" Version="4.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.StaFact" Version="1.0.37" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />

--- a/Tests/TestFrameworks/MSTestV2.Specs/MSTestV2.Specs.csproj
+++ b/Tests/TestFrameworks/MSTestV2.Specs/MSTestV2.Specs.csproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="..\..\..\Src\FluentAssertions\FluentAssertions.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>

--- a/Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj
+++ b/Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="..\..\..\Src\FluentAssertions\FluentAssertions.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Machine.Specifications" Version="1.0.0" />
     <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.10.1" />
   </ItemGroup>

--- a/Tests/TestFrameworks/NUnit3.Specs/NUnit3.Specs.csproj
+++ b/Tests/TestFrameworks/NUnit3.Specs/NUnit3.Specs.csproj
@@ -9,8 +9,8 @@
     <ProjectReference Include="..\..\..\Src\FluentAssertions\FluentAssertions.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/TestFrameworks/XUnit2.Specs/XUnit2.Specs.csproj
+++ b/Tests/TestFrameworks/XUnit2.Specs/XUnit2.Specs.csproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="..\..\..\Src\FluentAssertions\FluentAssertions.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Skipped the FxCop assemblies because bumping them causes deprecation message to appear. See also https://docs.microsoft.com/en-us/visualstudio/code-quality/migrate-from-fxcop-analyzers-to-net-analyzers?view=vs-2019