### PR TITLE
More use of Invariant culture

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -133,7 +133,6 @@ dotnet_code_quality.CA1062.exclude_extension_method_this_parameter = true
 dotnet_code_quality.exclude_extension_method_this_parameter = true
 dotnet_code_quality.null_check_validation_methods = ThrowIfArgumentIsNull
 dotnet_diagnostic.CA1304.severity = error
-dotnet_diagnostic.CA1305.severity = none
 dotnet_diagnostic.CA1307.severity = error
 dotnet_diagnostic.CA1308.severity = error
 dotnet_diagnostic.CA1309.severity = error

--- a/Src/FluentAssertions/AndWhichConstraint.cs
+++ b/Src/FluentAssertions/AndWhichConstraint.cs
@@ -43,10 +43,8 @@ namespace FluentAssertions
                     matchedElements.Select(
                         ele => "\t" + Formatter.ToString(ele)));
 
-                string message = string.Format(
-                    "More than one object found.  FluentAssertions cannot determine which object is meant.  Found objects:{0}{1}",
-                    Environment.NewLine,
-                    foundObjects);
+                string message = "More than one object found.  FluentAssertions cannot determine which object is meant."
+                              + $"  Found objects:{Environment.NewLine}{foundObjects}";
 
                 Services.ThrowException(message);
             }

