### PR TITLE
Fix unit test namespaces according to the file structure

### DIFF
--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -4,10 +4,11 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using FluentAssertions.Execution;
+using FluentAssertions.Specs.Equivalency;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Collections
 {
     public class CollectionAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -6,7 +6,7 @@ using FluentAssertions.Collections;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Collections
 {
     public class GenericCollectionAssertionOfStringSpecs
     {

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
@@ -3,10 +3,11 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using FluentAssertions.Specs.Equivalency;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Collections
 {
     public class GenericCollectionAssertionsSpecs
     {

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Collections
 {
     public class GenericDictionaryAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
@@ -9,10 +9,11 @@ using System.Net;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Extensions;
+using FluentAssertions.Specs.Primitives;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Equivalency
 {
     public class BasicEquivalencySpecs
     {

--- a/Tests/FluentAssertions.Specs/Equivalency/BasicNonEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/BasicNonEquivalencySpecs.cs
@@ -2,7 +2,7 @@
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Equivalency
 {
     public class BasicNonEquivalencySpecs
     {

--- a/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
@@ -6,10 +6,11 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using FluentAssertions.Equivalency;
 using FluentAssertions.Extensions;
+using FluentAssertions.Specs.Primitives;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Equivalency
 {
     public class CollectionEquivalencySpecs
     {

--- a/Tests/FluentAssertions.Specs/Equivalency/DictionaryEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DictionaryEquivalencySpecs.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Equivalency
 {
     public class DictionaryEquivalencySpecs
     {

--- a/Tests/FluentAssertions.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
@@ -8,7 +8,7 @@ using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Equivalency
 {
     /// <summary>
     /// Test Class containing specs over the extensibility points of Should().BeEquivalentTo

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -9,7 +9,7 @@ using FluentAssertions.Specs.Common;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs // TODO Move to FluentAssertions.Specs.Exceptions to follow file structure?
+namespace FluentAssertions.Specs.Exceptions
 {
     [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
     public class AsyncFunctionExceptionAssertionSpecs

--- a/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
@@ -10,7 +10,7 @@ using Xunit.Sdk;
 
 using static FluentAssertions.Extensions.FluentTimeSpanExtensions;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Exceptions
 {
     public class ExceptionAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/FunctionExceptionAssertionSpecs.cs
@@ -9,7 +9,7 @@ using FluentAssertions.Specs.Common;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Exceptions
 {
     public class FunctionExceptionAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Exceptions/ThrowAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/ThrowAssertionsSpecs.cs
@@ -2,7 +2,7 @@
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Exceptions
 {
     public class ThrowAssertionsSpecs
     {

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -12,7 +12,7 @@ using FluentAssertions.Specs.Execution;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Execution
 {
     public class AssertionScopeSpecs
     {

--- a/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
@@ -3,7 +3,7 @@ using FluentAssertions;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Execution
 {
     public class CallerIdentifierSpecs
     {

--- a/Tests/FluentAssertions.Specs/Extensions/FluentActionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Extensions/FluentActionsSpecs.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Xunit;
 using static FluentAssertions.FluentActions;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Extensions
 {
     public class FluentActionsSpecs
     {

--- a/Tests/FluentAssertions.Specs/Extensions/FluentDateTimeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Extensions/FluentDateTimeSpecs.cs
@@ -3,7 +3,7 @@ using FluentAssertions.Common;
 using FluentAssertions.Extensions;
 using Xunit;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Extensions
 {
     public class FluentDateTimeSpecs
     {

--- a/Tests/FluentAssertions.Specs/Extensions/ObjectCastingSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Extensions/ObjectCastingSpecs.cs
@@ -1,6 +1,6 @@
 ﻿using Xunit;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Extensions
 {
     public class ObjectCastingSpecs
     {

--- a/Tests/FluentAssertions.Specs/Extensions/ObjectExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Extensions/ObjectExtensionsSpecs.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using FluentAssertions.Common;
 using Xunit;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Extensions
 {
     public class ObjectExtensionsSpecs
     {

--- a/Tests/FluentAssertions.Specs/Extensions/TimeSpanConversionExtensionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Extensions/TimeSpanConversionExtensionSpecs.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using FluentAssertions.Extensions;
 using Xunit;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Extensions
 {
     public class TimeSpanConversionExtensionSpecs
     {

--- a/Tests/FluentAssertions.Specs/FindAssembly.cs
+++ b/Tests/FluentAssertions.Specs/FindAssembly.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
 
-namespace FluentAssertions
+namespace FluentAssertions.Specs
 {
     public static class FindAssembly
     {

--- a/Tests/FluentAssertions.Specs/Formatting/DateTimeOffsetValueFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/DateTimeOffsetValueFormatterSpecs.cs
@@ -4,7 +4,7 @@ using FluentAssertions.Extensions;
 using FluentAssertions.Formatting;
 using Xunit;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Formatting
 {
     public class DateTimeOffsetValueFormatterSpecs
     {

--- a/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
@@ -10,7 +10,7 @@ using FluentAssertions.Specs.Common;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Formatting
 {
     [Collection("FormatterSpecs")]
     public class FormatterSpecs
@@ -822,7 +822,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             str.Should().Match(
-"{FluentAssertions.Specs.FormatterSpecs+CustomClass" + Environment.NewLine +
+"{FluentAssertions*FormatterSpecs+CustomClass" + Environment.NewLine +
 "   {" + Environment.NewLine +
 "      IntProperty = 1" + Environment.NewLine +
 "      StringProperty = <null>" + Environment.NewLine +

--- a/Tests/FluentAssertions.Specs/Formatting/MultidimensionalArrayFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/MultidimensionalArrayFormatterSpecs.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using FluentAssertions.Formatting;
 using Xunit;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Formatting
 {
     [Collection("FormatterSpecs")]
     public class MultidimensionalArrayFormatterSpecs

--- a/Tests/FluentAssertions.Specs/Formatting/TimeSpanFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/TimeSpanFormatterSpecs.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 using FluentAssertions.Formatting;
 using Xunit;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Formatting
 {
     public class TimeSpanFormatterSpecs
     {

--- a/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
@@ -2,7 +2,7 @@
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Numeric
 {
     public class ComparableSpecs
     {

--- a/Tests/FluentAssertions.Specs/Numeric/NullableNumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NullableNumericAssertionSpecs.cs
@@ -2,7 +2,7 @@ using System;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Numeric
 {
     public class NullableNumericAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
@@ -2,7 +2,7 @@ using System;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Numeric
 {
     public class NumericAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/BooleanAssertionSpecs.cs
@@ -2,7 +2,7 @@
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Primitives
 {
     public class BooleanAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeAssertionSpecs.cs
@@ -3,7 +3,7 @@ using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Primitives
 {
     public class DateTimeAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
@@ -4,7 +4,7 @@ using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Primitives
 {
     public class DateTimeOffsetAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Primitives/EnumAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/EnumAssertionSpecs.cs
@@ -2,7 +2,7 @@
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Primitives
 {
     public enum EnumULong : ulong
     {

--- a/Tests/FluentAssertions.Specs/Primitives/GuidAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/GuidAssertionSpecs.cs
@@ -2,7 +2,7 @@
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Primitives
 {
     public class GuidAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Primitives/NullableBooleanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/NullableBooleanAssertionSpecs.cs
@@ -2,7 +2,7 @@ using System;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Primitives
 {
     public class NullableBooleanAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Primitives/NullableGuidAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/NullableGuidAssertionSpecs.cs
@@ -2,7 +2,7 @@
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Primitives
 {
     public class NullableGuidAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Primitives/NullableSimpleTimeSpanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/NullableSimpleTimeSpanAssertionSpecs.cs
@@ -3,7 +3,7 @@ using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Primitives
 {
     public class NullableSimpleTimeSpanAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -10,7 +10,7 @@ using FluentAssertions.Primitives;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Primitives
 {
     public class ObjectAssertionSpecs
     {
@@ -438,7 +438,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be FluentAssertions.Specs.DummyBaseClass, but found FluentAssertions.Specs.DummyImplementingClass.");
+                "Expected type to be FluentAssertions*DummyBaseClass, but found FluentAssertions*DummyImplementingClass.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
@@ -3,7 +3,7 @@ using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Primitives
 {
     public class ReferenceTypeAssertionsSpecs
     {
@@ -342,8 +342,8 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject to be*FluentAssertions.Specs.SomeDto*{*Age = 2*Birthdate = <2009-02-22>*" +
-                    "   Name = \"Teddie\"*}, but found*FluentAssertions.Specs.SomeDto*{*Age = 37*" +
+                "Expected subject to be*FluentAssertions*SomeDto*{*Age = 2*Birthdate = <2009-02-22>*" +
+                    "   Name = \"Teddie\"*}, but found*FluentAssertions*SomeDto*{*Age = 37*" +
                         "   Birthdate = <1973-09-20>*Name = \"Dennis\"*}.");
         }
 

--- a/Tests/FluentAssertions.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
@@ -3,7 +3,7 @@ using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Primitives
 {
     public class SimpleTimeSpanAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
@@ -5,7 +5,7 @@ using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Primitives
 {
     public class StringAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Specialized/AggregateExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/AggregateExceptionAssertionSpecs.cs
@@ -2,7 +2,7 @@
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Specialized
 {
     public class AggregateExceptionAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
@@ -2,10 +2,11 @@
 using System.Reflection;
 using AssemblyA;
 using AssemblyB;
+using FluentAssertions.Specs.Types;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Specialized
 {
     public class AssemblyAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Specialized/DelegateAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/DelegateAssertionSpecs.cs
@@ -2,7 +2,7 @@
 using FluentAssertions.Specialized;
 using Xunit;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Specialized
 {
     public class DelegateAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
@@ -6,7 +6,7 @@ using FluentAssertions.Specialized;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Specialized
 {
     public class ExecutionTimeAssertionsSpecs
     {

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -5,7 +5,7 @@ using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Specialized
 {
     public class TaskAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
@@ -5,7 +5,7 @@ using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Specialized
 {
     public class TaskCompletionSourceAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -5,10 +5,11 @@ using FluentAssertions.Extensions;
 #if NET47
 using FluentAssertions.Specs.Common;
 #endif
+using FluentAssertions.Specs.Exceptions;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Specialized
 {
     [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
     public class TaskOfTAssertionSpecs

--- a/Tests/FluentAssertions.Specs/Types/MethodBaseAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodBaseAssertionSpecs.cs
@@ -5,7 +5,7 @@ using FluentAssertions.Specs.Common;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Types
 {
     public class MethodBaseAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoAssertionSpecs.cs
@@ -6,7 +6,7 @@ using FluentAssertions.Common;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Types
 {
     public class MethodInfoAssertionSpecs
     {
@@ -38,7 +38,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method Void FluentAssertions.Specs.ClassWithNonVirtualPublicMethods.PublicDoNothing" +
+                .WithMessage("Expected method Void FluentAssertions*ClassWithNonVirtualPublicMethods.PublicDoNothing" +
                     " to be virtual because we want to test the error message," +
                     " but it is not virtual.");
         }
@@ -137,7 +137,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected method Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing to be decorated with " +
+                    "Expected method Void FluentAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing to be decorated with " +
                         "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
         }
 
@@ -154,7 +154,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected method Void FluentAssertions.Specs.ClassWithMethodWithImplementationAttribute.NoOptions to be decorated with " +
+                    "Expected method Void FluentAssertions*ClassWithMethodWithImplementationAttribute.NoOptions to be decorated with " +
                         "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
         }
 
@@ -171,7 +171,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected method Void FluentAssertions.Specs.ClassWithMethodWithImplementationAttribute.ZeroOptions to be decorated with " +
+                    "Expected method Void FluentAssertions*ClassWithMethodWithImplementationAttribute.ZeroOptions to be decorated with " +
                         "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
         }
 
@@ -188,7 +188,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected type FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute to be decorated with " +
+                    "Expected type FluentAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute to be decorated with " +
                         "System.Runtime.CompilerServices.MethodImplAttribute, but the attribute was not found.");
         }
 
@@ -218,8 +218,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected method Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing to be decorated with " +
-                        "FluentAssertions.Specs.DummyMethodAttribute because we want to test the error message," +
+                    "Expected method Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing to be decorated with " +
+                        "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
                         " but that attribute was not found.");
         }
 
@@ -278,8 +278,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected method Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing to be decorated with " +
-                        "FluentAssertions.Specs.DummyMethodAttribute because we want to test the error message," +
+                    "Expected method Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing to be decorated with " +
+                        "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
                         " but that attribute was not found.");
         }
 
@@ -296,7 +296,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected method Void FluentAssertions.Specs.ClassWithMethodWithImplementationAttribute.DoNotInlineMe to be decorated with " +
+                    "Expected method Void FluentAssertions*ClassWithMethodWithImplementationAttribute.DoNotInlineMe to be decorated with " +
                         "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was not found.");
         }
 
@@ -377,8 +377,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected method Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing to not be decorated with " +
-                        "FluentAssertions.Specs.DummyMethodAttribute because we want to test the error message," +
+                    "Expected method Void FluentAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing to not be decorated with " +
+                        "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
                         " but that attribute was found.");
         }
 
@@ -395,7 +395,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
             .WithMessage(
-                "Expected method Void FluentAssertions.Specs.ClassWithMethodWithImplementationAttribute.DoNotInlineMe to not be decorated with " +
+                "Expected method Void FluentAssertions*ClassWithMethodWithImplementationAttribute.DoNotInlineMe to not be decorated with " +
                     "System.Runtime.CompilerServices.MethodImplAttribute, but that attribute was found.");
         }
 
@@ -440,8 +440,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected method Void FluentAssertions.Specs.ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing to not be decorated with " +
-                        "FluentAssertions.Specs.DummyMethodAttribute because we want to test the error message," +
+                    "Expected method Void FluentAssertions*ClassWithAllMethodsDecoratedWithDummyAttribute.PublicDoNothing to not be decorated with " +
+                        "FluentAssertions*DummyMethodAttribute because we want to test the error message," +
                         " but that attribute was found.");
         }
 
@@ -475,7 +475,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method Task FluentAssertions.Specs.ClassWithNonAsyncMethods.PublicDoNothing" +
+                .WithMessage("Expected method Task FluentAssertions*ClassWithNonAsyncMethods.PublicDoNothing" +
                     " to be async because we want to test the error message," +
                     " but it is not.");
         }

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorAssertionSpecs.cs
@@ -4,7 +4,7 @@ using FluentAssertions.Types;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Types
 {
     public class MethodInfoSelectorAssertionSpecs
     {
@@ -51,9 +51,9 @@ namespace FluentAssertions.Specs
                 .WithMessage("Expected all selected methods" +
                              " to be virtual because we want to test the error message," +
                              " but the following methods are not virtual:*" +
-                             "Void FluentAssertions.Specs.ClassWithNonVirtualPublicMethods.PublicDoNothing*" +
-                             "Void FluentAssertions.Specs.ClassWithNonVirtualPublicMethods.InternalDoNothing*" +
-                             "Void FluentAssertions.Specs.ClassWithNonVirtualPublicMethods.ProtectedDoNothing");
+                             "Void FluentAssertions*ClassWithNonVirtualPublicMethods.PublicDoNothing*" +
+                             "Void FluentAssertions*ClassWithNonVirtualPublicMethods.InternalDoNothing*" +
+                             "Void FluentAssertions*ClassWithNonVirtualPublicMethods.ProtectedDoNothing");
         }
 
         [Fact]
@@ -162,11 +162,11 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected methods to be decorated with" +
-                             " FluentAssertions.Specs.DummyMethodAttribute because we want to test the error message," +
+                             " FluentAssertions*DummyMethodAttribute because we want to test the error message," +
                              " but the following methods are not:*" +
-                             "Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing*" +
-                             "Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.ProtectedDoNothing*" +
-                             "Void FluentAssertions.Specs.ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PrivateDoNothing");
+                             "Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PublicDoNothing*" +
+                             "Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.ProtectedDoNothing*" +
+                             "Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PrivateDoNothing");
         }
 
         [Fact]
@@ -261,9 +261,9 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected methods to be Public" +
                              ", but the following methods are not:*" +
-                             "Void FluentAssertions.Specs.ClassWithNonPublicMethods.PublicDoNothing*" +
-                             "Void FluentAssertions.Specs.ClassWithNonPublicMethods.DoNothingWithParameter*" +
-                             "Void FluentAssertions.Specs.ClassWithNonPublicMethods.DoNothingWithAnotherParameter");
+                             "Void FluentAssertions*ClassWithNonPublicMethods.PublicDoNothing*" +
+                             "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithParameter*" +
+                             "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithAnotherParameter");
         }
 
         [Fact]
@@ -281,9 +281,9 @@ namespace FluentAssertions.Specs
                 .WithMessage("Expected all selected methods to be Public" +
                              " because we want to test the error message" +
                              ", but the following methods are not:*" +
-                             "Void FluentAssertions.Specs.ClassWithNonPublicMethods.PublicDoNothing*" +
-                             "Void FluentAssertions.Specs.ClassWithNonPublicMethods.DoNothingWithParameter*" +
-                             "Void FluentAssertions.Specs.ClassWithNonPublicMethods.DoNothingWithAnotherParameter");
+                             "Void FluentAssertions*ClassWithNonPublicMethods.PublicDoNothing*" +
+                             "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithParameter*" +
+                             "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithAnotherParameter");
         }
 
         [Fact]
@@ -314,7 +314,7 @@ namespace FluentAssertions.Specs
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected methods to not be Public" +
                              ", but the following methods are:*" +
-                             "Void FluentAssertions.Specs.ClassWithPublicMethods.PublicDoNothing*");
+                             "Void FluentAssertions*ClassWithPublicMethods.PublicDoNothing*");
         }
 
         [Fact]
@@ -332,7 +332,7 @@ namespace FluentAssertions.Specs
                 .WithMessage("Expected all selected methods to not be Public" +
                              " because we want to test the error message" +
                              ", but the following methods are:*" +
-                             "Void FluentAssertions.Specs.ClassWithPublicMethods.PublicDoNothing*");
+                             "Void FluentAssertions*ClassWithPublicMethods.PublicDoNothing*");
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using Internal.Main.Test;
 using Xunit;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Types
 {
     public class MethodInfoSelectorSpecs
     {

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
@@ -4,7 +4,7 @@ using FluentAssertions.Common;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Types
 {
     public class PropertyInfoAssertionSpecs
     {
@@ -37,7 +37,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                .WithMessage(
-                   "Expected property String FluentAssertions.Specs.ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty" +
+                   "Expected property String FluentAssertions*ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty" +
                        " to be virtual because we want to test the error message," +
                        " but it is not.");
         }
@@ -137,8 +137,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                .WithMessage("Expected property String " +
-                   "FluentAssertions.Specs.ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty to be decorated with " +
-                   "FluentAssertions.Specs.DummyPropertyAttribute because we want to test the error message, but that attribute was not found.");
+                   "FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty to be decorated with " +
+                   "FluentAssertions*DummyPropertyAttribute because we want to test the error message, but that attribute was not found.");
         }
 
         [Fact]
@@ -154,8 +154,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected property String FluentAssertions.Specs.ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty to be decorated with " +
-                        "FluentAssertions.Specs.DummyPropertyAttribute because we want to test the error message," +
+                    "Expected property String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty to be decorated with " +
+                        "FluentAssertions*DummyPropertyAttribute because we want to test the error message," +
                         " but that attribute was not found.");
         }
 

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorAssertionSpecs.cs
@@ -4,7 +4,7 @@ using FluentAssertions.Types;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Types
 {
     public class PropertyInfoSelectorAssertionSpecs
     {
@@ -52,9 +52,9 @@ namespace FluentAssertions.Specs
                .WithMessage("Expected all selected properties" +
                    " to be virtual because we want to test the error message," +
                    " but the following properties are not virtual:*" +
-                   "String FluentAssertions.Specs.ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty*" +
-                   "String FluentAssertions.Specs.ClassWithNonVirtualPublicProperties.InternalNonVirtualProperty*" +
-                   "String FluentAssertions.Specs.ClassWithNonVirtualPublicProperties.ProtectedNonVirtualProperty");
+                   "String FluentAssertions*ClassWithNonVirtualPublicProperties.PublicNonVirtualProperty*" +
+                   "String FluentAssertions*ClassWithNonVirtualPublicProperties.InternalNonVirtualProperty*" +
+                   "String FluentAssertions*ClassWithNonVirtualPublicProperties.ProtectedNonVirtualProperty");
         }
 
         [Fact]
@@ -150,11 +150,11 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected all selected properties to be decorated with" +
-                   " FluentAssertions.Specs.DummyPropertyAttribute because we want to test the error message," +
+                   " FluentAssertions*DummyPropertyAttribute because we want to test the error message," +
                    " but the following properties are not:*" +
-                   "String FluentAssertions.Specs.ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty*" +
-                   "String FluentAssertions.Specs.ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.InternalProperty*" +
-                   "String FluentAssertions.Specs.ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.ProtectedProperty");
+                   "String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.PublicProperty*" +
+                   "String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.InternalProperty*" +
+                   "String FluentAssertions*ClassWithPropertiesThatAreNotDecoratedWithDummyAttribute.ProtectedProperty");
         }
 
         [Fact]
@@ -223,8 +223,8 @@ namespace FluentAssertions.Specs
                 .WithMessage(
                     "Expected all selected properties to have a setter because we want to test the error message, " +
                     "but the following properties do not:*" +
-                    "String FluentAssertions.Specs.ClassWithReadOnlyProperties.ReadOnlyProperty*" +
-                    "String FluentAssertions.Specs.ClassWithReadOnlyProperties.ReadOnlyProperty2");
+                    "String FluentAssertions*ClassWithReadOnlyProperties.ReadOnlyProperty*" +
+                    "String FluentAssertions*ClassWithReadOnlyProperties.ReadOnlyProperty2");
         }
 
         [Fact]
@@ -255,8 +255,8 @@ namespace FluentAssertions.Specs
                 .WithMessage(
                     "Expected selected properties to not have a setter because we want to test the error message, " +
                     "but the following properties do:*" +
-                    "String FluentAssertions.Specs.ClassWithWritableProperties.ReadWriteProperty*" +
-                    "String FluentAssertions.Specs.ClassWithWritableProperties.ReadWriteProperty2");
+                    "String FluentAssertions*ClassWithWritableProperties.ReadWriteProperty*" +
+                    "String FluentAssertions*ClassWithWritableProperties.ReadWriteProperty2");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoSelectorSpecs.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using Internal.Main.Test;
 using Xunit;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Types
 {
     public class PropertyInfoSelectorSpecs
     {

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
@@ -6,11 +6,13 @@ using DummyNamespace.InnerDummyNamespace;
 using DummyNamespaceTwo;
 using FluentAssertions.Common;
 using FluentAssertions.Primitives;
+using FluentAssertions.Specs.Equivalency;
+using FluentAssertions.Specs.Primitives;
 using FluentAssertions.Types;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Types
 {
     public class TypeAssertionSpecs
     {
@@ -59,8 +61,8 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be FluentAssertions.Specs.ClassWithoutAttribute" +
-                    " because we want to test the error message, but found FluentAssertions.Specs.ClassWithAttribute.");
+                "Expected type to be FluentAssertions*ClassWithoutAttribute" +
+                    " because we want to test the error message, but found FluentAssertions*ClassWithAttribute.");
         }
 
         [Fact]
@@ -90,7 +92,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be FluentAssertions.Specs.ClassWithAttribute" +
+                "Expected type to be FluentAssertions*ClassWithAttribute" +
                     " because we want to test the error message, but found <null>.");
         }
 
@@ -108,7 +110,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected type to be <null>" +
-                    " because we want to test the error message, but found FluentAssertions.Specs.ClassWithAttribute.");
+                    " because we want to test the error message, but found FluentAssertions*ClassWithAttribute.");
         }
 
         [Fact]
@@ -179,8 +181,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected type to be FluentAssertions.Specs.ClassWithoutAttribute because we want to test " +
-                        "the error message, but found FluentAssertions.Specs.ClassWithAttribute.");
+                    "Expected type to be FluentAssertions*ClassWithoutAttribute because we want to test " +
+                        "the error message, but found FluentAssertions*ClassWithAttribute.");
         }
 
         #endregion
@@ -245,7 +247,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type not to be [FluentAssertions.Specs.ClassWithAttribute*]" +
+                .WithMessage("Expected type not to be [FluentAssertions*ClassWithAttribute*]" +
                              " because we want to test the error message, but it is.");
         }
 
@@ -290,7 +292,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected type not to be [FluentAssertions.Specs.ClassWithAttribute*] because we want to test " +
+                    "Expected type not to be [FluentAssertions*ClassWithAttribute*] because we want to test " +
                     "the error message, but it is.");
         }
 
@@ -568,8 +570,8 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.DummyBaseClass to be derived from " +
-                             "FluentAssertions.Specs.ClassWithMembers because we want to test the error message, but it is not.");
+                .WithMessage("Expected type FluentAssertions*DummyBaseClass to be derived from " +
+                             "FluentAssertions*ClassWithMembers because we want to test the error message, but it is not.");
         }
 
         [Fact]
@@ -823,8 +825,8 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.ClassWithoutAttribute to be decorated with " +
-                    "FluentAssertions.Specs.DummyClassAttribute because we want to test the error message, but the attribute " +
+                .WithMessage("Expected type FluentAssertions*ClassWithoutAttribute to be decorated with " +
+                    "FluentAssertions*DummyClassAttribute because we want to test the error message, but the attribute " +
                         "was not found.");
         }
 
@@ -887,8 +889,8 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.ClassWithAttribute to be decorated with " +
-                    "FluentAssertions.Specs.DummyClassAttribute that matches ((a.Name == \"Unexpected\")*a.IsEnabled), " +
+                .WithMessage("Expected type FluentAssertions*ClassWithAttribute to be decorated with " +
+                    "FluentAssertions*DummyClassAttribute that matches ((a.Name == \"Unexpected\")*a.IsEnabled), " +
                         "but no matching attribute was found.");
         }
 
@@ -1033,8 +1035,8 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.ClassWithoutAttribute to be decorated with or inherit " +
-                    "FluentAssertions.Specs.DummyClassAttribute because we want to test the error message, but the attribute " +
+                .WithMessage("Expected type FluentAssertions*ClassWithoutAttribute to be decorated with or inherit " +
+                    "FluentAssertions*DummyClassAttribute because we want to test the error message, but the attribute " +
                         "was not found.");
         }
 
@@ -1097,8 +1099,8 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.ClassWithInheritedAttribute to be decorated with or inherit " +
-                    "FluentAssertions.Specs.DummyClassAttribute that matches ((a.Name == \"Unexpected\")*a.IsEnabled), " +
+                .WithMessage("Expected type FluentAssertions*ClassWithInheritedAttribute to be decorated with or inherit " +
+                    "FluentAssertions*DummyClassAttribute that matches ((a.Name == \"Unexpected\")*a.IsEnabled), " +
                         "but no matching attribute was found.");
         }
 
@@ -1937,9 +1939,9 @@ namespace FluentAssertions.Specs
         }
 
         [Theory]
-        [InlineData(typeof(ClassWithoutMembers), "Expected type FluentAssertions.Specs.ClassWithoutMembers to be sealed.")]
-        [InlineData(typeof(Abstract), "Expected type FluentAssertions.Specs.Abstract to be sealed.")]
-        [InlineData(typeof(Static), "Expected type FluentAssertions.Specs.Static to be sealed.")]
+        [InlineData(typeof(ClassWithoutMembers), "Expected type FluentAssertions*ClassWithoutMembers to be sealed.")]
+        [InlineData(typeof(Abstract), "Expected type FluentAssertions*Abstract to be sealed.")]
+        [InlineData(typeof(Static), "Expected type FluentAssertions*Static to be sealed.")]
         public void When_type_is_not_sealed_it_fails(Type type, string exceptionMessage)
         {
             // Act
@@ -1961,13 +1963,13 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.ClassWithoutMembers to be sealed because it's very important.");
+                .WithMessage("Expected type FluentAssertions*ClassWithoutMembers to be sealed because it's very important.");
         }
 
         [Theory]
-        [InlineData(typeof(IDummyInterface), "FluentAssertions.Specs.IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "FluentAssertions.Specs.Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "FluentAssertions.Specs.ExampleDelegate must be a class.")]
+        [InlineData(typeof(IDummyInterface), "FluentAssertions*IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "FluentAssertions*Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "FluentAssertions*ExampleDelegate must be a class.")]
         public void When_type_is_not_valid_for_BeSealed_it_throws_exception(Type type, string exceptionMessage)
         {
             // Act
@@ -2036,7 +2038,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.Sealed not to be sealed.");
+                .WithMessage("Expected type FluentAssertions*Sealed not to be sealed.");
         }
 
         [Fact]
@@ -2050,13 +2052,13 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.Sealed not to be sealed because it's very important.");
+                .WithMessage("Expected type FluentAssertions*Sealed not to be sealed because it's very important.");
         }
 
         [Theory]
-        [InlineData(typeof(IDummyInterface), "FluentAssertions.Specs.IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "FluentAssertions.Specs.Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "FluentAssertions.Specs.ExampleDelegate must be a class.")]
+        [InlineData(typeof(IDummyInterface), "FluentAssertions*IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "FluentAssertions*Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "FluentAssertions*ExampleDelegate must be a class.")]
         public void When_type_is_not_valid_for_NotBeSealed_it_throws_exception(Type type, string exceptionMessage)
         {
             // Act
@@ -2112,9 +2114,9 @@ namespace FluentAssertions.Specs
         }
 
         [Theory]
-        [InlineData(typeof(ClassWithoutMembers), "Expected type FluentAssertions.Specs.ClassWithoutMembers to be abstract.")]
-        [InlineData(typeof(Sealed), "Expected type FluentAssertions.Specs.Sealed to be abstract.")]
-        [InlineData(typeof(Static), "Expected type FluentAssertions.Specs.Static to be abstract.")]
+        [InlineData(typeof(ClassWithoutMembers), "Expected type FluentAssertions*ClassWithoutMembers to be abstract.")]
+        [InlineData(typeof(Sealed), "Expected type FluentAssertions*Sealed to be abstract.")]
+        [InlineData(typeof(Static), "Expected type FluentAssertions*Static to be abstract.")]
         public void When_type_is_not_abstract_it_fails(Type type, string exceptionMessage)
         {
             // Act
@@ -2136,13 +2138,13 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.ClassWithoutMembers to be abstract because it's very important.");
+                .WithMessage("Expected type FluentAssertions*ClassWithoutMembers to be abstract because it's very important.");
         }
 
         [Theory]
-        [InlineData(typeof(IDummyInterface), "FluentAssertions.Specs.IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "FluentAssertions.Specs.Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "FluentAssertions.Specs.ExampleDelegate must be a class.")]
+        [InlineData(typeof(IDummyInterface), "FluentAssertions*IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "FluentAssertions*Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "FluentAssertions*ExampleDelegate must be a class.")]
         public void When_type_is_not_valid_for_BeAbstract_it_throws_exception(Type type, string exceptionMessage)
         {
             // Act
@@ -2178,7 +2180,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.Abstract not to be abstract.");
+                .WithMessage("Expected type FluentAssertions*Abstract not to be abstract.");
         }
 
         [Fact]
@@ -2192,13 +2194,13 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.Abstract not to be abstract because it's very important.");
+                .WithMessage("Expected type FluentAssertions*Abstract not to be abstract because it's very important.");
         }
 
         [Theory]
-        [InlineData(typeof(IDummyInterface), "FluentAssertions.Specs.IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "FluentAssertions.Specs.Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "FluentAssertions.Specs.ExampleDelegate must be a class.")]
+        [InlineData(typeof(IDummyInterface), "FluentAssertions*IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "FluentAssertions*Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "FluentAssertions*ExampleDelegate must be a class.")]
         public void When_type_is_not_valid_for_NotBeAbstract_it_throws_exception(Type type, string exceptionMessage)
         {
             // Act
@@ -2221,9 +2223,9 @@ namespace FluentAssertions.Specs
         }
 
         [Theory]
-        [InlineData(typeof(ClassWithoutMembers), "Expected type FluentAssertions.Specs.ClassWithoutMembers to be static.")]
-        [InlineData(typeof(Sealed), "Expected type FluentAssertions.Specs.Sealed to be static.")]
-        [InlineData(typeof(Abstract), "Expected type FluentAssertions.Specs.Abstract to be static.")]
+        [InlineData(typeof(ClassWithoutMembers), "Expected type FluentAssertions*ClassWithoutMembers to be static.")]
+        [InlineData(typeof(Sealed), "Expected type FluentAssertions*Sealed to be static.")]
+        [InlineData(typeof(Abstract), "Expected type FluentAssertions*Abstract to be static.")]
         public void When_type_is_not_static_it_fails(Type type, string exceptionMessage)
         {
             // Act
@@ -2245,13 +2247,13 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.ClassWithoutMembers to be static because it's very important.");
+                .WithMessage("Expected type FluentAssertions*ClassWithoutMembers to be static because it's very important.");
         }
 
         [Theory]
-        [InlineData(typeof(IDummyInterface), "FluentAssertions.Specs.IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "FluentAssertions.Specs.Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "FluentAssertions.Specs.ExampleDelegate must be a class.")]
+        [InlineData(typeof(IDummyInterface), "FluentAssertions*IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "FluentAssertions*Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "FluentAssertions*ExampleDelegate must be a class.")]
         public void When_type_is_not_valid_for_BeStatic_it_throws_exception(Type type, string exceptionMessage)
         {
             // Act
@@ -2287,7 +2289,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.Static not to be static.");
+                .WithMessage("Expected type FluentAssertions*Static not to be static.");
         }
 
         [Fact]
@@ -2301,13 +2303,13 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.Static not to be static because it's very important.");
+                .WithMessage("Expected type FluentAssertions*Static not to be static because it's very important.");
         }
 
         [Theory]
-        [InlineData(typeof(IDummyInterface), "FluentAssertions.Specs.IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "FluentAssertions.Specs.Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "FluentAssertions.Specs.ExampleDelegate must be a class.")]
+        [InlineData(typeof(IDummyInterface), "FluentAssertions*IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "FluentAssertions*Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "FluentAssertions*ExampleDelegate must be a class.")]
         public void When_type_is_not_valid_for_NotBeStatic_it_throws_exception(Type type, string exceptionMessage)
         {
             // Act
@@ -2348,8 +2350,8 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.ClassThatDoesNotImplementInterface to implement " +
-                             "interface FluentAssertions.Specs.IDummyInterface because we want to test the error message, " +
+                .WithMessage("Expected type FluentAssertions*ClassThatDoesNotImplementInterface to implement " +
+                             "interface FluentAssertions*IDummyInterface because we want to test the error message, " +
                              "but it does not.");
         }
 
@@ -2417,8 +2419,8 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.ClassThatImplementsInterface to not implement interface " +
-                             "FluentAssertions.Specs.IDummyInterface because we want to test the error message, but it does.");
+                .WithMessage("Expected type FluentAssertions*ClassThatImplementsInterface to not implement interface " +
+                             "FluentAssertions*IDummyInterface because we want to test the error message, but it does.");
         }
 
         [Fact]
@@ -2490,7 +2492,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected String FluentAssertions.Specs.ClassWithNoMembers.PublicProperty to exist because we want to " +
+                    "Expected String FluentAssertions*ClassWithNoMembers.PublicProperty to exist because we want to " +
                     "test the error message, but it does not.");
         }
 
@@ -2507,7 +2509,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected String FluentAssertions.Specs.ClassWithMembers.PrivateWriteProtectedReadProperty to be of type System.Int32 because we want to test the error message, but it is not.");
+                    "Expected String FluentAssertions*ClassWithMembers.PrivateWriteProtectedReadProperty to be of type System.Int32 because we want to test the error message, but it is not.");
         }
 
         #endregion
@@ -2563,7 +2565,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected String FluentAssertions.Specs.ClassWithMembers.PrivateWriteProtectedReadProperty to not exist because we want to " +
+                    "Expected String FluentAssertions*ClassWithMembers.PrivateWriteProtectedReadProperty to not exist because we want to " +
                     "test the error message, but it does.");
         }
 
@@ -2621,8 +2623,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected FluentAssertions.Specs.ClassExplicitlyImplementingInterface to explicitly implement " +
-                    "FluentAssertions.Specs.IExplicitInterface.ImplicitStringProperty, but it does not.");
+                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to explicitly implement " +
+                    "FluentAssertions*IExplicitInterface.ImplicitStringProperty, but it does not.");
         }
 
         [Fact]
@@ -2641,8 +2643,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected FluentAssertions.Specs.ClassExplicitlyImplementingInterface to explicitly implement " +
-                    "FluentAssertions.Specs.IExplicitInterface.NonExistentProperty, but it does not.");
+                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to explicitly implement " +
+                    "FluentAssertions*IExplicitInterface.NonExistentProperty, but it does not.");
         }
 
         [Fact]
@@ -2661,8 +2663,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected type FluentAssertions.Specs.ClassExplicitlyImplementingInterface to implement interface " +
-                    "FluentAssertions.Specs.IDummyInterface, but it does not.");
+                    "Expected type FluentAssertions*ClassExplicitlyImplementingInterface to implement interface " +
+                    "FluentAssertions*IDummyInterface, but it does not.");
         }
 
         #endregion
