### PR TITLE
Add WithResult to TaskCompletionSourceAssertion

### DIFF
--- a/Src/FluentAssertions/AsyncAssertionsExtensions.cs
+++ b/Src/FluentAssertions/AsyncAssertionsExtensions.cs
@@ -1,0 +1,55 @@
+using System.Threading.Tasks;
+using FluentAssertions.Specialized;
+
+namespace FluentAssertions
+{
+    public static class AsyncAssertionsExtensions
+    {
+#pragma warning disable AV1755 // "Name of async method ... should end with Async"; Async suffix is too noisy in fluent API
+        /// <summary>
+        /// Asserts that the completed <see cref="Task{TResult}"/> provides the specified result.
+        /// </summary>
+        /// <param name="task">The <see cref="GenericAsyncFunctionAssertions{T}"/> containing the <see cref="Task{TResult}"/>.</param>
+        /// <param name="expected">The expected value.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public static async Task<AndWhichConstraint<GenericAsyncFunctionAssertions<T>, T>> WithResult<T>(
+            this Task<AndWhichConstraint<GenericAsyncFunctionAssertions<T>, T>> task,
+            T expected, string because = "", params object[] becauseArgs)
+        {
+            var andWhichConstraint = await task;
+            var subject = andWhichConstraint.Subject;
+            subject.Should().Be(expected, because, becauseArgs);
+
+            return andWhichConstraint;
+        }
+
+        /// <summary>
+        /// Asserts that the completed <see cref="TaskCompletionSource{TResult}"/> provides the specified result.
+        /// </summary>
+        /// <param name="task">The <see cref="TaskCompletionSourceAssertions{T}"/> containing the <see cref="TaskCompletionSource{TResult}"/>.</param>
+        /// <param name="expected">The expected value.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public static async Task<AndWhichConstraint<TaskCompletionSourceAssertions<T>, T>> WithResult<T>(
+            this Task<AndWhichConstraint<TaskCompletionSourceAssertions<T>, T>> task,
+            T expected, string because = "", params object[] becauseArgs)
+        {
+            var andWhichConstraint = await task;
+            var subject = andWhichConstraint.Subject;
+            subject.Should().Be(expected, because, becauseArgs);
+
+            return andWhichConstraint;
+        }
+    }
+}

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -104,6 +104,11 @@ namespace FluentAssertions
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
     }
+    public static class AsyncAssertionsExtensions
+    {
+        public static System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T>, T>> WithResult<T>(this System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T>, T>> task, T expected, string because = "", params object[] becauseArgs) { }
+        public static System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> WithResult<T>(this System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> task, T expected, string because = "", params object[] becauseArgs) { }
+    }
     public static class AtLeast
     {
         public static FluentAssertions.OccurrenceConstraint Once() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -104,6 +104,11 @@ namespace FluentAssertions
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
     }
+    public static class AsyncAssertionsExtensions
+    {
+        public static System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T>, T>> WithResult<T>(this System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T>, T>> task, T expected, string because = "", params object[] becauseArgs) { }
+        public static System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> WithResult<T>(this System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> task, T expected, string because = "", params object[] becauseArgs) { }
+    }
     public static class AtLeast
     {
         public static FluentAssertions.OccurrenceConstraint Once() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -104,6 +104,11 @@ namespace FluentAssertions
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
     }
+    public static class AsyncAssertionsExtensions
+    {
+        public static System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T>, T>> WithResult<T>(this System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T>, T>> task, T expected, string because = "", params object[] becauseArgs) { }
+        public static System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> WithResult<T>(this System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> task, T expected, string because = "", params object[] becauseArgs) { }
+    }
     public static class AtLeast
     {
         public static FluentAssertions.OccurrenceConstraint Once() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -103,6 +103,11 @@ namespace FluentAssertions
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
     }