--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions.Common;
@@ -677,7 +678,7 @@ namespace FluentAssertions.Collections
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith(expectationPrefix + "but " + count.ToString() + " such items were found.", predicate.Body);
+                    .FailWith(expectationPrefix + "but " + count.ToString(CultureInfo.InvariantCulture) + " such items were found.", predicate.Body);
             }
             else
             {

--- a/Src/FluentAssertions/Common/Configuration.cs
+++ b/Src/FluentAssertions/Common/Configuration.cs
@@ -66,9 +66,8 @@ namespace FluentAssertions.Common
                 }
                 catch (ArgumentException)
                 {
-                    throw new InvalidOperationException(string.Format(
-                        "'{0}' is not a valid option for detecting value formatters. Valid options include Disabled, Specific and Scan.",
-                        setting));
+                    throw new InvalidOperationException(
+                        $"'{setting}' is not a valid option for detecting value formatters. Valid options include Disabled, Specific and Scan.");
                 }
             }
 

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -354,10 +354,10 @@ namespace FluentAssertions.Common
 
         public static bool HasExplicitlyImplementedProperty(this Type type, Type interfaceType, string propertyName)
         {
-            bool hasGetter = type.HasParameterlessMethod(string.Format("{0}.get_{1}", interfaceType.FullName, propertyName));
+            bool hasGetter = type.HasParameterlessMethod($"{interfaceType.FullName}.get_{propertyName}");
             bool hasSetter = type.GetMethods(AllMembersFlag)
                 .SingleOrDefault(m =>
-                    m.Name == string.Format("{0}.set_{1}", interfaceType.FullName, propertyName) &&
+                    m.Name == $"{interfaceType.FullName}.set_{propertyName}" &&
                     m.GetParameters().Length == 1) is not null;
 
             return hasGetter || hasSetter;

--- a/Src/FluentAssertions/Equivalency/AutoConversionStep.cs
+++ b/Src/FluentAssertions/Equivalency/AutoConversionStep.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using FluentAssertions.Common;
+using static System.FormattableString;
 
 namespace FluentAssertions.Equivalency
 {
@@ -47,13 +48,13 @@ namespace FluentAssertions.Equivalency
 
             if (TryChangeType(context.Subject, expectationType, out object convertedSubject))
             {
-                context.Tracer.WriteLine(member => $"Converted subject {context.Subject} at {member.Description} to {expectationType}");
+                context.Tracer.WriteLine(member => Invariant($"Converted subject {context.Subject} at {member.Description} to {expectationType}"));
 
                 context.Subject = convertedSubject;
             }
             else
             {
-                context.Tracer.WriteLine(member => $"Subject {context.Subject} at {member.Description} could not be converted to {expectationType}");
+                context.Tracer.WriteLine(member => Invariant($"Subject {context.Subject} at {member.Description} could not be converted to {expectationType}"));
             }
 
             return false;

--- a/Src/FluentAssertions/Equivalency/DataRowCollectionEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRowCollectionEquivalencyStep.cs
@@ -65,7 +65,7 @@ namespace FluentAssertions.Equivalency
             for (int i = 0; i < expectation.Count; i++)
             {
                 IEquivalencyValidationContext nestedContext = context.AsCollectionItem(
-                    i.ToString(),
+                    i,
                     subject[i],
                     expectation[i]);
 

--- a/Src/FluentAssertions/Equivalency/DictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DictionaryEquivalencyStep.cs
@@ -3,6 +3,8 @@ using System.Diagnostics.CodeAnalysis;
 
 using FluentAssertions.Execution;
 
+using static System.FormattableString;
+
 namespace FluentAssertions.Equivalency
 {
     public class DictionaryEquivalencyStep : IEquivalencyStep
@@ -39,12 +41,13 @@ namespace FluentAssertions.Equivalency
                     {
                         if (config.IsRecursive)
                         {
-                            context.Tracer.WriteLine(member => $"Recursing into dictionary item {key} at {member.Description}");
+                            context.Tracer.WriteLine(member => Invariant($"Recursing into dictionary item {key} at {member.Description}"));
                             parent.AssertEqualityUsing(context.AsDictionaryItem(key, subject[key], expectation[key]));
                         }
                         else
                         {
-                            context.Tracer.WriteLine(member => $"Comparing dictionary item {key} at {member.Description} between subject and expectation");
+                            context.Tracer.WriteLine(member =>
+                                Invariant($"Comparing dictionary item {key} at {member.Description} between subject and expectation"));
                             subject[key].Should().Be(expectation[key], context.Reason.FormattedMessage, context.Reason.Arguments);
                         }
                     }

--- a/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
+++ b/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
@@ -45,8 +45,7 @@ namespace FluentAssertions.Equivalency
                     break;
 
                 default:
-                    throw new InvalidOperationException(string.Format("Do not know how to handle {0}",
-                        config.EnumEquivalencyHandling));
+                    throw new InvalidOperationException($"Do not know how to handle {config.EnumEquivalencyHandling}");
             }
 
             return true;

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyValidator.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions.Equivalency.Tracing;
 using FluentAssertions.Execution;
+using static System.FormattableString;
 
 namespace FluentAssertions.Equivalency
 {
@@ -36,12 +37,14 @@ namespace FluentAssertions.Equivalency
             {
                 if (Recursive)
                 {
-                    using var _ = context.Tracer.WriteBlock(member => $"Structurally comparing {subject} and expectation {expectation} at {member.Description}");
+                    using var _ = context.Tracer.WriteBlock(member =>
+                        Invariant($"Structurally comparing {subject} and expectation {expectation} at {member.Description}"));
                     AssertElementGraphEquivalency(subject, expectation);
                 }
                 else
                 {
-                    using var _ = context.Tracer.WriteBlock(member => $"Comparing subject {subject} and expectation {expectation} at {member.Description} using simple value equality");
+                    using var _ = context.Tracer.WriteBlock(member =>
+                        Invariant($"Comparing subject {subject} and expectation {expectation} at {member.Description} using simple value equality"));
                     subject.Should().BeEquivalentTo(expectation);
                 }
             }
@@ -90,7 +93,7 @@ namespace FluentAssertions.Equivalency
                 T expectation = expectations[index];
 
                 using var _ = context.Tracer.WriteBlock(member =>
-                    $"Strictly comparing expectation {expectation} at {member.Description} to item with index {index} in {subjects}");
+                    Invariant($"Strictly comparing expectation {expectation} at {member.Description} to item with index {index} in {subjects}"));
                 bool succeeded = StrictlyMatchAgainst(subjects, expectation, index);
                 if (!succeeded)
                 {
@@ -113,7 +116,7 @@ namespace FluentAssertions.Equivalency
                 T expectation = expectations[index];
 
                 using var _ = context.Tracer.WriteBlock(member =>
-                    $"Finding the best match of {expectation} within all items in {subjects} at {member.Description}[{index}]");
+                    Invariant($"Finding the best match of {expectation} within all items in {subjects} at {member.Description}[{index}]"));
                 bool succeeded = LooselyMatchAgainst(subjects, expectation, index);
                 if (!succeeded)
                 {
@@ -174,7 +177,7 @@ namespace FluentAssertions.Equivalency
         private string[] TryToMatch<T>(object subject, T expectation, int expectationIndex)
         {
             using var scope = new AssertionScope();
-            parent.AssertEqualityUsing(context.AsCollectionItem(expectationIndex.ToString(), subject, expectation));
+            parent.AssertEqualityUsing(context.AsCollectionItem(expectationIndex, subject, expectation));
 
             return scope.Discard();
         }
@@ -183,9 +186,8 @@ namespace FluentAssertions.Equivalency
         {
             using var scope = new AssertionScope();
             object subject = subjects[expectationIndex];
-            string indexString = expectationIndex.ToString();
             IEquivalencyValidationContext equivalencyValidationContext =
-                context.AsCollectionItem(indexString, subject, expectation);
+                context.AsCollectionItem(expectationIndex, subject, expectation);
 
             parent.AssertEqualityUsing(equivalencyValidationContext);
 

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidationContext.cs
@@ -1,6 +1,7 @@
 using System;
 using FluentAssertions.Equivalency.Tracing;
 using FluentAssertions.Execution;
+using static System.FormattableString;
 
 namespace FluentAssertions.Equivalency
 {
@@ -118,7 +119,7 @@ namespace FluentAssertions.Equivalency
 
         public override string ToString()
         {
-            return $"{{Path=\"{CurrentNode.Description}\", Subject={Subject}, Expectation={Expectation}}}";
+            return Invariant($"{{Path=\"{CurrentNode.Description}\", Subject={Subject}, Expectation={Expectation}}}");
         }
     }
 }

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidationContextExtensions.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidationContextExtensions.cs
@@ -1,0 +1,11 @@
+﻿using System.Globalization;
+
+namespace FluentAssertions.Equivalency
+{
+    internal static class EquivalencyValidationContextExtensions
+    {
+        public static IEquivalencyValidationContext AsCollectionItem<T>(this IEquivalencyValidationContext context,
+            int index, object subject, T expectation) =>
+            context.AsCollectionItem(index.ToString(CultureInfo.InvariantCulture), subject, expectation);
+    }
+}

--- a/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
@@ -83,12 +83,9 @@ namespace FluentAssertions.Equivalency
             }
 
             AssertionScope.Current.FailWith(
-                string.Format(
-                    "{{context:Expectation}} implements multiple dictionary types.  "
-                    + "It is not known which type should be use for equivalence.{0}"
-                    + "The following IDictionary interfaces are implemented: {1}",
-                    Environment.NewLine,
-                    string.Join(", ", (IEnumerable<Type>)interfaces)));
+                "{{context:Expectation}} implements multiple dictionary types.  "
+             + $"It is not known which type should be use for equivalence.{Environment.NewLine}"
+             + $"The following IDictionary interfaces are implemented: {string.Join(", ", (IEnumerable<Type>)interfaces)}");
 
             return false;
         }
@@ -123,13 +120,9 @@ namespace FluentAssertions.Equivalency
             if (!suitableDictionaryInterfaces.Any())
             {
                 AssertionScope.Current.FailWith(
-                    string.Format(
-                        "The {{context:subject}} dictionary has keys of type {0}; "
-                        + "however, the expectation is not keyed with any compatible types.{1}"
-                        + "The subject implements: {2}",
-                        expectedKeyType,
-                        Environment.NewLine,
-                        string.Join(",", (IEnumerable<Type>)subjectDictionaryInterfaces)));
+                    $"The {{context:subject}} dictionary has keys of type {expectedKeyType}; "
+                  + $"however, the expectation is not keyed with any compatible types.{Environment.NewLine}"
+                  + $"The subject implements: {string.Join(",", (IEnumerable<Type>)subjectDictionaryInterfaces)}");
 
                 return false;
             }

