### PR TITLE
Changed Subject to non-nullable for primitive types

### DIFF
--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -23,15 +23,22 @@ namespace FluentAssertions.Primitives
     public class BooleanAssertions<TAssertions>
         where TAssertions : BooleanAssertions<TAssertions>
     {
-        public BooleanAssertions(bool? value)
+        public BooleanAssertions(bool value)
+            : this((bool?)value)
         {
-            Subject = value;
+        }
+
+        private protected BooleanAssertions(bool? value)
+        {
+            SubjectInternal = value;
         }
 
         /// <summary>
         /// Gets the object which value is being asserted.
         /// </summary>
-        public bool? Subject { get; }
+        public bool Subject => SubjectInternal.Value;
+
+        private protected bool? SubjectInternal { get; }
 
         /// <summary>
         /// Asserts that the value is <c>false</c>.
@@ -46,9 +53,9 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject == false)
+                .ForCondition(SubjectInternal == false)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:boolean} to be false{reason}, but found {0}.", Subject);
+                .FailWith("Expected {context:boolean} to be false{reason}, but found {0}.", SubjectInternal);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -66,9 +73,9 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject == true)
+                .ForCondition(SubjectInternal == true)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:boolean} to be true{reason}, but found {0}.", Subject);
+                .FailWith("Expected {context:boolean} to be true{reason}, but found {0}.", SubjectInternal);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -87,9 +94,9 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && Subject.Value == expected)
+                .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:boolean} to be {0}{reason}, but found {1}.", expected, Subject);
+                .FailWith("Expected {context:boolean} to be {0}{reason}, but found {1}.", expected, SubjectInternal);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -108,9 +115,9 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.HasValue || (Subject.Value != unexpected))
+                .ForCondition(!SubjectInternal.HasValue || (SubjectInternal.Value != unexpected))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:boolean} not to be {0}{reason}, but found {1}.", unexpected, Subject);
+                .FailWith("Expected {context:boolean} not to be {0}{reason}, but found {1}.", unexpected, SubjectInternal);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -33,15 +33,22 @@ namespace FluentAssertions.Primitives
     public class DateTimeAssertions<TAssertions>
         where TAssertions : DateTimeAssertions<TAssertions>
     {
-        public DateTimeAssertions(DateTime? value)
+        public DateTimeAssertions(DateTime value)
+            : this((DateTime?)value)
         {
-            Subject = value;
+        }
+
+        private protected DateTimeAssertions(DateTime? value)
+        {
+            SubjectInternal = value;
         }
 
         /// <summary>
         /// Gets the object which value is being asserted.
         /// </summary>
-        public DateTime? Subject { get; }
+        public DateTime Subject => SubjectInternal.Value;
+
+        private protected DateTime? SubjectInternal { get; }
 
         /// <summary>
         /// Asserts that the current <see cref="DateTime"/> is exactly equal to the <paramref name="expected"/> value.
@@ -57,10 +64,10 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> Be(DateTime expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && (Subject.Value == expected))
+                .ForCondition(SubjectInternal.HasValue && (SubjectInternal.Value == expected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} to be {0}{reason}, but found {1}.",
-                    expected, Subject ?? default(DateTime?));
+                    expected, SubjectInternal ?? default(DateTime?));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -79,10 +86,10 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> Be(DateTime? expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject == expected)
+                .ForCondition(SubjectInternal == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} to be {0}{reason}, but found {1}.",
-                    expected, Subject ?? default(DateTime?));
+                    expected, SubjectInternal ?? default(DateTime?));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -102,7 +109,7 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.HasValue || (Subject.Value != unexpected))
+                .ForCondition(!SubjectInternal.HasValue || (SubjectInternal.Value != unexpected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} not to be {0}{reason}, but it is.", unexpected);
 
@@ -125,8 +132,8 @@ namespace FluentAssertions.Primitives
         {
             Execute.Assertion
                 .ForCondition(
-                    (!Subject.HasValue == unexpected.HasValue) ||
-                    (Subject.HasValue && unexpected.HasValue && Subject.Value != unexpected))
+                    (!SubjectInternal.HasValue == unexpected.HasValue) ||
+                    (SubjectInternal.HasValue && unexpected.HasValue && SubjectInternal.Value != unexpected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} not to be {0}{reason}, but it is.", unexpected);
 
@@ -169,11 +176,11 @@ namespace FluentAssertions.Primitives
             DateTime maximumValue = nearbyTime.AddTicks(Math.Min(precision.Ticks, distanceToMaxInTicks));
 
             Execute.Assertion
-                .ForCondition(Subject.HasValue && (Subject.Value >= minimumValue) && (Subject.Value <= maximumValue))
+                .ForCondition(SubjectInternal.HasValue && (SubjectInternal.Value >= minimumValue) && (SubjectInternal.Value <= maximumValue))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be within {0} from {1}{reason}, but found {2}.",
                     precision,
-                    nearbyTime, Subject ?? default(DateTime?));
+                    nearbyTime, SubjectInternal ?? default(DateTime?));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -214,12 +221,12 @@ namespace FluentAssertions.Primitives
             DateTime maximumValue = distantTime.AddTicks(Math.Min(precision.Ticks, distanceToMaxInTicks));
 
             Execute.Assertion
-                .ForCondition(Subject.HasValue && ((Subject.Value < minimumValue) || (Subject.Value > maximumValue)))
+                .ForCondition(SubjectInternal.HasValue && ((SubjectInternal.Value < minimumValue) || (SubjectInternal.Value > maximumValue)))
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Did not expect {context:the date and time} to be within {0} from {1}{reason}, but it was {2}.",
                     precision,
-                    distantTime, Subject ?? default(DateTime?));
+                    distantTime, SubjectInternal ?? default(DateTime?));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -239,10 +246,10 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) < 0)
+                .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) < 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be before {0}{reason}, but found {1}.", expected,
-                    Subject ?? default(DateTime?));
+                    SubjectInternal ?? default(DateTime?));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -279,10 +286,10 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) <= 0)
+                .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) <= 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be on or before {0}{reason}, but found {1}.", expected,
-                    Subject ?? default(DateTime?));
+                    SubjectInternal ?? default(DateTime?));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -319,10 +326,10 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) > 0)
+                .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) > 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be after {0}{reason}, but found {1}.", expected,
-                    Subject ?? default(DateTime?));
+                    SubjectInternal ?? default(DateTime?));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -359,10 +366,10 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) >= 0)
+                .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) >= 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be on or after {0}{reason}, but found {1}.", expected,
-                    Subject ?? default(DateTime?));
+                    SubjectInternal ?? default(DateTime?));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -400,11 +407,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the year part of {context:the date} to be {0}{reason}", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith(", but found <null>.")
                 .Then
