### PR TITLE
Limit formatting to a maximum number of lines

### DIFF
--- a/Src/FluentAssertions/AssertionOptions.cs
+++ b/Src/FluentAssertions/AssertionOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
+using FluentAssertions.Formatting;
 
 namespace FluentAssertions
 {
@@ -48,5 +49,10 @@ namespace FluentAssertions
         /// is structurally equivalent to another (collection of) object(s).
         /// </summary>
         public static EquivalencyStepCollection EquivalencySteps { get; }
+
+        /// <summary>
+        /// Gets the default formatting options used by the formatters in Fluent Assertions.
+        /// </summary>
+        public static FormattingOptions FormattingOptions { get; } = new();
     }
 }

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -131,7 +131,7 @@ namespace FluentAssertions
             int startOfSecondFluentAssertionsScopeStackFrameIndex = Array.FindIndex(
                 allStackFrames,
                 startIndex: firstNonFluentAssertionsStackFrameIndex + 1,
-                frame => IsCurrentAssembly(frame));
+                IsCurrentAssembly);
 
             return startOfSecondFluentAssertionsScopeStackFrameIndex < 0;
         }
@@ -148,7 +148,7 @@ namespace FluentAssertions
 
         private static bool IsCurrentAssembly(StackFrame frame)
         {
-            return frame.GetMethod().DeclaringType.Assembly == typeof(CallerIdentifier).Assembly;
+            return frame.GetMethod().DeclaringType?.Assembly == typeof(CallerIdentifier).Assembly;
         }
 
         private static bool IsDotNet(StackFrame frame)
@@ -162,7 +162,7 @@ namespace FluentAssertions
 
         private static bool IsCompilerServices(StackFrame frame)
         {
-            return frame.GetMethod().DeclaringType.Namespace == "System.Runtime.CompilerServices";
+            return frame.GetMethod().DeclaringType?.Namespace == "System.Runtime.CompilerServices";
         }
 
         private static string ExtractVariableNameFrom(StackFrame frame)

--- a/Src/FluentAssertions/Common/Iterator.cs
+++ b/Src/FluentAssertions/Common/Iterator.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace FluentAssertions.Common
+{
+    /// <summary>
+    /// A smarter enumerator that can provide information about the relative location (current, first, last)
+    /// of the current item within the collection without unnecessarily iterating the collection.
+    /// </summary>
+    internal class Iterator<T> : IEnumerator<T>
+    {
+        private const int InitialIndex = -1;
+        private readonly IEnumerable<T> enumerable;
+        private readonly int? maxItems;
+        private IEnumerator<T> enumerator;
+        private T current;
+        private T next;
+
+        private bool hasNext;
+        private bool hasCurrent;
+
+        private bool hasCompleted;
+
+        public Iterator(IEnumerable<T> enumerable, int maxItems = int.MaxValue)
+        {
+            this.enumerable = enumerable;
+            this.maxItems = maxItems;
+
+            Reset();
+        }
+
+        public void Reset()
+        {
+            Index = InitialIndex;
+
+            enumerator = enumerable.GetEnumerator();
+            hasCurrent = false;
+            hasNext = false;
+            hasCompleted = false;
+            current = default;
+            next = default;
+        }
+
+        public int Index { get; private set; }
+
+        public bool IsFirst => Index == 0;
+
+        public bool IsLast => (hasCurrent && !hasNext) || HasReachedMaxItems;
+
+        object IEnumerator.Current => Current;
+
+        public T Current
+        {
+            get
+            {
+                if (!hasCurrent)
+                {
+                    throw new InvalidOperationException($"Please call {nameof(MoveNext)} first");
+                }
+
+                return current;
+            }
+
+            private set
+            {
+                current = value;
+                hasCurrent = true;
+            }
+        }
+
+        public bool MoveNext()
+        {
+            if (!hasCompleted)
+            {
+                if (FetchCurrent())
+                {
+                    PrefetchNext();
+                    return true;
+                }
+            }
+
+            hasCompleted = true;
+            return false;
+        }
+
+        private bool FetchCurrent()
+        {
+            if (hasNext && !HasReachedMaxItems)
+            {
+                Current = next;
+                Index++;
+
+                return true;
+            }
+
+            if (enumerator.MoveNext() && !HasReachedMaxItems)
+            {
+                Current = enumerator.Current;
+                Index++;
+
+                return true;
+            }
+            else
+            {
+                hasCompleted = true;
+                return false;
+            }
+        }
+
+        public bool HasReachedMaxItems => Index == maxItems;
+
+        private void PrefetchNext()
+        {
+            if (enumerator.MoveNext())
+            {
+                next = enumerator.Current;
+                hasNext = true;
+            }
+            else
+            {
+                next = default;
+                hasNext = false;
+            }
+        }
+
+        public bool IsEmpty
+        {
+            get
+            {
+                if (!hasCurrent && !hasCompleted)
+                {
+                    throw new InvalidOperationException($"Please call {nameof(MoveNext)} first");
+                }
+
+                return Index == InitialIndex;
+            }
+        }
+
+        public void Dispose()
+        {
+            enumerator.Dispose();
+        }
+    }
+}

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -18,11 +18,11 @@ namespace FluentAssertions.Execution
     {
         #region Private Definitions
 
+        private readonly FormattingOptions formattingOptions = AssertionOptions.FormattingOptions.Clone();
         private readonly IAssertionStrategy assertionStrategy;
         private readonly ContextDataItems contextData = new();
 
         private Func<string> reason;
-        private FormattingOptions formattingOptions = new();
 
         private static readonly AsyncLocal<AssertionScope> CurrentScope = new();
         private AssertionScope parent;
@@ -122,6 +122,12 @@ namespace FluentAssertions.Execution
             private set => SetCurrentAssertionScope(value);
         }
 
+        /// <summary>
+        /// Forces the formatters that support it to add the necessary line breaks.
+        /// </summary>
+        /// <remarks>
+        /// This is just shorthand for modifying the <see cref="FormattingOptions"/> property.
+        /// </remarks>
         public AssertionScope UsingLineBreaks
         {
             get
@@ -130,6 +136,11 @@ namespace FluentAssertions.Execution
                 return this;
             }
         }
+
+        /// <summary>
+        /// Exposes the options the scope will use for formatting objects in case an assertion fails.
+        /// </summary>
+        public FormattingOptions FormattingOptions => formattingOptions;
 
         internal bool Succeeded
         {

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -130,7 +130,7 @@ namespace FluentAssertions.Execution
             }
         }
 
-        public bool Succeeded
+        internal bool Succeeded
         {
             get => succeeded == true;
         }

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using FluentAssertions.Common;
+using FluentAssertions.Formatting;
 
 namespace FluentAssertions.Execution
 {
@@ -21,7 +22,7 @@ namespace FluentAssertions.Execution
         private readonly ContextDataItems contextData = new();
 
         private Func<string> reason;
-        private bool useLineBreaks;
+        private FormattingOptions formattingOptions = new();
 
         private static readonly AsyncLocal<AssertionScope> CurrentScope = new();
         private AssertionScope parent;
@@ -125,7 +126,7 @@ namespace FluentAssertions.Execution
         {
             get
             {
-                useLineBreaks = true;
+                formattingOptions.UseLineBreaks = true;
                 return this;
             }
         }
@@ -184,7 +185,7 @@ namespace FluentAssertions.Execution
             Func<string> localReason = reason;
             expectation = () =>
             {
-                var messageBuilder = new MessageBuilder(useLineBreaks);
+                var messageBuilder = new MessageBuilder(formattingOptions);
                 string reason = localReason?.Invoke() ?? string.Empty;
                 string identifier = GetIdentifier();
 
@@ -240,7 +241,7 @@ namespace FluentAssertions.Execution
             return FailWith(() =>
             {
                 string localReason = reason?.Invoke() ?? string.Empty;
-                var messageBuilder = new MessageBuilder(useLineBreaks);
+                var messageBuilder = new MessageBuilder(formattingOptions);
                 string identifier = GetIdentifier();
                 FailReason failReason = failReasonFunc();
                 string result = messageBuilder.Build(failReason.Message, failReason.Args, localReason, contextData, identifier, fallbackIdentifier);

--- a/Src/FluentAssertions/Execution/MessageBuilder.cs
+++ b/Src/FluentAssertions/Execution/MessageBuilder.cs
@@ -16,17 +16,17 @@ namespace FluentAssertions.Execution
     /// </summary>
     internal class MessageBuilder
     {
-        #region Private Definitions
+        private readonly FormattingOptions formattingOptions;
 
-        private readonly bool useLineBreaks;
+        #region Private Definitions
 
         private readonly char[] blanks = { '\r', '\n', ' ', '\t' };
 
         #endregion
 
-        public MessageBuilder(bool useLineBreaks)
+        public MessageBuilder(FormattingOptions formattingOptions)
         {
-            this.useLineBreaks = useLineBreaks;
+            this.formattingOptions = formattingOptions;
         }
 
         // SMELL: Too many parameters.
@@ -89,10 +89,9 @@ namespace FluentAssertions.Execution
 
         private string FormatArgumentPlaceholders(string failureMessage, object[] failureArgs)
         {
-            string[] values = failureArgs.Select(a => Formatter.ToString(a, useLineBreaks)).ToArray();
-            string formattedMessage = string.Format(CultureInfo.InvariantCulture, failureMessage, values);
+            string[] values = failureArgs.Select(a => Formatter.ToString(a, formattingOptions)).ToArray();
 
-            return formattedMessage;
+            return string.Format(CultureInfo.InvariantCulture, failureMessage, values);
         }
 
         private string SanitizeReason(string reason)

--- a/Src/FluentAssertions/Formatting/AggregateExceptionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AggregateExceptionValueFormatter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.Globalization;
-using System.Text;
+using static System.FormattableString;
 
 namespace FluentAssertions.Formatting
 {
@@ -18,27 +17,24 @@ namespace FluentAssertions.Formatting
             return value is AggregateException;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
             var exception = (AggregateException)value;
             if (exception.InnerExceptions.Count == 1)
             {
-                return "(aggregated) " + formatChild("inner", exception.InnerException);
+                formattedGraph.AddFragment("(aggregated) ");
+
+                formatChild("inner", exception.InnerException, formattedGraph);
             }
             else
             {
-                var builder = new StringBuilder();
-
-                builder.AppendFormat(CultureInfo.InvariantCulture, "{0} (aggregated) exceptions:\n", exception.InnerExceptions.Count);
+                formattedGraph.AddLine(Invariant($"{exception.InnerExceptions.Count} (aggregated) exceptions:"));
 
                 foreach (Exception innerException in exception.InnerExceptions)
                 {
-                    builder.AppendLine();
-                    builder.AppendLine(formatChild("InnerException", innerException));
+                    formattedGraph.AddLine(string.Empty);
+                    formatChild("InnerException", innerException, formattedGraph);
                 }
-
-                return builder.ToString();
             }
         }
     }

--- a/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AttributeBasedFormatter.cs
@@ -33,14 +33,13 @@ namespace FluentAssertions.Formatting
             get { return Configuration.Current.ValueFormatterDetectionMode != ValueFormatterDetectionMode.Disabled; }
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
             MethodInfo method = GetFormatter(value);
 
-            object[] parameters = new[] { value };
+            object[] parameters = new[] { value, formattedGraph };
 
-            return (string)method.Invoke(null, parameters);
+            method.Invoke(null, parameters);
         }
 
         private MethodInfo GetFormatter(object value)
@@ -86,10 +85,11 @@ namespace FluentAssertions.Formatting
                 where type is not null
                 from method in type.GetMethods(BindingFlags.Static | BindingFlags.Public)
                 where method.IsStatic
-                where method.ReturnType == typeof(string)
+                where method.ReturnType == typeof(void)
                 where method.IsDecoratedWithOrInherit<ValueFormatterAttribute>()
-                where method.GetParameters().Length == 1
-                select new { Type = method.GetParameters().Single().ParameterType, Method = method } into formatter
+                let methodParameters = method.GetParameters()
+                where methodParameters.Length == 2
+                select new { Type = methodParameters.First().ParameterType, Method = method } into formatter
                 group formatter by formatter.Type into formatterGroup
                 select formatterGroup.First();
 

--- a/Src/FluentAssertions/Formatting/ByteValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ByteValueFormatter.cs
@@ -16,10 +16,9 @@ namespace FluentAssertions.Formatting
             return value is byte;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
-            return "0x" + ((byte)value).ToString("X2", CultureInfo.InvariantCulture);
+            formattedGraph.AddFragment("0x" + ((byte)value).ToString("X2", CultureInfo.InvariantCulture));
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Formatting
@@ -21,8 +18,7 @@ namespace FluentAssertions.Formatting
             return (value is DateTime) || (value is DateTimeOffset);
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
             DateTimeOffset dateTimeOffset;
 
@@ -35,56 +31,65 @@ namespace FluentAssertions.Formatting
                 dateTimeOffset = (DateTimeOffset)value;
             }
 
-            var fragments = new List<string>();
+            formattedGraph.AddFragment("<");
 
-            if (HasDate(dateTimeOffset))
+            bool hasDate = HasDate(dateTimeOffset);
+            if (hasDate)
             {
-                fragments.Add(dateTimeOffset.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+                formattedGraph.AddFragment(dateTimeOffset.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
             }
 
-            if (HasTime(dateTimeOffset))
+            bool hasTime = HasTime(dateTimeOffset);
+            if (hasTime)
             {
+                if (hasDate)
+                {
+                    formattedGraph.AddFragment(" ");
+                }
+
                 if (HasNanoSeconds(dateTimeOffset))
                 {
-                    fragments.Add(dateTimeOffset.ToString("HH:mm:ss.fffffff", CultureInfo.InvariantCulture));
+                    formattedGraph.AddFragment(dateTimeOffset.ToString("HH:mm:ss.fffffff", CultureInfo.InvariantCulture));
                 }
                 else if (HasMicroSeconds(dateTimeOffset))
                 {
-                    fragments.Add(dateTimeOffset.ToString("HH:mm:ss.ffffff", CultureInfo.InvariantCulture));
+                    formattedGraph.AddFragment(dateTimeOffset.ToString("HH:mm:ss.ffffff", CultureInfo.InvariantCulture));
                 }
                 else if (HasMilliSeconds(dateTimeOffset))
                 {
-                    fragments.Add(dateTimeOffset.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture));
+                    formattedGraph.AddFragment(dateTimeOffset.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture));
                 }
                 else
                 {
-                    fragments.Add(dateTimeOffset.ToString("HH:mm:ss", CultureInfo.InvariantCulture));
+                    formattedGraph.AddFragment(dateTimeOffset.ToString("HH:mm:ss", CultureInfo.InvariantCulture));
                 }
             }
 
             if (dateTimeOffset.Offset > TimeSpan.Zero)
             {
-                fragments.Add("+" + formatChild("offset", dateTimeOffset.Offset));
+                formattedGraph.AddFragment(" +");
+                formatChild("offset", dateTimeOffset.Offset, formattedGraph);
             }
 
             if (dateTimeOffset.Offset < TimeSpan.Zero)
             {
-                fragments.Add(formatChild("offset", dateTimeOffset.Offset));
+                formattedGraph.AddFragment(" ");
+                formatChild("offset", dateTimeOffset.Offset, formattedGraph);
             }
 
-            if (!fragments.Any())
+            if (!hasDate && !hasTime)
             {
                 if (HasMilliSeconds(dateTimeOffset))
                 {
-                    fragments.Add("0001-01-01 00:00:00." + dateTimeOffset.ToString("fff", CultureInfo.InvariantCulture));
+                    formattedGraph.AddFragment("0001-01-01 00:00:00." + dateTimeOffset.ToString("fff", CultureInfo.InvariantCulture));
                 }
                 else
                 {
-                    fragments.Add("0001-01-01 00:00:00.000");
+                    formattedGraph.AddFragment("0001-01-01 00:00:00.000");
                 }
             }
 
-            return "<" + string.Join(" ", fragments.ToArray()) + ">";
+            formattedGraph.AddFragment(">");
         }
 
         private static bool HasTime(DateTimeOffset dateTime)

--- a/Src/FluentAssertions/Formatting/DecimalValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DecimalValueFormatter.cs
@@ -16,10 +16,9 @@ namespace FluentAssertions.Formatting
             return value is decimal;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
-            return ((decimal)value).ToString(CultureInfo.InvariantCulture) + "M";
+            formattedGraph.AddFragment(((decimal)value).ToString(CultureInfo.InvariantCulture) + "M");
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -36,7 +36,7 @@ namespace FluentAssertions.Formatting
                 return $"System.Object (HashCode={value.GetHashCode()})";
             }
 
