### PR TITLE
Rework EnumAssertions

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -131,13 +131,6 @@ namespace FluentAssertions
         }
 
         /// <summary>
-        /// Returns an <see cref="EnumAssertions"/> object that can be used to assert the
-        /// current <see cref="Enum"/>.
-        /// </summary>
-        public static EnumAssertions Should(this Enum @enum)
-            => new EnumAssertions(@enum);
-
-        /// <summary>
         /// Returns an <see cref="ExecutionTimeAssertions"/> object that can be used to assert the
         /// current <see cref="FluentAssertions.Specialized.ExecutionTime"/>.
         /// </summary>

--- a/Src/FluentAssertions/Common/ObjectExtensions.cs
+++ b/Src/FluentAssertions/Common/ObjectExtensions.cs
@@ -31,8 +31,8 @@ namespace FluentAssertions.Common
             Type actualType = actual.GetType();
 
             return actualType != expectedType
-                && (actual.IsNumericType() || actualType.IsEnum)
-                && (expected.IsNumericType() || expectedType.IsEnum)
+                && actual.IsNumericType()
+                && expected.IsNumericType()
                 && CanConvert(actual, expected, actualType, expectedType)
                 && CanConvert(expected, actual, expectedType, actualType);
         }
@@ -55,9 +55,7 @@ namespace FluentAssertions.Common
 
         private static object ConvertTo(this object source, Type targetType)
         {
-            return targetType.IsEnum
-                ? Enum.ToObject(targetType, source)
-                : Convert.ChangeType(source, targetType, CultureInfo.InvariantCulture);
+            return Convert.ChangeType(source, targetType, CultureInfo.InvariantCulture);
         }
 
         private static bool IsNumericType(this object obj)

--- a/Src/FluentAssertions/EnumAssertionsExtensions.cs
+++ b/Src/FluentAssertions/EnumAssertionsExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using FluentAssertions.Primitives;
+
+namespace FluentAssertions
+{
+    /// <summary>
+    /// Contains an extension method for custom assertions in unit tests related to Enum objects.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public static class EnumAssertionsExtensions
+    {
+        /// <summary>
+        /// Returns an <see cref="EnumAssertions{TEnum, TAssertions}"/> object that can be used to assert the
+        /// current <typeparamref name="TEnum"/>.
+        /// </summary>
+        [Pure]
+        public static EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)
+            where TEnum : struct, Enum
+        {
+            return new EnumAssertions<TEnum>(@enum);
+        }
+
+        /// <summary>
+        /// Returns an <see cref="EnumAssertions{TEnum, TAssertions}"/> object that can be used to assert the
+        /// current <typeparamref name="TEnum"/>.
+        /// </summary>
+        [Pure]
+        public static NullableEnumAssertions<TEnum> Should<TEnum>(this TEnum? @enum)
+            where TEnum : struct, Enum
+        {
+            return new NullableEnumAssertions<TEnum>(@enum);
+        }
+    }
+}

--- a/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
+++ b/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
@@ -15,10 +15,9 @@ namespace FluentAssertions.Equivalency
         /// </summary>
         public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
         {
-            Type subjectType = config.GetExpectationType(context.RuntimeType, context.CompileTimeType);
+            Type expectationType = config.GetExpectationType(context.RuntimeType, context.CompileTimeType);
 
-            return (subjectType?.IsEnum == true) ||
-                   (context.Expectation?.GetType().IsEnum == true);
+            return expectationType.IsEnum;
         }
 
         /// <summary>
@@ -96,9 +95,9 @@ namespace FluentAssertions.Equivalency
             if (o.GetType().IsEnum)
             {
                 string typePart = o.GetType().Name;
-                string namePart = Enum.GetName(o.GetType(), o);
+                string namePart = o.ToString().Replace(", ", "|", StringComparison.Ordinal);
                 string valuePart = v.Value.ToString(CultureInfo.InvariantCulture);
-                return $"{typePart}.{namePart}({valuePart})";
+                return $"{typePart}.{namePart} {{{{value: {valuePart}}}}}";
             }
 
             return v.Value.ToString(CultureInfo.InvariantCulture);