@@ -2704,8 +2706,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected FluentAssertions.Specs.ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "FluentAssertions.Specs.IExplicitInterface.ExplicitStringProperty, but it does.");
+                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to not explicitly implement " +
+                    "FluentAssertions*IExplicitInterface.ExplicitStringProperty, but it does.");
         }
 
         [Fact]
@@ -2724,8 +2726,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected FluentAssertions.Specs.ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "FluentAssertions.Specs.IExplicitInterface.ExplicitImplicitStringProperty, but it does.");
+                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to not explicitly implement " +
+                    "FluentAssertions*IExplicitInterface.ExplicitImplicitStringProperty, but it does.");
         }
 
         [Fact]
@@ -2777,8 +2779,8 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.ClassExplicitlyImplementingInterface to implement interface " +
-                             "FluentAssertions.Specs.IDummyInterface, but it does not.");
+                .WithMessage("Expected type FluentAssertions*ClassExplicitlyImplementingInterface to implement interface " +
+                             "FluentAssertions*IDummyInterface, but it does not.");
         }
 
         #endregion
@@ -2799,8 +2801,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected FluentAssertions.Specs.ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "FluentAssertions.Specs.IExplicitInterface.ExplicitStringProperty, but it does.");
+                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to not explicitly implement " +
+                    "FluentAssertions*IExplicitInterface.ExplicitStringProperty, but it does.");
         }
 
         #endregion