-            string prefix = context.UseLineBreaks ? Environment.NewLine : string.Empty;
+            string prefix = context.Options.UseLineBreaks ? Environment.NewLine : string.Empty;
 
             if (HasDefaultToStringImplementation(value))
             {

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Formatting
 {
     public class DefaultValueFormatter : IValueFormatter
     {
-        private const int RootLevel = 0;
-
         /// <summary>
         /// The number of spaces to indent the members of this object by.
         /// </summary>
@@ -28,22 +25,29 @@ namespace FluentAssertions.Formatting
             return true;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
             if (value.GetType() == typeof(object))
             {
-                return $"System.Object (HashCode={value.GetHashCode()})";
+                formattedGraph.AddFragment($"System.Object (HashCode={value.GetHashCode()})");
+                return;
             }
-
-            string prefix = context.Options.UseLineBreaks ? Environment.NewLine : string.Empty;
 
             if (HasDefaultToStringImplementation(value))
             {
-                return prefix + GetTypeAndMemberValues(value, context, formatChild);
+                WriteTypeAndMemberValues(value, formattedGraph, formatChild);
             }
-
-            return prefix + value;
+            else
+            {
+                if (context.UseLineBreaks)
+                {
+                    formattedGraph.AddLine(value.ToString());
+                }
+                else
+                {
+                    formattedGraph.AddFragment(value.ToString());
+                }
+            }
         }
 
         /// <summary>
@@ -57,6 +61,34 @@ namespace FluentAssertions.Formatting
             return type.GetNonPrivateMembers().ToArray();
         }
 
+        private static bool HasDefaultToStringImplementation(object value)
+        {
+            string str = value.ToString();
+
+            return str is null || str == value.GetType().ToString();
+        }
+
+        private void WriteTypeAndMemberValues(object obj, FormattedObjectGraph formattedGraph, FormatChild formatChild)
+        {
+            Type type = obj.GetType();
+            formattedGraph.AddLine(TypeDisplayName(type));
+            formattedGraph.AddLine("{");
+
+            MemberInfo[] members = GetMembers(type);
+            using var iterator = new Iterator<MemberInfo>(members.OrderBy(mi => mi.Name));
+            while (iterator.MoveNext())
+            {
+                WriteMemberValueTextFor(obj, iterator.Current, formattedGraph, formatChild);
+
+                if (!iterator.IsLast)
+                {
+                    formattedGraph.AddFragment(", ");
+                }
+            }
+
+            formattedGraph.AddFragmentOnNewLine("}");
+        }
+
         /// <summary>
         /// Selects the name to display for <paramref name="type"/>.
         /// </summary>
@@ -65,40 +97,7 @@ namespace FluentAssertions.Formatting
         /// <remarks>The default is <see cref="System.Type.FullName"/>.</remarks>
         protected virtual string TypeDisplayName(Type type) => type.FullName;
 
-        private static bool HasDefaultToStringImplementation(object value)
-        {
-            string str = value.ToString();
-
-            return str is null || str == value.GetType().ToString();
-        }
-
-        private string GetTypeAndMemberValues(object obj, FormattingContext context, FormatChild formatChild)
-        {
-            var builder = new StringBuilder();
-
-            if (context.Depth == RootLevel)
-            {
-                builder.AppendLine();
-                builder.AppendLine();
-            }
-
-            Type type = obj.GetType();
-            builder.AppendLine(TypeDisplayName(type));
-            builder.Append(CreateWhitespaceForLevel(context.Depth)).Append('{').AppendLine();
-
-            MemberInfo[] members = GetMembers(type);
-            foreach (var memberInfo in members.OrderBy(mi => mi.Name))
-            {
-                string memberValueText = GetMemberValueTextFor(obj, memberInfo, context, formatChild);
-                builder.AppendLine(memberValueText);
-            }
-
-            builder.Append(CreateWhitespaceForLevel(context.Depth)).Append('}');
-
-            return builder.ToString();
-        }
-
-        private string GetMemberValueTextFor(object value, MemberInfo member, FormattingContext context, FormatChild formatChild)
+        private static void WriteMemberValueTextFor(object value, MemberInfo member, FormattedObjectGraph formattedGraph, FormatChild formatChild)
         {
             object memberValue;
 
@@ -116,13 +115,8 @@ namespace FluentAssertions.Formatting
                 memberValue = $"[Member '{member.Name}' threw an exception: '{ex.Message}']";
             }
 
-            return
-                $"{CreateWhitespaceForLevel(context.Depth + 1)}{member.Name} = {formatChild(member.Name, memberValue)}";
-        }
-
-        private string CreateWhitespaceForLevel(int level)
-        {
-            return new string(' ', level * SpacesPerIndentionLevel);
+            formattedGraph.AddFragmentOnNewLine($"{new string(' ', FormattedObjectGraph.SpacesPerIndentation)}{member.Name} = ");
+            formatChild(member.Name, memberValue, formattedGraph);
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/DoubleValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DoubleValueFormatter.cs
@@ -17,19 +17,23 @@ namespace FluentAssertions.Formatting
             return value is double;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
+        {
+            formattedGraph.AddFragment(Format(value));
+        }
+
+        private static string Format(object value)
         {
             double doubleValue = (double)value;
 
             if (double.IsPositiveInfinity(doubleValue))
             {
-                return typeof(double).Name + "." + nameof(double.PositiveInfinity);
+                return nameof(Double) + "." + nameof(double.PositiveInfinity);
             }
 
             if (double.IsNegativeInfinity(doubleValue))
             {
-                return typeof(double).Name + "." + nameof(double.NegativeInfinity);
+                return nameof(Double) + "." + nameof(double.NegativeInfinity);
             }
 
             if (double.IsNaN(doubleValue))

--- a/Src/FluentAssertions/Formatting/EnumValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/EnumValueFormatter.cs
@@ -18,14 +18,14 @@ namespace FluentAssertions.Formatting
         }
 
         /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
             string typePart = value.GetType().Name;
             string namePart = value.ToString().Replace(", ", "|", StringComparison.Ordinal);
             string valuePart = Convert.ToDecimal(value, CultureInfo.InvariantCulture)
                 .ToString(CultureInfo.InvariantCulture);
 
-            return $"{typePart}.{namePart} {{value: {valuePart}}}";
+            formattedGraph.AddFragment($"{typePart}.{namePart} {{value: {valuePart}}}");
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/ExceptionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ExceptionValueFormatter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.Globalization;
-using System.Text;
+using static System.FormattableString;
 
 namespace FluentAssertions.Formatting
 {
@@ -18,24 +17,19 @@ namespace FluentAssertions.Formatting
             return value is Exception;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
             var exception = (Exception)value;
 
-            var builder = new StringBuilder();
-            builder.AppendFormat(CultureInfo.InvariantCulture, "{0} with message \"{1}\"\n",
-                exception.GetType().FullName, exception.Message);
+            formattedGraph.AddFragment(Invariant($"{exception.GetType().FullName} with message \"{exception.Message}\""));
 
             if (exception.StackTrace is not null)
             {
                 foreach (string line in exception.StackTrace.Split(new[] { Environment.NewLine }, StringSplitOptions.None))
                 {
-                    builder.Append("  ").AppendLine(line);
+                    formattedGraph.AddLine("  " + line);
                 }
             }
-
-            return builder.ToString();
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/ExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ExpressionValueFormatter.cs
@@ -17,10 +17,9 @@ namespace FluentAssertions.Formatting
             return value is Expression;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
-            return value.ToString().Replace(" = ", " == ", StringComparison.Ordinal);
+            formattedGraph.AddFragment(value.ToString().Replace(" = ", " == ", StringComparison.Ordinal));
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/FormatChild.cs
+++ b/Src/FluentAssertions/Formatting/FormatChild.cs
@@ -1,0 +1,13 @@
+﻿namespace FluentAssertions.Formatting
+{
+    /// <summary>
+    /// Represents a method that can be used to format child values from inside an <see cref="IValueFormatter"/>.
+    /// </summary>
+    /// <param name="childPath">
+    /// Represents the path from the current location to the child value.
+    /// </param>
+    /// <param name="value">
+    /// The child value to format with the configured <see cref="IValueFormatter"/>s.
+    /// </param>
+    public delegate void FormatChild(string childPath, object value, FormattedObjectGraph formattedGraph);
+}

--- a/Src/FluentAssertions/Formatting/FormattedObjectGraph.cs
+++ b/Src/FluentAssertions/Formatting/FormattedObjectGraph.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Formatting
+{
+    /// <summary>
+    /// This class is used by the <see cref="Formatter"/> class to collect all the output of the (nested calls of an) <see cref="IValueFormatter"/> into
+    /// a the final representation.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="FormattedObjectGraph"/> will ensure that the number of lines will be limited
+    /// to the maximum number of lines provided through its constructor. It will throw
+    /// a <see cref="MaxLinesExceededException"/> if the number of lines exceeds the maximum.
+    /// </remarks>
+    public class FormattedObjectGraph
+    {
+        private readonly int maxLines;
+        private readonly List<string> lines = new();
+        private readonly StringBuilder lineBuilder = new();
+        private int indentation;
+        private string lineBuilderWhitespace = string.Empty;
+
+        public FormattedObjectGraph(int maxLines)
+        {
+            this.maxLines = maxLines;
+        }
+
+        /// <summary>
+        /// The number of spaces that should be used by every indentation level.
+        /// </summary>
+        public static int SpacesPerIndentation => 4;
+
+        /// <summary>
+        /// Returns the number of lines of text currently in the graph.
+        /// </summary>
+        public int LineCount => lines.Count + ((lineBuilder.Length > 0) ? 1 : 0);
+
+        /// <summary>
+        /// Starts a new line with the provided text fragment. Additional text can be added to
+        /// that same line through <see cref="AddFragment"/>.
+        /// </summary>
+        public void AddFragmentOnNewLine(string fragment)
+        {
+            FlushCurrentLine();
+
+            AddFragment(fragment);
+        }
+
+        /// <summary>
+        /// Starts a new line with the provided line of text that does not allow
+        /// adding more fragments of text.
+        /// </summary>
+        public void AddLine(string line)
+        {
+            FlushCurrentLine();
+
+            AppendSafely(Whitespace + line);
+        }
+
+        /// <summary>
+        /// Adds a new fragment of text to the current line.
+        /// </summary>
+        public void AddFragment(string fragment)
+        {
+            if (lineBuilderWhitespace.Length > 0)
+            {
+                lineBuilder.Append(lineBuilderWhitespace);
+                lineBuilderWhitespace = string.Empty;
+            }
+
+            lineBuilder.Append(fragment);
+        }
+
+        private void FlushCurrentLine()
+        {
+            if (lineBuilder.Length > 0)
+            {
+                AppendSafely(lineBuilderWhitespace + lineBuilder);
+
+                lineBuilder.Clear();
+                lineBuilderWhitespace = Whitespace;
+            }
+        }
+
+        private void AppendSafely(string line)
+        {
+            if (lines.Count == maxLines)
+            {
+                lines.Add(string.Empty);
+                lines.Add(
+                    $"(Output has exceeded the maximum of {maxLines} lines. " +
+                    $"Increase {nameof(FormattingOptions)}.{nameof(FormattingOptions.MaxLines)} on {nameof(AssertionScope)} or {nameof(AssertionOptions)} to include more lines.)");
+
+                throw new MaxLinesExceededException();
+            }
+
+            lines.Add(line);
+        }
+
+        /// <summary>
+        /// Increases the indentation of every line written into this text block until the returned disposable is disposed.
+        /// </summary>
+        /// <remarks>
+        /// The amount of spacing used for each indentation level is determined by <see cref="SpacesPerIndentation"/>.
+        /// </remarks>
+        public IDisposable WithIndentation()
+        {
+            indentation++;
+            return new Disposable(() =>
+            {
+                if (indentation > 0)
+                {
+                    indentation--;
+                }
+            });
+        }
+
+        /// <summary>
+        /// Returns the final textual multi-line representation of the object graph.
+        /// </summary>
+        public override string ToString()
+        {
+            return string.Join(Environment.NewLine, lines.Concat(new[] { lineBuilder.ToString() }));
+        }
+
+        private string Whitespace => new(' ', indentation * SpacesPerIndentation);
+    }
+}

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions.Common;
@@ -68,14 +68,16 @@ namespace FluentAssertions.Formatting
         /// Returns a human-readable representation of a particular object.
         /// </summary>
         /// <param name="value">The value for which to create a <see cref="string"/>.</param>
-        /// <param name="useLineBreaks">
+        /// <param name="options">
         /// Indicates whether the formatter should use line breaks when the specific <see cref="IValueFormatter"/> supports it.
         /// </param>
         /// <returns>
         /// A <see cref="string" /> that represents this instance.
         /// </returns>
-        public static string ToString(object value, bool useLineBreaks = false)
+        public static string ToString(object value, FormattingOptions options = null)
         {
+            options ??= new FormattingOptions();
+
             try
             {
                 if (isReentry)
@@ -91,10 +93,10 @@ namespace FluentAssertions.Formatting
                 var context = new FormattingContext
                 {
                     Depth = graph.Depth,
-                    UseLineBreaks = useLineBreaks
+                    Options = options
                 };
 
-                return Format(value, context, (path, childValue) => FormatChild(path, childValue, useLineBreaks, graph));
+                return Format(value, context, (path, childValue) => FormatChild(path, childValue, context, graph));
             }
             finally
             {
@@ -102,7 +104,7 @@ namespace FluentAssertions.Formatting
             }
         }
 
-        private static string FormatChild(string path, object childValue, bool useLineBreaks, ObjectGraph graph)
+        private static string FormatChild(string path, object childValue, FormattingContext formattingContext, ObjectGraph graph)
         {
             try
             {
@@ -121,10 +123,10 @@ namespace FluentAssertions.Formatting
                     var context = new FormattingContext
                     {
                         Depth = graph.Depth,
-                        UseLineBreaks = useLineBreaks
+                        Options = formattingContext.Options
                     };
 
-                    return Format(childValue, context, (x, y) => FormatChild(x, y, useLineBreaks, graph));
+                    return Format(childValue, context, (x, y) => FormatChild(x, y, context, graph));
                 }
             }
             finally
@@ -203,5 +205,13 @@ namespace FluentAssertions.Formatting
                 return string.Join(".", pathStack.Reverse().ToArray());
             }
         }