--- a/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
+++ b/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
@@ -33,6 +33,16 @@ namespace FluentAssertions.Equivalency
         public bool Handle(IEquivalencyValidationContext context, IEquivalencyValidator parent,
             IEquivalencyAssertionOptions config)
         {
+            Execute.Assertion
+                .ForCondition(context.Subject?.GetType().IsEnum == true)
+                .FailWith(() =>
+                {
+                    decimal? expectationsUnderlyingValue = ExtractDecimal(context.Expectation);
+                    string expectationName = GetDisplayNameForEnumComparison(context.Expectation, expectationsUnderlyingValue);
+
+                    return new FailReason($"Expected {{context:enum}} to be equivalent to {expectationName}{{reason}}, but found {{0}}.", context.Subject);
+                });
+
             switch (config.EnumEquivalencyHandling)
             {
                 case EnumEquivalencyHandling.ByValue:
@@ -68,7 +78,7 @@ namespace FluentAssertions.Equivalency
 
         private static void HandleByName(IEquivalencyValidationContext context)
         {
-            string subject = context.Subject?.ToString();
+            string subject = context.Subject.ToString();
             string expected = context.Expectation.ToString();
 
             Execute.Assertion
@@ -89,18 +99,13 @@ namespace FluentAssertions.Equivalency
         {
             if (o is null || v is null)
             {
-                return "null";
+                return "<null>";
             }
 
-            if (o.GetType().IsEnum)
-            {
-                string typePart = o.GetType().Name;
-                string namePart = o.ToString().Replace(", ", "|", StringComparison.Ordinal);
-                string valuePart = v.Value.ToString(CultureInfo.InvariantCulture);
-                return $"{typePart}.{namePart} {{{{value: {valuePart}}}}}";
-            }
-
-            return v.Value.ToString(CultureInfo.InvariantCulture);
+            string typePart = o.GetType().Name;
+            string namePart = o.ToString().Replace(", ", "|", StringComparison.Ordinal);
+            string valuePart = v.Value.ToString(CultureInfo.InvariantCulture);
+            return $"{typePart}.{namePart} {{{{value: {valuePart}}}}}";
         }
 
         private static decimal? ExtractDecimal(object o)

--- a/Src/FluentAssertions/Equivalency/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/EnumerableEquivalencyStep.cs
@@ -13,9 +13,9 @@ namespace FluentAssertions.Equivalency
         /// </summary>
         public bool CanHandle(IEquivalencyValidationContext context, IEquivalencyAssertionOptions config)
         {
-            Type subjectType = config.GetExpectationType(context.RuntimeType, context.CompileTimeType);
+            Type expectationType = config.GetExpectationType(context.RuntimeType, context.CompileTimeType);
 
-            return IsCollection(subjectType);
+            return IsCollection(expectationType);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Formatting/EnumValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/EnumValueFormatter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Globalization;
+
+namespace FluentAssertions.Formatting
+{
+    public class EnumValueFormatter : IValueFormatter
+    {
+        /// <summary>
+        /// Indicates whether the current <see cref="IValueFormatter"/> can handle the specified <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value for which to create a <see cref="string"/>.</param>
+        /// <returns>
+        /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+        /// </returns>
+        public virtual bool CanHandle(object value)
+        {
+            return value is Enum;
+        }
+
+        /// <inheritdoc />
+        public string Format(object value, FormattingContext context, FormatChild formatChild)
+        {
+            string typePart = value.GetType().Name;
+            string namePart = value.ToString().Replace(", ", "|", StringComparison.Ordinal);
+            string valuePart = Convert.ToDecimal(value, CultureInfo.InvariantCulture)
+                .ToString(CultureInfo.InvariantCulture);
+
+            return $"{typePart}.{namePart} {{value: {valuePart}}}";
+        }
+    }
+}

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -46,6 +46,7 @@ namespace FluentAssertions.Formatting
             new ExceptionValueFormatter(),
             new MultidimensionalArrayFormatter(),
             new EnumerableValueFormatter(),
+            new EnumValueFormatter(),
             new DefaultValueFormatter()
         };
 

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -911,12 +911,12 @@ namespace FluentAssertions.Primitives
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:the date and time} to be in {0}{reason}", expectedKind)
+                .WithExpectation("Expected {context:the date and time} to be in " + expectedKind.ToString() + "{reason}")
                 .ForCondition(Subject.HasValue)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
                 .ForCondition(Subject.Value.Kind == expectedKind)
-                .FailWith(", but found {0}.", Subject.Value.Kind)
+                .FailWith(", but found " + Subject.Value.Kind.ToString() + ".")
                 .Then
                 .ClearExpectation();
 

--- a/Src/FluentAssertions/Primitives/EnumAssertions.cs
+++ b/Src/FluentAssertions/Primitives/EnumAssertions.cs
@@ -1,14 +1,16 @@
 ﻿using System;
+using System.Globalization;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Primitives
 {
     /// <summary>
-    /// Contains a number of methods to assert that an <see cref="Enum"/> is in the expected state.
+    /// Contains a number of methods to assert that a <typeparamref name="TEnum"/> is in the expected state.
     /// </summary>
-    public class EnumAssertions : EnumAssertions<Enum, EnumAssertions>
+    public class EnumAssertions<TEnum> : EnumAssertions<TEnum, EnumAssertions<TEnum>>
+        where TEnum : struct, Enum
     {
-        public EnumAssertions(Enum subject)
+        public EnumAssertions(TEnum subject)
             : base(subject)
         {
         }
@@ -17,15 +19,246 @@ namespace FluentAssertions.Primitives
     /// <summary>
     /// Contains a number of methods to assert that a <typeparamref name="TEnum"/> is in the expected state.
     /// </summary>
-    public class EnumAssertions<TEnum, TAssertions> : ObjectAssertions<TEnum, TAssertions>
-        where TEnum : Enum
+    public class EnumAssertions<TEnum, TAssertions>
+        where TEnum : struct, Enum
         where TAssertions : EnumAssertions<TEnum, TAssertions>
     {
-        protected override string Identifier => "enum";
-
         public EnumAssertions(TEnum subject)
-            : base(subject)
+            : this((TEnum?)subject)
         {
+        }
+
+        private protected EnumAssertions(TEnum? value)
+        {
+            SubjectInternal = value;
+        }
+
+        public TEnum Subject => SubjectInternal.Value;
+
+        private protected TEnum? SubjectInternal { get; }
+
+        /// <summary>
+        /// Asserts that the current <typeparamref name="TEnum"/> is exactly equal to the <paramref name="expected"/> value.
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> Be(TEnum expected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(SubjectInternal?.Equals(expected) == true)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected the enum to be {0}{reason}, but found {1}.",
+                    expected, SubjectInternal);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <typeparamref name="TEnum"/> is exactly equal to the <paramref name="expected"/> value.
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> Be(TEnum? expected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(Nullable.Equals(SubjectInternal, expected))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected the enum to be {0}{reason}, but found {1}.",
+                    expected, SubjectInternal);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <typeparamref name="TEnum"/> or <typeparamref name="TEnum"/> is not equal to the <paramref name="unexpected"/> value.
+        /// </summary>
+        /// <param name="unexpected">The unexpected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotBe(TEnum unexpected, string because = "",
+            params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(SubjectInternal?.Equals(unexpected) != true)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected the enum not to be {0}{reason}, but it is.", unexpected);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <typeparamref name="TEnum"/> or <typeparamref name="TEnum"/> is not equal to the <paramref name="unexpected"/> value.
+        /// </summary>
+        /// <param name="unexpected">The unexpected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotBe(TEnum? unexpected, string because = "",
+            params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(!Nullable.Equals(SubjectInternal, unexpected))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected the enum not to be {0}{reason}, but it is.", unexpected);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <typeparamref name="TEnum"/> is exactly equal to the <paramref name="expected"/> value.
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> HaveValue(decimal expected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(SubjectInternal.HasValue && (GetValue(SubjectInternal.Value) == expected))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected the enum to have value {0}{reason}, but found {1}.",
+                    expected, SubjectInternal);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <typeparamref name="TEnum"/> is exactly equal to the <paramref name="unexpected"/> value.
+        /// </summary>
+        /// <param name="unexpected">The expected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotHaveValue(decimal unexpected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(!(SubjectInternal.HasValue && (GetValue(SubjectInternal.Value) == unexpected)))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected the enum to not have value {0}{reason}, but found {1}.",
+                    unexpected, SubjectInternal);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <typeparamref name="TEnum"/> has the same numeric value as <paramref name="expected"/>.
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> HaveSameValueAs<T>(T expected, string because = "", params object[] becauseArgs)
+            where T : struct, Enum
+        {
+            Execute.Assertion
+                .ForCondition(SubjectInternal.HasValue && (GetValue(SubjectInternal.Value) == GetValue(expected)))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected the enum to have same value as {0}{reason}, but found {1}.",
+                    expected, SubjectInternal);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <typeparamref name="TEnum"/> does not have the same numeric value as <paramref name="unexpected"/>.
+        /// </summary>
+        /// <param name="unexpected">The expected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotHaveSameValueAs<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T : struct, Enum
+        {
+            Execute.Assertion
+                .ForCondition(!(SubjectInternal.HasValue && (GetValue(SubjectInternal.Value) == GetValue(unexpected))))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected the enum to not have same value as {0}{reason}, but found {1}.",
+                    unexpected, SubjectInternal);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <typeparamref name="TEnum"/> has the same name as <paramref name="expected"/>.
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> HaveSameNameAs<T>(T expected, string because = "", params object[] becauseArgs)
+            where T : struct, Enum
+        {
+            Execute.Assertion
+                .ForCondition(SubjectInternal.HasValue && (GetName(SubjectInternal.Value) == GetName(expected)))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected the enum to have same name as {0}{reason}, but found {1}.",
+                    expected, SubjectInternal);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <typeparamref name="TEnum"/> does not have the same name as <paramref name="unexpected"/>.
+        /// </summary>
+        /// <param name="unexpected">The expected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotHaveSameNameAs<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T : struct, Enum
+        {
+            Execute.Assertion
+                .ForCondition(!(SubjectInternal.HasValue && (GetName(SubjectInternal.Value) == GetName(unexpected))))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected the enum to not have same name as {0}{reason}, but found {1}.",
+                    unexpected, SubjectInternal);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
@@ -39,20 +272,13 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        public AndConstraint<TAssertions> HaveFlag<T>(T expectedFlag, string because = "",
+        public AndConstraint<TAssertions> HaveFlag(TEnum expectedFlag, string because = "",
             params object[] becauseArgs)
-            where T : struct, TEnum
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject is not null)
-                .FailWith("Expected type to be {0}{reason}, but found <null>.", expectedFlag.GetType())
-                .Then
-                .ForCondition(Subject.GetType() == expectedFlag.GetType())
-                .FailWith("Expected the enum to be of type {0} type but found {1}{reason}.", expectedFlag.GetType(), Subject.GetType())
-                .Then
-                .ForCondition(Subject.HasFlag(expectedFlag))
-                .FailWith("The enum was expected to have flag {0} but found {1}{reason}.", expectedFlag, Subject);
+                .ForCondition(SubjectInternal?.HasFlag(expectedFlag) == true)
+                .FailWith("Expected the enum to have flag {0}{reason}, but found {1}.", expectedFlag, SubjectInternal);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -68,22 +294,27 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        public AndConstraint<TAssertions> NotHaveFlag<T>(T unexpectedFlag, string because = "",
+        public AndConstraint<TAssertions> NotHaveFlag(TEnum unexpectedFlag, string because = "",
             params object[] becauseArgs)
-            where T : struct, TEnum
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject is not null)
-                .FailWith("Expected type to be {0}{reason}, but found <null>.", unexpectedFlag.GetType())
-                .Then
-                .ForCondition(Subject.GetType() == unexpectedFlag.GetType())
-                .FailWith("Expected the enum to be of type {0} type but found {1}{reason}.", unexpectedFlag.GetType(), Subject.GetType())
-                .Then
-                .ForCondition(!Subject.HasFlag(unexpectedFlag))
-                .FailWith("Did not expect the enum to have flag {0}{reason}.", unexpectedFlag);
+                .ForCondition(SubjectInternal?.HasFlag(unexpectedFlag) != true)
+                .FailWith("Expected the enum to not have flag {0}{reason}.", unexpectedFlag);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        private static decimal GetValue<T>(T @enum)
+            where T : struct, Enum
+        {
+            return Convert.ToDecimal(@enum, CultureInfo.InvariantCulture);
+        }
+
+        private static string GetName<T>(T @enum)
+            where T : struct, Enum
+        {
+            return @enum.ToString();
         }
     }
 }

--- a/Src/FluentAssertions/Primitives/NullableEnumAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableEnumAssertions.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Primitives
+{
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <typeparamref name="TEnum"/> is in the expected state.
+    /// </summary>
+    public class NullableEnumAssertions<TEnum> : NullableEnumAssertions<TEnum, NullableEnumAssertions<TEnum>>
+        where TEnum : struct, Enum
+    {
+        public NullableEnumAssertions(TEnum? subject)
+            : base(subject)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that a nullable <typeparamref name="TEnum"/> is in the expected state.
+    /// </summary>
+    public class NullableEnumAssertions<TEnum, TAssertions> : EnumAssertions<TEnum, TAssertions>
+        where TEnum : struct, Enum
+        where TAssertions : NullableEnumAssertions<TEnum, TAssertions>
+    {
+        public NullableEnumAssertions(TEnum? subject)
+            : base(subject)
+        {
+        }
+
+        public new TEnum? Subject => SubjectInternal;
+
+        /// <summary>
+        /// Asserts that a nullable <typeparamref name="TEnum"/> value is not <c>null</c>.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndWhichConstraint<TAssertions, TEnum> HaveValue(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(SubjectInternal.HasValue)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:nullable date and time} to have a value{reason}, but found {0}.", SubjectInternal);
+
+            return new AndWhichConstraint<TAssertions, TEnum>((TAssertions)this, SubjectInternal.GetValueOrDefault());
+        }
+
+        /// <summary>
+        /// Asserts that a nullable <typeparamref name="TEnum"/> is not <c>null</c>.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndWhichConstraint<TAssertions, TEnum> NotBeNull(string because = "", params object[] becauseArgs)
+        {
+            return HaveValue(because, becauseArgs);
+        }
+
+        /// <summary>
+        /// Asserts that a nullable <typeparamref name="TEnum"/> value is <c>null</c>.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(!SubjectInternal.HasValue)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Did not expect {context:nullable date and time} to have a value{reason}, but found {0}.", SubjectInternal);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that a nullable <typeparamref name="TEnum"/> value is <c>null</c>.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])"/> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs)
+        {
+            return NotHaveValue(because, becauseArgs);
+        }
+    }
+}

--- a/Src/FluentAssertions/Types/MethodBaseAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodBaseAssertions.cs
@@ -39,8 +39,8 @@ namespace FluentAssertions.Types
 
             Execute.Assertion.ForCondition(accessModifier == subjectAccessModifier)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected method " + Subject.Name + " to be {0}{reason}, but it is {1}.",
-                    accessModifier, subjectAccessModifier);
+                .FailWith("Expected method " + Subject.Name + " to be " + accessModifier.ToString()
+                    + "{reason}, but it is " + subjectAccessModifier.ToString() + ".");
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -61,7 +61,7 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .ForCondition(accessModifier != Subject.GetCSharpAccessModifier())
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected method " + Subject.Name + " not to be {0}{reason}, but it is.", accessModifier);
+                .FailWith("Expected method " + Subject.Name + " not to be " + accessModifier.ToString() + "{reason}, but it is.");
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -1239,8 +1239,8 @@ namespace FluentAssertions.Types
 
             Execute.Assertion.ForCondition(accessModifier == subjectAccessModifier)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected type " + Subject.Name + " to be {0}{reason}, but it is {1}.",
-                    accessModifier, subjectAccessModifier);
+                .FailWith("Expected type " + Subject.Name + " to be " + accessModifier.ToString()
+                    + "{reason}, but it is " + subjectAccessModifier.ToString() + ".");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1261,8 +1261,7 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .ForCondition(accessModifier != Subject.GetCSharpAccessModifier())
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected type " + Subject.Name + " not to be {0}{reason}, but it is.",
-                    accessModifier);
+                .FailWith("Expected type " + Subject.Name + " not to be " + accessModifier.ToString() + "{reason}, but it is.");
 
             return new AndConstraint<TypeAssertions>(this);
         }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -49,7 +49,6 @@ namespace FluentAssertions
         public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