-                .ForCondition(Subject.Value.Year == expected)
-                .FailWith(", but found {0}.", Subject.Value.Year)
+                .ForCondition(SubjectInternal.Value.Year == expected)
+                .FailWith(", but found {0}.", SubjectInternal.Value.Year)
                 .Then
                 .ClearExpectation();
 
@@ -426,12 +433,12 @@ namespace FluentAssertions.Primitives
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("Did not expect the year part of {context:the date} to be {0}{reason}, but found a <null> DateTime.", unexpected)
                 .Then
-                .ForCondition(Subject.Value.Year != unexpected)
+                .ForCondition(SubjectInternal.Value.Year != unexpected)
                 .FailWith("Did not expect the year part of {context:the date} to be {0}{reason}, but it was.", unexpected,
-                    Subject.Value.Year);
+                    SubjectInternal.Value.Year);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -452,11 +459,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the month part of {context:the date} to be {0}{reason}", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
-                .ForCondition(Subject.Value.Month == expected)
-                .FailWith(", but found {0}.", Subject.Value.Month)
+                .ForCondition(SubjectInternal.Value.Month == expected)
+                .FailWith(", but found {0}.", SubjectInternal.Value.Month)
                 .Then
                 .ClearExpectation();
 
@@ -479,10 +486,10 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the month part of {context:the date} to be {0}{reason}", unexpected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
-                .ForCondition(Subject.Value.Month != unexpected)
+                .ForCondition(SubjectInternal.Value.Month != unexpected)
                 .FailWith(", but it was.")
                 .Then
                 .ClearExpectation();
@@ -506,11 +513,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the day part of {context:the date} to be {0}{reason}", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
-                .ForCondition(Subject.Value.Day == expected)
-                .FailWith(", but found {0}.", Subject.Value.Day)
+                .ForCondition(SubjectInternal.Value.Day == expected)
+                .FailWith(", but found {0}.", SubjectInternal.Value.Day)
                 .Then
                 .ClearExpectation();
 
@@ -533,10 +540,10 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the day part of {context:the date} to be {0}{reason}", unexpected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
-                .ForCondition(Subject.Value.Day != unexpected)
+                .ForCondition(SubjectInternal.Value.Day != unexpected)
                 .FailWith(", but it was.")
                 .Then
                 .ClearExpectation();
@@ -560,11 +567,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the hour part of {context:the time} to be {0}{reason}", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
-                .ForCondition(Subject.Value.Hour == expected)
-                .FailWith(", but found {0}.", Subject.Value.Hour)
+                .ForCondition(SubjectInternal.Value.Hour == expected)
+                .FailWith(", but found {0}.", SubjectInternal.Value.Hour)
                 .Then
                 .ClearExpectation();
 
@@ -587,11 +594,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the hour part of {context:the time} to be {0}{reason}", unexpected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith(", but found a <null> DateTime.", unexpected)
                 .Then
-                .ForCondition(Subject.Value.Hour != unexpected)
-                .FailWith(", but it was.", unexpected, Subject.Value.Hour)
+                .ForCondition(SubjectInternal.Value.Hour != unexpected)
+                .FailWith(", but it was.", unexpected, SubjectInternal.Value.Hour)
                 .Then
                 .ClearExpectation();
 
@@ -615,11 +622,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the minute part of {context:the time} to be {0}{reason}", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
-                .ForCondition(Subject.Value.Minute == expected)
-                .FailWith(", but found {0}.", Subject.Value.Minute)
+                .ForCondition(SubjectInternal.Value.Minute == expected)
+                .FailWith(", but found {0}.", SubjectInternal.Value.Minute)
                 .Then
                 .ClearExpectation();
 
@@ -643,11 +650,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the minute part of {context:the time} to be {0}{reason}", unexpected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith(", but found a <null> DateTime.", unexpected)
                 .Then
-                .ForCondition(Subject.Value.Minute != unexpected)
-                .FailWith(", but it was.", unexpected, Subject.Value.Minute)
+                .ForCondition(SubjectInternal.Value.Minute != unexpected)
+                .FailWith(", but it was.", unexpected, SubjectInternal.Value.Minute)
                 .Then
                 .ClearExpectation();
 
@@ -671,11 +678,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the seconds part of {context:the time} to be {0}{reason}", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
-                .ForCondition(Subject.Value.Second == expected)
-                .FailWith(", but found {0}.", Subject.Value.Second)
+                .ForCondition(SubjectInternal.Value.Second == expected)
+                .FailWith(", but found {0}.", SubjectInternal.Value.Second)
                 .Then
                 .ClearExpectation();
 
@@ -699,10 +706,10 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the seconds part of {context:the time} to be {0}{reason}", unexpected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
-                .ForCondition(Subject.Value.Second != unexpected)
+                .ForCondition(SubjectInternal.Value.Second != unexpected)
                 .FailWith(", but it was.")
                 .Then
                 .ClearExpectation();
@@ -719,7 +726,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public DateTimeRangeAssertions<TAssertions> BeMoreThan(TimeSpan timeSpan)
         {
-            return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.MoreThan, timeSpan);
+            return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, SubjectInternal, TimeSpanCondition.MoreThan, timeSpan);
         }
 
         /// <summary>
@@ -732,7 +739,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public DateTimeRangeAssertions<TAssertions> BeAtLeast(TimeSpan timeSpan)
         {
-            return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.AtLeast, timeSpan);
+            return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, SubjectInternal, TimeSpanCondition.AtLeast, timeSpan);
         }
 
         /// <summary>
@@ -744,7 +751,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public DateTimeRangeAssertions<TAssertions> BeExactly(TimeSpan timeSpan)
         {
-            return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.Exactly, timeSpan);
+            return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, SubjectInternal, TimeSpanCondition.Exactly, timeSpan);
         }
 
         /// <summary>
@@ -756,7 +763,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public DateTimeRangeAssertions<TAssertions> BeWithin(TimeSpan timeSpan)
         {
-            return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.Within, timeSpan);
+            return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, SubjectInternal, TimeSpanCondition.Within, timeSpan);
         }
 
         /// <summary>