+    }
+
+    public class FormattingOptions
+    {
+        /// <summary>
+        /// Indicates whether the formatter should use line breaks when the <see cref="IValueFormatter"/> supports it.
+        /// </summary>
+        public bool UseLineBreaks { get; set; }
     }
 }

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
+using FluentAssertions.Execution;
 using FluentAssertions.Xml;
 
 namespace FluentAssertions.Formatting
@@ -92,11 +93,21 @@ namespace FluentAssertions.Formatting
 
                 var context = new FormattingContext
                 {
-                    Depth = graph.Depth,
-                    Options = options
+                    UseLineBreaks = options.UseLineBreaks
                 };
 
-                return Format(value, context, (path, childValue) => FormatChild(path, childValue, context, graph));
+                FormattedObjectGraph output = new(options.MaxLines);
+
+                try
+                {
+                    Format(value, output, context, (path, childValue,
+                        output) => FormatChild(path, childValue, output, context, options, graph));
+                }
+                catch (MaxLinesExceededException)
+                {
+                }
+
+                return output.ToString();
             }
             finally
             {
@@ -104,29 +115,28 @@ namespace FluentAssertions.Formatting
             }
         }
 
-        private static string FormatChild(string path, object childValue, FormattingContext formattingContext, ObjectGraph graph)
+        private static void FormatChild(string path, object value, FormattedObjectGraph output, FormattingContext context, FormattingOptions options, ObjectGraph graph)
         {
             try
             {
                 Guard.ThrowIfArgumentIsNullOrEmpty(path, nameof(path), "Formatting a child value requires a path");
 
-                if (!graph.TryPush(path, childValue))
+                if (!graph.TryPush(path, value))
                 {
-                    return $"{{Cyclic reference to type {childValue.GetType()} detected}}";
+                    output.AddFragment($"{{Cyclic reference to type {value.GetType()} detected}}");
                 }
-                else if (graph.Depth > formattingContext.Options.MaxDepth)
+                else if (graph.Depth > options.MaxDepth)
                 {
-                    return $"Maximum recursion depth of {formattingContext.Options.MaxDepth} was reached…";
+                    output.AddLine($"Maximum recursion depth of {options.MaxDepth} was reached. " +
+                           $" Increase {nameof(FormattingOptions.MaxDepth)} on {nameof(AssertionScope)} or {nameof(AssertionOptions)} to get more details.");
                 }
                 else
                 {
-                    var context = new FormattingContext
+                    using (output.WithIndentation())
                     {
-                        Depth = graph.Depth,
-                        Options = formattingContext.Options
-                    };
-
-                    return Format(childValue, context, (x, y) => FormatChild(x, y, context, graph));
+                        Format(value, output, context, (childPath, childValue, nestedOutput) =>
+                            FormatChild(childPath, childValue, nestedOutput, context, options, graph));
+                    }
                 }
             }
             finally
@@ -135,10 +145,10 @@ namespace FluentAssertions.Formatting
             }
         }
 
-        private static string Format(object value, FormattingContext context, FormatChild formatChild)
+        private static void Format(object value, FormattedObjectGraph output, FormattingContext context, FormatChild formatChild)
         {
             IValueFormatter firstFormatterThatCanHandleValue = Formatters.First(f => f.CanHandle(value));
-            return firstFormatterThatCanHandleValue.Format(value, context, formatChild);
+            firstFormatterThatCanHandleValue.Format(value, output, context, formatChild);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions.Common;
@@ -114,9 +114,9 @@ namespace FluentAssertions.Formatting
                 {
                     return $"{{Cyclic reference to type {childValue.GetType()} detected}}";
                 }
-                else if (graph.Depth > 5)
+                else if (graph.Depth > formattingContext.Options.MaxDepth)
                 {
-                    return "{Maximum recursion depth was reached…}";
+                    return $"Maximum recursion depth of {formattingContext.Options.MaxDepth} was reached…";
                 }
                 else
                 {
@@ -205,13 +205,5 @@ namespace FluentAssertions.Formatting
                 return string.Join(".", pathStack.Reverse().ToArray());
             }
         }
-    }
-
-    public class FormattingOptions
-    {
-        /// <summary>
-        /// Indicates whether the formatter should use line breaks when the <see cref="IValueFormatter"/> supports it.
-        /// </summary>
-        public bool UseLineBreaks { get; set; }
     }
 }

--- a/Src/FluentAssertions/Formatting/FormattingContext.cs
+++ b/Src/FluentAssertions/Formatting/FormattingContext.cs
@@ -1,0 +1,13 @@
+﻿namespace FluentAssertions.Formatting
+{
+    /// <summary>
+    /// Provides information about the current formatting action.
+    /// </summary>
+    public class FormattingContext
+    {
+        /// <summary>
+        /// Indicates whether the formatter should use line breaks when the <see cref="IValueFormatter"/> supports it.
+        /// </summary>
+        public bool UseLineBreaks { get; set; }
+    }
+}

--- a/Src/FluentAssertions/Formatting/FormattingOptions.cs
+++ b/Src/FluentAssertions/Formatting/FormattingOptions.cs
@@ -15,12 +15,21 @@
         /// </value>
         public int MaxDepth { get; set; } = 5;
 
-        public FormattingOptions Clone()
+        /// <summary>
+        /// Sets the maximum number of lines of the failure message.
+        /// </summary>
+        /// <remarks>
+        /// Because of technical reasons, the actual output may be one or two lines longer.
+        /// </remarks>
+        public int MaxLines { get; set; } = 100;
+
+        internal FormattingOptions Clone()
         {
             return new()
             {
                 UseLineBreaks = UseLineBreaks,
-                MaxDepth = MaxDepth
+                MaxDepth = MaxDepth,
+                MaxLines = MaxLines
             };
         }
     }

--- a/Src/FluentAssertions/Formatting/FormattingOptions.cs
+++ b/Src/FluentAssertions/Formatting/FormattingOptions.cs
@@ -1,0 +1,27 @@
+﻿namespace FluentAssertions.Formatting
+{
+    public class FormattingOptions
+    {
+        /// <summary>
+        /// Indicates whether the formatter should use line breaks when the <see cref="IValueFormatter"/> supports it.
+        /// </summary>
+        public bool UseLineBreaks { get; set; }
+
+        /// <summary>
+        /// Determines the depth until which the library should try to render an object graph.
+        /// </summary>
+        /// <value>
+        /// A depth of 1 will only the display the members of the root object.
+        /// </value>
+        public int MaxDepth { get; set; } = 5;
+
+        public FormattingOptions Clone()
+        {
+            return new()
+            {
+                UseLineBreaks = UseLineBreaks,
+                MaxDepth = MaxDepth
+            };
+        }
+    }
+}

--- a/Src/FluentAssertions/Formatting/GuidValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/GuidValueFormatter.cs
@@ -16,10 +16,9 @@ namespace FluentAssertions.Formatting
             return value is Guid;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