--- a/Src/FluentAssertions/Equivalency/ObjectReference.cs
+++ b/Src/FluentAssertions/Equivalency/ObjectReference.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using FluentAssertions.Common;
+using static System.FormattableString;
 
 namespace FluentAssertions.Equivalency
 {
@@ -59,12 +61,12 @@ namespace FluentAssertions.Equivalency
         /// <filterpriority>2</filterpriority>
         public override int GetHashCode()
         {
-            return System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(@object);
+            return RuntimeHelpers.GetHashCode(@object);
         }
 
         public override string ToString()
         {
-            return $"{{\"{path}\", {@object}}}";
+            return Invariant($"{{\"{path}\", {@object}}}");
         }
 
         public bool IsComplexType => isComplexType ?? (@object is not null && !@object.GetType().OverridesEquals());

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
@@ -644,7 +645,8 @@ namespace FluentAssertions.Equivalency
                 }
             }
 
-            builder.AppendFormat("- Compare enums by {0}" + Environment.NewLine,
+            builder.AppendFormat(CultureInfo.InvariantCulture,
+                "- Compare enums by {0}" + Environment.NewLine,
                 enumEquivalencyHandling == EnumEquivalencyHandling.ByName ? "name" : "value");
 
             if (cyclicReferenceHandling == CyclicReferenceHandling.Ignore)

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using FluentAssertions.Common;
@@ -140,7 +141,7 @@ namespace FluentAssertions.Execution
                 try
                 {
                     string becauseOrEmpty = because ?? string.Empty;
-                    return (becauseArgs?.Any() == true) ? string.Format(becauseOrEmpty, becauseArgs) : becauseOrEmpty;
+                    return (becauseArgs?.Any() == true) ? string.Format(CultureInfo.InvariantCulture, becauseOrEmpty, becauseArgs) : becauseOrEmpty;
                 }
                 catch (FormatException formatException)
                 {

--- a/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
+++ b/Src/FluentAssertions/Execution/CollectingAssertionStrategy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -40,7 +41,7 @@ namespace FluentAssertions.Execution
                 {
                     foreach (KeyValuePair<string, object> pair in context)
                     {
-                        builder.AppendFormat("\nWith {0}:\n{1}", pair.Key, pair.Value);
+                        builder.AppendFormat(CultureInfo.InvariantCulture, "\nWith {0}:\n{1}", pair.Key, pair.Value);
                     }
                 }
 

--- a/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
+++ b/Src/FluentAssertions/Execution/LateBoundTestFramework.cs
@@ -13,9 +13,8 @@ namespace FluentAssertions.Execution
             Type exceptionType = assembly.GetType(ExceptionFullName);
             if (exceptionType is null)
             {
-                throw new Exception(string.Format(
-                    "Failed to create the assertion exception for the current test framework: \"{0}, {1}\"",
-                    ExceptionFullName, assembly.FullName));
+                throw new Exception(
+                    $"Failed to create the assertion exception for the current test framework: \"{ExceptionFullName}, {assembly.FullName}\"");
             }
 
             throw (Exception)Activator.CreateInstance(exceptionType, message);

--- a/Src/FluentAssertions/Execution/MessageBuilder.cs
+++ b/Src/FluentAssertions/Execution/MessageBuilder.cs
@@ -1,6 +1,7 @@
 ﻿#region
 
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using FluentAssertions.Common;
@@ -89,7 +90,7 @@ namespace FluentAssertions.Execution
         private string FormatArgumentPlaceholders(string failureMessage, object[] failureArgs)
         {
             string[] values = failureArgs.Select(a => Formatter.ToString(a, useLineBreaks)).ToArray();
-            string formattedMessage = string.Format(failureMessage, values);
+            string formattedMessage = string.Format(CultureInfo.InvariantCulture, failureMessage, values);
 
             return formattedMessage;
         }

--- a/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
+++ b/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
@@ -51,19 +51,21 @@ namespace FluentAssertions.Execution
 
             if (!Frameworks.TryGetValue(frameworkName, out ITestFramework framework))
             {
-                var message = string.Format("FluentAssertions was configured to use {0} but the requested test framework is not supported. " +
-                    "Please use one of the supported frameworks: {1}", frameworkName, string.Join(", ", Frameworks.Keys));
+                string frameworks = string.Join(", ", Frameworks.Keys);
+                var message = $"FluentAssertions was configured to use {frameworkName} but the requested test framework is not supported. " +
+                    $"Please use one of the supported frameworks: {frameworks}";
 
                 throw new Exception(message);
             }
 
             if (!framework.IsAvailable)
             {
+                string frameworks = string.Join(", ", Frameworks.Keys);
                 var message = framework is LateBoundTestFramework lateBoundTestFramework
-                    ? string.Format("FluentAssertions was configured to use {0} but the required test framework assembly {1} could not be found. " +
-                        "Please use one of the supported frameworks: {2}", frameworkName, lateBoundTestFramework.AssemblyName, string.Join(", ", Frameworks.Keys))
-                    : string.Format("FluentAssertions was configured to use {0} but the required test framework could not be found. " +
-                        "Please use one of the supported frameworks: {1}", frameworkName, string.Join(", ", Frameworks.Keys));
+                    ? $"FluentAssertions was configured to use {frameworkName} but the required test framework assembly {lateBoundTestFramework.AssemblyName} could not be found. " +
+                        $"Please use one of the supported frameworks: {frameworks}"
+                    : $"FluentAssertions was configured to use {frameworkName} but the required test framework could not be found. " +
+                        $"Please use one of the supported frameworks: {frameworks}";
 
                 throw new Exception(message);
             }

--- a/Src/FluentAssertions/Formatting/AggregateExceptionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/AggregateExceptionValueFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Text;
 
 namespace FluentAssertions.Formatting
@@ -29,7 +30,7 @@ namespace FluentAssertions.Formatting
             {
                 var builder = new StringBuilder();
 
-                builder.AppendFormat("{0} (aggregated) exceptions:\n", exception.InnerExceptions.Count);
+                builder.AppendFormat(CultureInfo.InvariantCulture, "{0} (aggregated) exceptions:\n", exception.InnerExceptions.Count);
 
                 foreach (Exception innerException in exception.InnerExceptions)
                 {

--- a/Src/FluentAssertions/Formatting/EnumerableValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/EnumerableValueFormatter.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using FluentAssertions.Common;
 
@@ -40,7 +41,7 @@ namespace FluentAssertions.Formatting
                     enumerable = enumerable.Take(MaxItems).ToArray();
                 }
 
-                return "{" + string.Join(", ", enumerable.Select((item, index) => formatChild(index.ToString(), item))) + postfix + "}";
+                return "{" + string.Join(", ", enumerable.Select((item, index) => formatChild(index.ToString(CultureInfo.InvariantCulture), item))) + postfix + "}";
             }
             else
             {

--- a/Src/FluentAssertions/Formatting/ExceptionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/ExceptionValueFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Text;
 
 namespace FluentAssertions.Formatting
@@ -23,7 +24,8 @@ namespace FluentAssertions.Formatting
             var exception = (Exception)value;
 
             var builder = new StringBuilder();
-            builder.AppendFormat("{0} with message \"{1}\"\n", exception.GetType().FullName, exception.Message);
+            builder.AppendFormat(CultureInfo.InvariantCulture, "{0} with message \"{1}\"\n",
+                exception.GetType().FullName, exception.Message);
 
             if (exception.StackTrace is not null)
             {

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -178,9 +178,7 @@ namespace FluentAssertions.Specialized
                 {
                     string thrownExceptions = BuildExceptionsString(Subject);
                     Services.ThrowException(
-                        string.Format(
-                            "More than one exception was thrown.  FluentAssertions cannot determine which Exception was meant.{0}{1}",
-                            Environment.NewLine, thrownExceptions));
+                        $"More than one exception was thrown.  FluentAssertions cannot determine which Exception was meant.{Environment.NewLine}{thrownExceptions}");
                 }
 
                 return Subject.Single();

--- a/Src/FluentAssertions/Types/ConstructorInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/ConstructorInfoAssertions.cs
@@ -20,8 +20,7 @@ namespace FluentAssertions.Types
 
         internal static string GetDescriptionFor(ConstructorInfo constructorInfo)
         {
-            return string.Format("{0}({1})",
-                constructorInfo.DeclaringType, GetParameterString(constructorInfo));
+            return $"{constructorInfo.DeclaringType}({GetParameterString(constructorInfo)})";
         }
 
         internal override string SubjectDescription => GetDescriptionFor(Subject);

--- a/Src/FluentAssertions/Types/MemberInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MemberInfoAssertions.cs
@@ -78,9 +78,7 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate, nameof(isMatchingAttributePredicate));
 
-            string failureMessage = string.Format("Expected {0} {1}" +
-                                                  " to be decorated with {2}{{reason}}, but that attribute was not found.",
-                                                  Identifier, SubjectDescription, typeof(TAttribute));
+            string failureMessage = $"Expected {Identifier} {SubjectDescription} to be decorated with {typeof(TAttribute)}{{reason}}, but that attribute was not found.";
 
             IEnumerable<TAttribute> attributes = Subject.GetMatchingAttributes(isMatchingAttributePredicate);
 
@@ -113,9 +111,7 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate, nameof(isMatchingAttributePredicate));
 
-            string failureMessage = string.Format("Expected {0} {1}" +
-                                                  " to not be decorated with {2}{{reason}}, but that attribute was found.",
-                                                  Identifier, SubjectDescription, typeof(TAttribute));
+            string failureMessage = $"Expected {Identifier} {SubjectDescription} to not be decorated with {typeof(TAttribute)}{{reason}}, but that attribute was found.";
 
             IEnumerable<TAttribute> attributes = Subject.GetMatchingAttributes(isMatchingAttributePredicate);
 
@@ -129,12 +125,6 @@ namespace FluentAssertions.Types
 
         protected override string Identifier => "member";
 
-        internal virtual string SubjectDescription
-        {
-            get
-            {
-                return string.Format("{0}.{1}", Subject.DeclaringType, Subject.Name);
-            }
-        }
+        internal virtual string SubjectDescription => $"{Subject.DeclaringType}.{Subject.Name}";
     }
 }