-        public static FluentAssertions.Primitives.EnumAssertions Should(this System.Enum @enum) { }
         public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
@@ -143,6 +142,13 @@ namespace FluentAssertions
     {
         public static FluentAssertions.Data.DataTableAssertions<TDataTable> Should<TDataTable>(this TDataTable actualValue)
             where TDataTable : System.Data.DataTable { }
+    }
+    public static class EnumAssertionsExtensions
+    {
+        public static FluentAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)
+            where TEnum :  struct, System.Enum { }
+        public static FluentAssertions.Primitives.NullableEnumAssertions<TEnum> Should<TEnum>(this TEnum? @enum)
+            where TEnum :  struct, System.Enum { }
     }
     public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
     {
@@ -1388,6 +1394,12 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
+    public class EnumValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public EnumValueFormatter() { }
+        public virtual bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
     public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumerableValueFormatter() { }
@@ -1738,20 +1750,33 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
     }
-    public class EnumAssertions : FluentAssertions.Primitives.EnumAssertions<System.Enum, FluentAssertions.Primitives.EnumAssertions>
+    public class EnumAssertions<TEnum> : FluentAssertions.Primitives.EnumAssertions<TEnum, FluentAssertions.Primitives.EnumAssertions<TEnum>>
+        where TEnum :  struct, System.Enum
     {
-        public EnumAssertions(System.Enum subject) { }
+        public EnumAssertions(TEnum subject) { }
     }