@@ -2857,8 +2859,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected FluentAssertions.Specs.ClassExplicitlyImplementingInterface to explicitly implement " +
-                    "FluentAssertions.Specs.IExplicitInterface.ImplicitMethod, but it does not.");
+                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to explicitly implement " +
+                    "FluentAssertions*IExplicitInterface.ImplicitMethod, but it does not.");
         }
 
         [Fact]
@@ -2877,8 +2879,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected FluentAssertions.Specs.ClassExplicitlyImplementingInterface to explicitly implement " +
-                    "FluentAssertions.Specs.IExplicitInterface.NonExistentMethod, but it does not.");
+                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to explicitly implement " +
+                    "FluentAssertions*IExplicitInterface.NonExistentMethod, but it does not.");
         }
 
         [Fact]
@@ -2897,8 +2899,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected type FluentAssertions.Specs.ClassExplicitlyImplementingInterface to implement interface " +
-                    "FluentAssertions.Specs.IDummyInterface, but it does not.");
+                    "Expected type FluentAssertions*ClassExplicitlyImplementingInterface to implement interface " +
+                    "FluentAssertions*IDummyInterface, but it does not.");
         }
 
         #endregion
@@ -2940,8 +2942,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected FluentAssertions.Specs.ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "FluentAssertions.Specs.IExplicitInterface.ExplicitMethod, but it does.");
+                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to not explicitly implement " +
+                    "FluentAssertions*IExplicitInterface.ExplicitMethod, but it does.");
         }
 
         [Fact]