--- a/Src/FluentAssertions/Types/MethodInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoAssertions.cs
@@ -228,8 +228,7 @@ namespace FluentAssertions.Types
         {
             string returnTypeName = method.ReturnType.Name;
 
-            return string.Format("{0} {1}.{2}", returnTypeName,
-                method.DeclaringType, method.Name);
+            return $"{returnTypeName} {method.DeclaringType}.{method.Name}";
         }
 
         internal override string SubjectDescription => GetDescriptionFor(Subject);

--- a/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
@@ -270,8 +270,7 @@ namespace FluentAssertions.Types
         internal static string GetDescriptionFor(PropertyInfo property)
         {
             string propTypeName = property.PropertyType.Name;
-            return string.Format("{0} {1}.{2}", propTypeName,
-                property.DeclaringType, property.Name);
+            return $"{propTypeName} {property.DeclaringType}.{property.Name}";
         }
 
         internal override string SubjectDescription => GetDescriptionFor(Subject);

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -188,7 +188,7 @@ namespace FluentAssertions.Types
                 actualType = "[" + actual.AssemblyQualifiedName + "]";
             }
 
-            return string.Format("Expected type to be {0}{{reason}}, but found {1}.", expectedType, actualType);
+            return $"Expected type to be {expectedType}{{reason}}, but found {actualType}.";
         }
 
         /// <summary>
