### PR TITLE
Add WithParameterName

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -882,6 +882,51 @@ namespace FluentAssertions
             return (await task).WithInnerException<TInnerException>(because, becauseArgs);
         }
 
+        /// <summary>
+        /// Asserts that the thrown exception has a parameter which name matches <paramref name="paramName" />.
+        /// </summary>
+        /// <param name="parent">The <see cref="ExceptionAssertions{TException}"/> containing the thrown exception.</param>
+        /// <param name="paramName">The expected name of the parameter</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public static ExceptionAssertions<TException> WithParameterName<TException>(
+            this ExceptionAssertions<TException> parent,
+            string paramName,
+            string because = "",
+            params object[] becauseArgs)
+            where TException : ArgumentException
+        {
+            parent.Which.ParamName.Should().Be(paramName, because, becauseArgs);
+            return parent;
+        }
+
+        /// <summary>
+        /// Asserts that the thrown exception has a parameter which name matches <paramref name="paramName" />.
+        /// </summary>
+        /// <param name="task">The <see cref="ExceptionAssertions{TException}"/> containing the thrown exception.</param>
+        /// <param name="paramName">The expected name of the parameter</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public static async Task<ExceptionAssertions<TException>> WithParameterName<TException>(
+            this Task<ExceptionAssertions<TException>> task,
+            string paramName,
+            string because = "",
+            params object[] becauseArgs)
+            where TException : ArgumentException
+        {
+            return (await task).WithParameterName(paramName, because, becauseArgs);
+        }
+
 #pragma warning restore AV1755
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -105,6 +105,10 @@ namespace FluentAssertions
             where TInnerException : System.Exception { }
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public static FluentAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this FluentAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, string because = "", params object[] becauseArgs)
+            where TException : System.ArgumentException { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithParameterName<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string paramName, string because = "", params object[] becauseArgs)
+            where TException : System.ArgumentException { }
     }
     public static class AssertionOptions
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -105,6 +105,10 @@ namespace FluentAssertions
             where TInnerException : System.Exception { }
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public static FluentAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this FluentAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, string because = "", params object[] becauseArgs)
+            where TException : System.ArgumentException { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithParameterName<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string paramName, string because = "", params object[] becauseArgs)
+            where TException : System.ArgumentException { }
     }
     public static class AssertionOptions
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -105,6 +105,10 @@ namespace FluentAssertions
             where TInnerException : System.Exception { }
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public static FluentAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this FluentAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, string because = "", params object[] becauseArgs)
+            where TException : System.ArgumentException { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithParameterName<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string paramName, string because = "", params object[] becauseArgs)
+            where TException : System.ArgumentException { }
     }
     public static class AssertionOptions
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -104,6 +104,10 @@ namespace FluentAssertions
             where TInnerException : System.Exception { }
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public static FluentAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this FluentAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, string because = "", params object[] becauseArgs)
+            where TException : System.ArgumentException { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithParameterName<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string paramName, string because = "", params object[] becauseArgs)
+            where TException : System.ArgumentException { }
     }
     public static class AssertionOptions
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -105,6 +105,10 @@ namespace FluentAssertions
             where TInnerException : System.Exception { }
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
+        public static FluentAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this FluentAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, string because = "", params object[] becauseArgs)
+            where TException : System.ArgumentException { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithParameterName<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string paramName, string because = "", params object[] becauseArgs)
+            where TException : System.ArgumentException { }
     }
     public static class AssertionOptions
     {

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -966,6 +966,37 @@ namespace FluentAssertions.Specs // TODO Move to FluentAssertions.Specs.Exceptio
             action.Should().Throw<InvalidOperationException>("*async*void*");
         }
 
+        [Fact]
+        public async Task When_a_method_throws_with_a_matching_parameter_name_it_should_succeed()
+        {
+            // Arrange
+            Func<Task> task = () => new AsyncClass().ThrowAsync(new ArgumentNullException("someParameter"));
+
+            // Act
+            Func<Task> act = () =>
+                task.Should().ThrowAsync<ArgumentException>()
+                    .WithParameterName("someParameter");
+
+            // Assert
+            await act.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_a_method_throws_with_a_non_matching_parameter_name_it_should_fail_with_a_descriptive_message()
+        {
+            // Arrange
+            Func<Task> task = () => new AsyncClass().ThrowAsync(new ArgumentNullException("someOtherParameter"));
+
+            // Act
+            Func<Task> act = () =>
+                task.Should().ThrowAsync<ArgumentException>()
+                    .WithParameterName("someParameter", "we want to test the failure {0}", "message");
+
+            // Assert
+            await act.Should().ThrowAsync<XunitException>()
+                .WithMessage("*someParameter*we want to test the failure message*someOtherParameter*");
+        }
+
         #region NotThrowAfterAsync
         [Fact]
         public async Task When_wait_time_is_zero_for_async_func_executed_with_wait_it_should_not_throw()
@@ -1199,6 +1230,12 @@ namespace FluentAssertions.Specs // TODO Move to FluentAssertions.Specs.Exceptio
         {
             await Task.Yield();
             throw new TException();
+        }
+
+        public async Task ThrowAsync(Exception exception)
+        {
+            await Task.Yield();
+            throw exception;
         }
 
         public async ValueTask ThrowAsyncValueTask<TException>()

--- a/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
@@ -750,6 +750,37 @@ namespace FluentAssertions.Specs
                         typeof(ExceptionWithEmptyToString)));
         }
 
+        [Fact]
+        public void When_a_method_throws_with_a_matching_parameter_name_it_should_succeed()
+        {
+            // Arrange
+            Action throwException = () => throw new ArgumentNullException("someParameter");
+
+            // Act
+            Action act = () =>
+                throwException.Should().Throw<ArgumentException>()
+                    .WithParameterName("someParameter");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_a_method_throws_with_a_non_matching_parameter_name_it_should_fail_with_a_descriptive_message()
+        {
+            // Arrange
+            Action throwException = () => throw new ArgumentNullException("someOtherParameter");
+
+            // Act
+            Action act = () =>
+                throwException.Should().Throw<ArgumentException>()
+                    .WithParameterName("someParameter", "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*someParameter*we want to test the failure message*someOtherParameter*");
+        }
+
         #endregion
 
         #region Not Throw

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -10,6 +10,7 @@ sidebar:
 ## 6.0.0
 
 **What's New**
+* Added `WithParameterName` extension to ease asserting on the parameter name for a thrown `ArgumentException` - [#1466](https://github.com/fluentassertions/fluentassertions/pull/1466).
 
 **Fixes**
 * Sometimes `BeEquivalentTo` reported an incorrect message when a dictionary was missing a key - [#1454](https://github.com/fluentassertions/fluentassertions/pull/1454)


### PR DESCRIPTION
Add `WithParameterName` extension to assert on the `ParamName` property on `ArgumentException`.

This fixes #1453 