@@ -2960,8 +2962,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected FluentAssertions.Specs.ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "FluentAssertions.Specs.IExplicitInterface.ExplicitImplicitMethod, but it does.");
+                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to not explicitly implement " +
+                    "FluentAssertions*IExplicitInterface.ExplicitImplicitMethod, but it does.");
         }
 
         [Fact]
@@ -3013,8 +3015,8 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions.Specs.ClassExplicitlyImplementingInterface to implement interface " +
-                             "FluentAssertions.Specs.IDummyInterface, but it does not.");
+                .WithMessage("Expected type FluentAssertions*ClassExplicitlyImplementingInterface to implement interface " +
+                             "FluentAssertions*IDummyInterface, but it does not.");
         }
 
         #endregion
@@ -3035,8 +3037,8 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected FluentAssertions.Specs.ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "FluentAssertions.Specs.IExplicitInterface.ExplicitMethod, but it does.");
+                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to not explicitly implement " +
+                    "FluentAssertions*IExplicitInterface.ExplicitMethod, but it does.");
         }
 
         #endregion
@@ -3074,7 +3076,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected String FluentAssertions.Specs.ClassWithNoMembers[System.Int32, System.Type] to exist because we want to test the error" +
+                    "Expected String FluentAssertions*ClassWithNoMembers[System.Int32, System.Type] to exist because we want to test the error" +
                     " message, but it does not.");
         }
 