@@ -795,8 +795,7 @@ namespace FluentAssertions.Types
                 .FailWith($"Expected {propertyType.Name} {Subject.FullName}.{name} to exist{{reason}}, but it does not.")
                 .Then
                 .ForCondition(propertyInfo.PropertyType == propertyType)
-                .FailWith(string.Format("Expected {0} to be of type {1}{{reason}}, but it is not.",
-                    propertyInfoDescription, propertyType));
+                .FailWith($"Expected {propertyInfoDescription} to be of type {propertyType}{{reason}}, but it is not.");
 
             return new AndWhichConstraint<TypeAssertions, PropertyInfo>(this, propertyInfo);
         }
@@ -842,7 +841,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion.ForCondition(propertyInfo is null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(string.Format("Expected {0} to not exist{{reason}}, but it does.", propertyInfoDescription));
+                .FailWith($"Expected {propertyInfoDescription} to not exist{{reason}}, but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -868,8 +867,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion.ForCondition(explicitlyImplementsProperty)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(string.Format("Expected {0} to explicitly implement {1}.{2}{{reason}}, but it does not.",
-                    Subject.FullName, interfaceType.FullName, name));
+                .FailWith($"Expected {Subject.FullName} to explicitly implement {interfaceType.FullName}.{name}{{reason}}, but it does not.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -914,8 +912,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion.ForCondition(!explicitlyImplementsProperty)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(string.Format("Expected {0} to not explicitly implement {1}.{2}{{reason}}, but it does.",
-                    Subject.FullName, interfaceType.FullName, name));
+                .FailWith($"Expected {Subject.FullName} to not explicitly implement {interfaceType.FullName}.{name}{{reason}}, but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -957,12 +954,11 @@ namespace FluentAssertions.Types
         {
             Subject.Should().Implement(interfaceType, because, becauseArgs);
 
-            var explicitlyImplementsMethod = Subject.HasMethod(string.Format("{0}.{1}", interfaceType.FullName, name), parameterTypes);
+            var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType.FullName}.{name}", parameterTypes);
 
             Execute.Assertion.ForCondition(explicitlyImplementsMethod)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(string.Format("Expected {0} to explicitly implement {1}.{2}{{reason}}, but it does not.",
-                    Subject.FullName, interfaceType.FullName, name));
+                .FailWith($"Expected {Subject.FullName} to explicitly implement {interfaceType.FullName}.{name}{{reason}}, but it does not.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1005,12 +1001,11 @@ namespace FluentAssertions.Types
         {
             Subject.Should().Implement(interfaceType, because, becauseArgs);
 
-            var explicitlyImplementsMethod = Subject.HasMethod(string.Format("{0}.{1}", interfaceType.FullName, name), parameterTypes);
+            var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType.FullName}.{name}", parameterTypes);
 
             Execute.Assertion.ForCondition(!explicitlyImplementsMethod)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(string.Format("Expected {0} to not explicitly implement {1}.{2}{{reason}}, but it does.",
-                    Subject.FullName, interfaceType.FullName, name));
+                .FailWith($"Expected {Subject.FullName} to not explicitly implement {interfaceType.FullName}.{name}{{reason}}, but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1061,14 +1056,11 @@ namespace FluentAssertions.Types
 
             Execute.Assertion.ForCondition(propertyInfo is not null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(string.Format("Expected {0} {1}[{2}] to exist{{reason}}, but it does not.",
-                    indexerType.Name, Subject.FullName,
-                    GetParameterString(parameterTypes)));
+                .FailWith($"Expected {indexerType.Name} {Subject.FullName}[{GetParameterString(parameterTypes)}] to exist{{reason}}, but it does not.");
 
             Execute.Assertion.ForCondition(propertyInfo.PropertyType == indexerType)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(string.Format("Expected {0} to be of type {1}{{reason}}, but it is not.",
-                    propertyInfoDescription, indexerType));
+                .FailWith($"Expected {propertyInfoDescription} to be of type {indexerType}{{reason}}, but it is not.");
 
             return new AndWhichConstraint<TypeAssertions, PropertyInfo>(this, propertyInfo);
         }
@@ -1090,9 +1082,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion.ForCondition(propertyInfo is null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(string.Format("Expected indexer {0}[{1}] to not exist{{reason}}, but it does.",
-                    Subject.FullName,
-                    GetParameterString(parameterTypes)));
+                .FailWith($"Expected indexer {Subject.FullName}[{GetParameterString(parameterTypes)}] to not exist{{reason}}, but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1115,9 +1105,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion.ForCondition(methodInfo is not null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(string.Format("Expected method {0}.{1}({2}) to exist{{reason}}, but it does not.",
-                    Subject.FullName, name,
-                    GetParameterString(parameterTypes)));
+                .FailWith($"Expected method {Subject.FullName}.{name}({GetParameterString(parameterTypes)}) to exist{{reason}}, but it does not.");
 
             return new AndWhichConstraint<TypeAssertions, MethodInfo>(this, methodInfo);
         }
@@ -1148,8 +1136,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion.ForCondition(methodInfo is null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(string.Format("Expected method {0}({1}) to not exist{{reason}}, but it does.", methodInfoDescription,
-                    GetParameterString(parameterTypes)));
+                .FailWith($"Expected method {methodInfoDescription}({GetParameterString(parameterTypes)}) to not exist{{reason}}, but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1171,9 +1158,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion.ForCondition(constructorInfo is not null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(string.Format("Expected constructor {0}({1}) to exist{{reason}}, but it does not.",
-                    Subject.FullName,
-                    GetParameterString(parameterTypes)));
+                .FailWith($"Expected constructor {Subject.FullName}({GetParameterString(parameterTypes)}) to exist{{reason}}, but it does not.");
 
             return new AndWhichConstraint<TypeAssertions, ConstructorInfo>(this, constructorInfo);
         }
@@ -1211,9 +1196,7 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .ForCondition(constructorInfo is null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(string.Format("Expected constructor {0}({1}) not to exist{{reason}}, but it does.",
-                    Subject.FullName,
-                    GetParameterString(parameterTypes)));
+                .FailWith($"Expected constructor {Subject.FullName}({GetParameterString(parameterTypes)}) not to exist{{reason}}, but it does.");
 
             return new AndWhichConstraint<TypeAssertions, ConstructorInfo>(this, constructorInfo);
         }
@@ -1319,8 +1302,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion.ForCondition(methodInfo is not null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(string.Format("Expected public static implicit {0}({1}) to exist{{reason}}, but it does not.",
-                    targetType.FullName, sourceType.FullName));
+                .FailWith($"Expected public static implicit {targetType.FullName}({sourceType.FullName}) to exist{{reason}}, but it does not.");
 
             return new AndWhichConstraint<TypeAssertions, MethodInfo>(this, methodInfo);
         }
@@ -1360,8 +1342,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion.ForCondition(methodInfo is null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(string.Format("Expected public static implicit {0}({1}) to not exist{{reason}}, but it does.",
-                    targetType.FullName, sourceType.FullName));
+                .FailWith($"Expected public static implicit {targetType.FullName}({sourceType.FullName}) to not exist{{reason}}, but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1401,8 +1382,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion.ForCondition(methodInfo is not null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(string.Format("Expected public static explicit {0}({1}) to exist{{reason}}, but it does not.",
-                    targetType.FullName, sourceType.FullName));
+                .FailWith($"Expected public static explicit {targetType.FullName}({sourceType.FullName}) to exist{{reason}}, but it does not.");
 
             return new AndWhichConstraint<TypeAssertions, MethodInfo>(this, methodInfo);
         }