+    public static class AsyncAssertionsExtensions
+    {
+        public static System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T>, T>> WithResult<T>(this System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T>, T>> task, T expected, string because = "", params object[] becauseArgs) { }
+        public static System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> WithResult<T>(this System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> task, T expected, string because = "", params object[] becauseArgs) { }
+    }
     public static class AtLeast
     {
         public static FluentAssertions.OccurrenceConstraint Once() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -104,6 +104,11 @@ namespace FluentAssertions
         public static void AssertEquivalencyUsing(System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions, FluentAssertions.Equivalency.EquivalencyAssertionOptions> defaultsConfigurer) { }
         public static FluentAssertions.Equivalency.EquivalencyAssertionOptions<T> CloneDefaults<T>() { }
     }
+    public static class AsyncAssertionsExtensions
+    {
+        public static System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T>, T>> WithResult<T>(this System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<T>, T>> task, T expected, string because = "", params object[] becauseArgs) { }
+        public static System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> WithResult<T>(this System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> task, T expected, string because = "", params object[] becauseArgs) { }
+    }
     public static class AtLeast
     {
         public static FluentAssertions.OccurrenceConstraint Once() { }

--- a/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
@@ -42,20 +42,53 @@ namespace FluentAssertions.Specs.Specialized
         }
 
         [Fact]