@@ -3091,7 +3093,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected String FluentAssertions.Specs.ClassWithMembers[System.Int32, System.Type] to exist because we want to test the error" +
+                    "Expected String FluentAssertions*ClassWithMembers[System.Int32, System.Type] to exist because we want to test the error" +
                     " message, but it does not.");
         }
 
@@ -3126,7 +3128,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected indexer FluentAssertions.Specs.ClassWithMembers[System.String] to not exist because we want to " +
+                    "Expected indexer FluentAssertions*ClassWithMembers[System.String] to not exist because we want to " +
                     "test the error message, but it does.");
         }
 
@@ -3164,7 +3166,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected constructor FluentAssertions.Specs.ClassWithNoMembers(System.Int32, System.Type) to exist because " +
+                    "Expected constructor FluentAssertions*ClassWithNoMembers(System.Int32, System.Type) to exist because " +
                     "we want to test the error message, but it does not.");
         }
 
@@ -3240,7 +3242,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected constructor FluentAssertions.Specs.ClassWithCctorAndNonDefaultConstructor() to exist because we " +
+                    "Expected constructor FluentAssertions*ClassWithCctorAndNonDefaultConstructor() to exist because we " +
                     "want to test the error message, but it does not.");
         }
 
@@ -3383,7 +3385,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected method FluentAssertions.Specs.ClassWithNoMembers.NonExistentMethod(System.Int32, System.Type) to exist " +
+                    "Expected method FluentAssertions*ClassWithNoMembers.NonExistentMethod(System.Int32, System.Type) to exist " +
                     "because we want to test the error message, but it does not.");
         }
 