-            return "{" + value + "}";
+            formattedGraph.AddFragment("{" + value + "}");
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/IValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/IValueFormatter.cs
@@ -1,4 +1,6 @@
-﻿namespace FluentAssertions.Formatting
+﻿using System.Collections.Generic;
+
+namespace FluentAssertions.Formatting
 {
     /// <summary>
     /// Represents a strategy for formatting an arbitrary value into a human-readable string representation.
@@ -9,7 +11,8 @@
     public interface IValueFormatter
     {
         /// <summary>
-        /// Indicates whether the current <see cref="IValueFormatter"/> can handle the specified <paramref name="value"/>.
+        /// Indicates
+        /// whether the current <see cref="IValueFormatter"/> can handle the specified <paramref name="value"/>.
         /// </summary>
         /// <param name="value">The value for which to create a <see cref="string"/>.</param>
         /// <returns>
@@ -20,44 +23,22 @@
         /// <summary>
         /// Returns a human-readable representation of <paramref name="value"/>.
         /// </summary>
-        /// <param name="value">The value for which to format.</param>
+        /// <param name="value">The value to format into a human-readable representation</param>
+        /// <param name="formattedGraph">
+        ///     An object to write the textual representation to.
+        /// </param>
         /// <param name="context">
-        /// Contains additional information about the formatting task.
+        ///     Contains additional information that the implementation should take into account.
         /// </param>
         /// <param name="formatChild">
-        /// Allows the formatter to recursively format any child objects.
+        ///     Allows the formatter to recursively format any child objects.
         /// </param>
         /// <remarks>
         /// DO NOT CALL <see cref="Formatter.ToString(object,FormattingOptions)"/> directly, but use <paramref name="formatChild"/>
         /// instead. This will ensure cyclic dependencies are properly detected.
+        /// Also, the <see cref="FormattedObjectGraph"/> may throw
+        /// an <see cref="MaxLinesExceededException"/> that must be ignored by implementations of this interface.
         /// </remarks>
-        string Format(object value, FormattingContext context, FormatChild formatChild);
+        void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild);
     }
-
-    /// <summary>
-    /// Provides information about the current formatting action.
-    /// </summary>
-    public class FormattingContext
-    {
-        /// <summary>
-        /// Gets the zero-based depth of the object that is being formatted within the object graph
-        /// </summary>
-        public int Depth { get; set; }
-
-        /// <summary>
-        /// All options that should be used while formatting.
-        /// </summary>
-        public FormattingOptions Options { get; set; }
-    }
-
-    /// <summary>
-    /// Represents a method that can be used to format child values from inside a <see cref="IValueFormatter"/>.
-    /// </summary>
-    /// <param name="childPath">
-    /// Represents the path from the current location to the child value.
-    /// </param>
-    /// <param name="value">
-    /// The child value to run through the configured <see cref="IValueFormatter"/>s.
-    /// </param>
-    public delegate string FormatChild(string childPath, object value);
 }

--- a/Src/FluentAssertions/Formatting/IValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/IValueFormatter.cs
@@ -28,7 +28,7 @@
         /// Allows the formatter to recursively format any child objects.
         /// </param>
         /// <remarks>
-        /// DO NOT CALL <see cref="Formatter.ToString(object,bool)"/> directly, but use <paramref name="formatChild"/>
+        /// DO NOT CALL <see cref="Formatter.ToString(object,FormattingOptions)"/> directly, but use <paramref name="formatChild"/>
         /// instead. This will ensure cyclic dependencies are properly detected.
         /// </remarks>
         string Format(object value, FormattingContext context, FormatChild formatChild);
@@ -39,9 +39,15 @@
     /// </summary>
     public class FormattingContext
     {
+        /// <summary>
+        /// Gets the zero-based depth of the object that is being formatted within the object graph
+        /// </summary>
         public int Depth { get; set; }
 
-        public bool UseLineBreaks { get; set; }
+        /// <summary>
+        /// All options that should be used while formatting.
+        /// </summary>
+        public FormattingOptions Options { get; set; }
     }
 
     /// <summary>

--- a/Src/FluentAssertions/Formatting/Int16ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/Int16ValueFormatter.cs
@@ -16,10 +16,9 @@ namespace FluentAssertions.Formatting
             return value is short;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
-            return ((short)value).ToString(CultureInfo.InvariantCulture) + "s";
+            formattedGraph.AddFragment(((short)value).ToString(CultureInfo.InvariantCulture) + "s");
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/Int32ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/Int32ValueFormatter.cs
@@ -16,10 +16,9 @@ namespace FluentAssertions.Formatting
             return value is int;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
-            return ((int)value).ToString(CultureInfo.InvariantCulture);
+            formattedGraph.AddFragment(((int)value).ToString(CultureInfo.InvariantCulture));
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/Int64ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/Int64ValueFormatter.cs
@@ -16,10 +16,9 @@ namespace FluentAssertions.Formatting
             return value is long;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
-            return ((long)value).ToString(CultureInfo.InvariantCulture) + "L";
+            formattedGraph.AddFragment(((long)value).ToString(CultureInfo.InvariantCulture) + "L");
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/MaxLinesExceededException.cs
+++ b/Src/FluentAssertions/Formatting/MaxLinesExceededException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace FluentAssertions.Formatting
+{
+    public class MaxLinesExceededException : Exception
+    {
+        public MaxLinesExceededException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public MaxLinesExceededException(string message)
+            : base(message)
+        {
+        }
+
+        public MaxLinesExceededException()
+        {
+        }
+    }
+}

--- a/Src/FluentAssertions/Formatting/NullValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/NullValueFormatter.cs
@@ -14,10 +14,9 @@
             return value is null;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
-            return "<null>";
+            formattedGraph.AddFragment("<null>");
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -12,7 +12,7 @@ namespace FluentAssertions.Formatting
     {
         public bool CanHandle(object value) => value is LambdaExpression lambdaExpression && lambdaExpression.ReturnType == typeof(bool);
 
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
             var lambdaExpression = (LambdaExpression)value;
 
@@ -21,10 +21,12 @@ namespace FluentAssertions.Formatting
             if (reducedExpression is BinaryExpression binaryExpression && binaryExpression.NodeType == ExpressionType.AndAlso)
             {
                 var subExpressions = ExtractChainOfExpressionsJoinedWithAndOperator(binaryExpression);
-                return string.Join(" AndAlso ", subExpressions.Select(e => e.ToString()));
+                formattedGraph.AddFragment(string.Join(" AndAlso ", subExpressions.Select(e => e.ToString())));
             }
-
-            return reducedExpression.ToString();
+            else
+            {
+                formattedGraph.AddFragment(reducedExpression.ToString());
+            }
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Formatting/PropertyInfoFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PropertyInfoFormatter.cs
@@ -16,10 +16,9 @@ namespace FluentAssertions.Formatting
             return value is PropertyInfo;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
-            return ((PropertyInfo)value).Name;
+            formattedGraph.AddFragment(((PropertyInfo)value).Name);
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/SByteValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/SByteValueFormatter.cs
@@ -16,10 +16,9 @@ namespace FluentAssertions.Formatting
             return value is sbyte;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
-            return ((sbyte)value).ToString(CultureInfo.InvariantCulture) + "y";
+            formattedGraph.AddFragment(((sbyte)value).ToString(CultureInfo.InvariantCulture) + "y");
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/SingleValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/SingleValueFormatter.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 
 namespace FluentAssertions.Formatting
 {
@@ -16,27 +17,26 @@ namespace FluentAssertions.Formatting
             return value is float;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
             float singleValue = (float)value;
 
             if (float.IsPositiveInfinity(singleValue))
             {
-                return typeof(float).Name + "." + nameof(float.PositiveInfinity);
+                formattedGraph.AddFragment(nameof(Single) + "." + nameof(float.PositiveInfinity));
             }
-
-            if (float.IsNegativeInfinity(singleValue))
+            else if (float.IsNegativeInfinity(singleValue))
             {
-                return typeof(float).Name + "." + nameof(float.NegativeInfinity);
+                formattedGraph.AddFragment(nameof(Single) + "." + nameof(float.NegativeInfinity));
             }
-
-            if (float.IsNaN(singleValue))
+            else if (float.IsNaN(singleValue))
             {
-                return singleValue.ToString(CultureInfo.InvariantCulture);
+                formattedGraph.AddFragment(singleValue.ToString(CultureInfo.InvariantCulture));
             }
-
-            return singleValue.ToString("R", CultureInfo.InvariantCulture) + "F";
+            else
+            {
+                formattedGraph.AddFragment(singleValue.ToString("R", CultureInfo.InvariantCulture) + "F");
+            }
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/StringValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/StringValueFormatter.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.Formatting
         /// <inheritdoc />
         public string Format(object value, FormattingContext context, FormatChild formatChild)
         {
-            string prefix = context.UseLineBreaks ? Environment.NewLine : string.Empty;
+            string prefix = context.Options.UseLineBreaks ? Environment.NewLine : string.Empty;
             string escapedString = value.ToString();
 
             return prefix + "\"" + escapedString + "\"";

--- a/Src/FluentAssertions/Formatting/StringValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/StringValueFormatter.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace FluentAssertions.Formatting
+﻿namespace FluentAssertions.Formatting
 {
     public class StringValueFormatter : IValueFormatter
     {
@@ -16,13 +14,18 @@ namespace FluentAssertions.Formatting
             return value is string;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
-            string prefix = context.Options.UseLineBreaks ? Environment.NewLine : string.Empty;
-            string escapedString = value.ToString();
+            string result = "\"" + value + "\"";
 
-            return prefix + "\"" + escapedString + "\"";
+            if (context.UseLineBreaks)
+            {
+                formattedGraph.AddFragmentOnNewLine(result);
+            }
+            else
+            {
+                formattedGraph.AddFragment(result);
+            }
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/TaskFormatter.cs
+++ b/Src/FluentAssertions/Formatting/TaskFormatter.cs
@@ -13,15 +13,16 @@ namespace FluentAssertions.Formatting
             return value is Task;
         }
 
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
             if (value is Task task)
             {
-                return $"{formatChild("type", task.GetType())} {{Status={task.Status}}}";
+                formatChild("type", task.GetType(), formattedGraph);
+                formattedGraph.AddFragment($" {{Status={task.Status}}}");
             }
             else
             {
-                return "<null>";
+                formattedGraph.AddFragment("<null>");
             }
         }
     }

--- a/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/TimeSpanValueFormatter.cs
@@ -19,37 +19,38 @@ namespace FluentAssertions.Formatting
             return value is TimeSpan;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
             var timeSpan = (TimeSpan)value;
 
             if (timeSpan == TimeSpan.MinValue)
             {
-                return "min time span";
+                formattedGraph.AddFragment("min time span");
+                return;
             }
 
             if (timeSpan == TimeSpan.MaxValue)
             {
-                return "max time span";
+                formattedGraph.AddFragment("max time span");
+                return;
             }
 
             List<string> fragments = GetNonZeroFragments(timeSpan);
 
             if (!fragments.Any())
             {
-                return "default";
+                formattedGraph.AddFragment("default");
             }
 
             string sign = (timeSpan.Ticks >= 0) ? string.Empty : "-";
 
             if (fragments.Count == 1)
             {
-                return sign + fragments.Single();
+                formattedGraph.AddFragment(sign + fragments.Single());
             }
             else
             {
-                return sign + fragments.JoinUsingWritingStyle();
+                formattedGraph.AddFragment(sign + fragments.JoinUsingWritingStyle());
             }
         }
 

--- a/Src/FluentAssertions/Formatting/UInt16ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/UInt16ValueFormatter.cs
@@ -16,10 +16,9 @@ namespace FluentAssertions.Formatting
             return value is ushort;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
-            return ((ushort)value).ToString(CultureInfo.InvariantCulture) + "us";
+            formattedGraph.AddFragment(((ushort)value).ToString(CultureInfo.InvariantCulture) + "us");
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/UInt32ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/UInt32ValueFormatter.cs
@@ -16,10 +16,9 @@ namespace FluentAssertions.Formatting
             return value is uint;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
-            return ((uint)value).ToString(CultureInfo.InvariantCulture) + "u";
+            formattedGraph.AddFragment(((uint)value).ToString(CultureInfo.InvariantCulture) + "u");
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/UInt64ValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/UInt64ValueFormatter.cs
@@ -16,10 +16,9 @@ namespace FluentAssertions.Formatting
             return value is ulong;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
-            return ((ulong)value).ToString(CultureInfo.InvariantCulture) + "UL";
+            formattedGraph.AddFragment(((ulong)value).ToString(CultureInfo.InvariantCulture) + "UL");
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/XAttributeValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XAttributeValueFormatter.cs
@@ -16,11 +16,9 @@ namespace FluentAssertions.Formatting
             return value is XAttribute;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
-            var attribute = (XAttribute)value;
-            return attribute.ToString();
+            formattedGraph.AddFragment(((XAttribute)value).ToString());
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/XDocumentValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XDocumentValueFormatter.cs
@@ -9,19 +9,18 @@ namespace FluentAssertions.Formatting
             return value is XDocument;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
             var document = (XDocument)value;
 
-            return (document.Root is not null)
-                ? formatChild("root", document.Root)
-                : FormatDocumentWithoutRoot();
-        }
-
-        private static string FormatDocumentWithoutRoot()
-        {
-            return "[XML document without root element]";
+            if (document.Root is not null)
+            {
+                formatChild("root", document.Root, formattedGraph);
+            }
+            else
+            {
+                formattedGraph.AddFragment("[XML document without root element]");
+            }
         }
     }
 }