-        public async Task When_TCS_completes_in_time_and_result_is_not_expected_it_should_fail()
+        public async Task When_TCS_completes_in_time_and_async_result_is_expected_it_should_succeed()
         {
             // Arrange
             var subject = new TaskCompletionSource<int>();
             var timer = new FakeClock();
 
             // Act
-            Func<Task> action = async () => (await subject.Should(timer).CompleteWithinAsync(1.Seconds())).Which.Should().Be(42);
-            subject.SetResult(99);
+            Func<Task> action = () => subject.Should(timer).CompleteWithinAsync(1.Seconds()).WithResult(42);
+            subject.SetResult(42);
+            timer.Complete();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task When_TCS_completes_in_time_and_result_is_not_expected_it_should_fail()
+        {
+            // Arrange
+            var testSubject = new TaskCompletionSource<int>();
+            var timer = new FakeClock();
+
+            // Act
+            Func<Task> action = async () => (await testSubject.Should(timer).CompleteWithinAsync(1.Seconds())).Which.Should().Be(42);
+            testSubject.SetResult(99);
             timer.Complete();
 
             // Assert
             await action.Should().ThrowAsync<XunitException>()
-                .WithMessage("Expected * to be 42, but found 99.");
+                .WithMessage("Expected *testSubject* to be 42, but found 99.");
+        }
+
+        [Fact]
+        public async Task When_TCS_completes_in_time_and_async_result_is_not_expected_it_should_fail()
+        {
+            // Arrange
+            var testSubject = new TaskCompletionSource<int>();
+            var timer = new FakeClock();
+
+            // Act
+            Func<Task> action = () => testSubject.Should(timer).CompleteWithinAsync(1.Seconds()).WithResult(42);
+            testSubject.SetResult(99);
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>()
+                .WithMessage("Expected testSubject to be 42, but found 99.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -15,6 +15,7 @@ namespace FluentAssertions.Specs.Specialized
     public class TaskOfTAssertionSpecs
     {
         #region CompleteWithinAsync
+
         [Fact]
         public async Task When_subject_is_null_when_expecting_to_complete_async_it_should_throw()
         {
@@ -55,6 +56,53 @@ namespace FluentAssertions.Specs.Specialized
         }
 
         [Fact]
+        public async Task When_task_completes_async_and_result_is_not_expected_it_should_throw()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<int>();
+
+            // Act
+            Func<Task> action = async () =>
+            {
+                Func<Task<int>> funcSubject = () => taskFactory.Task;
+
+                (await funcSubject.Should(timer).CompleteWithinAsync(100.Milliseconds()))
+                    .Which.Should().Be(42);
+            };
+
+            taskFactory.SetResult(99);
+            timer.Complete();
+
+            // Assert
+            // TODO message currently shows "Expected (await funcSubject to be...", but should be "Expected funcSubject to be...",
+            // maybe with or without await.
+            await action.Should().ThrowAsync<XunitException>().WithMessage("*to be 42, but found 99.");
+        }
+
+        [Fact]
+        public async Task When_task_completes_async_and_async_result_is_not_expected_it_should_throw()
+        {
+            // Arrange
+            var timer = new FakeClock();
+            var taskFactory = new TaskCompletionSource<int>();
+
+            // Act
+            Func<Task> action = async () =>
+            {
+                Func<Task<int>> funcSubject = () => taskFactory.Task;
+
+                await funcSubject.Should(timer).CompleteWithinAsync(100.Milliseconds()).WithResult(42);
+            };
+
+            taskFactory.SetResult(99);
+            timer.Complete();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>().WithMessage("Expected await funcSubject to be 42, but found 99.");
+        }
+
+        [Fact]
         public async Task When_task_completes_slow_async_it_should_fail()
         {
             // Arrange
@@ -74,9 +122,11 @@ namespace FluentAssertions.Specs.Specialized
             // Assert
             await action.Should().ThrowAsync<XunitException>();
         }
+
         #endregion
 
         #region NotThrowAfterAsync
+
         [Fact]
         public async Task When_subject_is_null_when_expecting_to_not_throw_async_it_should_throw()
         {
@@ -372,6 +422,7 @@ namespace FluentAssertions.Specs.Specialized
             // Assert
             await act.Should().NotThrowAsync();
         }
+
         #endregion
     }
 }

--- a/docs/_pages/executiontime.md
+++ b/docs/_pages/executiontime.md
@@ -59,7 +59,7 @@ If the `Task` is generic and returns a value, you can use that to write a contin
 ```csharp
 Func<Task<int>> someAsyncFunc;
 
-(await someAsyncFunc.Should().CompleteWithinAsync(100.Milliseconds())).Which.Should().Be(42);
+await someAsyncFunc.Should().CompleteWithinAsync(100.Milliseconds()).WithResult(42);
 ```
 
 A fully `async` version is available as well.

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,6 +13,7 @@ sidebar:
 * Added `WithParameterName` extension to ease asserting on the parameter name for a thrown `ArgumentException` - [#1466](https://github.com/fluentassertions/fluentassertions/pull/1466).
 * Added `NotCompleteWithinAsync` to `TaskCompletionSourceAssertions` - [#1474](https://github.com/fluentassertions/fluentassertions/pull/1474).
 * Added `HaveValue(decimal)`, `HaveSameValueAs` and `HaveSameNameAs` to `EnumAssertions` - [#1479](https://github.com/fluentassertions/fluentassertions/pull/1479).
+* Added `WithResult` extension method to `CompleteWithinAsync` assertions for `Task<T>` and `TaskCompletionSource<T>` - [#1478](https://github.com/fluentassertions/fluentassertions/pull/1478).
 
 **Fixes**
 * Sometimes `BeEquivalentTo` reported an incorrect message when a dictionary was missing a key - [#1454](https://github.com/fluentassertions/fluentassertions/pull/1454)

--- a/docs/_pages/specialized.md
+++ b/docs/_pages/specialized.md
@@ -19,7 +19,7 @@ The assertion returns the result for subsequent value assertions.
 
 ```csharp
 var tcs = new TaskCompletionSource<bool>();
-(await tcs.Should().CompleteWithinAsync(1.Seconds())).Which.Should().BeTrue();
+await tcs.Should().CompleteWithinAsync(1.Seconds()).WithResult(true);
 ```
 
 Additionally it is possible to assert that the task will *not* complete within specific time.


### PR DESCRIPTION
While further development of tests using async assertions (async methods and TaskCompletionSource) I found that asserting the result is not as fluent as possible.
Therefore I provide new idea to assert the result.

If you agree I'll complete with
* extention method for Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>>
* documentation, release notes, etc.
* api validation update