@@ -768,7 +775,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public DateTimeRangeAssertions<TAssertions> BeLessThan(TimeSpan timeSpan)
         {
-            return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.LessThan, timeSpan);
+            return new DateTimeRangeAssertions<TAssertions>((TAssertions)this, SubjectInternal, TimeSpanCondition.LessThan, timeSpan);
         }
 
         /// <summary>
@@ -790,11 +797,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the date part of {context:the date and time} to be {0}{reason}", expectedDate)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith(", but found a <null> DateTime.", expectedDate)
                 .Then
-                .ForCondition(Subject.Value.Date == expectedDate)
-                .FailWith(", but found {1}.", expectedDate, Subject.Value)
+                .ForCondition(SubjectInternal.Value.Date == expectedDate)
+                .FailWith(", but found {1}.", expectedDate, SubjectInternal.Value)
                 .Then
                 .ClearExpectation();
 
@@ -820,10 +827,10 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the date part of {context:the date and time} to be {0}{reason}", unexpectedDate)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
-                .ForCondition(Subject.Value.Date != unexpectedDate)
+                .ForCondition(SubjectInternal.Value.Date != unexpectedDate)
                 .FailWith(", but it was.")
                 .Then
                 .ClearExpectation();
@@ -887,9 +894,9 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> BeOneOf(IEnumerable<DateTime?> validValues, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(validValues.Contains(Subject))
+                .ForCondition(validValues.Contains(SubjectInternal))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:date and time} to be one of {0}{reason}, but found {1}.", validValues, Subject);
+                .FailWith("Expected {context:date and time} to be one of {0}{reason}, but found {1}.", validValues, SubjectInternal);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -912,11 +919,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:the date and time} to be in {0}{reason}", expectedKind)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith(", but found a <null> DateTime.")
                 .Then
-                .ForCondition(Subject.Value.Kind == expectedKind)
-                .FailWith(", but found {0}.", Subject.Value.Kind)
+                .ForCondition(SubjectInternal.Value.Kind == expectedKind)
+                .FailWith(", but found {0}.", SubjectInternal.Value.Kind)
                 .Then
                 .ClearExpectation();
 

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -34,15 +34,22 @@ namespace FluentAssertions.Primitives
     public class DateTimeOffsetAssertions<TAssertions>
         where TAssertions : DateTimeOffsetAssertions<TAssertions>
     {
-        public DateTimeOffsetAssertions(DateTimeOffset? value)
+        public DateTimeOffsetAssertions(DateTimeOffset value)
+            : this((DateTimeOffset?)value)
         {
-            Subject = value;
+        }
+
+        private protected DateTimeOffsetAssertions(DateTimeOffset? value)
+        {
+            SubjectInternal = value;
         }
 
         /// <summary>
         /// Gets the object which value is being asserted.
         /// </summary>
-        public DateTimeOffset? Subject { get; }
+        public DateTimeOffset Subject => SubjectInternal.Value;
+
+        private protected DateTimeOffset? SubjectInternal { get; }
 
         /// <summary>
         /// Asserts that the current <see cref="DateTimeOffset"/> is exactly equal to the <paramref name="expected"/> value.
@@ -59,10 +66,10 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && (Subject.Value == expected))
+                .ForCondition(SubjectInternal.HasValue && (SubjectInternal.Value == expected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be {0}{reason}, but it was {1}.",
-                    expected, Subject ?? default(DateTimeOffset?));
+                    expected, SubjectInternal ?? default(DateTimeOffset?));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -82,10 +89,10 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject == expected)
+                .ForCondition(SubjectInternal == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be {0}{reason}, but it was {1}.",
-                    expected, Subject ?? default(DateTimeOffset?));
+                    expected, SubjectInternal ?? default(DateTimeOffset?));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -105,7 +112,7 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.HasValue || (Subject.Value != unexpected))
+                .ForCondition(!SubjectInternal.HasValue || (SubjectInternal.Value != unexpected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:the date and time} to be {0}{reason}, but it was.", unexpected);
 
@@ -127,8 +134,8 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition((!Subject.HasValue == unexpected.HasValue) ||
-                (Subject.HasValue && unexpected.HasValue && Subject.Value != unexpected))
+                .ForCondition((!SubjectInternal.HasValue == unexpected.HasValue) ||
+                (SubjectInternal.HasValue && unexpected.HasValue && SubjectInternal.Value != unexpected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:the date and time} to be {0}{reason}, but it was.", unexpected);
 
@@ -172,11 +179,11 @@ namespace FluentAssertions.Primitives
             DateTimeOffset maximumValue = nearbyTime.AddTicks(Math.Min(precision.Ticks, distanceToMaxInTicks));
 
             Execute.Assertion
-                .ForCondition(Subject.HasValue && (Subject.Value >= minimumValue) && (Subject.Value <= maximumValue))
+                .ForCondition(SubjectInternal.HasValue && (SubjectInternal.Value >= minimumValue) && (SubjectInternal.Value <= maximumValue))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be within {0} from {1}{reason}, but it was {2}.",
                     precision,
-                    nearbyTime, Subject);
+                    nearbyTime, SubjectInternal);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -217,12 +224,12 @@ namespace FluentAssertions.Primitives
             DateTimeOffset maximumValue = distantTime.AddTicks(Math.Min(precision.Ticks, distanceToMaxInTicks));
 
             Execute.Assertion
-                .ForCondition(Subject.HasValue && ((Subject.Value < minimumValue) || (Subject.Value > maximumValue)))
+                .ForCondition(SubjectInternal.HasValue && ((SubjectInternal.Value < minimumValue) || (SubjectInternal.Value > maximumValue)))
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Did not expect {context:the date and time} to be within {0} from {1}{reason}, but it was {2}.",
                     precision,