@@ -3400,7 +3402,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected method FluentAssertions.Specs.ClassWithMembers.VoidMethod(System.Int32, System.Type) to exist " +
+                    "Expected method FluentAssertions*ClassWithMembers.VoidMethod(System.Int32, System.Type) to exist " +
                     "because we want to test the error message, but it does not.");
         }
 
@@ -3449,7 +3451,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected method Void FluentAssertions.Specs.ClassWithMembers.VoidMethod() to not exist because we want to " +
+                    "Expected method Void FluentAssertions*ClassWithMembers.VoidMethod() to not exist because we want to " +
                     "test the error message, but it does.");
         }
 
@@ -3929,7 +3931,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected public static explicit System.String(FluentAssertions.Specs.TypeWithConversionOperators) to exist " +
+                    "Expected public static explicit System.String(FluentAssertions*TypeWithConversionOperators) to exist " +
                     "because we want to test the error message, but it does not.");
         }
 
@@ -3967,7 +3969,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected public static explicit System.String(FluentAssertions.Specs.TypeWithConversionOperators) to exist " +
+                    "Expected public static explicit System.String(FluentAssertions*TypeWithConversionOperators) to exist " +
                     "because we want to test the error message, but it does not.");
         }
 
@@ -4007,7 +4009,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected public static explicit System.Byte(FluentAssertions.Specs.TypeWithConversionOperators) to not exist " +
+                    "Expected public static explicit System.Byte(FluentAssertions*TypeWithConversionOperators) to not exist " +
                     "because we want to test the error message, but it does.");
         }
 