-    public class EnumAssertions<TEnum, TAssertions> : FluentAssertions.Primitives.ObjectAssertions<TEnum, TAssertions>
-        where TEnum : System.Enum
+    public class EnumAssertions<TEnum, TAssertions>
+        where TEnum :  struct, System.Enum
         where TAssertions : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
     {
         public EnumAssertions(TEnum subject) { }
-        protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<TAssertions> HaveFlag<T>(T expectedFlag, string because = "", params object[] becauseArgs)
-            where T :  struct, TEnum { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveFlag<T>(T unexpectedFlag, string because = "", params object[] becauseArgs)
-            where T :  struct, TEnum { }
+        public TEnum Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TEnum expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TEnum? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveFlag(TEnum expectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameNameAs<T>(T expected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameValueAs<T>(T expected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(decimal expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TEnum unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TEnum? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveFlag(TEnum unexpectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameNameAs<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameValueAs<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(decimal unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class GuidAssertions : FluentAssertions.Primitives.GuidAssertions<FluentAssertions.Primitives.GuidAssertions>
     {
@@ -1808,6 +1833,22 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableEnumAssertions<TEnum> : FluentAssertions.Primitives.NullableEnumAssertions<TEnum, FluentAssertions.Primitives.NullableEnumAssertions<TEnum>>
+        where TEnum :  struct, System.Enum
+    {
+        public NullableEnumAssertions(TEnum? subject) { }
+    }
+    public class NullableEnumAssertions<TEnum, TAssertions> : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
+        where TEnum :  struct, System.Enum
+        where TAssertions : FluentAssertions.Primitives.NullableEnumAssertions<TEnum, TAssertions>
+    {
+        public NullableEnumAssertions(TEnum? subject) { }
+        public TEnum? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
     public class NullableGuidAssertions : FluentAssertions.Primitives.NullableGuidAssertions<FluentAssertions.Primitives.NullableGuidAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -49,7 +49,6 @@ namespace FluentAssertions
         public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
-        public static FluentAssertions.Primitives.EnumAssertions Should(this System.Enum @enum) { }
         public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
@@ -143,6 +142,13 @@ namespace FluentAssertions
     {
         public static FluentAssertions.Data.DataTableAssertions<TDataTable> Should<TDataTable>(this TDataTable actualValue)
             where TDataTable : System.Data.DataTable { }
+    }
+    public static class EnumAssertionsExtensions
+    {
+        public static FluentAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)
+            where TEnum :  struct, System.Enum { }
+        public static FluentAssertions.Primitives.NullableEnumAssertions<TEnum> Should<TEnum>(this TEnum? @enum)
+            where TEnum :  struct, System.Enum { }
     }
     public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
     {
@@ -1388,6 +1394,12 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
+    public class EnumValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public EnumValueFormatter() { }
+        public virtual bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
     public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumerableValueFormatter() { }
@@ -1738,20 +1750,33 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
     }
-    public class EnumAssertions : FluentAssertions.Primitives.EnumAssertions<System.Enum, FluentAssertions.Primitives.EnumAssertions>
+    public class EnumAssertions<TEnum> : FluentAssertions.Primitives.EnumAssertions<TEnum, FluentAssertions.Primitives.EnumAssertions<TEnum>>
+        where TEnum :  struct, System.Enum
     {
-        public EnumAssertions(System.Enum subject) { }
+        public EnumAssertions(TEnum subject) { }
     }
-    public class EnumAssertions<TEnum, TAssertions> : FluentAssertions.Primitives.ObjectAssertions<TEnum, TAssertions>
-        where TEnum : System.Enum
+    public class EnumAssertions<TEnum, TAssertions>
+        where TEnum :  struct, System.Enum
         where TAssertions : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
     {
         public EnumAssertions(TEnum subject) { }
-        protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<TAssertions> HaveFlag<T>(T expectedFlag, string because = "", params object[] becauseArgs)
-            where T :  struct, TEnum { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveFlag<T>(T unexpectedFlag, string because = "", params object[] becauseArgs)
-            where T :  struct, TEnum { }
+        public TEnum Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TEnum expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TEnum? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveFlag(TEnum expectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameNameAs<T>(T expected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameValueAs<T>(T expected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(decimal expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TEnum unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TEnum? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveFlag(TEnum unexpectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameNameAs<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameValueAs<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(decimal unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class GuidAssertions : FluentAssertions.Primitives.GuidAssertions<FluentAssertions.Primitives.GuidAssertions>
     {
@@ -1808,6 +1833,22 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableEnumAssertions<TEnum> : FluentAssertions.Primitives.NullableEnumAssertions<TEnum, FluentAssertions.Primitives.NullableEnumAssertions<TEnum>>
+        where TEnum :  struct, System.Enum
+    {
+        public NullableEnumAssertions(TEnum? subject) { }
+    }
+    public class NullableEnumAssertions<TEnum, TAssertions> : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
+        where TEnum :  struct, System.Enum
+        where TAssertions : FluentAssertions.Primitives.NullableEnumAssertions<TEnum, TAssertions>
+    {
+        public NullableEnumAssertions(TEnum? subject) { }
+        public TEnum? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
     public class NullableGuidAssertions : FluentAssertions.Primitives.NullableGuidAssertions<FluentAssertions.Primitives.NullableGuidAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -49,7 +49,6 @@ namespace FluentAssertions
         public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
-        public static FluentAssertions.Primitives.EnumAssertions Should(this System.Enum @enum) { }
         public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
@@ -143,6 +142,13 @@ namespace FluentAssertions
     {
         public static FluentAssertions.Data.DataTableAssertions<TDataTable> Should<TDataTable>(this TDataTable actualValue)
             where TDataTable : System.Data.DataTable { }
+    }
+    public static class EnumAssertionsExtensions
+    {
+        public static FluentAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)
+            where TEnum :  struct, System.Enum { }
+        public static FluentAssertions.Primitives.NullableEnumAssertions<TEnum> Should<TEnum>(this TEnum? @enum)
+            where TEnum :  struct, System.Enum { }
     }
     public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
     {
@@ -1388,6 +1394,12 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
+    public class EnumValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public EnumValueFormatter() { }
+        public virtual bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
     public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumerableValueFormatter() { }
@@ -1738,20 +1750,33 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
     }
-    public class EnumAssertions : FluentAssertions.Primitives.EnumAssertions<System.Enum, FluentAssertions.Primitives.EnumAssertions>
+    public class EnumAssertions<TEnum> : FluentAssertions.Primitives.EnumAssertions<TEnum, FluentAssertions.Primitives.EnumAssertions<TEnum>>
+        where TEnum :  struct, System.Enum
     {
-        public EnumAssertions(System.Enum subject) { }
+        public EnumAssertions(TEnum subject) { }
     }
-    public class EnumAssertions<TEnum, TAssertions> : FluentAssertions.Primitives.ObjectAssertions<TEnum, TAssertions>
-        where TEnum : System.Enum
+    public class EnumAssertions<TEnum, TAssertions>
+        where TEnum :  struct, System.Enum
         where TAssertions : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
     {
         public EnumAssertions(TEnum subject) { }
-        protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<TAssertions> HaveFlag<T>(T expectedFlag, string because = "", params object[] becauseArgs)
-            where T :  struct, TEnum { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveFlag<T>(T unexpectedFlag, string because = "", params object[] becauseArgs)
-            where T :  struct, TEnum { }
+        public TEnum Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TEnum expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TEnum? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveFlag(TEnum expectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameNameAs<T>(T expected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameValueAs<T>(T expected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(decimal expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TEnum unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TEnum? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveFlag(TEnum unexpectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameNameAs<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameValueAs<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(decimal unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class GuidAssertions : FluentAssertions.Primitives.GuidAssertions<FluentAssertions.Primitives.GuidAssertions>
     {
@@ -1808,6 +1833,22 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableEnumAssertions<TEnum> : FluentAssertions.Primitives.NullableEnumAssertions<TEnum, FluentAssertions.Primitives.NullableEnumAssertions<TEnum>>
+        where TEnum :  struct, System.Enum
+    {
+        public NullableEnumAssertions(TEnum? subject) { }
+    }
+    public class NullableEnumAssertions<TEnum, TAssertions> : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
+        where TEnum :  struct, System.Enum
+        where TAssertions : FluentAssertions.Primitives.NullableEnumAssertions<TEnum, TAssertions>
+    {
+        public NullableEnumAssertions(TEnum? subject) { }
+        public TEnum? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
     public class NullableGuidAssertions : FluentAssertions.Primitives.NullableGuidAssertions<FluentAssertions.Primitives.NullableGuidAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -48,7 +48,6 @@ namespace FluentAssertions
         public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
-        public static FluentAssertions.Primitives.EnumAssertions Should(this System.Enum @enum) { }
         public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
@@ -142,6 +141,13 @@ namespace FluentAssertions
     {
         public static FluentAssertions.Data.DataTableAssertions<TDataTable> Should<TDataTable>(this TDataTable actualValue)
             where TDataTable : System.Data.DataTable { }
+    }
+    public static class EnumAssertionsExtensions
+    {
+        public static FluentAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)
+            where TEnum :  struct, System.Enum { }
+        public static FluentAssertions.Primitives.NullableEnumAssertions<TEnum> Should<TEnum>(this TEnum? @enum)
+            where TEnum :  struct, System.Enum { }
     }
     public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
     {
@@ -1341,6 +1347,12 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
+    public class EnumValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public EnumValueFormatter() { }
+        public virtual bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
     public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumerableValueFormatter() { }
@@ -1691,20 +1703,33 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
     }
-    public class EnumAssertions : FluentAssertions.Primitives.EnumAssertions<System.Enum, FluentAssertions.Primitives.EnumAssertions>
+    public class EnumAssertions<TEnum> : FluentAssertions.Primitives.EnumAssertions<TEnum, FluentAssertions.Primitives.EnumAssertions<TEnum>>
+        where TEnum :  struct, System.Enum
     {
-        public EnumAssertions(System.Enum subject) { }
+        public EnumAssertions(TEnum subject) { }
     }
-    public class EnumAssertions<TEnum, TAssertions> : FluentAssertions.Primitives.ObjectAssertions<TEnum, TAssertions>
-        where TEnum : System.Enum
+    public class EnumAssertions<TEnum, TAssertions>
+        where TEnum :  struct, System.Enum
         where TAssertions : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
     {
         public EnumAssertions(TEnum subject) { }
-        protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<TAssertions> HaveFlag<T>(T expectedFlag, string because = "", params object[] becauseArgs)
-            where T :  struct, TEnum { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveFlag<T>(T unexpectedFlag, string because = "", params object[] becauseArgs)
-            where T :  struct, TEnum { }
+        public TEnum Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TEnum expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TEnum? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveFlag(TEnum expectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameNameAs<T>(T expected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameValueAs<T>(T expected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(decimal expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TEnum unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TEnum? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveFlag(TEnum unexpectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameNameAs<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameValueAs<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(decimal unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class GuidAssertions : FluentAssertions.Primitives.GuidAssertions<FluentAssertions.Primitives.GuidAssertions>
     {
@@ -1761,6 +1786,22 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableEnumAssertions<TEnum> : FluentAssertions.Primitives.NullableEnumAssertions<TEnum, FluentAssertions.Primitives.NullableEnumAssertions<TEnum>>
+        where TEnum :  struct, System.Enum
+    {
+        public NullableEnumAssertions(TEnum? subject) { }
+    }
+    public class NullableEnumAssertions<TEnum, TAssertions> : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
+        where TEnum :  struct, System.Enum
+        where TAssertions : FluentAssertions.Primitives.NullableEnumAssertions<TEnum, TAssertions>
+    {
+        public NullableEnumAssertions(TEnum? subject) { }
+        public TEnum? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
     public class NullableGuidAssertions : FluentAssertions.Primitives.NullableGuidAssertions<FluentAssertions.Primitives.NullableGuidAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -49,7 +49,6 @@ namespace FluentAssertions
         public static FluentAssertions.Primitives.NullableDateTimeAssertions Should(this System.DateTime? actualValue) { }
         public static FluentAssertions.Primitives.DateTimeOffsetAssertions Should(this System.DateTimeOffset actualValue) { }
         public static FluentAssertions.Primitives.NullableDateTimeOffsetAssertions Should(this System.DateTimeOffset? actualValue) { }
-        public static FluentAssertions.Primitives.EnumAssertions Should(this System.Enum @enum) { }
         public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
@@ -143,6 +142,13 @@ namespace FluentAssertions
     {
         public static FluentAssertions.Data.DataTableAssertions<TDataTable> Should<TDataTable>(this TDataTable actualValue)
             where TDataTable : System.Data.DataTable { }
+    }
+    public static class EnumAssertionsExtensions
+    {
+        public static FluentAssertions.Primitives.EnumAssertions<TEnum> Should<TEnum>(this TEnum @enum)
+            where TEnum :  struct, System.Enum { }
+        public static FluentAssertions.Primitives.NullableEnumAssertions<TEnum> Should<TEnum>(this TEnum? @enum)
+            where TEnum :  struct, System.Enum { }
     }
     public class EquivalencyStepCollection : System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IEquivalencyStep>, System.Collections.IEnumerable
     {
@@ -1388,6 +1394,12 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
+    public class EnumValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public EnumValueFormatter() { }
+        public virtual bool CanHandle(object value) { }
+        public string Format(object value, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
     public class EnumerableValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public EnumerableValueFormatter() { }
@@ -1738,20 +1750,33 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> After(System.DateTime target, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Before(System.DateTime target, string because = "", params object[] becauseArgs) { }
     }
-    public class EnumAssertions : FluentAssertions.Primitives.EnumAssertions<System.Enum, FluentAssertions.Primitives.EnumAssertions>
+    public class EnumAssertions<TEnum> : FluentAssertions.Primitives.EnumAssertions<TEnum, FluentAssertions.Primitives.EnumAssertions<TEnum>>
+        where TEnum :  struct, System.Enum
     {
-        public EnumAssertions(System.Enum subject) { }
+        public EnumAssertions(TEnum subject) { }
     }
-    public class EnumAssertions<TEnum, TAssertions> : FluentAssertions.Primitives.ObjectAssertions<TEnum, TAssertions>
-        where TEnum : System.Enum
+    public class EnumAssertions<TEnum, TAssertions>
+        where TEnum :  struct, System.Enum
         where TAssertions : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
     {
         public EnumAssertions(TEnum subject) { }
-        protected override string Identifier { get; }
-        public FluentAssertions.AndConstraint<TAssertions> HaveFlag<T>(T expectedFlag, string because = "", params object[] becauseArgs)
-            where T :  struct, TEnum { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveFlag<T>(T unexpectedFlag, string because = "", params object[] becauseArgs)
-            where T :  struct, TEnum { }
+        public TEnum Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TEnum expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> Be(TEnum? expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveFlag(TEnum expectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameNameAs<T>(T expected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameValueAs<T>(T expected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveValue(decimal expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TEnum unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(TEnum? unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveFlag(TEnum unexpectedFlag, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameNameAs<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameValueAs<T>(T unexpected, string because = "", params object[] becauseArgs)
+            where T :  struct, System.Enum { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(decimal unexpected, string because = "", params object[] becauseArgs) { }
     }
     public class GuidAssertions : FluentAssertions.Primitives.GuidAssertions<FluentAssertions.Primitives.GuidAssertions>
     {
@@ -1808,6 +1833,22 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
+    }
+    public class NullableEnumAssertions<TEnum> : FluentAssertions.Primitives.NullableEnumAssertions<TEnum, FluentAssertions.Primitives.NullableEnumAssertions<TEnum>>
+        where TEnum :  struct, System.Enum
+    {
+        public NullableEnumAssertions(TEnum? subject) { }
+    }
+    public class NullableEnumAssertions<TEnum, TAssertions> : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
+        where TEnum :  struct, System.Enum
+        where TAssertions : FluentAssertions.Primitives.NullableEnumAssertions<TEnum, TAssertions>
+    {
+        public NullableEnumAssertions(TEnum? subject) { }
+        public TEnum? Subject { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> HaveValue(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> NotBeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs) { }
     }
     public class NullableGuidAssertions : FluentAssertions.Primitives.NullableGuidAssertions<FluentAssertions.Primitives.NullableGuidAssertions>

--- a/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
@@ -3521,8 +3521,12 @@ namespace FluentAssertions.Specs.Equivalency
         [Fact]
         public void When_asserting_the_same_enum_member_is_equivalent_it_should_succeed()
         {
-            // Arrange / Act
-            Action act = () => EnumOne.One.Should().BeEquivalentTo(EnumOne.One);
+            // Arrange
+            object subject = EnumOne.One;
+            object expectation = EnumOne.One;
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation);
 
             // Assert
             act.Should().NotThrow();
@@ -3575,12 +3579,16 @@ namespace FluentAssertions.Specs.Equivalency
         [Fact]
         public void When_asserting_different_enum_members_are_equivalent_it_should_fail()
         {
-            // Arrange / Act
-            Action act = () => EnumOne.One.Should().BeEquivalentTo(EnumOne.Two);
+            // Arrange
+            object subject = EnumOne.One;
+            object expectation = EnumOne.Two;
+
+            // Act
+            Action act = () => subject.Should().BeEquivalentTo(expectation);
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected *EnumOne.Two(3)*but*EnumOne.One(0)*");
+                .WithMessage("Expected *EnumOne.Two {value: 3}*but*EnumOne.One {value: 0}*");
         }
 
         [Fact]
@@ -3636,7 +3644,7 @@ namespace FluentAssertions.Specs.Equivalency
             Action act = () => subject.Should().BeEquivalentTo(expectation, config => config.ComparingEnumsByName());
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected*to equal EnumFour.Three(3) by name, but found EnumOne.Two(3)*");
+            act.Should().Throw<XunitException>().WithMessage("Expected*to equal EnumFour.Three {value: 3} by name, but found EnumOne.Two {value: 3}*");
         }
 
         [Fact]
@@ -3691,6 +3699,81 @@ namespace FluentAssertions.Specs.Equivalency
         public enum TestEnum
         {
             First = 1
+        }
+
+        [Fact]
+        public void When_subject_is_null_and_enum_has_some_value_it_should_throw()
+        {
+            // Arrange
+            object subject = null;
+            object expectedEnum = EnumULong.UInt64Max;
+
+            // Act
+            // ReSharper disable once ExpressionIsAlwaysNull
+            Action act = () => subject.Should().BeEquivalentTo(expectedEnum, x => x.ComparingEnumsByName(), "comparing enums should throw");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected*to equal EnumULong.UInt64Max {value: 18446744073709551615} by name because comparing enums should throw, but found null*");
+        }
+
+        [Fact]
+        public void When_expectation_is_null_and_subject_enum_has_some_value_it_should_throw_with_a_useful_message()
+        {
+            // Arrange
+            object subjectEnum = EnumULong.UInt64Max;
+            object expected = null;
+
+            // Act
+            // ReSharper disable once ExpressionIsAlwaysNull
+            Action act = () => subjectEnum.Should().BeEquivalentTo(expected, x => x.ComparingEnumsByName(), "comparing enums should throw");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected*to be <null> because comparing enums should throw, but found EnumULong.UInt64Max*");
+        }
+
+        [Fact]
+        public void When_both_enums_are_equal_and_greater_than_max_long_it_should_not_throw()
+        {
+            // Arrange
+            object enumOne = EnumULong.UInt64Max;
+            object enumTwo = EnumULong.UInt64Max;
+
+            // Act
+            Action act = () => enumOne.Should().BeEquivalentTo(enumTwo);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_both_enums_are_equal_and_of_different_underlying_types_it_should_not_throw()
+        {
+            // Arrange
+            object enumOne = EnumLong.Int64Max;
+            object enumTwo = EnumULong.Int64Max;
+
+            // Act
+            Action act = () => enumOne.Should().BeEquivalentTo(enumTwo);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_both_enums_are_large_and_not_equal_it_should_throw()
+        {
+            // Arrange
+            object subjectEnum = EnumLong.Int64LessOne;
+            object expectedEnum = EnumULong.UInt64Max;
+
+            // Act
+            Action act = () => subjectEnum.Should().BeEquivalentTo(expectedEnum, "comparing enums should throw");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected subjectEnum*to equal EnumULong.UInt64Max {value: 18446744073709551615} by value because comparing enums should throw, but found EnumLong.Int64LessOne {value: 9223372036854775806}*");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
@@ -3676,7 +3676,7 @@ namespace FluentAssertions.Specs.Equivalency
         }
 
         [Fact]
-        public void When_a_numeric_member_is_compared_with_an_enum_it_should_respect_the_enum_options()
+        public void When_a_numeric_member_is_compared_with_an_enum_it_should_throw()
         {
             // Arrange
             var actual = new
@@ -3693,7 +3693,91 @@ namespace FluentAssertions.Specs.Equivalency
             Action act = () => actual.Should().BeEquivalentTo(expected, options => options.ComparingEnumsByValue());
 
             // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_a_string_member_is_compared_with_an_enum_it_should_throw()
+        {
+            // Arrange
+            var actual = new
+            {
+                Property = "First"
+            };
+
+            var expected = new
+            {
+                Property = TestEnum.First
+            };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected, options => options.ComparingEnumsByName());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_null_enum_members_are_compared_by_name_it_should_succeed()
+        {
+            // Arrange
+            var actual = new
+            {
+                Property = null as TestEnum?
+            };
+
+            var expected = new
+            {
+                Property = null as TestEnum?
+            };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected, options => options.ComparingEnumsByName());
+
+            // Assert
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_null_enum_members_are_compared_by_value_it_should_succeed()
+        {
+            // Arrange
+            var actual = new
+            {
+                Property = null as TestEnum?
+            };
+
+            var expected = new
+            {
+                Property = null as TestEnum?
+            };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected, options => options.ComparingEnumsByValue());
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_zero_and_null_enum_are_compared_by_value_it_should_throw()
+        {
+            // Arrange
+            var actual = new
+            {
+                Property = (TestEnum)0
+            };
+
+            var expected = new
+            {
+                Property = null as TestEnum?
+            };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected, options => options.ComparingEnumsByValue());
+
+            // Assert
+            act.Should().Throw<XunitException>();
         }
 
         public enum TestEnum
@@ -3714,7 +3798,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*to equal EnumULong.UInt64Max {value: 18446744073709551615} by name because comparing enums should throw, but found null*");
+                .WithMessage("Expected*to be equivalent to EnumULong.UInt64Max {value: 18446744073709551615} because comparing enums should throw, but found <null>*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/EnumAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/EnumAssertionSpecs.cs
@@ -32,30 +32,7 @@ namespace FluentAssertions.Specs.Primitives
         }
 
         [Fact]
-        public void When_a_nullable_enum_has_the_expected_flag_it_should_succeed()
-        {
-            // Arrange
-            TestEnum? someObject = TestEnum.One | TestEnum.Two;
-
-            // Act / Assert
-            someObject.Should().HaveFlag(TestEnum.Two);
-        }
-
-        [Fact]
-        public void When_enum_is_null_it_should_fail_with_a_descriptive_message()
-        {
-            // Arrange
-            Enum someObject = null;
-
-            // Act
-            Action act = () => someObject.Should().HaveFlag(TestEnum.Three);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected*type*but found <null>*");
-        }
-
-        [Fact]
-        public void When_nullable_enum_is_null_it_should_fail_with_a_descriptive_message()
+        public void When_null_enum_does_not_have_the_expected_flag_it_should_fail()
         {
             // Arrange
             TestEnum? someObject = null;
@@ -64,7 +41,7 @@ namespace FluentAssertions.Specs.Primitives
             Action act = () => someObject.Should().HaveFlag(TestEnum.Three);
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected*type*but found <null>*");
+            act.Should().Throw<XunitException>();
         }
 
         [Fact]
@@ -74,10 +51,11 @@ namespace FluentAssertions.Specs.Primitives
             TestEnum someObject = TestEnum.One | TestEnum.Two;
 
             // Act
-            Action act = () => someObject.Should().HaveFlag(TestEnum.Three);
+            Action act = () => someObject.Should().HaveFlag(TestEnum.Three, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("The enum was expected to have flag Three but found One, Two.");
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected*have flag TestEnum.Three {value: 4}*because we want to test the failure message*but found TestEnum.One|Two {value: 3}.");
         }
 
         [Fact]
@@ -97,27 +75,15 @@ namespace FluentAssertions.Specs.Primitives
             TestEnum someObject = TestEnum.One | TestEnum.Two;
 
             // Act
-            Action act = () => someObject.Should().NotHaveFlag(TestEnum.Two);
+            Action act = () => someObject.Should().NotHaveFlag(TestEnum.Two, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Did not expect the enum to have flag Two.");
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the enum to not have flag TestEnum.Two {value: 2}*because we want to test the failure message*");
         }
 
         [Fact]
-        public void When_enum_should_not_have_flag_but_is_null_it_should_fail_with_a_descriptive_message()
-        {
-            // Arrange
-            Enum someObject = null;
-
-            // Act
-            Action act = () => someObject.Should().NotHaveFlag(TestEnum.Three);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected*type*but found <null>*");
-        }
-
-        [Fact]
-        public void When_nullable_enum_should_not_have_flag_but_is_null_it_should_fail_with_a_descriptive_message()
+        public void When_null_enum_does_not_have_the_expected_flag_it_should_not_fail()
         {
             // Arrange
             TestEnum? someObject = null;
@@ -126,7 +92,7 @@ namespace FluentAssertions.Specs.Primitives
             Action act = () => someObject.Should().NotHaveFlag(TestEnum.Three);
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Expected*type*but found <null>*");
+            act.Should().NotThrow();
         }
 
         [Flags]
@@ -148,414 +114,586 @@ namespace FluentAssertions.Specs.Primitives
 
         #endregion
 
-        #region BeEquivalentTo
+        #region Be / NotBe
 
         [Fact]
-        public void When_both_enums_are_equal_and_greater_than_max_long_it_should_not_throw()
+        public void When_enums_are_equal_it_should_succeed()
         {
             // Arrange
-            var enumOne = EnumULong.UInt64Max;
-            var enumTwo = EnumULong.UInt64Max;
+            MyEnum subject = MyEnum.One;
+            MyEnum expected = MyEnum.One;
 
             // Act
-            Action act = () => enumOne.Should().BeEquivalentTo(enumTwo);
+            Action act = () => subject.Should().Be(expected);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(MyEnum.One, MyEnum.One)]
+        public void When_nullable_enums_are_equal_it_should_succeed(MyEnum? subject, MyEnum? expected)
+        {
+            // Act
+            Action act = () => subject.Should().Be(expected);
 
             // Assert
             act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_both_enums_are_equal_and_of_different_underlying_types_it_should_not_throw()
+        public void When_a_null_enum_and_an_enum_are_unequal_it_should_throw()
         {
             // Arrange
-            var enumOne = EnumLong.Int64Max;
-            var enumTwo = EnumULong.Int64Max;
+            MyEnum? subject = null;
+            MyEnum expected = MyEnum.Two;
 
             // Act
-            Action act = () => enumOne.Should().BeEquivalentTo(enumTwo);
+            Action act = () => subject.Should().Be(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_enums_are_unequal_it_should_throw()
+        {
+            // Arrange
+            MyEnum subject = MyEnum.One;
+            MyEnum expected = MyEnum.Two;
+
+            // Act
+            Action act = () => subject.Should().Be(expected, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
+        }
+
+        [Theory]
+        [InlineData(null, MyEnum.One)]
+        [InlineData(MyEnum.One, null)]
+        [InlineData(MyEnum.One, MyEnum.Two)]
+        public void When_nullable_enums_are_equal_it_should_throw(MyEnum? subject, MyEnum? expected)
+        {
+            // Act
+            Action act = () => subject.Should().Be(expected, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
+        }
+
+        [Fact]
+        public void When_enums_are_unequal_it_should_succeed()
+        {
+            // Arrange
+            MyEnum subject = MyEnum.One;
+            MyEnum expected = MyEnum.Two;
+
+            // Act
+            Action act = () => subject.Should().NotBe(expected);
 
             // Assert
             act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_both_enums_are_large_and_not_equal_it_should_throw()
+        public void When_a_null_enum_and_an_enum_are_unequal_it_should_succeed()
         {
             // Arrange
-            var subjectEnum = EnumLong.Int64LessOne;
-            var expectedEnum = EnumULong.UInt64Max;
+            MyEnum? subject = null;
+            MyEnum expected = MyEnum.Two;
 
             // Act
-            Action act = () => subjectEnum.Should().BeEquivalentTo(expectedEnum, "comparing enums should throw");
+            Action act = () => subject.Should().NotBe(expected);
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage($"Expected subjectEnum*to equal EnumULong.UInt64Max({(ulong)EnumULong.UInt64Max}) by value because comparing enums should throw, but found EnumLong.Int64LessOne({(long)EnumLong.Int64LessOne})*");
+            act.Should().NotThrow();
+        }
+
+        [Theory]
+        [InlineData(null, MyEnum.One)]
+        [InlineData(MyEnum.One, null)]
+        [InlineData(MyEnum.One, MyEnum.Two)]
+        public void When_nullable_enums_are_unequal_it_should_succeed(MyEnum? subject, MyEnum? expected)
+        {
+            // Act
+            Action act = () => subject.Should().NotBe(expected);
+
+            // Assert
+            act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_subject_is_null_and_enum_has_some_value_it_should_throw()
+        public void When_enums_are_equal_it_should_throw()
         {
             // Arrange
-            object subject = null;
-            object expectedEnum = EnumULong.UInt64Max;
+            MyEnum subject = MyEnum.One;
+            MyEnum expected = MyEnum.One;
 
             // Act
-            // ReSharper disable once ExpressionIsAlwaysNull
-            Action act = () => subject.Should().BeEquivalentTo(expectedEnum, x => x.ComparingEnumsByName(), "comparing enums should throw");
+            Action act = () => subject.Should().NotBe(expected, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"Expected*to equal EnumULong.UInt64Max({(ulong)EnumULong.UInt64Max}) by name because comparing enums should throw, but found null*");
+                .WithMessage("*because we want to test the failure message*");
         }
 
-        [Fact]
-        public void When_expectation_is_null_and_subject_enum_has_some_value_it_should_throw_with_a_useful_message()
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(MyEnum.One, MyEnum.One)]
+        public void When_nullable_enums_are_unequal_it_should_throw(MyEnum? subject, MyEnum? expected)
         {
-            // Arrange
-            object subjectEnum = EnumULong.UInt64Max;
-            object expected = null;
-
             // Act
-            // ReSharper disable once ExpressionIsAlwaysNull
-            Action act = () => subjectEnum.Should().BeEquivalentTo(expected, x => x.ComparingEnumsByName(), "comparing enums should throw");
+            Action act = () => subject.Should().NotBe(expected, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*to be <null> because comparing enums should throw, but found UInt64Max*");
+                .WithMessage("*because we want to test the failure message*");
+        }
+
+        public enum MyEnum
+        {
+            One = 1,
+            Two = 2
         }
 
         #endregion
 
-        #region Be / NotBe
+        #region HaveValue / NotHaveValue
 
         [Fact]
-        public void When_comparing_a_null_enum_against_a_null_enum_for_equality_it_should_succeed()
+        public void When_enum_has_the_expected_value_it_should_succeed()
         {
             // Arrange
-            MyEnum? subject = null;
-            MyEnum? expected = null;
+            TestEnum someObject = TestEnum.One;
+
+            // Act / Assert
+            someObject.Should().HaveValue(1);
+        }
+
+        [Fact]
+        public void When_null_enum_does_not_have_the_expected_value_it_should_fail()
+        {
+            // Arrange
+            TestEnum? someObject = null;
 
             // Act
-            Action act = () => subject.Should().Be(expected);
+            Action act = () => someObject.Should().HaveValue(3);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_enum_does_not_have_specified_value_it_should_fail_with_a_descriptive_message()
+        {
+            // Arrange
+            TestEnum someObject = TestEnum.One;
+
+            // Act
+            Action act = () => someObject.Should().HaveValue(3, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected*have value 3*because we want to test the failure message*but found*");
+        }
+
+        [Fact]
+        public void When_enum_does_not_have_the_unexpected_value_it_should_succeed()
+        {
+            // Arrange
+            TestEnum someObject = TestEnum.One;
+
+            // Act / Assert
+            someObject.Should().NotHaveValue(3);
+        }
+
+        [Fact]
+        public void When_enum_does_have_specified_value_it_should_fail_with_a_descriptive_message()
+        {
+            // Arrange
+            TestEnum someObject = TestEnum.One;
+
+            // Act
+            Action act = () => someObject.Should().NotHaveValue(1, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the enum to not have value 1*because we want to test the failure message*");
+        }
+
+        [Fact]
+        public void When_null_enum_does_not_have_the_expected_value_it_should_not_fail()
+        {
+            // Arrange
+            TestEnum? someObject = null;
+
+            // Act
+            Action act = () => someObject.Should().NotHaveValue(3);
 
             // Assert
             act.Should().NotThrow();
         }
 
-        [Fact]
-        public void When_comparing_a_nullable_enum_against_an_enum_for_equality_it_should_succeed()
-        {
-            // Arrange
-            MyEnum? subject = MyEnum.One;
-            MyEnum expected = MyEnum.One;
+        #endregion
 
-            // Act
-            Action act = () => subject.Should().Be(expected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
+        #region HaveSameValueAs / NotHaveSameValueAs
 
         [Fact]
-        public void When_comparing_an_enum_against_a_nullable_enum_for_equality_it_should_succeed()
+        public void When_enums_have_equal_values_it_should_succeed()
         {
             // Arrange
             MyEnum subject = MyEnum.One;
-            MyEnum? expected = MyEnum.One;
+            MyEnumOtherName expected = MyEnumOtherName.OtherOne;
 
             // Act
-            Action act = () => subject.Should().Be(expected);
+            Action act = () => subject.Should().HaveSameValueAs(expected);
 
             // Assert
             act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_comparing_a_nullable_enum_against_a_nullable_enum_for_equality_it_should_succeed()
+        public void When_nullable_enums_have_equal_values_it_should_succeed()
         {
             // Arrange
             MyEnum? subject = MyEnum.One;
-            MyEnum? expected = MyEnum.One;
+            MyEnumOtherName expected = MyEnumOtherName.OtherOne;
 
             // Act
-            Action act = () => subject.Should().Be(expected);
+            Action act = () => subject.Should().HaveSameValueAs(expected);
 
             // Assert
             act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_comparing_a_nullable_enum_against_an_enum_for_equality_it_should_throw()
-        {
-            // Arrange
-            MyEnum? subject = MyEnum.One;
-            MyEnum expected = MyEnum.Two;
-
-            // Act
-            Action act = () => subject.Should().Be(expected);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_comparing_an_enum_against_a_nullable_enum_for_equality_it_should_throw()
+        public void When_enums_have_equal_values_it_should_throw()
         {
             // Arrange
             MyEnum subject = MyEnum.One;
-            MyEnum? expected = MyEnum.Two;
+            MyEnumOtherName expected = MyEnumOtherName.OtherTwo;
 
             // Act
-            Action act = () => subject.Should().Be(expected);
+            Action act = () => subject.Should().HaveSameValueAs(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
         }
 
-        [Fact]
-        public void When_comparing_a_nullable_enum_against_a_nullable_enum_for_equality_it_should_throw()
+        [Theory]
+        [InlineData(null, MyEnumOtherName.OtherOne)]
+        [InlineData(MyEnum.One, MyEnumOtherName.OtherTwo)]
+        public void When_nullable_enums_have_equal_values_it_should_throw(MyEnum? subject, MyEnumOtherName expected)
         {
-            // Arrange
-            MyEnum? subject = MyEnum.One;
-            MyEnum? expected = MyEnum.Two;
-
             // Act
-            Action act = () => subject.Should().Be(expected);
+            Action act = () => subject.Should().HaveSameValueAs(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
         }
 
         [Fact]
-        public void When_comparing_a_null_enum_against_a_nullable_enum_for_equality_it_should_throw()
-        {
-            // Arrange
-            MyEnum? subject = null;
-            MyEnum? expected = MyEnum.Two;
-
-            // Act
-            Action act = () => subject.Should().Be(expected);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_comparing_a_null_enum_against_an_enum_for_equality_it_should_throw()
-        {
-            // Arrange
-            MyEnum? subject = null;
-            MyEnum expected = MyEnum.Two;
-
-            // Act
-            Action act = () => subject.Should().Be(expected);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_comparing_a_nullable_enum_against_a_null_enum_for_equality_it_should_throw()
-        {
-            // Arrange
-            MyEnum? subject = MyEnum.One;
-            MyEnum? expected = null;
-
-            // Act
-            Action act = () => subject.Should().Be(expected);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_comparing_an_enum_against_a_null_enum_for_equality_it_should_throw()
+        public void When_enum_have_unequal_values_it_should_succeed()
         {
             // Arrange
             MyEnum subject = MyEnum.One;
-            MyEnum? expected = null;
+            MyEnumOtherName expected = MyEnumOtherName.OtherTwo;
 
             // Act
-            Action act = () => subject.Should().Be(expected);
+            Action act = () => subject.Should().NotHaveSameValueAs(expected);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().NotThrow();
         }
 
-        [Fact]
-        public void When_comparing_a_null_enum_against_a_null_enum_for_inequality_it_should_throw()
+        [Theory]
+        [InlineData(null, MyEnumOtherName.OtherOne)]
+        [InlineData(MyEnum.One, MyEnumOtherName.OtherTwo)]
+        public void When_nullable_enums_have_unequal_values_it_should_succeed(MyEnum? subject, MyEnumOtherName expected)
         {
-            // Arrange
-            MyEnum? subject = null;
-            MyEnum? expected = null;
-
             // Act
-            Action act = () => subject.Should().NotBe(expected);
+            Action act = () => subject.Should().NotHaveSameValueAs(expected);
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_comparing_a_nullable_enum_against_an_enum_for_inequality_it_should_throw()
-        {
-            // Arrange
-            MyEnum? subject = MyEnum.One;
-            MyEnum expected = MyEnum.One;
-
-            // Act
-            Action act = () => subject.Should().NotBe(expected);
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_comparing_an_enum_against_a_nullable_enum_for_inequality_it_should_throww()
+        public void When_enums_have_unequal_values_it_should_throw()
         {
             // Arrange
             MyEnum subject = MyEnum.One;
-            MyEnum? expected = MyEnum.One;
+            MyEnumOtherName expected = MyEnumOtherName.OtherOne;
 
             // Act
-            Action act = () => subject.Should().NotBe(expected);
+            Action act = () => subject.Should().NotHaveSameValueAs(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
         }
 
         [Fact]
-        public void When_comparing_a_nullable_enum_against_a_nullable_enum_for_inequality_it_should_throw()
+        public void When_nullable_enums_have_unequal_values_it_should_throw()
         {
             // Arrange
             MyEnum? subject = MyEnum.One;
-            MyEnum? expected = MyEnum.One;
+            MyEnumOtherName expected = MyEnumOtherName.OtherOne;
 
             // Act
-            Action act = () => subject.Should().NotBe(expected);
+            Action act = () => subject.Should().NotHaveSameValueAs(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
         }
 
-        [Fact]
-        public void When_comparing_a_nullable_enum_against_an_enum_for_inequality_it_should_succeed()
+        public enum MyEnumOtherName
         {
-            // Arrange
-            MyEnum? subject = MyEnum.One;
-            MyEnum expected = MyEnum.Two;
-
-            // Act
-            Action act = () => subject.Should().NotBe(expected);
-
-            // Assert
-            act.Should().NotThrow();
+            OtherOne = 1,
+            OtherTwo = 2
         }
 
+        #endregion
+
+        #region HaveSameNameAs / NotHaveSameNameAs
+
         [Fact]
-        public void When_comparing_an_enum_against_a_nullable_enum_for_inequality_it_should_succeed()
+        public void When_enums_have_equal_names_it_should_succeed()
         {
             // Arrange
             MyEnum subject = MyEnum.One;
-            MyEnum? expected = MyEnum.Two;
+            MyEnumOtherValue expected = MyEnumOtherValue.One;
 
             // Act
-            Action act = () => subject.Should().NotBe(expected);
+            Action act = () => subject.Should().HaveSameNameAs(expected);
 
             // Assert
             act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_comparing_a_nullable_enum_against_a_nullable_enum_for_inequality_it_should_succeed()
+        public void When_nullable_enums_have_equal_names_it_should_succeed()
         {
             // Arrange
             MyEnum? subject = MyEnum.One;
-            MyEnum? expected = MyEnum.Two;
+            MyEnumOtherValue expected = MyEnumOtherValue.One;
 
             // Act
-            Action act = () => subject.Should().NotBe(expected);
+            Action act = () => subject.Should().HaveSameNameAs(expected);
 
             // Assert
             act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_comparing_a_null_enum_against_a_nullable_enum_for_inequality_it_should_succeed()
-        {
-            // Arrange
-            MyEnum? subject = null;
-            MyEnum? expected = MyEnum.Two;
-
-            // Act
-            Action act = () => subject.Should().NotBe(expected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_comparing_a_null_enum_against_an_enum_for_inequality_it_should_succeed()
-        {
-            // Arrange
-            MyEnum? subject = null;
-            MyEnum expected = MyEnum.Two;
-
-            // Act
-            Action act = () => subject.Should().NotBe(expected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_comparing_a_nullable_enum_against_a_null_enum_for_inequality_it_should_succeed()
-        {
-            // Arrange
-            MyEnum? subject = MyEnum.One;
-            MyEnum? expected = null;
-
-            // Act
-            Action act = () => subject.Should().NotBe(expected);
-
-            // Assert
-            act.Should().NotThrow();
-        }
-
-        [Fact]
-        public void When_comparing_an_enum_against_a_null_enum_for_inequality_it_should_succeed()
+        public void When_enums_have_equal_names_it_should_throw()
         {
             // Arrange
             MyEnum subject = MyEnum.One;
-            MyEnum? expected = null;
+            MyEnumOtherValue expected = MyEnumOtherValue.Two;
 
             // Act
-            Action act = () => subject.Should().NotBe(expected);
+            Action act = () => subject.Should().HaveSameNameAs(expected, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().NotThrow();
+            act.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
         }
 
-        // TODO: should probably fail in 6.0, see #1204
+        [Theory]
+        [InlineData(null, MyEnumOtherValue.One)]
+        [InlineData(MyEnum.One, MyEnumOtherValue.Two)]
+        public void When_nullable_enums_have_equal_names_it_should_throw(MyEnum? subject, MyEnumOtherValue expected)
+        {
+            // Act
+            Action act = () => subject.Should().HaveSameNameAs(expected, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
+        }
+
         [Fact]
-        public void When_comparing_a_numeric_and_an_enum_for_equality_it_should_not_throw()
+        public void When_senum_have_unequal_names_it_should_succeed()
         {
             // Arrange
-            object subject = 1;
-            MyEnum expected = MyEnum.One;
+            MyEnum subject = MyEnum.One;
+            MyEnumOtherValue expected = MyEnumOtherValue.Two;
 
             // Act
-            Action act = () => subject.Should().Be(expected);
+            Action act = () => subject.Should().NotHaveSameNameAs(expected);
 
             // Assert
             act.Should().NotThrow();
         }
 
-        private enum MyEnum
+        [Theory]
+        [InlineData(null, MyEnumOtherValue.One)]
+        [InlineData(MyEnum.One, MyEnumOtherValue.Two)]
+        public void When_nullable_enums_have_unequal_names_it_should_succeed(MyEnum? subject, MyEnumOtherValue expected)
         {
-            One = 1,
-            Two = 2
+            // Act
+            Action act = () => subject.Should().NotHaveSameNameAs(expected);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_enums_have_unequal_names_it_should_throw()
+        {
+            // Arrange
+            MyEnum subject = MyEnum.One;
+            MyEnumOtherValue expected = MyEnumOtherValue.One;
+
+            // Act
+            Action act = () => subject.Should().NotHaveSameNameAs(expected, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
+        }
+
+        [Fact]
+        public void When_nullable_enums_have_unequal_names_it_should_throw()
+        {
+            // Arrange
+            MyEnum? subject = MyEnum.One;
+            MyEnumOtherValue expected = MyEnumOtherValue.One;
+
+            // Act
+            Action act = () => subject.Should().NotHaveSameNameAs(expected, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
+        }
+
+        public enum MyEnumOtherValue
+        {
+            One = 11,
+            Two = 22
+        }
+
+        #endregion
+
+        #region BeNull / NotBeNull
+
+        [Fact]
+        public void When_nullable_enum_has_value_it_should_be_chainable()
+        {
+            // Arrange
+            MyEnum? subject = MyEnum.One;
+
+            // Act
+            Action act = () => subject.Should().HaveValue()
+                .Which.Should().Be(MyEnum.One);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_nullable_enum_is_not_null_it_should_be_chainable()
+        {
+            // Arrange
+            MyEnum? subject = MyEnum.One;
+
+            // Act
+            Action act = () => subject.Should().NotBeNull()
+                .Which.Should().Be(MyEnum.One);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_nullable_enum_does_not_have_value_it_should_throw()
+        {
+            // Arrange
+            MyEnum? subject = null;
+
+            // Act
+            Action act = () => subject.Should().HaveValue("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
+        }
+
+        [Fact]
+        public void When_nullable_enum_is_null_it_should_throw()
+        {
+            // Arrange
+            MyEnum? subject = null;
+
+            // Act
+            Action act = () => subject.Should().NotBeNull("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
+        }
+
+        [Fact]
+        public void When_nullable_enum_does_not_have_value_it_should_succeed()
+        {
+            // Arrange
+            MyEnum? subject = null;
+
+            // Act
+            Action act = () => subject.Should().NotHaveValue();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_nullable_enum_is_null_it_should_succeed()
+        {
+            // Arrange
+            MyEnum? subject = null;
+
+            // Act
+            Action act = () => subject.Should().BeNull();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_nullable_enum_has_value_it_should_throw()
+        {
+            // Arrange
+            MyEnum? subject = MyEnum.One;
+
+            // Act
+            Action act = () => subject.Should().NotHaveValue("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
+        }
+
+        [Fact]
+        public void When_nullable_enum_is_not_null_it_should_throw()
+        {
+            // Arrange
+            MyEnum? subject = MyEnum.One;
+
+            // Act
+            Action act = () => subject.Should().BeNull("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*because we want to test the failure message*");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -128,6 +128,26 @@ namespace FluentAssertions.Specs.Primitives
                 "because we want to test the failure message.");
         }
 
+        [Fact]
+        public void When_comparing_a_numeric_and_an_enum_for_equality_it_should_throw()
+        {
+            // Arrange
+            object subject = 1;
+            MyEnum expected = MyEnum.One;
+
+            // Act
+            Action act = () => subject.Should().Be(expected);
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        private enum MyEnum
+        {
+            One = 1,
+            Two = 2
+        }
+
         #endregion
 
         #region BeNull / BeNotNull

--- a/docs/_pages/basicassertions.md
+++ b/docs/_pages/basicassertions.md
@@ -76,10 +76,3 @@ Internally, `BeBinarySerializable` uses the [Object graph comparison](#object-gr
 theObject.Should().BeBinarySerializable<MyClass>(
     options => options.Excluding(s => s.SomeNonSerializableProperty));
 ```
-
-Fluent Assertions has special support for `[Flags]` based enumerations, which allow you to do something like this:
-
-```csharp
-regexOptions.Should().HaveFlag(RegexOptions.Global);
-regexOptions.Should().NotHaveFlag(RegexOptions.CaseInsensitive);
-```

--- a/docs/_pages/enums.md
+++ b/docs/_pages/enums.md
@@ -8,5 +8,37 @@ sidebar:
 ---
 
 ## Enums ##
-With the standard `Should().Be()` method, Enums are compared using .NET's `Enum.Equals()` implementation.
-This means that the Enums must be of the same type, and have the same underlying value.
+
+Fluent Assertions have several ways to compare enums.
+
+The basic ones, `Be` and `HaveFlag`, just calls directly into `Enum.Equals` and `Enum.HasFlag`.
+
+```csharp
+enum MyEnum { One = 1, Two = 2}
+
+enum.Should().Be(MyEnum.One);
+enum.Should().NotBe(MyEnum.Two);
+
+regexOptions.Should().HaveFlag(RegexOptions.Global);
+regexOptions.Should().NotHaveFlag(RegexOptions.CaseInsensitive);
+```
+
+If you want to compare enums of different types, you can use `HaveSameValueAs` or `HaveSameNameAs` depending on how _you_ define equality for different enums.
+
+```csharp
+enum SameNameEnum { One = 11 }
+enum SameValueEnum { OneOne = 1 }
+
+MyEnum.One.Should().HaveSameNameAs(SameNameEnum.One)
+MyEnum.One.Should().HaveSameValueAs(SameValueEnum.OneOne)
+
+MyEnum.One.Should().NotHaveSameNameAs(SameValueEnum.OneOne)
+MyEnum.One.Should().NotHaveSameValueAs(SameNameEnum.One)
+```
+
+Lastly, if you want to verify than an enum has a specific integral value, you can use `HaveValue`.
+
+```csharp
+MyEnum.One.Should().HaveValue(1);
+MyEnum.One.Should().NotHaveValue(2);
+```

--- a/docs/_pages/objectgraphs.md
+++ b/docs/_pages/objectgraphs.md
@@ -183,6 +183,9 @@ An option to compare an `Enum` only by name is also available, using the followi
 orderDto.Should().BeEquivalentTo(expectation, options => options.ComparingEnumsByName());
 ```
 
+Note that even though an enum's underlying value equals a numeric value or the enum's name equals some string value, we do not consider those to be equivalent.
+In other words, enums are only considered to be equivalent to enums of the same or another type, but you can control whether they should equal by name or by value.
+
 ### Collections and Dictionaries ###
 Considering our running example, you could use the following against a collection of `OrderDto`s: 
 

--- a/docs/_pages/objectgraphs.md
+++ b/docs/_pages/objectgraphs.md
@@ -300,7 +300,7 @@ For instance, to always compare enumerations by name, use the following statemen
 
 ```csharp
 AssertionOptions.AssertEquivalencyUsing(options => 
-   options.ComparingEnumsByValue);
+   options.ComparingEnumsByName);
 ``` 
 
 All the options available to an individual call to `Should().BeEquivalentTo` are supported, with the exception of some of the overloads that are specific to the type of the subject (for obvious reasons).

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 **What's New**
 * Added `WithParameterName` extension to ease asserting on the parameter name for a thrown `ArgumentException` - [#1466](https://github.com/fluentassertions/fluentassertions/pull/1466).
 * Added `NotCompleteWithinAsync` to `TaskCompletionSourceAssertions` - [#1474](https://github.com/fluentassertions/fluentassertions/pull/1474).
+* Added `HaveValue(decimal)`, `HaveSameValueAs` and `HaveSameNameAs` to `EnumAssertions` - [#1479](https://github.com/fluentassertions/fluentassertions/pull/1479).
 
 **Fixes**
 * Sometimes `BeEquivalentTo` reported an incorrect message when a dictionary was missing a key - [#1454](https://github.com/fluentassertions/fluentassertions/pull/1454)
@@ -19,6 +20,7 @@ sidebar:
 
 **Breaking Changes**
 * Changed `becauseArgs` of `[Not]Reference(Assembly)` from `string[]` to `object[]` - [#1459](https://github.com/fluentassertions/fluentassertions/pull/1459)
+* Major overhaul on how enums are handled, see the [Migration Guide](/upgradingtov6) for more details - [#1479](https://github.com/fluentassertions/fluentassertions/pull/1479).
 
 **Breaking Changes (Extensibility)**
 * Pascal cased `CallerIdentifier.logger` - [#1458](https://github.com/fluentassertions/fluentassertions/pull/1458).

--- a/docs/_pages/upgradingtov6.md
+++ b/docs/_pages/upgradingtov6.md
@@ -7,3 +7,49 @@ sidebar:
   nav: "sidebar"
 ---
 
+## Enums ##
+
+In Fluent Assertions v5 enums were handled by the `ObjectAssertions` class, which is what you have in hand when invoking `Should()` on any type not handled by a specialized overload of `Should()`.
+`ObjectAssertions` derives from `ReferenceTypeAssertions`, so all these assertions were available when asserting on an enum.
+
+* `[Not]Be(object)`
+* `[Not]BeEquivalentTo<T>(T)`
+* `[Not]BeNull()`
+* `[Not]BeSameAs(object)`
+* `[Not]BeOfType<T>()`
+* `[Not]BeOfType(Type)`
+* `[Not]BeAssignableTo<T>()`
+* `[Not]BeAssignableTo(Type)`
+* `Match(Func<object, bool>)`
+* `Match<T>(Func<T, bool>)`
+* `[Not]HaveFlag(Enum)`
+
+This design had several downsides.
+
+A lot, if not most, of the assertions listed above are irrelevant for enums.
+Conversely, `HaveFlag` is only relevant for enums, but it was always available even though your object was not an enum.
+We wanted to introduce new enum specific assertions, but adding those would be even more auto-complete noise for non enums.
+`HaveFlag` was written long before the enum type constraint was introduced i C# 7.3, so checking whether the subject and expectation was the same of enum was performed on runtime instead of compile-time.
+
+`Be` has some workarounds to ensure that a boxed `1` and boxed `1.0` are considered to be equal.
+This approach did not work well for enums as it would consider two enums to be equal if their underlying integral values are equal.
+To put it in code, in the snippet below all four assertions would pass, but only the first one should.
+```c#
+public enum MyEnum { One = 1 }
+public enum MyOtherEnum { One = 1 }
+
+MyEnum.One.Should().Be(MyEnum.One);
+
+MyEnum.One.Should().Be(MyOtherEnum.One);
+MyEnum.One.Should().Be(1);
+1.As<object>().Should().Be(MyOtherEnum.One);
+```
+
+In Fluent Assertions v6 enums are now handled by `EnumAssertions` which should cover the same use cases and even more, but without the old bugs and unexpected surprises.
+Technically nullable enums are handled by `NullableEnumAssertions` which in addition to the assertions mentioned below have `[Not]BeNull` and `[Not]HaveValue`.
+`Be` and `HaveFlag` now calls directly into `Enum.Equals` and `Enum.HasFlag`, as you would expect, and any try to compare an enum with another type of enum or integer leads to a compilation error.
+If you want to compare two enums of different types, you can use `HaveSameValueAs` or `HaveSameNameAs` depending on how _you_ define equality for different enums.
+Lastly, if you want to verify than an enum has a specific integral value, you can use `HaveValue`.
+
+If your assertions rely on the formatting of enums in failure messages, you'll notice that we have given it a facelift.
+Previously, formatting an enum would simply be a call to `ToString()`, but to provide more detail we now format `MyEnum.One` as `"MyEnum.One(1)"` instead of `"One"`.

--- a/docs/_pages/upgradingtov6.md
+++ b/docs/_pages/upgradingtov6.md
@@ -51,5 +51,18 @@ Technically nullable enums are handled by `NullableEnumAssertions` which in addi
 If you want to compare two enums of different types, you can use `HaveSameValueAs` or `HaveSameNameAs` depending on how _you_ define equality for different enums.
 Lastly, if you want to verify than an enum has a specific integral value, you can use `HaveValue`.
 
+When comparing object graphs with enum members, we have constrained when we consider them to be equivalent.
+An enum is now only considered to be equivalent to an enum of the same of another type, but you can control whether they should equal by name or by value.
+The practical implications are that the following examples now fails.
+```cs
+var subject = new { Value = "One" };
+var expectation = new { Value = MyOtherEnum.One };
+subject.Should().BeEquivalentTo(expectation,  opt => opt.ComparingEnumsByName());
+
+var subject = new { Value = 1 };
+var expectation = new { Value = MyOtherEnum.One };
+subject.Should().BeEquivalentTo(expectation,  opt => opt.ComparingEnumsByValue());
+```
+
 If your assertions rely on the formatting of enums in failure messages, you'll notice that we have given it a facelift.
 Previously, formatting an enum would simply be a call to `ToString()`, but to provide more detail we now format `MyEnum.One` as `"MyEnum.One(1)"` instead of `"One"`.


### PR DESCRIPTION
New `EnumAssertions` to follow up #1375 and to solve #1204

`Be()` now expects an expectation of the same type of enum, which was an issue that gave false negatives, e.g. #1403.

More lightweight/relevant IntelliSense as it doesn't inherit assertion methods from `ReferenceAssertions`.

Before:
![image](https://user-images.githubusercontent.com/919634/105574005-de6f9e80-5d61-11eb-930f-858fe0825b0c.png)

After:
![image](https://user-images.githubusercontent.com/919634/105573984-b718d180-5d61-11eb-9365-29679fa56264.png)

I've excluded `[Not]BeEquivalentTo(object)` as all cases that I can think of are now covered by:
* `[Not]HaveSameValueAs`
* `[Not]HaveSameNameAs`
* `[Not]HaveValue(decimal)`

One question that remains for me, it whether it is too confusing that `HaveValue` is both used in:
* `NullableEnumAssertions` to assert if it is not null, and in
* `EnumAssertions` to assert on the underlying numeric value.

cc: @lg2de

This fixes #1204 
This fixes #1403 