-                    distantTime, Subject ?? default(DateTimeOffset?));
+                    distantTime, SubjectInternal ?? default(DateTimeOffset?));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -242,10 +249,10 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) < 0)
+                .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) < 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be before {0}{reason}, but it was {1}.", expected,
-                    Subject ?? default(DateTimeOffset?));
+                    SubjectInternal ?? default(DateTimeOffset?));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -282,10 +289,10 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) <= 0)
+                .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) <= 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be on or before {0}{reason}, but it was {1}.", expected,
-                    Subject ?? default(DateTimeOffset?));
+                    SubjectInternal ?? default(DateTimeOffset?));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -322,10 +329,10 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) > 0)
+                .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) > 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be after {0}{reason}, but it was {1}.", expected,
-                    Subject ?? default(DateTimeOffset?));
+                    SubjectInternal ?? default(DateTimeOffset?));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -362,10 +369,10 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) >= 0)
+                .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) >= 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be on or after {0}{reason}, but it was {1}.", expected,
-                    Subject ?? default(DateTimeOffset?));
+                    SubjectInternal ?? default(DateTimeOffset?));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -404,11 +411,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the year part of {context:the date} to be {0}{reason}, ", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
-                .ForCondition(Subject.Value.Year == expected)
-                .FailWith("but it was {0}.", Subject.Value.Year)
+                .ForCondition(SubjectInternal.Value.Year == expected)
+                .FailWith("but it was {0}.", SubjectInternal.Value.Year)
                 .Then
                 .ClearExpectation();
 
@@ -431,10 +438,10 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the year part of {context:the date} to be {0}{reason}, ", unexpected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
-                .ForCondition(Subject.Value.Year != unexpected)
+                .ForCondition(SubjectInternal.Value.Year != unexpected)
                 .FailWith("but it was.")
                 .Then
                 .ClearExpectation();
@@ -459,11 +466,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the month part of {context:the date} to be {0}{reason}, ", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
-                .ForCondition(Subject.Value.Month == expected)
-                .FailWith("but it was {0}.", Subject.Value.Month)
+                .ForCondition(SubjectInternal.Value.Month == expected)
+                .FailWith("but it was {0}.", SubjectInternal.Value.Month)
                 .Then
                 .ClearExpectation();
 
@@ -486,10 +493,10 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the month part of {context:the date} to be {0}{reason}, ", unexpected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
-                .ForCondition(Subject.Value.Month != unexpected)
+                .ForCondition(SubjectInternal.Value.Month != unexpected)
                 .FailWith("but it was.")
                 .Then
                 .ClearExpectation();
@@ -514,11 +521,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the day part of {context:the date} to be {0}{reason}, ", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
-                .ForCondition(Subject.Value.Day == expected)
-                .FailWith("but it was {0}.", Subject.Value.Day)
+                .ForCondition(SubjectInternal.Value.Day == expected)
+                .FailWith("but it was {0}.", SubjectInternal.Value.Day)
                 .Then
                 .ClearExpectation();
 
@@ -541,10 +548,10 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the day part of {context:the date} to be {0}{reason}, ", unexpected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
-                .ForCondition(Subject.Value.Day != unexpected)
+                .ForCondition(SubjectInternal.Value.Day != unexpected)
                 .FailWith("but it was.")
                 .Then
                 .ClearExpectation();
@@ -569,11 +576,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the hour part of {context:the time} to be {0}{reason}, ", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
-                .ForCondition(Subject.Value.Hour == expected)
-                .FailWith("but it was {0}.", Subject.Value.Hour)
+                .ForCondition(SubjectInternal.Value.Hour == expected)
+                .FailWith("but it was {0}.", SubjectInternal.Value.Hour)
                 .Then
                 .ClearExpectation();
 
@@ -596,10 +603,10 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the hour part of {context:the time} to be {0}{reason}, ", unexpected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
-                .ForCondition(Subject.Value.Hour != unexpected)
+                .ForCondition(SubjectInternal.Value.Hour != unexpected)
                 .FailWith("but it was.")
                 .Then
                 .ClearExpectation();
@@ -624,11 +631,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the minute part of {context:the time} to be {0}{reason}, ", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
-                .ForCondition(Subject.Value.Minute == expected)
-                .FailWith("but it was {0}.", Subject.Value.Minute)
+                .ForCondition(SubjectInternal.Value.Minute == expected)
+                .FailWith("but it was {0}.", SubjectInternal.Value.Minute)
                 .Then
                 .ClearExpectation();
 
@@ -652,10 +659,10 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the minute part of {context:the time} to be {0}{reason}, ", unexpected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
-                .ForCondition(Subject.Value.Minute != unexpected)
+                .ForCondition(SubjectInternal.Value.Minute != unexpected)
                 .FailWith("but it was.")
                 .Then
                 .ClearExpectation();
@@ -680,11 +687,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the seconds part of {context:the time} to be {0}{reason}, ", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
-                .ForCondition(Subject.Value.Second == expected)
-                .FailWith("but it was {0}.", Subject.Value.Second)
+                .ForCondition(SubjectInternal.Value.Second == expected)
+                .FailWith("but it was {0}.", SubjectInternal.Value.Second)
                 .Then
                 .ClearExpectation();
 
@@ -708,10 +715,10 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the seconds part of {context:the time} to be {0}{reason}, ", unexpected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
-                .ForCondition(Subject.Value.Second != unexpected)
+                .ForCondition(SubjectInternal.Value.Second != unexpected)
                 .FailWith("but it was.")
                 .Then
                 .ClearExpectation();
@@ -736,11 +743,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the offset of {context:the date} to be {0}{reason}, ", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
-                .ForCondition(Subject.Value.Offset == expected)
-                .FailWith("but it was {0}.", Subject.Value.Offset)
+                .ForCondition(SubjectInternal.Value.Offset == expected)
+                .FailWith("but it was {0}.", SubjectInternal.Value.Offset)
                 .Then
                 .ClearExpectation();
 
@@ -764,10 +771,10 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the offset of {context:the date} to be {0}{reason}, ", unexpected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
-                .ForCondition(Subject.Value.Offset != unexpected)
+                .ForCondition(SubjectInternal.Value.Offset != unexpected)
                 .FailWith("but it was.")
                 .Then
                 .ClearExpectation();
@@ -784,7 +791,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(TimeSpan timeSpan)
         {
-            return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.MoreThan, timeSpan);
+            return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, SubjectInternal, TimeSpanCondition.MoreThan, timeSpan);
         }
 
         /// <summary>
@@ -797,7 +804,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public DateTimeOffsetRangeAssertions<TAssertions> BeAtLeast(TimeSpan timeSpan)
         {
-            return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.AtLeast, timeSpan);
+            return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, SubjectInternal, TimeSpanCondition.AtLeast, timeSpan);
         }
 
         /// <summary>
