### PR TITLE
Add missing reason to failure message

### DIFF
--- a/Src/FluentAssertions/Primitives/ObjectAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ObjectAssertions.cs
@@ -203,7 +203,7 @@ namespace FluentAssertions.Primitives
             bool hasMismatches;
             using (var scope = new AssertionScope())
             {
-                Subject.Should().BeEquivalentTo(unexpected, config, because, becauseArgs);
+                Subject.Should().BeEquivalentTo(unexpected, config);
                 hasMismatches = scope.Discard().Length > 0;
             }
 
@@ -211,7 +211,7 @@ namespace FluentAssertions.Primitives
                 .ForCondition(hasMismatches)
                 .BecauseOf(because, becauseArgs)
                 .WithDefaultIdentifier(Identifier)
-                .FailWith("Expected {context} not to be equivalent to {0}, but they are.", unexpected);
+                .FailWith("Expected {context} not to be equivalent to {0}{reason}, but they are.", unexpected);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -585,7 +585,7 @@ namespace FluentAssertions.Primitives
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:string} that does not end with {1}, but found {0}.", Subject, unexpected);
+                    .FailWith("Expected {context:string} that does not end with {1}{reason}, but found {0}.", Subject, unexpected);
             }
 
             Execute.Assertion
@@ -654,7 +654,7 @@ namespace FluentAssertions.Primitives
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:string} that does not end with equivalent of {0}, but found {1}.", unexpected, Subject);
+                    .FailWith("Expected {context:string} that does not end with equivalent of {0}{reason}, but found {1}.", unexpected, Subject);
             }
 
             Execute.Assertion

--- a/Tests/FluentAssertions.Specs/Equivalency/BasicNonEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/BasicNonEquivalencySpecs.cs
@@ -70,10 +70,11 @@ namespace FluentAssertions.Specs.Equivalency
             var o2 = new { Name = "A" };
 
             // Act
-            Action act = () => o1.Should().NotBeEquivalentTo(o2);
+            Action act = () => o1.Should().NotBeEquivalentTo(o2, "some {0}", "reason");
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>()
+                .WithMessage("*some reason*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
@@ -1260,7 +1260,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Act
             Action action = () =>
-                value.Should().NotEndWith("BC", "because of some reason");
+                value.Should().NotEndWith("BC", "because of some {0}", "reason");
 
             // Assert
             action.Should().Throw<XunitException>().WithMessage(
@@ -1302,11 +1302,11 @@ namespace FluentAssertions.Specs.Primitives
         {
             // Act
             string someString = null;
-            Action act = () => someString.Should().NotEndWith("ABC");
+            Action act = () => someString.Should().NotEndWith("ABC", "some {0}", "reason");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected someString that does not end with \"ABC\", but found <null>.");
+                "Expected someString that does not end with \"ABC\"*some reason*, but found <null>.");
         }
 
         #endregion
@@ -1582,7 +1582,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Act
             Action action = () =>
-                value.Should().NotEndWithEquivalentOf("Bc", "because of some reason");
+                value.Should().NotEndWithEquivalentOf("Bc", "because of some {0}", "reason");
 
             // Assert
             action.Should().Throw<XunitException>().WithMessage(
@@ -1624,11 +1624,11 @@ namespace FluentAssertions.Specs.Primitives
         {
             // Act
             string someString = null;
-            Action act = () => someString.Should().NotEndWithEquivalentOf("Abc");
+            Action act = () => someString.Should().NotEndWithEquivalentOf("Abc", "some {0}", "reason");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected someString that does not end with equivalent of \"Abc\", but found <null>.");
+                "Expected someString that does not end with equivalent of \"Abc\"*some reason*, but found <null>.");
         }
 
         #endregion


### PR DESCRIPTION
I found some assertions that created failure messages without the provided `because` and `becauseArgs`.