@@ -1442,8 +1422,7 @@ namespace FluentAssertions.Types
 
             Execute.Assertion.ForCondition(methodInfo is null)
                 .BecauseOf(because, becauseArgs)
-                .FailWith(string.Format("Expected public static explicit {0}({1}) to not exist{{reason}}, but it does.",
-                    targetType.FullName, sourceType.FullName));
+                .FailWith($"Expected public static explicit {targetType.FullName}({sourceType.FullName}) to not exist{{reason}}, but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
         }

--- a/Src/FluentAssertions/Xml/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Xml/Equivalency/Node.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -26,11 +27,11 @@ namespace FluentAssertions.Xml.Equivalency
             {
                 if (location.count > 1)
                 {
-                    resultBuilder.AppendFormat("/{0}[{1}]", location.name, location.count);
+                    resultBuilder.AppendFormat(CultureInfo.InvariantCulture, "/{0}[{1}]", location.name, location.count);
                 }
                 else
                 {
-                    resultBuilder.AppendFormat("/{0}", location.name);
+                    resultBuilder.AppendFormat(CultureInfo.InvariantCulture, "/{0}", location.name);
                 }
             }
 

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
@@ -352,8 +352,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             string expectedMessage =
-                string.Format("Expected collection to contain a single item matching {0}, " +
-                              "but the collection is empty.", expression.Body);
+                $"Expected collection to contain a single item matching {expression.Body}, but the collection is empty.";
 
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }
@@ -370,8 +369,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             string expectedMessage =
-                string.Format("Expected collection to contain a single item matching {0}, " +
-                              "but found <null>.", expression.Body);
+                $"Expected collection to contain a single item matching {expression.Body}, but found <null>.";
 
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }
@@ -388,8 +386,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             string expectedMessage =
-                string.Format("Expected collection to contain a single item matching {0}, " +
-                              "but no such item was found.", expression.Body);
+                $"Expected collection to contain a single item matching {expression.Body}, but no such item was found.";
 
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }
@@ -406,8 +403,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             string expectedMessage =
-                string.Format("Expected collection to contain a single item matching {0}, " +
-                              "but 3 such items were found.", expression.Body);
+                $"Expected collection to contain a single item matching {expression.Body}, but 3 such items were found.";
 
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }

--- a/Tests/FluentAssertions.Specs/Equivalency/DictionaryEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DictionaryEquivalencySpecs.cs
@@ -228,7 +228,7 @@ namespace FluentAssertions.Specs
 
             private int Parse(string key)
             {
-                return int.Parse(key);
+                return int.Parse(key, CultureInfo.InvariantCulture);
             }
         }
 