@@ -809,7 +816,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public DateTimeOffsetRangeAssertions<TAssertions> BeExactly(TimeSpan timeSpan)
         {
-            return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.Exactly, timeSpan);
+            return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, SubjectInternal, TimeSpanCondition.Exactly, timeSpan);
         }
 
         /// <summary>
@@ -821,7 +828,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public DateTimeOffsetRangeAssertions<TAssertions> BeWithin(TimeSpan timeSpan)
         {
-            return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.Within, timeSpan);
+            return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, SubjectInternal, TimeSpanCondition.Within, timeSpan);
         }
 
         /// <summary>
@@ -833,7 +840,7 @@ namespace FluentAssertions.Primitives
         /// </param>
         public DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(TimeSpan timeSpan)
         {
-            return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, Subject, TimeSpanCondition.LessThan, timeSpan);
+            return new DateTimeOffsetRangeAssertions<TAssertions>((TAssertions)this, SubjectInternal, TimeSpanCondition.LessThan, timeSpan);
         }
 
         /// <summary>
@@ -855,11 +862,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the date part of {context:the date and time} to be {0}{reason}, ", expectedDate)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found a <null> DateTimeOffset.", expectedDate)
                 .Then
-                .ForCondition(Subject.Value.Date == expectedDate)
-                .FailWith("but it was {0}.", Subject.Value)
+                .ForCondition(SubjectInternal.Value.Date == expectedDate)
+                .FailWith("but it was {0}.", SubjectInternal.Value)
                 .Then
                 .ClearExpectation();
 
@@ -885,10 +892,10 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Did not expect the date part of {context:the date and time} to be {0}{reason}, ", unexpectedDate)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found a <null> DateTimeOffset.")
                 .Then
-                .ForCondition(Subject.Value.Date != unexpectedDate)
+                .ForCondition(SubjectInternal.Value.Date != unexpectedDate)
                 .FailWith("but it was.")
                 .Then
                 .ClearExpectation();
@@ -952,9 +959,9 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> BeOneOf(IEnumerable<DateTimeOffset?> validValues, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(validValues.Contains(Subject))
+                .ForCondition(validValues.Contains(SubjectInternal))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:the date and time} to be one of {0}{reason}, but it was {1}.", validValues, Subject);
+                .FailWith("Expected {context:the date and time} to be one of {0}{reason}, but it was {1}.", validValues, SubjectInternal);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Primitives/GuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/GuidAssertions.cs
@@ -23,15 +23,22 @@ namespace FluentAssertions.Primitives
     public class GuidAssertions<TAssertions>
         where TAssertions : GuidAssertions<TAssertions>
     {
-        public GuidAssertions(Guid? value)
+        public GuidAssertions(Guid value)
+            : this((Guid?)value)
         {
-            Subject = value;
+        }
+
+        private protected GuidAssertions(Guid? value)
+        {
+            SubjectInternal = value;
         }
 
         /// <summary>
         /// Gets the object which value is being asserted.
         /// </summary>
-        public Guid? Subject { get; }
+        public Guid Subject => SubjectInternal.Value;
+
+        private protected Guid? SubjectInternal { get; }
 
         #region BeEmpty / NotBeEmpty
 
@@ -48,9 +55,9 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && (Subject.Value == Guid.Empty))
+                .ForCondition(SubjectInternal.HasValue && (SubjectInternal.Value == Guid.Empty))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:Guid} to be empty{reason}, but found {0}.", Subject);
+                .FailWith("Expected {context:Guid} to be empty{reason}, but found {0}.", SubjectInternal);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -68,7 +75,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && (Subject.Value != Guid.Empty))
+                .ForCondition(SubjectInternal.HasValue && (SubjectInternal.Value != Guid.Empty))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:Guid} to be empty{reason}.");
 
@@ -110,9 +117,9 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> Be(Guid expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && Subject.Value == expected)
+                .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:Guid} to be {0}{reason}, but found {1}.", expected, Subject);
+                .FailWith("Expected {context:Guid} to be {0}{reason}, but found {1}.", expected, SubjectInternal);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -131,9 +138,9 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotBe(Guid unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.HasValue || Subject.Value != unexpected)
+                .ForCondition(!SubjectInternal.HasValue || SubjectInternal.Value != unexpected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {context:Guid} to be {0}{reason}.", Subject);
+                .FailWith("Did not expect {context:Guid} to be {0}{reason}.", SubjectInternal);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Primitives/NullableBooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableBooleanAssertions.cs
@@ -28,6 +28,11 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
+        /// Gets the object which value is being asserted.
+        /// </summary>
+        public new bool? Subject => SubjectInternal;
+
+        /// <summary>
         /// Asserts that a nullable boolean value is not <c>null</c>.
         /// </summary>
         /// <param name="because">

--- a/Src/FluentAssertions/Primitives/NullableDateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateTimeAssertions.cs
@@ -38,6 +38,11 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
+        /// Gets the object which value is being asserted.
+        /// </summary>
+        public new DateTime? Subject => SubjectInternal;
+
+        /// <summary>
         /// Asserts that a nullable <see cref="DateTime"/> value is not <c>null</c>.
         /// </summary>
         /// <param name="because">

--- a/Src/FluentAssertions/Primitives/NullableDateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableDateTimeOffsetAssertions.cs
@@ -37,6 +37,11 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
+        /// Gets the object which value is being asserted.
+        /// </summary>
+        public new DateTimeOffset? Subject => SubjectInternal;
+
+        /// <summary>
         /// Asserts that a nullable <see cref="DateTimeOffset"/> value is not <c>null</c>.
         /// </summary>
         /// <param name="because">
@@ -49,9 +54,9 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:variable} to have a value{reason}, but found {0}", Subject);
+                .FailWith("Expected {context:variable} to have a value{reason}, but found {0}", SubjectInternal);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -85,9 +90,9 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.HasValue)
+                .ForCondition(!SubjectInternal.HasValue)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {context:variable} to have a value{reason}, but found {0}", Subject);
+                .FailWith("Did not expect {context:variable} to have a value{reason}, but found {0}", SubjectInternal);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Primitives/NullableGuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableGuidAssertions.cs
@@ -29,6 +29,11 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
+        /// Gets the object which value is being asserted.
+        /// </summary>
+        public new Guid? Subject => SubjectInternal;
+
+        /// <summary>
         /// Asserts that a nullable <see cref="Guid"/> value is not <c>null</c>.
         /// </summary>
         /// <param name="because">