@@ -4043,7 +4045,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected public static explicit System.Byte(FluentAssertions.Specs.TypeWithConversionOperators) to not exist " +
+                    "Expected public static explicit System.Byte(FluentAssertions*TypeWithConversionOperators) to not exist " +
                     "because we want to test the error message, but it does.");
         }
 
@@ -4085,7 +4087,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected public static implicit System.String(FluentAssertions.Specs.TypeWithConversionOperators) to exist " +
+                    "Expected public static implicit System.String(FluentAssertions*TypeWithConversionOperators) to exist " +
                     "because we want to test the error message, but it does not.");
         }
 
@@ -4123,7 +4125,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected public static implicit System.String(FluentAssertions.Specs.TypeWithConversionOperators) to exist " +
+                    "Expected public static implicit System.String(FluentAssertions*TypeWithConversionOperators) to exist " +
                     "because we want to test the error message, but it does not.");
         }
 
@@ -4163,7 +4165,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected public static implicit System.Int32(FluentAssertions.Specs.TypeWithConversionOperators) to not exist " +
+                    "Expected public static implicit System.Int32(FluentAssertions*TypeWithConversionOperators) to not exist " +
                     "because we want to test the error message, but it does.");
         }
 
@@ -4199,7 +4201,7 @@ namespace FluentAssertions.Specs
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage(
-                    "Expected public static implicit System.Int32(FluentAssertions.Specs.TypeWithConversionOperators) to not exist " +
+                    "Expected public static implicit System.Int32(FluentAssertions*TypeWithConversionOperators) to not exist " +
                     "because we want to test the error message, but it does.");
         }
 