@@ -1064,13 +1064,13 @@ namespace FluentAssertions.Specs
         public void When_a_dictionary_is_missing_a_key_it_should_report_the_specific_key()
         {
             // Arrange
-            var actual = new Dictionary<string,string>
+            var actual = new Dictionary<string, string>
             {
                 { "a", "x" },
                 { "b", "x" },
             };
 
-            var expected = new Dictionary<string,string>
+            var expected = new Dictionary<string, string>
             {
                 { "a", "x" },
                 { "c", "x" }, // key mismatch

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -709,7 +709,7 @@ namespace FluentAssertions.Specs.Events
             MethodBuilder emitAddRemoveEventHandler(string methodName)
             {
                 MethodBuilder method =
-                    typeBuilder.DefineMethod(string.Format("{0}.{1}_InterfaceEvent", interfaceType.FullName, methodName),
+                    typeBuilder.DefineMethod($"{interfaceType.FullName}.{methodName}_InterfaceEvent",
                         MethodAttributes.Private | MethodAttributes.Virtual | MethodAttributes.Final |
                         MethodAttributes.HideBySig |
                         MethodAttributes.NewSlot);

--- a/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
@@ -500,7 +500,7 @@ namespace FluentAssertions.Specs
 
         private static string BuildExpectedMessageForWithInnerExceptionExactly(string because, string innerExceptionMessage)
         {
-            var expectedMessage = string.Format("{0} \"{1}\"\n.", because, innerExceptionMessage);
+            var expectedMessage = $"{because} \"{innerExceptionMessage}\"\n.";
 
             return expectedMessage;
         }
@@ -745,9 +745,7 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    string.Format("*System.ArgumentNullException*{0}*",
-                        typeof(ExceptionWithEmptyToString)));
+                .WithMessage($"*System.ArgumentNullException*{typeof(ExceptionWithEmptyToString)}*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -262,7 +263,7 @@ namespace FluentAssertions.Specs
                     {
                         foreach (KeyValuePair<string, object> pair in context)
                         {
-                            builder.AppendFormat("\nWith {0}:\n{1}", pair.Key, pair.Value);
+                            builder.AppendFormat(CultureInfo.InvariantCulture, "\nWith {0}:\n{1}", pair.Key, pair.Value);
                         }
                     }
 

--- a/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using Xunit;
 using Xunit.Sdk;
 
@@ -663,7 +664,7 @@ namespace FluentAssertions.Specs
 
         public override string ToString()
         {
-            return Value.ToString();
+            return Value.ToString(CultureInfo.InvariantCulture);
         }
     }
 
@@ -683,7 +684,7 @@ namespace FluentAssertions.Specs
 
         public override string ToString()
         {
-            return Value.ToString();
+            return Value.ToString(CultureInfo.InvariantCulture);
         }
     }
 

--- a/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
@@ -797,7 +797,7 @@ namespace FluentAssertions.Specs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage(string.Format("Expected value to be one of {{4, 5}}, but found {0}.", value));
+                .WithMessage("Expected value to be one of {4, 5}, but found 3.");
         }
 
         [Fact]
@@ -812,8 +812,7 @@ namespace FluentAssertions.Specs
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage(
-                    string.Format("Expected value to be one of {{4, 5}} because those are the valid values, but found {0}.", value));
+                .WithMessage("Expected value to be one of {4, 5} because those are the valid values, but found 3.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
@@ -373,9 +373,9 @@ namespace FluentAssertions.Specs
             Action act = () => subject.Should().Be(other);
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage(string.Format(
-                "Expected subject to be System.Object (HashCode={0}), but found System.Object (HashCode={1}).",
-                other.GetHashCode(), subject.GetHashCode()));
+            act.Should().Throw<XunitException>()
+                .WithMessage($"Expected subject to be System.Object (HashCode={other.GetHashCode()}), " +
+                             $"but found System.Object (HashCode={subject.GetHashCode()}).");
         }
 
         #endregion
@@ -451,7 +451,7 @@ namespace FluentAssertions.Specs
 
         public override string ToString()
         {
-            return string.Format("ClassWithCustomEqualMethod({0})", Key);
+            return $"ClassWithCustomEqualMethod({Key})";
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
@@ -2318,17 +2318,13 @@ namespace FluentAssertions.Specs
             const string blue = "blue";
             var testString = $"{red} {green}";
 
-            const string because = "some {0} reason";
-            var becauseArgs = new[] { "special" };
-            var expectedErrorReason = string.Format(because, becauseArgs);
-
             // Act
-            Action act = () => testString.Should().ContainAll(new[] { yellow, blue }, because, becauseArgs);
+            Action act = () => testString.Should().ContainAll(new[] { yellow, blue }, "some {0} reason", "special");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage($"*{testString}*contain*{yellow}*{blue}*because {expectedErrorReason}*");
+                .WithMessage($"*{testString}*contain*{yellow}*{blue}*because some special reason*");
         }
 
         [Fact]
@@ -2458,17 +2454,13 @@ namespace FluentAssertions.Specs
             const string purple = "purple";
             var testString = $"{red} {green}";
 
-            const string because = "some {0} reason";
-            var becauseArgs = new[] { "special" };
-            var expectedErrorReason = string.Format(because, becauseArgs);
-
             // Act
-            Action act = () => testString.Should().ContainAny(new[] { blue, purple }, because, becauseArgs);
+            Action act = () => testString.Should().ContainAny(new[] { blue, purple }, "some {0} reason", "special");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage($"*{testString}*contain at least one of*{blue}*{purple}*because {expectedErrorReason}*");
+                .WithMessage($"*{testString}*contain at least one of*{blue}*{purple}*because some special reason*");
         }
 
         #endregion
@@ -2576,17 +2568,13 @@ namespace FluentAssertions.Specs
             const string yellow = "yellow";
             var testString = $"{red} {green} {yellow}";
 
-            const string because = "some {0} reason";
-            var becauseArgs = new[] { "special" };
-            var expectedErrorReason = string.Format(because, becauseArgs);
-
             // Act
-            Action act = () => testString.Should().NotContainAll(new[] { red, green, yellow }, because, becauseArgs);
+            Action act = () => testString.Should().NotContainAll(new[] { red, green, yellow }, "some {0} reason", "special");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage($"*not*{testString}*contain all*{red}*{green}*{yellow}*because*{expectedErrorReason}*");
+                .WithMessage($"*not*{testString}*contain all*{red}*{green}*{yellow}*because*some special reason*");
         }
 
         [Fact]
@@ -2713,17 +2701,13 @@ namespace FluentAssertions.Specs
             const string yellow = "yellow";
             var testString = $"{red} {green} {yellow}";
 