@@ -41,7 +46,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected a value{reason}.");
 
@@ -76,9 +81,9 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.HasValue)
+                .ForCondition(!SubjectInternal.HasValue)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect a value{reason}, but found {0}.", Subject);
+                .FailWith("Did not expect a value{reason}, but found {0}.", SubjectInternal);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -112,9 +117,9 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> Be(Guid? expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject == expected)
+                .ForCondition(SubjectInternal == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:Guid} to be {0}{reason}, but found {1}.", expected, Subject);
+                .FailWith("Expected {context:Guid} to be {0}{reason}, but found {1}.", expected, SubjectInternal);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Primitives/NullableSimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableSimpleTimeSpanAssertions.cs
@@ -37,6 +37,11 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
+        /// Gets the object which value is being asserted.
+        /// </summary>
+        public new TimeSpan? Subject => SubjectInternal;
+
+        /// <summary>
         /// Asserts that a nullable <see cref="TimeSpan"/> value is not <c>null</c>.
         /// </summary>
         /// <param name="because">

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -23,15 +23,22 @@ namespace FluentAssertions.Primitives
     public class SimpleTimeSpanAssertions<TAssertions>
         where TAssertions : SimpleTimeSpanAssertions<TAssertions>
     {
-        public SimpleTimeSpanAssertions(TimeSpan? value)
+        public SimpleTimeSpanAssertions(TimeSpan value)
+            : this((TimeSpan?)value)
         {
-            Subject = value;
+        }
+
+        private protected SimpleTimeSpanAssertions(TimeSpan? value)
+        {
+            SubjectInternal = value;
         }
 
         /// <summary>
         /// Gets the object which value is being asserted.
         /// </summary>
-        public TimeSpan? Subject { get; }
+        public TimeSpan Subject => SubjectInternal.Value;
+
+        private protected TimeSpan? SubjectInternal { get; }
 
         /// <summary>
         /// Asserts that the time difference of the current <see cref="TimeSpan"/> is greater than zero.
@@ -48,11 +55,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:time} to be positive{reason}, ")
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found <null>.")
                 .Then
-                .ForCondition(Subject.Value.CompareTo(TimeSpan.Zero) > 0)
-                .FailWith("but found {0}.", Subject.Value)
+                .ForCondition(SubjectInternal.Value.CompareTo(TimeSpan.Zero) > 0)
+                .FailWith("but found {0}.", SubjectInternal.Value)
                 .Then
                 .ClearExpectation();
 
@@ -74,11 +81,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:time} to be negative{reason}, ")
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found <null>.")
                 .Then
-                .ForCondition(Subject.Value.CompareTo(TimeSpan.Zero) < 0)
-                .FailWith("but found {0}.", Subject.Value)
+                .ForCondition(SubjectInternal.Value.CompareTo(TimeSpan.Zero) < 0)
+                .FailWith("but found {0}.", SubjectInternal.Value)
                 .Then
                 .ClearExpectation();
 
@@ -102,11 +109,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {0}{reason}, ", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found <null>.")
                 .Then
-                .ForCondition(Subject.Value.CompareTo(expected) == 0)
-                .FailWith("but found {0}.", Subject.Value)
+                .ForCondition(SubjectInternal.Value.CompareTo(expected) == 0)
+                .FailWith("but found {0}.", SubjectInternal.Value)
                 .Then
                 .ClearExpectation();
 
@@ -128,7 +135,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotBe(TimeSpan unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.HasValue || Subject.Value.CompareTo(unexpected) != 0)
+                .ForCondition(!SubjectInternal.HasValue || SubjectInternal.Value.CompareTo(unexpected) != 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {0}{reason}.", unexpected);
 
@@ -152,11 +159,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:time} to be less than {0}{reason}, ", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found <null>.")
                 .Then
-                .ForCondition(Subject.Value.CompareTo(expected) < 0)
-                .FailWith("but found {0}.", Subject.Value)
+                .ForCondition(SubjectInternal.Value.CompareTo(expected) < 0)
+                .FailWith("but found {0}.", SubjectInternal.Value)
                 .Then
                 .ClearExpectation();
 
@@ -180,11 +187,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:time} to be less or equal to {0}{reason}, ", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found <null>.")
                 .Then
-                .ForCondition(Subject.Value.CompareTo(expected) <= 0)
-                .FailWith("but found {0}.", Subject.Value)
+                .ForCondition(SubjectInternal.Value.CompareTo(expected) <= 0)
+                .FailWith("but found {0}.", SubjectInternal.Value)
                 .Then
                 .ClearExpectation();
 
@@ -208,11 +215,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:time} to be greater than {0}{reason}, ", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found <null>.")
                 .Then
-                .ForCondition(Subject.Value.CompareTo(expected) > 0)
-                .FailWith("but found {0}.", Subject.Value)
+                .ForCondition(SubjectInternal.Value.CompareTo(expected) > 0)
+                .FailWith("but found {0}.", SubjectInternal.Value)
                 .Then
                 .ClearExpectation();
 
@@ -237,11 +244,11 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:time} to be greater or equal to {0}{reason}, ", expected)
-                .ForCondition(Subject.HasValue)
+                .ForCondition(SubjectInternal.HasValue)
                 .FailWith("but found <null>.")
                 .Then
-                .ForCondition(Subject.Value.CompareTo(expected) >= 0)
-                .FailWith("but found {0}.", Subject.Value)
+                .ForCondition(SubjectInternal.Value.CompareTo(expected) >= 0)
+                .FailWith("but found {0}.", SubjectInternal.Value)
                 .Then
                 .ClearExpectation();
 
@@ -281,11 +288,11 @@ namespace FluentAssertions.Primitives
             TimeSpan maximumValue = nearbyTime + precision;
 
             Execute.Assertion
-                .ForCondition(Subject.HasValue && (Subject.Value >= minimumValue) && (Subject.Value <= maximumValue))
+                .ForCondition(SubjectInternal.HasValue && (SubjectInternal.Value >= minimumValue) && (SubjectInternal.Value <= maximumValue))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:time} to be within {0} from {1}{reason}, but found {2}.",
                     precision,
-                    nearbyTime, Subject ?? default(TimeSpan?));
+                    nearbyTime, SubjectInternal ?? default(TimeSpan?));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -323,11 +330,11 @@ namespace FluentAssertions.Primitives
             TimeSpan maximumValue = distantTime + precision;
 
             Execute.Assertion