--- a/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XElementValueFormatter.cs
@@ -19,14 +19,13 @@ namespace FluentAssertions.Formatting
             return value is XElement;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
             var element = (XElement)value;
 
-            return element.HasElements
+            formattedGraph.AddFragment(element.HasElements
                 ? FormatElementWithChildren(element)
-                : FormatElementWithoutChildren(element);
+                : FormatElementWithoutChildren(element));
         }
 
         private static string FormatElementWithoutChildren(XElement element)

--- a/Src/FluentAssertions/Xml/XmlNodeFormatter.cs
+++ b/Src/FluentAssertions/Xml/XmlNodeFormatter.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml;
+﻿using System.Collections.Generic;
+using System.Xml;
 using FluentAssertions.Common;
 using FluentAssertions.Formatting;
 
@@ -11,8 +12,7 @@ namespace FluentAssertions.Xml
             return value is XmlNode;
         }
 
-        /// <inheritdoc />
-        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
             string outerXml = ((XmlNode)value).OuterXml;
 
@@ -23,7 +23,7 @@ namespace FluentAssertions.Xml
                 outerXml = outerXml.Substring(0, maxLength).TrimEnd() + "…";
             }
 
-            return outerXml.EscapePlaceholders();
+            formattedGraph.AddLine(outerXml.EscapePlaceholders());
         }
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1,8 +1,12 @@
 <<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions.git")]
 =======
 >>>>>>> 94b2b45d (Made AssertionScope.Succeeded internal):Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
+=======
+﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
+>>>>>>> 78ddd79b (Formatter.ToString() now takes a FormattingOptions that wraps the UseLineBreaks option ):Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.7", FrameworkDisplayName=".NET Framework 4.7")]
 namespace FluentAssertions
@@ -1437,12 +1441,17 @@ namespace FluentAssertions.Formatting
         public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
         public static void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
         public static void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
-        public static string ToString(object value, bool useLineBreaks = false) { }
+        public static string ToString(object value, FluentAssertions.Formatting.FormattingOptions options = null) { }
     }
     public class FormattingContext
     {
         public FormattingContext() { }
         public int Depth { get; set; }
+        public FluentAssertions.Formatting.FormattingOptions Options { get; set; }
+    }
+    public class FormattingOptions
+    {
+        public FormattingOptions() { }
         public bool UseLineBreaks { get; set; }
     }
     public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -109,6 +109,7 @@ namespace FluentAssertions
     public static class AssertionOptions
     {
         public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
+        public static FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
     }
@@ -1202,6 +1203,7 @@ namespace FluentAssertions.Execution
         public AssertionScope(System.Lazy<string> context) { }
         public AssertionScope(string context) { }
         public System.Lazy<string> Context { get; set; }
+        public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
         public void AddNonReportable(string key, object value) { }
@@ -1452,7 +1454,9 @@ namespace FluentAssertions.Formatting
     public class FormattingOptions
     {
         public FormattingOptions() { }
+        public int MaxDepth { get; set; }
         public bool UseLineBreaks { get; set; }
+        public FluentAssertions.Formatting.FormattingOptions Clone() { }
     }
     public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1,4 +1,7 @@
+<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions.git")]
+=======
+>>>>>>> 94b2b45d (Made AssertionScope.Succeeded internal):Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.7", FrameworkDisplayName=".NET Framework 4.7")]
@@ -1195,7 +1198,6 @@ namespace FluentAssertions.Execution
         public AssertionScope(System.Lazy<string> context) { }
         public AssertionScope(string context) { }
         public System.Lazy<string> Context { get; set; }
-        public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
         public void AddNonReportable(string key, object value) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1,12 +1,5 @@
-<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
-<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions.git")]
-=======
->>>>>>> 94b2b45d (Made AssertionScope.Succeeded internal):Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
-=======
-﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
->>>>>>> 78ddd79b (Formatter.ToString() now takes a FormattingOptions that wraps the UseLineBreaks option ):Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.7", FrameworkDisplayName=".NET Framework 4.7")]
 namespace FluentAssertions
@@ -1371,38 +1364,38 @@ namespace FluentAssertions.Formatting
     {
         public AggregateExceptionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class AttributeBasedFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public AttributeBasedFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public ByteValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class DateTimeOffsetValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DateTimeOffsetValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class DecimalValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DecimalValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DefaultValueFormatter() { }
         protected virtual int SpacesPerIndentionLevel { get; }
         public virtual bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
         protected virtual System.Reflection.MemberInfo[] GetMembers(System.Type type) { }
         protected virtual string TypeDisplayName(System.Type type) { }
     }