-            const string because = "some {0} reason";
-            var becauseArgs = new[] { "special" };
-            var expectedErrorReason = string.Format(because, becauseArgs);
-
             // Act
-            Action act = () => testString.Should().NotContainAny(new[] { red }, because, becauseArgs);
+            Action act = () => testString.Should().NotContainAny(new[] { red }, "some {0} reason", "special");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage($"*not*{testString}*contain any*{red}*because*{expectedErrorReason}*");
+                .WithMessage($"*not*{testString}*contain any*{red}*because*some special reason*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/StringComparisonSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringComparisonSpecs.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using FluentAssertions.Equivalency;
+using FluentAssertions.Execution;
 using FluentAssertions.Specs.CultureAwareTesting;
 using Xunit;
 using Xunit.Sdk;
@@ -256,6 +258,52 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().NotThrow<XunitException>();
+        }
+
+        [CulturedFact("tr-TR")]
+        public void When_formatting_reason_arguments_it_should_ignore_culture()
+        {
+            // Arrange
+            var scope = new AssertionScope();
+
+            // Act
+            scope.BecauseOf("{0}", 1.234)
+                 .FailWith("{reason}");
+
+            // Assert
+            scope.Invoking(e => e.Dispose()).Should().Throw<XunitException>()
+                .WithMessage("*1.234*", "it should always use . as decimal separator");
+        }
+
+        [CulturedFact("tr-TR")]
+        public void When_stringifying_an_object_it_should_ignore_culture()
+        {
+            // Arrange
+            var obj = new ObjectReference(1.234, string.Empty);
+
+            // Act
+            var str = obj.ToString();
+
+            // Assert
+            str.Should().Match("*1.234*", "it should always use . as decimal separator");
+        }
+
+        [CulturedFact("tr-TR")]
+        public void When_stringifying_a_validation_context_it_should_ignore_culture()
+        {
+            // Arrange
+            var root = FluentAssertions.Equivalency.Node.From<int>(() => string.Empty);
+            var context = new EquivalencyValidationContext(root)
+            {
+                Subject = 1.234,
+                Expectation = 5.678
+            };
+
+            // Act
+            var str = context.ToString();
+
+            // Assert
+            str.Should().Match("*1.234*5.678*", "it should always use . as decimal separator");
         }
 
         public static IEnumerable<object[]> EquivalencyData

--- a/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
@@ -122,9 +122,9 @@ namespace FluentAssertions.Specs
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(string.Format("Expected assembly \"{0}\" " +
+                .WithMessage($"Expected assembly \"{thisAssembly.FullName}\" " +
                              "to define type \"FakeNamespace\".\"FakeName\" " +
-                             "because we want to test the failure message, but it does not.", thisAssembly.FullName));
+                             "because we want to test the failure message, but it does not.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using DummyNamespace;
@@ -4269,11 +4270,11 @@ namespace FluentAssertions.Specs
 
         private ClassWithMembers(string _) { }
 
-        protected string PrivateWriteProtectedReadProperty { get { return null; } private set { } }
+        protected string PrivateWriteProtectedReadProperty { get => null; private set { } }
 
-        internal string this[string str] { private get { return str; } set { } }
+        internal string this[string str] { private get => str; set { } }
 
-        protected internal string this[int i] { get { return i.ToString(); } private set { } }
+        protected internal string this[int i] { get => i.ToString(CultureInfo.InvariantCulture); private set { } }
 
         private void VoidMethod() { }
 
@@ -4282,7 +4283,7 @@ namespace FluentAssertions.Specs
 
     public class ClassExplicitlyImplementingInterface : IExplicitInterface
     {
-        public string ImplicitStringProperty { get { return null; } private set { } }
+        public string ImplicitStringProperty { get => null; private set { } }
 
         string IExplicitInterface.ExplicitStringProperty { set { } }
 

--- a/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
@@ -756,9 +756,9 @@ namespace FluentAssertions.Specs
                 theDocument.Should().HaveRoot("unknown", "because we want to test the failure message");
 
             // Assert
-            string expectedMessage = string.Format("Expected theDocument to have root element \"unknown\"" +
-                                                   " because we want to test the failure message" +
-                                                   ", but found {0}.", Formatter.ToString(theDocument));
+            string expectedMessage = "Expected theDocument to have root element \"unknown\"" +
+                                     " because we want to test the failure message" +
+                                    $", but found {Formatter.ToString(theDocument)}.";
 
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }
@@ -844,10 +844,10 @@ namespace FluentAssertions.Specs
                     "because we want to test the failure message");
 
             // Assert
-            string expectedMessage = string.Format(
-                "Expected theDocument to have root element \"{{http://www.example.com/2012/test}}unknown\"" +
+            string expectedMessage =
+                "Expected theDocument to have root element \"{http://www.example.com/2012/test}unknown\"" +
                 " because we want to test the failure message" +
-                ", but found {0}.", Formatter.ToString(theDocument));
+               $", but found {Formatter.ToString(theDocument)}.";
 
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }


### PR DESCRIPTION
While working on another PR I had used `Convert.ChangeType(object, Type)` instead of `Convert.ChangeType(object, Type, IFormatProvider)` but I didn't get a build error from any analyzer.

It is handled by CA1305 which I [initially](https://github.com/fluentassertions/fluentassertions/pull/1283/files#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR130) disabled - as I recall due to being too noisy at that point in time.

Enabling it helped find an inconsistency where `becauseArgs` were formatted using `CurrentCulture` instead of `InvariantCulture`.

I've added some tests in `StringComparisonSpecs.cs`, but I omitted testing the addition of `Invariant` in `AutoConversionStep`, `DictionaryEquivalencyStep` and `EnumerableEquivalencyValidator`.
Partly because I found it difficult to write a test of good quality.