### PR TITLE
Add NotCompleteWithinAsync to TaskCompletionSourceAssertions

### DIFF
--- a/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertions.cs
+++ b/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertions.cs
@@ -34,27 +34,13 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public Task<AndWhichConstraint<TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(
+        public async Task<AndWhichConstraint<TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(
             TimeSpan timeSpan, string because = "", params object[] becauseArgs)
-        {
-            return AssertAsync(timeSpan, because, becauseArgs,
-                "Expected {context} to complete within {0}{reason}, but found <null>.",
-                "Expected {context:task} to complete within {0}{reason}.",
-                new object[] { timeSpan });
-        }
-
-        private async Task<AndWhichConstraint<TaskCompletionSourceAssertions<T>, T>> AssertAsync(
-            TimeSpan timeSpan,
-            string because,
-            object[] becauseArgs,
-            string failMessage1,
-            string failMessage2,
-            object[] failArgs)
         {
             Execute.Assertion
                 .ForCondition(subject is not null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(failMessage1, failArgs);
+                .FailWith("Expected {context} to complete within {0}{reason}, but found <null>.", timeSpan);
 
             using var timeoutCancellationTokenSource = new CancellationTokenSource();
             Task completedTask = await Task.WhenAny(
@@ -70,9 +56,44 @@ namespace FluentAssertions.Specialized
             Execute.Assertion
                 .ForCondition(completedTask == subject.Task)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(failMessage2, failArgs);
-
+                .FailWith("Expected {context:task} to complete within {0}{reason}.", timeSpan);
             return new AndWhichConstraint<TaskCompletionSourceAssertions<T>, T>(this, subject.Task.Result);
+        }
+
+        /// <summary>
+        /// Asserts that the <see cref="Task"/> of the current <see cref="TaskCompletionSource{T}"/> will not complete within the specified time.
+        /// </summary>
+        /// <param name="timeSpan">The time span to wait for the operation.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public async Task NotCompleteWithinAsync(
+            TimeSpan timeSpan, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(subject is not null)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context} to not complete within {0}{reason}, but found <null>.", timeSpan);
+
+            using var timeoutCancellationTokenSource = new CancellationTokenSource();
+            Task completedTask = await Task.WhenAny(
+                subject.Task,
+                Clock.DelayAsync(timeSpan, timeoutCancellationTokenSource.Token));
+
+            if (completedTask == subject.Task)
+            {
+                timeoutCancellationTokenSource.Cancel();
+                await completedTask;
+            }
+
+            Execute.Assertion
+                .ForCondition(completedTask != subject.Task)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:task} to not complete within {0}{reason}.", timeSpan);
         }
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -2090,6 +2090,7 @@ namespace FluentAssertions.Specialized
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -2090,6 +2090,7 @@ namespace FluentAssertions.Specialized
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -2090,6 +2090,7 @@ namespace FluentAssertions.Specialized
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -2043,6 +2043,7 @@ namespace FluentAssertions.Specialized
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -2090,6 +2090,7 @@ namespace FluentAssertions.Specialized
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,6 +11,7 @@ sidebar:
 
 **What's New**
 * Added `WithParameterName` extension to ease asserting on the parameter name for a thrown `ArgumentException` - [#1466](https://github.com/fluentassertions/fluentassertions/pull/1466).
+* Added `NotCompleteWithinAsync` to `TaskCompletionSourceAssertions` - [#1474](https://github.com/fluentassertions/fluentassertions/pull/1474).
 
 **Fixes**
 * Sometimes `BeEquivalentTo` reported an incorrect message when a dictionary was missing a key - [#1454](https://github.com/fluentassertions/fluentassertions/pull/1454)

--- a/docs/_pages/specialized.md
+++ b/docs/_pages/specialized.md
@@ -21,3 +21,10 @@ The assertion returns the result for subsequent value assertions.
 var tcs = new TaskCompletionSource<bool>();
 (await tcs.Should().CompleteWithinAsync(1.Seconds())).Which.Should().BeTrue();
 ```
+
+Additionally it is possible to assert that the task will *not* complete within specific time.
+
+```csharp
+var tcs = new TaskCompletionSource<bool>();
+await tcs.Should().NotCompleteWithinAsync(1.Seconds());
+```


### PR DESCRIPTION
The assertions on `TaskCompletionSource` introduced in #1267 was missing `NotCompletedWithinAsync`.