--- a/Tests/FluentAssertions.Specs/Types/TypeExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeExtensionsSpecs.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 using FluentAssertions.Common;
 using Xunit;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Types
 {
     public class TypeExtensionsSpecs
     {

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
@@ -14,7 +14,7 @@ using Internal.UnwrapSelectorTestTypes.Test;
 using Xunit;
 using ISomeInterface = Internal.Main.Test.ISomeInterface;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Types
 {
     public class TypeSelectorSpecs
     {

--- a/Tests/FluentAssertions.Specs/Xml/XAttributeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XAttributeAssertionSpecs.cs
@@ -3,7 +3,7 @@ using System.Xml.Linq;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Xml
 {
     public class XAttributeAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Xml/XAttributeFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XAttributeFormatterSpecs.cs
@@ -3,7 +3,7 @@ using System.Xml.Linq;
 using FluentAssertions.Formatting;
 using Xunit;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Xml
 {
     public class XAttributeFormatterSpecs
     {

--- a/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
@@ -5,7 +5,7 @@ using FluentAssertions.Formatting;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Xml
 {
     public class XDocumentAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Xml/XDocumentFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XDocumentFormatterSpecs.cs
@@ -3,7 +3,7 @@
 using FluentAssertions.Formatting;
 using Xunit;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Xml
 {
     public class XDocumentFormatterSpecs
     {

--- a/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
@@ -3,7 +3,7 @@ using System.Xml.Linq;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Xml
 {
     public class XElementAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Xml/XElementFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XElementFormatterSpecs.cs
@@ -3,7 +3,7 @@
 using FluentAssertions.Formatting;
 using Xunit;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Xml
 {
     public class XElementFormatterSpecs
     {

--- a/Tests/FluentAssertions.Specs/Xml/XmlElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XmlElementAssertionSpecs.cs
@@ -4,7 +4,7 @@ using FluentAssertions.Formatting;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Xml
 {
     public class XmlElementAssertionSpecs
     {

--- a/Tests/FluentAssertions.Specs/Xml/XmlNodeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XmlNodeAssertionSpecs.cs
@@ -3,7 +3,7 @@ using System.Xml;
 using Xunit;
 using Xunit.Sdk;
 
-namespace FluentAssertions.Specs
+namespace FluentAssertions.Specs.Xml
 {
     public class XmlNodeAssertionSpecs
     {


### PR DESCRIPTION
Having a look on the TODO window found that "low hanging fruit".
Because only unit tests are affected, I guess no changelog entry is required.