-                .ForCondition(Subject.HasValue && !((Subject.Value >= minimumValue) && (Subject.Value <= maximumValue)))
+                .ForCondition(SubjectInternal.HasValue && !((SubjectInternal.Value >= minimumValue) && (SubjectInternal.Value <= maximumValue)))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:time} to not be within {0} from {1}{reason}, but found {2}.",
                     precision,
-                    distantTime, Subject ?? default(TimeSpan?));
+                    distantTime, SubjectInternal ?? default(TimeSpan?));
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -1620,8 +1620,8 @@ namespace FluentAssertions.Primitives
     public class BooleanAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
     {
-        public BooleanAssertions(bool? value) { }
-        public bool? Subject { get; }
+        public BooleanAssertions(bool value) { }
+        public bool Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
@@ -1634,8 +1634,8 @@ namespace FluentAssertions.Primitives
     public class DateTimeAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
-        public DateTimeAssertions(System.DateTime? value) { }
-        public System.DateTime? Subject { get; }
+        public DateTimeAssertions(System.DateTime value) { }
+        public System.DateTime Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
@@ -1682,8 +1682,8 @@ namespace FluentAssertions.Primitives
     public class DateTimeOffsetAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
-        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
-        public System.DateTimeOffset? Subject { get; }
+        public DateTimeOffsetAssertions(System.DateTimeOffset value) { }
+        public System.DateTimeOffset Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -1760,8 +1760,8 @@ namespace FluentAssertions.Primitives
     public class GuidAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions>
     {
-        public GuidAssertions(System.Guid? value) { }
-        public System.Guid? Subject { get; }
+        public GuidAssertions(System.Guid value) { }
+        public System.Guid Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
@@ -1776,6 +1776,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<TAssertions>
     {
         public NullableBooleanAssertions(bool? value) { }
+        public bool? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1792,6 +1793,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<TAssertions>
     {
         public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public System.DateTime? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
@@ -1805,6 +1807,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<TAssertions>
     {
         public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public System.DateTimeOffset? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
@@ -1818,6 +1821,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableGuidAssertions<TAssertions>
     {
         public NullableGuidAssertions(System.Guid? value) { }
+        public System.Guid? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1832,6 +1836,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<TAssertions>
     {
         public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public System.TimeSpan? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1883,8 +1888,8 @@ namespace FluentAssertions.Primitives
     public class SimpleTimeSpanAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
     {
-        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
-        public System.TimeSpan? Subject { get; }
+        public SimpleTimeSpanAssertions(System.TimeSpan value) { }
+        public System.TimeSpan Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -1620,8 +1620,8 @@ namespace FluentAssertions.Primitives
     public class BooleanAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
     {
-        public BooleanAssertions(bool? value) { }
-        public bool? Subject { get; }
+        public BooleanAssertions(bool value) { }
+        public bool Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
@@ -1634,8 +1634,8 @@ namespace FluentAssertions.Primitives
     public class DateTimeAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
-        public DateTimeAssertions(System.DateTime? value) { }
-        public System.DateTime? Subject { get; }
+        public DateTimeAssertions(System.DateTime value) { }
+        public System.DateTime Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
@@ -1682,8 +1682,8 @@ namespace FluentAssertions.Primitives
     public class DateTimeOffsetAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
-        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
-        public System.DateTimeOffset? Subject { get; }
+        public DateTimeOffsetAssertions(System.DateTimeOffset value) { }
+        public System.DateTimeOffset Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -1760,8 +1760,8 @@ namespace FluentAssertions.Primitives
     public class GuidAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions>
     {
-        public GuidAssertions(System.Guid? value) { }
-        public System.Guid? Subject { get; }
+        public GuidAssertions(System.Guid value) { }
+        public System.Guid Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
@@ -1776,6 +1776,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<TAssertions>
     {
         public NullableBooleanAssertions(bool? value) { }
+        public bool? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1792,6 +1793,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<TAssertions>
     {
         public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public System.DateTime? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
@@ -1805,6 +1807,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<TAssertions>
     {
         public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public System.DateTimeOffset? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
@@ -1818,6 +1821,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableGuidAssertions<TAssertions>
     {
         public NullableGuidAssertions(System.Guid? value) { }
+        public System.Guid? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1832,6 +1836,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<TAssertions>
     {
         public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public System.TimeSpan? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1883,8 +1888,8 @@ namespace FluentAssertions.Primitives
     public class SimpleTimeSpanAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
     {
-        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
-        public System.TimeSpan? Subject { get; }
+        public SimpleTimeSpanAssertions(System.TimeSpan value) { }
+        public System.TimeSpan Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -1620,8 +1620,8 @@ namespace FluentAssertions.Primitives
     public class BooleanAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
     {
-        public BooleanAssertions(bool? value) { }
-        public bool? Subject { get; }
+        public BooleanAssertions(bool value) { }
+        public bool Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
@@ -1634,8 +1634,8 @@ namespace FluentAssertions.Primitives
     public class DateTimeAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
-        public DateTimeAssertions(System.DateTime? value) { }
-        public System.DateTime? Subject { get; }
+        public DateTimeAssertions(System.DateTime value) { }
+        public System.DateTime Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
@@ -1682,8 +1682,8 @@ namespace FluentAssertions.Primitives
     public class DateTimeOffsetAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
-        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
-        public System.DateTimeOffset? Subject { get; }
+        public DateTimeOffsetAssertions(System.DateTimeOffset value) { }
+        public System.DateTimeOffset Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -1760,8 +1760,8 @@ namespace FluentAssertions.Primitives
     public class GuidAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions>
     {
-        public GuidAssertions(System.Guid? value) { }
-        public System.Guid? Subject { get; }
+        public GuidAssertions(System.Guid value) { }
+        public System.Guid Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
@@ -1776,6 +1776,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<TAssertions>
     {
         public NullableBooleanAssertions(bool? value) { }
+        public bool? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1792,6 +1793,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<TAssertions>
     {
         public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public System.DateTime? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
@@ -1805,6 +1807,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<TAssertions>
     {
         public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public System.DateTimeOffset? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
@@ -1818,6 +1821,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableGuidAssertions<TAssertions>
     {
         public NullableGuidAssertions(System.Guid? value) { }
+        public System.Guid? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1832,6 +1836,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<TAssertions>
     {
         public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public System.TimeSpan? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1883,8 +1888,8 @@ namespace FluentAssertions.Primitives
     public class SimpleTimeSpanAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
     {
-        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
-        public System.TimeSpan? Subject { get; }
+        public SimpleTimeSpanAssertions(System.TimeSpan value) { }
+        public System.TimeSpan Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1573,8 +1573,8 @@ namespace FluentAssertions.Primitives
     public class BooleanAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
     {
-        public BooleanAssertions(bool? value) { }
-        public bool? Subject { get; }
+        public BooleanAssertions(bool value) { }
+        public bool Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
@@ -1587,8 +1587,8 @@ namespace FluentAssertions.Primitives
     public class DateTimeAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
-        public DateTimeAssertions(System.DateTime? value) { }
-        public System.DateTime? Subject { get; }
+        public DateTimeAssertions(System.DateTime value) { }
+        public System.DateTime Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
@@ -1635,8 +1635,8 @@ namespace FluentAssertions.Primitives
     public class DateTimeOffsetAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
-        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
-        public System.DateTimeOffset? Subject { get; }
+        public DateTimeOffsetAssertions(System.DateTimeOffset value) { }
+        public System.DateTimeOffset Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -1713,8 +1713,8 @@ namespace FluentAssertions.Primitives
     public class GuidAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions>
     {
-        public GuidAssertions(System.Guid? value) { }
-        public System.Guid? Subject { get; }
+        public GuidAssertions(System.Guid value) { }
+        public System.Guid Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
@@ -1729,6 +1729,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<TAssertions>
     {
         public NullableBooleanAssertions(bool? value) { }
+        public bool? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1745,6 +1746,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<TAssertions>
     {
         public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public System.DateTime? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
@@ -1758,6 +1760,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<TAssertions>
     {
         public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public System.DateTimeOffset? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
@@ -1771,6 +1774,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableGuidAssertions<TAssertions>
     {
         public NullableGuidAssertions(System.Guid? value) { }
+        public System.Guid? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1785,6 +1789,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<TAssertions>
     {
         public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public System.TimeSpan? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1836,8 +1841,8 @@ namespace FluentAssertions.Primitives
     public class SimpleTimeSpanAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
     {
-        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
-        public System.TimeSpan? Subject { get; }
+        public SimpleTimeSpanAssertions(System.TimeSpan value) { }
+        public System.TimeSpan Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -1620,8 +1620,8 @@ namespace FluentAssertions.Primitives
     public class BooleanAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.BooleanAssertions<TAssertions>
     {
-        public BooleanAssertions(bool? value) { }
-        public bool? Subject { get; }
+        public BooleanAssertions(bool value) { }
+        public bool Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeFalse(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeTrue(string because = "", params object[] becauseArgs) { }
@@ -1634,8 +1634,8 @@ namespace FluentAssertions.Primitives
     public class DateTimeAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.DateTimeAssertions<TAssertions>
     {
-        public DateTimeAssertions(System.DateTime? value) { }
-        public System.DateTime? Subject { get; }
+        public DateTimeAssertions(System.DateTime value) { }
+        public System.DateTime Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTime? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTime expected, string because = "", params object[] becauseArgs) { }
@@ -1682,8 +1682,8 @@ namespace FluentAssertions.Primitives
     public class DateTimeOffsetAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.DateTimeOffsetAssertions<TAssertions>
     {
-        public DateTimeOffsetAssertions(System.DateTimeOffset? value) { }
-        public System.DateTimeOffset? Subject { get; }
+        public DateTimeOffsetAssertions(System.DateTimeOffset value) { }
+        public System.DateTimeOffset Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -1760,8 +1760,8 @@ namespace FluentAssertions.Primitives
     public class GuidAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.GuidAssertions<TAssertions>
     {
-        public GuidAssertions(System.Guid? value) { }
-        public System.Guid? Subject { get; }
+        public GuidAssertions(System.Guid value) { }
+        public System.Guid Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
@@ -1776,6 +1776,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<TAssertions>
     {
         public NullableBooleanAssertions(bool? value) { }
+        public bool? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(bool? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1792,6 +1793,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeAssertions<TAssertions>
     {
         public NullableDateTimeAssertions(System.DateTime? expected) { }
+        public System.DateTime? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
@@ -1805,6 +1807,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableDateTimeOffsetAssertions<TAssertions>
     {
         public NullableDateTimeOffsetAssertions(System.DateTimeOffset? expected) { }
+        public System.DateTimeOffset? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeNull(string because = "", params object[] becauseArgs) { }
@@ -1818,6 +1821,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableGuidAssertions<TAssertions>
     {
         public NullableGuidAssertions(System.Guid? value) { }
+        public System.Guid? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.Guid? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1832,6 +1836,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableSimpleTimeSpanAssertions<TAssertions>
     {
         public NullableSimpleTimeSpanAssertions(System.TimeSpan? value) { }
+        public System.TimeSpan? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
@@ -1883,8 +1888,8 @@ namespace FluentAssertions.Primitives
     public class SimpleTimeSpanAssertions<TAssertions>
         where TAssertions : FluentAssertions.Primitives.SimpleTimeSpanAssertions<TAssertions>
     {
-        public SimpleTimeSpanAssertions(System.TimeSpan? value) { }
-        public System.TimeSpan? Subject { get; }
+        public SimpleTimeSpanAssertions(System.TimeSpan value) { }
+        public System.TimeSpan Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -19,6 +19,7 @@ sidebar:
 
 **Breaking Changes**
 * Changed `becauseArgs` of `[Not]Reference(Assembly)` from `string[]` to `object[]` - [#1459](https://github.com/fluentassertions/fluentassertions/pull/1459)
+* Changed `Subject` and constructor parameter to non-nullable type for assertions on `bool`, `DateTime`, `DateTimeOffset`, `Guid` and `TimeSpan` - [#1483](https://github.com/fluentassertions/fluentassertions/pull/1483).
 
 **Breaking Changes (Extensibility)**
 * Pascal cased `CallerIdentifier.logger` - [#1458](https://github.com/fluentassertions/fluentassertions/pull/1458).


### PR DESCRIPTION
For five primitive datatypes the `Subject` didn't match the `SUT` as we wrap it in a `Nullable` to share implementation between the nullable and non-nullable assertions class.

This aligns with how `NullableNumericAssertions` and `NumericAssertions` works.