@@ -1410,34 +1403,45 @@ namespace FluentAssertions.Formatting
     {
         public DoubleValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class EnumValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumValueFormatter() { }
         public virtual bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumerableValueFormatter() { }
         protected virtual int MaxItems { get; }
         public virtual bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public ExceptionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public ExpressionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
-    public delegate string FormatChild(string childPath, object value);
+    public delegate void FormatChild(string childPath, object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph);
+    public class FormattedObjectGraph
+    {
+        public FormattedObjectGraph(int maxLines) { }
+        public int LineCount { get; }
+        public static int SpacesPerIndentation { get; }
+        public void AddFragment(string fragment) { }
+        public void AddFragmentOnNewLine(string fragment) { }
+        public void AddLine(string line) { }
+        public override string ToString() { }
+        public System.IDisposable WithIndentation() { }
+    }
     public static class Formatter
     {
         public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
@@ -1448,116 +1452,121 @@ namespace FluentAssertions.Formatting
     public class FormattingContext
     {
         public FormattingContext() { }
-        public int Depth { get; set; }
-        public FluentAssertions.Formatting.FormattingOptions Options { get; set; }
+        public bool UseLineBreaks { get; set; }
     }
     public class FormattingOptions
     {
         public FormattingOptions() { }
         public int MaxDepth { get; set; }
+        public int MaxLines { get; set; }
         public bool UseLineBreaks { get; set; }
-        public FluentAssertions.Formatting.FormattingOptions Clone() { }
     }
     public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public GuidValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public interface IValueFormatter
     {
         bool CanHandle(object value);
-        string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
+        void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
     }
     public class Int16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public Int16ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class Int32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public Int32ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class Int64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public Int64ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class MaxLinesExceededException : System.Exception
+    {
+        public MaxLinesExceededException() { }
+        public MaxLinesExceededException(string message) { }
+        public MaxLinesExceededException(string message, System.Exception innerException) { }
     }
     public class MultidimensionalArrayFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public MultidimensionalArrayFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class NullValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public NullValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class PredicateLambdaExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public PredicateLambdaExpressionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class PropertyInfoFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public PropertyInfoFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class SByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public SByteValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class SingleValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public SingleValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class StringValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public StringValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class TaskFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public TaskFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class TimeSpanValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public TimeSpanValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class UInt16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public UInt16ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class UInt32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public UInt32ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class UInt64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public UInt64ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
     public class ValueFormatterAttribute : System.Attribute
@@ -1568,19 +1577,19 @@ namespace FluentAssertions.Formatting
     {
         public XAttributeValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class XDocumentValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public XDocumentValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class XElementValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public XElementValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
 }
 namespace FluentAssertions.Numeric
@@ -2505,6 +2514,6 @@ namespace FluentAssertions.Xml
     {
         public XmlNodeFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1,8 +1,12 @@
 <<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions.git")]
 =======
 >>>>>>> 94b2b45d (Made AssertionScope.Succeeded internal):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
+=======
+﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
+>>>>>>> 78ddd79b (Formatter.ToString() now takes a FormattingOptions that wraps the UseLineBreaks option ):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v2.1", FrameworkDisplayName="")]
 namespace FluentAssertions
@@ -1437,12 +1441,17 @@ namespace FluentAssertions.Formatting
         public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
         public static void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
         public static void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
-        public static string ToString(object value, bool useLineBreaks = false) { }
+        public static string ToString(object value, FluentAssertions.Formatting.FormattingOptions options = null) { }
     }
     public class FormattingContext
     {
         public FormattingContext() { }
         public int Depth { get; set; }
+        public FluentAssertions.Formatting.FormattingOptions Options { get; set; }
+    }
+    public class FormattingOptions
+    {
+        public FormattingOptions() { }
         public bool UseLineBreaks { get; set; }
     }
     public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1,4 +1,7 @@
+<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions.git")]
+=======
+>>>>>>> 94b2b45d (Made AssertionScope.Succeeded internal):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v2.1", FrameworkDisplayName="")]
@@ -1195,7 +1198,6 @@ namespace FluentAssertions.Execution
         public AssertionScope(System.Lazy<string> context) { }
         public AssertionScope(string context) { }
         public System.Lazy<string> Context { get; set; }
-        public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
         public void AddNonReportable(string key, object value) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -109,6 +109,7 @@ namespace FluentAssertions
     public static class AssertionOptions
     {
         public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
+        public static FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
     }
@@ -1202,6 +1203,7 @@ namespace FluentAssertions.Execution
         public AssertionScope(System.Lazy<string> context) { }
         public AssertionScope(string context) { }
         public System.Lazy<string> Context { get; set; }
+        public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
         public void AddNonReportable(string key, object value) { }
@@ -1452,7 +1454,9 @@ namespace FluentAssertions.Formatting
     public class FormattingOptions
     {
         public FormattingOptions() { }
+        public int MaxDepth { get; set; }
         public bool UseLineBreaks { get; set; }
+        public FluentAssertions.Formatting.FormattingOptions Clone() { }
     }
     public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1,12 +1,5 @@
-<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
-<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions.git")]
-=======
->>>>>>> 94b2b45d (Made AssertionScope.Succeeded internal):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
-=======
-﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
->>>>>>> 78ddd79b (Formatter.ToString() now takes a FormattingOptions that wraps the UseLineBreaks option ):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v2.1", FrameworkDisplayName="")]
 namespace FluentAssertions
@@ -1371,38 +1364,38 @@ namespace FluentAssertions.Formatting
     {
         public AggregateExceptionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class AttributeBasedFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public AttributeBasedFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public ByteValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class DateTimeOffsetValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DateTimeOffsetValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class DecimalValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DecimalValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DefaultValueFormatter() { }
         protected virtual int SpacesPerIndentionLevel { get; }
         public virtual bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
         protected virtual System.Reflection.MemberInfo[] GetMembers(System.Type type) { }
         protected virtual string TypeDisplayName(System.Type type) { }
     }
@@ -1410,34 +1403,45 @@ namespace FluentAssertions.Formatting
     {
         public DoubleValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class EnumValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumValueFormatter() { }
         public virtual bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumerableValueFormatter() { }
         protected virtual int MaxItems { get; }
         public virtual bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public ExceptionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public ExpressionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
-    public delegate string FormatChild(string childPath, object value);
+    public delegate void FormatChild(string childPath, object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph);
+    public class FormattedObjectGraph
+    {
+        public FormattedObjectGraph(int maxLines) { }
+        public int LineCount { get; }
+        public static int SpacesPerIndentation { get; }
+        public void AddFragment(string fragment) { }
+        public void AddFragmentOnNewLine(string fragment) { }
+        public void AddLine(string line) { }
+        public override string ToString() { }
+        public System.IDisposable WithIndentation() { }
+    }
     public static class Formatter
     {
         public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
@@ -1448,116 +1452,121 @@ namespace FluentAssertions.Formatting
     public class FormattingContext
     {
         public FormattingContext() { }
-        public int Depth { get; set; }
-        public FluentAssertions.Formatting.FormattingOptions Options { get; set; }
+        public bool UseLineBreaks { get; set; }
     }
     public class FormattingOptions
     {
         public FormattingOptions() { }
         public int MaxDepth { get; set; }
+        public int MaxLines { get; set; }
         public bool UseLineBreaks { get; set; }
-        public FluentAssertions.Formatting.FormattingOptions Clone() { }
     }
     public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public GuidValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public interface IValueFormatter
     {
         bool CanHandle(object value);
-        string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
+        void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
     }
     public class Int16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public Int16ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class Int32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public Int32ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class Int64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public Int64ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class MaxLinesExceededException : System.Exception
+    {
+        public MaxLinesExceededException() { }
+        public MaxLinesExceededException(string message) { }
+        public MaxLinesExceededException(string message, System.Exception innerException) { }
     }
     public class MultidimensionalArrayFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public MultidimensionalArrayFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class NullValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public NullValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class PredicateLambdaExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public PredicateLambdaExpressionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class PropertyInfoFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public PropertyInfoFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class SByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public SByteValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class SingleValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public SingleValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class StringValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public StringValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class TaskFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public TaskFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class TimeSpanValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public TimeSpanValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class UInt16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public UInt16ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class UInt32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public UInt32ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class UInt64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public UInt64ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
     public class ValueFormatterAttribute : System.Attribute
@@ -1568,19 +1577,19 @@ namespace FluentAssertions.Formatting
     {
         public XAttributeValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class XDocumentValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public XDocumentValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class XElementValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public XElementValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
 }
 namespace FluentAssertions.Numeric
@@ -2505,6 +2514,6 @@ namespace FluentAssertions.Xml
     {
         public XmlNodeFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1,12 +1,5 @@
-<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
-<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions.git")]
-=======
->>>>>>> 94b2b45d (Made AssertionScope.Succeeded internal):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
-=======
-﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
->>>>>>> 78ddd79b (Formatter.ToString() now takes a FormattingOptions that wraps the UseLineBreaks option ):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v3.0", FrameworkDisplayName="")]
 namespace FluentAssertions
@@ -1371,38 +1364,38 @@ namespace FluentAssertions.Formatting
     {
         public AggregateExceptionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class AttributeBasedFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public AttributeBasedFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public ByteValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class DateTimeOffsetValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DateTimeOffsetValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class DecimalValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DecimalValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DefaultValueFormatter() { }
         protected virtual int SpacesPerIndentionLevel { get; }
         public virtual bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
         protected virtual System.Reflection.MemberInfo[] GetMembers(System.Type type) { }
         protected virtual string TypeDisplayName(System.Type type) { }
     }
@@ -1410,34 +1403,45 @@ namespace FluentAssertions.Formatting
     {
         public DoubleValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class EnumValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumValueFormatter() { }
         public virtual bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumerableValueFormatter() { }
         protected virtual int MaxItems { get; }
         public virtual bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public ExceptionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public ExpressionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
-    public delegate string FormatChild(string childPath, object value);
+    public delegate void FormatChild(string childPath, object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph);
+    public class FormattedObjectGraph
+    {
+        public FormattedObjectGraph(int maxLines) { }
+        public int LineCount { get; }
+        public static int SpacesPerIndentation { get; }
+        public void AddFragment(string fragment) { }
+        public void AddFragmentOnNewLine(string fragment) { }
+        public void AddLine(string line) { }
+        public override string ToString() { }
+        public System.IDisposable WithIndentation() { }
+    }
     public static class Formatter
     {
         public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
@@ -1448,116 +1452,121 @@ namespace FluentAssertions.Formatting
     public class FormattingContext
     {
         public FormattingContext() { }
-        public int Depth { get; set; }
-        public FluentAssertions.Formatting.FormattingOptions Options { get; set; }
+        public bool UseLineBreaks { get; set; }
     }
     public class FormattingOptions
     {
         public FormattingOptions() { }
         public int MaxDepth { get; set; }
+        public int MaxLines { get; set; }
         public bool UseLineBreaks { get; set; }
-        public FluentAssertions.Formatting.FormattingOptions Clone() { }
     }
     public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public GuidValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public interface IValueFormatter
     {
         bool CanHandle(object value);
-        string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
+        void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
     }
     public class Int16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public Int16ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class Int32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public Int32ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class Int64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public Int64ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class MaxLinesExceededException : System.Exception
+    {
+        public MaxLinesExceededException() { }
+        public MaxLinesExceededException(string message) { }
+        public MaxLinesExceededException(string message, System.Exception innerException) { }
     }
     public class MultidimensionalArrayFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public MultidimensionalArrayFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class NullValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public NullValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class PredicateLambdaExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public PredicateLambdaExpressionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class PropertyInfoFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public PropertyInfoFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class SByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public SByteValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class SingleValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public SingleValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class StringValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public StringValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class TaskFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public TaskFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class TimeSpanValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public TimeSpanValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class UInt16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public UInt16ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class UInt32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public UInt32ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class UInt64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public UInt64ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
     public class ValueFormatterAttribute : System.Attribute
@@ -1568,19 +1577,19 @@ namespace FluentAssertions.Formatting
     {
         public XAttributeValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class XDocumentValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public XDocumentValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class XElementValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public XElementValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
 }
 namespace FluentAssertions.Numeric
@@ -2505,6 +2514,6 @@ namespace FluentAssertions.Xml
     {
         public XmlNodeFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -109,6 +109,7 @@ namespace FluentAssertions
     public static class AssertionOptions
     {
         public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
+        public static FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
     }
@@ -1202,6 +1203,7 @@ namespace FluentAssertions.Execution
         public AssertionScope(System.Lazy<string> context) { }
         public AssertionScope(string context) { }
         public System.Lazy<string> Context { get; set; }
+        public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
         public void AddNonReportable(string key, object value) { }
@@ -1452,7 +1454,9 @@ namespace FluentAssertions.Formatting
     public class FormattingOptions
     {
         public FormattingOptions() { }
+        public int MaxDepth { get; set; }
         public bool UseLineBreaks { get; set; }
+        public FluentAssertions.Formatting.FormattingOptions Clone() { }
     }
     public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1,4 +1,7 @@
+<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions.git")]
+=======
+>>>>>>> 94b2b45d (Made AssertionScope.Succeeded internal):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v3.0", FrameworkDisplayName="")]
@@ -1195,7 +1198,6 @@ namespace FluentAssertions.Execution
         public AssertionScope(System.Lazy<string> context) { }
         public AssertionScope(string context) { }
         public System.Lazy<string> Context { get; set; }
-        public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
         public void AddNonReportable(string key, object value) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1,8 +1,12 @@
 <<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions.git")]
 =======
 >>>>>>> 94b2b45d (Made AssertionScope.Succeeded internal):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
+=======
+﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
+>>>>>>> 78ddd79b (Formatter.ToString() now takes a FormattingOptions that wraps the UseLineBreaks option ):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v3.0", FrameworkDisplayName="")]
 namespace FluentAssertions
@@ -1437,12 +1441,17 @@ namespace FluentAssertions.Formatting
         public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
         public static void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
         public static void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
-        public static string ToString(object value, bool useLineBreaks = false) { }
+        public static string ToString(object value, FluentAssertions.Formatting.FormattingOptions options = null) { }
     }
     public class FormattingContext
     {
         public FormattingContext() { }
         public int Depth { get; set; }
+        public FluentAssertions.Formatting.FormattingOptions Options { get; set; }
+    }
+    public class FormattingOptions
+    {
+        public FormattingOptions() { }
         public bool UseLineBreaks { get; set; }
     }
     public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1,12 +1,5 @@
-<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
-<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions.git")]
-=======
->>>>>>> 94b2b45d (Made AssertionScope.Succeeded internal):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
-=======
-﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
->>>>>>> 78ddd79b (Formatter.ToString() now takes a FormattingOptions that wraps the UseLineBreaks option ):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace FluentAssertions
@@ -1324,38 +1317,38 @@ namespace FluentAssertions.Formatting
     {
         public AggregateExceptionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class AttributeBasedFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public AttributeBasedFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public ByteValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class DateTimeOffsetValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DateTimeOffsetValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class DecimalValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DecimalValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DefaultValueFormatter() { }
         protected virtual int SpacesPerIndentionLevel { get; }
         public virtual bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
         protected virtual System.Reflection.MemberInfo[] GetMembers(System.Type type) { }
         protected virtual string TypeDisplayName(System.Type type) { }
     }
@@ -1363,34 +1356,45 @@ namespace FluentAssertions.Formatting
     {
         public DoubleValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class EnumValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumValueFormatter() { }
         public virtual bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumerableValueFormatter() { }
         protected virtual int MaxItems { get; }
         public virtual bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public ExceptionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public ExpressionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
-    public delegate string FormatChild(string childPath, object value);
+    public delegate void FormatChild(string childPath, object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph);
+    public class FormattedObjectGraph
+    {
+        public FormattedObjectGraph(int maxLines) { }
+        public int LineCount { get; }
+        public static int SpacesPerIndentation { get; }
+        public void AddFragment(string fragment) { }
+        public void AddFragmentOnNewLine(string fragment) { }
+        public void AddLine(string line) { }
+        public override string ToString() { }
+        public System.IDisposable WithIndentation() { }
+    }
     public static class Formatter
     {
         public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
@@ -1401,116 +1405,121 @@ namespace FluentAssertions.Formatting
     public class FormattingContext
     {
         public FormattingContext() { }
-        public int Depth { get; set; }
-        public FluentAssertions.Formatting.FormattingOptions Options { get; set; }
+        public bool UseLineBreaks { get; set; }
     }
     public class FormattingOptions
     {
         public FormattingOptions() { }
         public int MaxDepth { get; set; }
+        public int MaxLines { get; set; }
         public bool UseLineBreaks { get; set; }
-        public FluentAssertions.Formatting.FormattingOptions Clone() { }
     }
     public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public GuidValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public interface IValueFormatter
     {
         bool CanHandle(object value);
-        string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
+        void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
     }
     public class Int16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public Int16ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class Int32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public Int32ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class Int64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public Int64ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class MaxLinesExceededException : System.Exception
+    {
+        public MaxLinesExceededException() { }
+        public MaxLinesExceededException(string message) { }
+        public MaxLinesExceededException(string message, System.Exception innerException) { }
     }
     public class MultidimensionalArrayFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public MultidimensionalArrayFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class NullValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public NullValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class PredicateLambdaExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public PredicateLambdaExpressionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class PropertyInfoFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public PropertyInfoFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class SByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public SByteValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class SingleValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public SingleValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class StringValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public StringValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class TaskFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public TaskFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class TimeSpanValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public TimeSpanValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class UInt16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public UInt16ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class UInt32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public UInt32ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class UInt64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public UInt64ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
     public class ValueFormatterAttribute : System.Attribute
@@ -1521,19 +1530,19 @@ namespace FluentAssertions.Formatting
     {
         public XAttributeValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class XDocumentValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public XDocumentValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class XElementValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public XElementValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
 }
 namespace FluentAssertions.Numeric
@@ -2458,6 +2467,6 @@ namespace FluentAssertions.Xml
     {
         public XmlNodeFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1,8 +1,12 @@
 <<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions.git")]
 =======
 >>>>>>> 94b2b45d (Made AssertionScope.Succeeded internal):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
+=======
+﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
+>>>>>>> 78ddd79b (Formatter.ToString() now takes a FormattingOptions that wraps the UseLineBreaks option ):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace FluentAssertions
@@ -1390,12 +1394,17 @@ namespace FluentAssertions.Formatting
         public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
         public static void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
         public static void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
-        public static string ToString(object value, bool useLineBreaks = false) { }
+        public static string ToString(object value, FluentAssertions.Formatting.FormattingOptions options = null) { }
     }
     public class FormattingContext
     {
         public FormattingContext() { }
         public int Depth { get; set; }
+        public FluentAssertions.Formatting.FormattingOptions Options { get; set; }
+    }
+    public class FormattingOptions
+    {
+        public FormattingOptions() { }
         public bool UseLineBreaks { get; set; }
     }
     public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -108,6 +108,7 @@ namespace FluentAssertions
     public static class AssertionOptions
     {
         public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
+        public static FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
     }
@@ -1155,6 +1156,7 @@ namespace FluentAssertions.Execution
         public AssertionScope(System.Lazy<string> context) { }
         public AssertionScope(string context) { }
         public System.Lazy<string> Context { get; set; }
+        public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
         public void AddNonReportable(string key, object value) { }
@@ -1405,7 +1407,9 @@ namespace FluentAssertions.Formatting
     public class FormattingOptions
     {
         public FormattingOptions() { }
+        public int MaxDepth { get; set; }
         public bool UseLineBreaks { get; set; }
+        public FluentAssertions.Formatting.FormattingOptions Clone() { }
     }
     public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1,4 +1,7 @@
+<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions.git")]
+=======
+>>>>>>> 94b2b45d (Made AssertionScope.Succeeded internal):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
@@ -1148,7 +1151,6 @@ namespace FluentAssertions.Execution
         public AssertionScope(System.Lazy<string> context) { }
         public AssertionScope(string context) { }
         public System.Lazy<string> Context { get; set; }
-        public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
         public void AddNonReportable(string key, object value) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1,4 +1,7 @@
+<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions.git")]
+=======
+>>>>>>> 94b2b45d (Made AssertionScope.Succeeded internal):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
@@ -1195,7 +1198,6 @@ namespace FluentAssertions.Execution
         public AssertionScope(System.Lazy<string> context) { }
         public AssertionScope(string context) { }
         public System.Lazy<string> Context { get; set; }
-        public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
         public void AddNonReportable(string key, object value) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1,8 +1,12 @@
 <<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions.git")]
 =======
 >>>>>>> 94b2b45d (Made AssertionScope.Succeeded internal):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
+=======
+﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
+>>>>>>> 78ddd79b (Formatter.ToString() now takes a FormattingOptions that wraps the UseLineBreaks option ):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
 namespace FluentAssertions
@@ -1437,12 +1441,17 @@ namespace FluentAssertions.Formatting
         public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
         public static void AddFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
         public static void RemoveFormatter(FluentAssertions.Formatting.IValueFormatter formatter) { }
-        public static string ToString(object value, bool useLineBreaks = false) { }
+        public static string ToString(object value, FluentAssertions.Formatting.FormattingOptions options = null) { }
     }
     public class FormattingContext
     {
         public FormattingContext() { }
         public int Depth { get; set; }
+        public FluentAssertions.Formatting.FormattingOptions Options { get; set; }
+    }
+    public class FormattingOptions
+    {
+        public FormattingOptions() { }
         public bool UseLineBreaks { get; set; }
     }
     public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -109,6 +109,7 @@ namespace FluentAssertions
     public static class AssertionOptions
     {
         public static FluentAssertions.EquivalencyStepCollection EquivalencySteps { get; }
+        public static FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
     }
@@ -1202,6 +1203,7 @@ namespace FluentAssertions.Execution
         public AssertionScope(System.Lazy<string> context) { }
         public AssertionScope(string context) { }
         public System.Lazy<string> Context { get; set; }
+        public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
         public void AddNonReportable(string key, object value) { }
@@ -1452,7 +1454,9 @@ namespace FluentAssertions.Formatting
     public class FormattingOptions
     {
         public FormattingOptions() { }
+        public int MaxDepth { get; set; }
         public bool UseLineBreaks { get; set; }
+        public FluentAssertions.Formatting.FormattingOptions Clone() { }
     }
     public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1,12 +1,5 @@
-<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
-<<<<<<< HEAD:Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions.git")]
-=======
->>>>>>> 94b2b45d (Made AssertionScope.Succeeded internal):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
-=======
-﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
->>>>>>> 78ddd79b (Formatter.ToString() now takes a FormattingOptions that wraps the UseLineBreaks option ):Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
 namespace FluentAssertions
@@ -1371,38 +1364,38 @@ namespace FluentAssertions.Formatting
     {
         public AggregateExceptionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class AttributeBasedFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public AttributeBasedFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public ByteValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class DateTimeOffsetValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DateTimeOffsetValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class DecimalValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DecimalValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class DefaultValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DefaultValueFormatter() { }
         protected virtual int SpacesPerIndentionLevel { get; }
         public virtual bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
         protected virtual System.Reflection.MemberInfo[] GetMembers(System.Type type) { }
         protected virtual string TypeDisplayName(System.Type type) { }
     }
@@ -1410,34 +1403,45 @@ namespace FluentAssertions.Formatting
     {
         public DoubleValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class EnumValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumValueFormatter() { }
         public virtual bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumerableValueFormatter() { }
         protected virtual int MaxItems { get; }
         public virtual bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ExceptionValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public ExceptionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class ExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public ExpressionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
-    public delegate string FormatChild(string childPath, object value);
+    public delegate void FormatChild(string childPath, object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph);
+    public class FormattedObjectGraph
+    {
+        public FormattedObjectGraph(int maxLines) { }
+        public int LineCount { get; }
+        public static int SpacesPerIndentation { get; }
+        public void AddFragment(string fragment) { }
+        public void AddFragmentOnNewLine(string fragment) { }
+        public void AddLine(string line) { }
+        public override string ToString() { }
+        public System.IDisposable WithIndentation() { }
+    }
     public static class Formatter
     {
         public static System.Collections.Generic.IEnumerable<FluentAssertions.Formatting.IValueFormatter> Formatters { get; }
@@ -1448,116 +1452,121 @@ namespace FluentAssertions.Formatting
     public class FormattingContext
     {
         public FormattingContext() { }
-        public int Depth { get; set; }
-        public FluentAssertions.Formatting.FormattingOptions Options { get; set; }
+        public bool UseLineBreaks { get; set; }
     }
     public class FormattingOptions
     {
         public FormattingOptions() { }
         public int MaxDepth { get; set; }
+        public int MaxLines { get; set; }
         public bool UseLineBreaks { get; set; }
-        public FluentAssertions.Formatting.FormattingOptions Clone() { }
     }
     public class GuidValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public GuidValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public interface IValueFormatter
     {
         bool CanHandle(object value);
-        string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
+        void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild);
     }
     public class Int16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public Int16ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class Int32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public Int32ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class Int64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public Int64ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
+    public class MaxLinesExceededException : System.Exception
+    {
+        public MaxLinesExceededException() { }
+        public MaxLinesExceededException(string message) { }
+        public MaxLinesExceededException(string message, System.Exception innerException) { }
     }
     public class MultidimensionalArrayFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public MultidimensionalArrayFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class NullValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public NullValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class PredicateLambdaExpressionValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public PredicateLambdaExpressionValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class PropertyInfoFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public PropertyInfoFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class SByteValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public SByteValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class SingleValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public SingleValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class StringValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public StringValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class TaskFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public TaskFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class TimeSpanValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public TimeSpanValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class UInt16ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public UInt16ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class UInt32ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public UInt32ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class UInt64ValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public UInt64ValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
     public class ValueFormatterAttribute : System.Attribute
@@ -1568,19 +1577,19 @@ namespace FluentAssertions.Formatting
     {
         public XAttributeValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class XDocumentValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public XDocumentValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
     public class XElementValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public XElementValueFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
 }
 namespace FluentAssertions.Numeric
@@ -2505,6 +2514,6 @@ namespace FluentAssertions.Xml
     {
         public XmlNodeFormatter() { }
         public bool CanHandle(object value) { }
-        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
 }

--- a/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Chill;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Execution;
+using FluentAssertions.Formatting;
 using Xunit;
 using Xunit.Sdk;
 
@@ -146,6 +147,7 @@ namespace FluentAssertions.Specs
             }
         }
 
+        [Collection("AssertionOptionsSpecs")]
         public class Given_temporary_equivalency_steps : GivenWhenThen
         {
             protected override void Dispose(bool disposing)
@@ -295,6 +297,41 @@ namespace FluentAssertions.Specs
                 Execute.Assertion.FailWith(GetType().FullName);
 
                 return true;
+            }
+        }
+
+        [Collection("AssertionOptionsSpecs")]
+        public class When_global_formatting_settings_are_modified : GivenWhenThen
+        {
+            private FormattingOptions oldSettings;
+
+            public When_global_formatting_settings_are_modified()
+            {
+                Given(() =>
+                {
+                    oldSettings = AssertionOptions.FormattingOptions.Clone();
+                });
+
+                When(() =>
+                {
+                    AssertionOptions.FormattingOptions.UseLineBreaks = true;
+                    AssertionOptions.FormattingOptions.MaxDepth = 123;
+                });
+            }
+
+            [Fact]
+            public void Then_the_current_assertion_scope_should_use_these_settings()
+            {
+                AssertionScope.Current.FormattingOptions.UseLineBreaks.Should().BeTrue();
+                AssertionScope.Current.FormattingOptions.MaxDepth.Should().Be(123);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                AssertionOptions.FormattingOptions.MaxDepth = oldSettings.MaxDepth;
+                AssertionOptions.FormattingOptions.UseLineBreaks = oldSettings.UseLineBreaks;
+
+                base.Dispose(disposing);
             }
         }
     }

--- a/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
@@ -316,6 +316,7 @@ namespace FluentAssertions.Specs
                 {
                     AssertionOptions.FormattingOptions.UseLineBreaks = true;
                     AssertionOptions.FormattingOptions.MaxDepth = 123;
+                    AssertionOptions.FormattingOptions.MaxLines = 33;
                 });
             }
 
@@ -324,12 +325,14 @@ namespace FluentAssertions.Specs
             {
                 AssertionScope.Current.FormattingOptions.UseLineBreaks.Should().BeTrue();
                 AssertionScope.Current.FormattingOptions.MaxDepth.Should().Be(123);
+                AssertionScope.Current.FormattingOptions.MaxLines.Should().Be(33);
             }
 
             protected override void Dispose(bool disposing)
             {
                 AssertionOptions.FormattingOptions.MaxDepth = oldSettings.MaxDepth;
                 AssertionOptions.FormattingOptions.UseLineBreaks = oldSettings.UseLineBreaks;
+                AssertionOptions.FormattingOptions.MaxLines = oldSettings.MaxLines;
 
                 base.Dispose(disposing);
             }

--- a/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
@@ -500,7 +500,7 @@ namespace FluentAssertions.Specs.Exceptions
 
         private static string BuildExpectedMessageForWithInnerExceptionExactly(string because, string innerExceptionMessage)
         {
-            var expectedMessage = $"{because} \"{innerExceptionMessage}\"\n.";
+            var expectedMessage = $"{because} \"{innerExceptionMessage}\".";
 
             return expectedMessage;
         }

--- a/Tests/FluentAssertions.Specs/Formatting/DateTimeOffsetValueFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/DateTimeOffsetValueFormatterSpecs.cs
@@ -11,11 +11,8 @@ namespace FluentAssertions.Specs.Formatting
         [Fact]
         public void When_time_is_not_relevant_it_should_not_be_included_in_the_output()
         {
-            // Arrange
-            var formatter = new DateTimeOffsetValueFormatter();
-
             // Act
-            string result = formatter.Format(new DateTime(1973, 9, 20), new FormattingContext(), null);
+            string result = Formatter.ToString(new DateTime(1973, 9, 20));
 
             // Assert
             result.Should().Be("<1973-09-20>");
@@ -24,12 +21,8 @@ namespace FluentAssertions.Specs.Formatting
         [Fact]
         public void When_the_offset_is_not_relevant_it_should_not_be_included_in_the_output()
         {
-            // Arrange
-            var formatter = new DateTimeOffsetValueFormatter();
-
             // Act
-            string result = formatter.Format(new DateTimeOffset(1973, 9, 20, 12, 59, 59, 0.Hours()), new FormattingContext(),
-                null);
+            string result = Formatter.ToString(new DateTimeOffset(1973, 9, 20, 12, 59, 59, 0.Hours()));
 
             // Assert
             result.Should().Be("<1973-09-20 12:59:59>");
@@ -61,13 +54,10 @@ namespace FluentAssertions.Specs.Formatting
         [Fact]
         public void When_date_is_not_relevant_it_should_not_be_included_in_the_output()
         {
-            // Arrange
-            var formatter = new DateTimeOffsetValueFormatter();
-
             // Act
             DateTime emptyDate = 1.January(0001);
             var dateTime = emptyDate.At(08, 20, 01);
-            string result = formatter.Format(dateTime, new FormattingContext(), null);
+            string result = Formatter.ToString(dateTime);
 
             // Assert
             result.Should().Be("<08:20:01>");
@@ -84,11 +74,10 @@ namespace FluentAssertions.Specs.Formatting
         public void When_date_is_relevant_it_should_be_included_in_the_output(string actual, string expected)
         {
             // Arrange
-            var formatter = new DateTimeOffsetValueFormatter();
             var value = DateTime.Parse(actual, CultureInfo.InvariantCulture);
 
             // Act
-            string result = formatter.Format(value, new FormattingContext(), null);
+            string result = Formatter.ToString(value);
 
             // Assert
             result.Should().Be(expected);
@@ -97,12 +86,9 @@ namespace FluentAssertions.Specs.Formatting
         [Fact]
         public void When_a_full_date_and_time_is_specified_all_parts_should_be_included_in_the_output()
         {
-            // Arrange
-            var formatter = new DateTimeOffsetValueFormatter();
-
             // Act
             var dateTime = 1.May(2012).At(20, 15, 30, 318);
-            string result = formatter.Format(dateTime, new FormattingContext(), null);
+            string result = Formatter.ToString(dateTime);
 
             // Assert
             result.Should().Be("<2012-05-01 20:15:30.318>");
@@ -127,11 +113,10 @@ namespace FluentAssertions.Specs.Formatting
         public void When_datetime_components_are_not_relevant_they_should_not_be_included_in_the_output(string actual, string expected)
         {
             // Arrange
-            var formatter = new DateTimeOffsetValueFormatter();
             var value = DateTime.Parse(actual, CultureInfo.InvariantCulture);
 
             // Act
-            string result = formatter.Format(value, new FormattingContext(), null);
+            string result = Formatter.ToString(value);
 
             // Assert
             result.Should().Be(expected);
@@ -170,25 +155,23 @@ namespace FluentAssertions.Specs.Formatting
             When_a_DateTime_is_used_it_should_format_the_same_as_a_DateTimeOffset()
         {
             // Arrange
-            var formatter = new DateTimeOffsetValueFormatter();
-
             var dateOnly = ToUtcWithoutChangingTime(new DateTime(1973, 9, 20));
             var timeOnly = ToUtcWithoutChangingTime(1.January(0001).At(08, 20, 01));
             var withoutMilliseconds = ToUtcWithoutChangingTime(1.May(2012).At(20, 15, 30));
             var withMilliseconds = ToUtcWithoutChangingTime(1.May(2012).At(20, 15, 30, 318));
 
             // Act / Assert
-            formatter.Format(dateOnly, new FormattingContext(), null)
-                .Should().Be(formatter.Format((DateTimeOffset)dateOnly, new FormattingContext(), null));
+            Formatter.ToString(dateOnly)
+                .Should().Be(Formatter.ToString((DateTimeOffset)dateOnly));
 
-            formatter.Format(timeOnly, new FormattingContext(), null).Should()
-                .Be(formatter.Format((DateTimeOffset)timeOnly, new FormattingContext(), null));
+            Formatter.ToString(timeOnly).Should()
+                .Be(Formatter.ToString((DateTimeOffset)timeOnly));
 
-            formatter.Format(withoutMilliseconds, new FormattingContext(), null).Should()
-                .Be(formatter.Format((DateTimeOffset)withoutMilliseconds, new FormattingContext(), null));
+            Formatter.ToString(withoutMilliseconds).Should()
+                .Be(Formatter.ToString((DateTimeOffset)withoutMilliseconds));
 
-            formatter.Format(withMilliseconds, new FormattingContext(), null).Should()
-                .Be(formatter.Format((DateTimeOffset)withMilliseconds, new FormattingContext(), null));
+            Formatter.ToString(withMilliseconds).Should()
+                .Be(Formatter.ToString((DateTimeOffset)withMilliseconds));
         }
 
         private static DateTime ToUtcWithoutChangingTime(DateTime date)

--- a/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
@@ -219,19 +219,51 @@ namespace FluentAssertions.Specs.Formatting
         {
             // Arrange
             var head = new Node();
+            var node = head;
 
-            foreach (int i in Enumerable.Range(0, 20))
+            int maxDepth = 10;
+            int iterations = (maxDepth / 2) + 1; // Each iteration adds two levels of depth to the graph
+            foreach (int i in Enumerable.Range(0, iterations))
             {
                 var newHead = new Node();
-                newHead.Children.Add(head);
-                head = newHead;
+                node.Children.Add(newHead);
+                node = newHead;
             }
 
             // Act
-            string result = Formatter.ToString(head);
+            string result = Formatter.ToString(head, new FormattingOptions
+            {
+                MaxDepth = maxDepth
+            });
 
             // Assert
-            result.Should().ContainEquivalentOf("maximum recursion depth");
+            result.Should().ContainEquivalentOf($"maximum recursion depth of {maxDepth}");
+        }
+
+        [Fact]
+        public void When_the_maximum_recursion_depth_is_never_reached_it_should_render_the_entire_graph()
+        {
+            // Arrange
+            var head = new Node();
+            var node = head;
+
+            int iterations = 10;
+            foreach (int i in Enumerable.Range(0, iterations))
+            {
+                var newHead = new Node();
+                node.Children.Add(newHead);
+                node = newHead;
+            }
+
+            // Act
+            string result = Formatter.ToString(head, new FormattingOptions
+            {
+                    // Each iteration adds two levels of depth to the graph
+                MaxDepth = (iterations * 2) + 1
+            });
+
+            // Assert
+            result.Should().NotContainEquivalentOf("maximum recursion depth");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Formatting/PredicateLambdaExpressionValueFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/PredicateLambdaExpressionValueFormatterSpecs.cs
@@ -45,7 +45,14 @@ namespace FluentAssertions.Specs.Formatting
             result.Should().Be("(a.Text == \"123\") AndAlso (a.Number >= 0) AndAlso (a.Number <= 1000)");
         }
 
-        private string Format(Expression<Func<SomeClass, bool>> expression) => formatter.Format(expression, new FormattingContext(), null);
+        private string Format(Expression<Func<SomeClass, bool>> expression)
+        {
+            var graph = new FormattedObjectGraph(maxLines: 100);
+
+            formatter.Format(expression, graph, new FormattingContext(), null);
+
+            return graph.ToString();
+        }
 
         private class SomeClass
         {

--- a/Tests/FluentAssertions.Specs/Formatting/TimeSpanFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/TimeSpanFormatterSpecs.cs
@@ -10,11 +10,8 @@ namespace FluentAssertions.Specs.Formatting
         [Fact]
         public void When_zero_time_span_it_should_return_a_literal()
         {
-            // Arrange
-            var formatter = new TimeSpanValueFormatter();
-
             // Act
-            string result = formatter.Format(TimeSpan.Zero, new FormattingContext(), null);
+            string result = Formatter.ToString(TimeSpan.Zero);
 
             // Assert
             result.Should().Be("default");
@@ -23,11 +20,8 @@ namespace FluentAssertions.Specs.Formatting
         [Fact]
         public void When_max_time_span_it_should_return_a_literal()
         {
-            // Arrange
-            var formatter = new TimeSpanValueFormatter();
-
             // Act
-            string result = formatter.Format(TimeSpan.MaxValue, new FormattingContext(), null);
+            string result = Formatter.ToString(TimeSpan.MaxValue);
 
             // Assert
             result.Should().Be("max time span");
@@ -36,11 +30,8 @@ namespace FluentAssertions.Specs.Formatting
         [Fact]
         public void When_min_time_span_it_should_return_a_literal()
         {
-            // Arrange
-            var formatter = new TimeSpanValueFormatter();
-
             // Act
-            string result = formatter.Format(TimeSpan.MinValue, new FormattingContext(), null);
+            string result = Formatter.ToString(TimeSpan.MinValue);
 
             // Assert
             result.Should().Be("min time span");
@@ -76,11 +67,10 @@ namespace FluentAssertions.Specs.Formatting
         public void When_timespan_components_are_not_relevant_they_should_not_be_included_in_the_output(string actual, string expected)
         {
             // Arrange
-            var formatter = new TimeSpanValueFormatter();
             var value = TimeSpan.Parse(actual, CultureInfo.InvariantCulture);
 
             // Act
-            string result = formatter.Format(value, new FormattingContext(), null);
+            string result = Formatter.ToString(value);
 
             // Assert
             result.Should().Be(expected);

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
@@ -343,8 +343,8 @@ namespace FluentAssertions.Specs.Primitives
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected subject to be*FluentAssertions*SomeDto*{*Age = 2*Birthdate = <2009-02-22>*" +
-                    "   Name = \"Teddie\"*}, but found*FluentAssertions*SomeDto*{*Age = 37*" +
-                        "   Birthdate = <1973-09-20>*Name = \"Dennis\"*}.");
+                    "  Name = \"Teddie\"*}, but found*FluentAssertions*SomeDto*{*Age = 37*" +
+                        "  Birthdate = <1973-09-20>*Name = \"Dennis\"*}.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Xml/XAttributeFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XAttributeFormatterSpecs.cs
@@ -10,13 +10,10 @@ namespace FluentAssertions.Specs.Xml
         [Fact]
         public void When_formatting_an_attribute_it_should_return_the_name_and_value()
         {
-            // Arrange
-            var formatter = new XAttributeValueFormatter();
-
             // Act
             var element = XElement.Parse(@"<person name=""Martin"" age=""36"" />");
             XAttribute attribute = element.Attribute("name");
-            string result = formatter.Format(attribute, new FormattingContext(), null);
+            string result = Formatter.ToString(attribute);
 
             // Assert
             result.Should().Be(@"name=""Martin""");

--- a/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
@@ -843,7 +843,7 @@ namespace FluentAssertions.Specs.Xml
 
             // Act
             Action act = () =>
-                theElement.Should().HaveAttribute(XName.Get("name", "http://www.example.com/2012/test"), "dennis",
+                 theElement.Should().HaveAttribute(XName.Get("name", "http://www.example.com/2012/test"), "dennis",
                     "because we want to test the failure {0}", "message");
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Xml/XElementFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XElementFormatterSpecs.cs
@@ -10,12 +10,9 @@ namespace FluentAssertions.Specs.Xml
         [Fact]
         public void When_element_has_attributes_it_should_include_them_in_the_output()
         {
-            // Arrange
-            var formatter = new XElementValueFormatter();
-
             // Act
             var element = XElement.Parse(@"<person name=""Martin"" age=""36"" />");
-            string result = formatter.Format(element, new FormattingContext(), null);
+            string result = Formatter.ToString(element);
 
             // Assert
             result.Should().Be(@"<person name=""Martin"" age=""36"" />");
@@ -24,16 +21,13 @@ namespace FluentAssertions.Specs.Xml
         [Fact]
         public void When_element_has_child_element_it_should_not_include_them_in_the_output()
         {
-            // Arrange
-            var formatter = new XElementValueFormatter();
-
             // Act
             var element = XElement.Parse(
                 @"<person name=""Martin"" age=""36"">
                       <child name=""Laura"" />
                   </person>");
 
-            string result = formatter.Format(element, new FormattingContext(), null);
+            string result = Formatter.ToString(element);
 
             // Assert
             result.Should().Be(@"<person name=""Martin"" age=""36"">…</person>");

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -17,6 +17,7 @@ sidebar:
 * Added `Satisfy` to be able to compare a collection with a set of predicates in any order - [#1500](https://github.com/fluentassertions/fluentassertions/pull/1500).
 * Added milliseconds formatting for error messages including `TimeSpan` - [#1504](https://github.com/fluentassertions/fluentassertions/pull/1504).
 * Added `AddReportable` overload to `AssertionScope` for deferring reportable value calculation only on a test failure - [#1515](https://github.com/fluentassertions/fluentassertions/pull/1515).
+* Added the possibility to set the maximum depth and other formatting settings either globally or per `AssertionScope` - [#1469](https://github.com/fluentassertions/fluentassertions/pull/1469).
 
 **Fixes**
 * Sometimes `BeEquivalentTo` reported an incorrect message when a dictionary was missing a key - [#1454](https://github.com/fluentassertions/fluentassertions/pull/1454)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -32,6 +32,7 @@ sidebar:
 * Pascal cased `SelfReferenceEquivalencyAssertionOptions.orderingRules` - [#1458](https://github.com/fluentassertions/fluentassertions/pull/1458).
 * Moved extension methods on `ExceptionAssertions` from `AssertionExtensions` to `ExceptionAssertionsExtensions` - [#1471](https://github.com/fluentassertions/fluentassertions/pull/1471).
 * Moved `Including(Expression<Func<IMemberInfo, bool>> predicate)` from `EquivalencyAssertionOptions<T>` to `SelfReferenceEquivalencyAssertionOptions<T>` - [#1495](https://github.com/fluentassertions/fluentassertions/pull/1495).
+* `Formatter.ToString()` and `IValueFormatter` now work with a `FormattingOptions` object that wraps the `UseLineBreaks` option - [#1469](https://github.com/fluentassertions/fluentassertions/pull/1469).
 
 ## 6.0.0 Alpha 2
 

--- a/docs/_pages/upgradingtov6.md
+++ b/docs/_pages/upgradingtov6.md
@@ -142,3 +142,22 @@ subject.Should().BeEquivalentTo(expectation, opt => opt
     .WhenTypeIs<int?>()
 );
 ```
+## Value Formatters ##
+
+Within Fluent Assertions, the `Formatter` class is responsible for rendering a textual representation of the objects involved in an assertion. Those objects can turn out to be entire graphs, especially when you use `BeEquivalentTo`. Rendering such a graph can be an expensive operation, so in 5.x we already had limits on how deep the `Formatter` would traverse the object graph. Because we received several performance-related issues, we decided to slightly redesign how implementations of `IValueFormatter` should work. This unfortunately required us to introduce some breaking changes in the signature of the `Format` method as well as some behavioral changes. You can read all about that in the updated [extensibility guide](/extensibility/#rendering-objects-with-beauty), but the gist of it is that instead of returning a `string`, you now need to use the `FormattedObjectGraph`, which acts like a kind of `StringBuilder`. For instance, this is what the `StringValueFormatter` now looks like:
+
+```csharp
+public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
+{
+    string result = "\"" + value + "\"";
+
+    if (context.UseLineBreaks)
+    {
+        formattedGraph.AddFragmentOnNewLine(result);
+    }
+    else
+    {
+        formattedGraph.AddFragment(result);
+    }
+}
+```


### PR DESCRIPTION
* Formatter.ToString will take an options object that allow you to specify the max depth and the max number of lines to produce
Both will have defaults
* AssertionScope will have properties to override this in case you need it
* Also considering to have the defaults come from AssertionOptions
* Limit formatting to a maximum number of lines

Fixes #1014

**Can be reviewed commit by commit**