### PR TITLE
Remove "Async" postfix from all assertions on asynchronous operations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -254,6 +254,8 @@ dotnet_diagnostic.AV1706.severity = suggestion
 dotnet_diagnostic.AV1708.severity = suggestion
 # AV1710: Field contains the name of its containing type
 dotnet_diagnostic.AV1710.severity = none
+# AV1755: Name of async method should end with Async or TaskAsync
+dotnet_diagnostic.AV1755.severity = none
 # AV2202: Replace call to Nullable<T>.HasValue with null check
 dotnet_diagnostic.AV2202.severity = none
 # AV2305: Missing XML comment for internally visible type or member

--- a/Src/FluentAssertions/ExceptionAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ExceptionAssertionsExtensions.cs
@@ -4,12 +4,12 @@ using System.Threading.Tasks;
 using FluentAssertions.Execution;
 using FluentAssertions.Specialized;
 
+#pragma warning disable AV1755 // "Name of async method ... should end with Async"; Async suffix is too noisy in fluent API
+
 namespace FluentAssertions
 {
     public static class ExceptionAssertionsExtensions
     {
-#pragma warning disable AV1755 // "Name of async method ... should end with Async"; Async suffix is too noisy in fluent API
-
         /// <summary>
         /// Asserts that the thrown exception has a message that matches <paramref name="expectedWildcardPattern" />.
         /// </summary>
@@ -128,7 +128,5 @@ namespace FluentAssertions
         {
             return (await task).WithParameterName(paramName, because, becauseArgs);
         }
-
-#pragma warning restore AV1755
     }
 }

--- a/Src/FluentAssertions/ExceptionAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ExceptionAssertionsExtensions.cs
@@ -4,8 +4,6 @@ using System.Threading.Tasks;
 using FluentAssertions.Execution;
 using FluentAssertions.Specialized;
 
-#pragma warning disable AV1755 // "Name of async method ... should end with Async"; Async suffix is too noisy in fluent API
-
 namespace FluentAssertions
 {
     public static class ExceptionAssertionsExtensions

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -5,8 +5,6 @@ using System.Threading.Tasks;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
-#pragma warning disable AV1755 // "Name of async method ... should end with Async"; Async suffix is too noisy in fluent API
-
 namespace FluentAssertions.Specialized
 {
     /// <summary>

--- a/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AsyncFunctionAssertions.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
+#pragma warning disable AV1755 // "Name of async method ... should end with Async"; Async suffix is too noisy in fluent API
+
 namespace FluentAssertions.Specialized
 {
     /// <summary>
@@ -38,7 +40,7 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public async Task<AndConstraint<TAssertions>> CompleteWithinAsync(
+        public async Task<AndConstraint<TAssertions>> CompleteWithin(
             TimeSpan timeSpan, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
@@ -82,8 +84,8 @@ namespace FluentAssertions.Specialized
         /// <returns>
         /// Returns an object that allows asserting additional members of the thrown exception.
         /// </returns>
-        public async Task<ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "",
-            params object[] becauseArgs)
+        public async Task<ExceptionAssertions<TException>> ThrowExactly<TException>(
+            string because = "", params object[] becauseArgs)
             where TException : Exception
         {
             Type expectedType = typeof(TException);
@@ -115,8 +117,8 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public async Task<ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "",
-            params object[] becauseArgs)
+        public async Task<ExceptionAssertions<TException>> Throw<TException>(
+            string because = "", params object[] becauseArgs)
             where TException : Exception
         {
             Execute.Assertion
@@ -138,7 +140,8 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public async Task<AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs)
+        public async Task<AndConstraint<TAssertions>> NotThrow(
+            string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject is not null)
@@ -167,7 +170,8 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public async Task<AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public async Task<AndConstraint<TAssertions>> NotThrow<TException>(
+            string because = "", params object[] becauseArgs)
             where TException : Exception
         {
             Execute.Assertion
@@ -210,7 +214,8 @@ namespace FluentAssertions.Specialized
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
         /// <exception cref="ArgumentOutOfRangeException">Throws if waitTime or pollInterval are negative.</exception>
-        public Task<AndConstraint<TAssertions>> NotThrowAfterAsync(TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
+        public Task<AndConstraint<TAssertions>> NotThrowAfter(
+            TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
         {
             if (waitTime < TimeSpan.Zero)
             {
@@ -264,13 +269,13 @@ namespace FluentAssertions.Specialized
                 // to match the contents of the subject rather than our own call site.
                 //
                 //   Func<Task> action = async () => await subject.Should().BeSomething();
-                //   await action.Should().ThrowAsync<Exception>();
+                //   await action.Should().Throw<Exception>();
                 //
                 // If an assertion failure occurs, we want the message to talk about "subject"
                 // not "await action".
                 using (CallerIdentifier.OnlyOneFluentAssertionScopeOnCallStack()
-                        ? CallerIdentifier.OverrideStackSearchUsingCurrentScope()
-                        : default)
+                    ? CallerIdentifier.OverrideStackSearchUsingCurrentScope()
+                    : default)
                 {
                     await action();
                 }

--- a/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
@@ -4,9 +4,12 @@ using System.Threading.Tasks;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
+#pragma warning disable AV1755 // "Name of async method ... should end with Async"; Async suffix is too noisy in fluent API
+
 namespace FluentAssertions.Specialized
 {
-    public class GenericAsyncFunctionAssertions<TResult> : AsyncFunctionAssertions<Task<TResult>, GenericAsyncFunctionAssertions<TResult>>
+    public class GenericAsyncFunctionAssertions<TResult> : AsyncFunctionAssertions<Task<TResult>,
+        GenericAsyncFunctionAssertions<TResult>>
     {
         public GenericAsyncFunctionAssertions(Func<Task<TResult>> subject, IExtractExceptions extractor)
             : this(subject, extractor, new Clock())
@@ -29,7 +32,7 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public new async Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(
+        public new async Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithin(
             TimeSpan timeSpan, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
@@ -67,7 +70,8 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public new async Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAsync(string because = "", params object[] becauseArgs)
+        public new async Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrow(
+            string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject is not null)
@@ -109,7 +113,8 @@ namespace FluentAssertions.Specialized
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
         /// <exception cref="ArgumentOutOfRangeException">Throws if waitTime or pollInterval are negative.</exception>
-        public new Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfterAsync(TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
+        public new Task<AndWhichConstraint<GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfter(
+            TimeSpan waitTime, TimeSpan pollInterval, string because = "", params object[] becauseArgs)
         {
             if (waitTime < TimeSpan.Zero)
             {

--- a/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/GenericAsyncFunctionAssertions.cs
@@ -4,8 +4,6 @@ using System.Threading.Tasks;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
-#pragma warning disable AV1755 // "Name of async method ... should end with Async"; Async suffix is too noisy in fluent API
-
 namespace FluentAssertions.Specialized
 {
     public class GenericAsyncFunctionAssertions<TResult> : AsyncFunctionAssertions<Task<TResult>,

--- a/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertions.cs
+++ b/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertions.cs
@@ -4,8 +4,6 @@ using System.Threading.Tasks;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
-#pragma warning disable AV1755 // "Name of async method ... should end with Async"; Async suffix is too noisy in fluent API
-
 namespace FluentAssertions.Specialized
 {
     public class TaskCompletionSourceAssertions<T>

--- a/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertions.cs
+++ b/Src/FluentAssertions/Specialized/TaskCompletionSourceAssertions.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
+#pragma warning disable AV1755 // "Name of async method ... should end with Async"; Async suffix is too noisy in fluent API
+
 namespace FluentAssertions.Specialized
 {
     public class TaskCompletionSourceAssertions<T>
@@ -34,7 +36,7 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public async Task<AndWhichConstraint<TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(
+        public async Task<AndWhichConstraint<TaskCompletionSourceAssertions<T>, T>> CompleteWithin(
             TimeSpan timeSpan, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
@@ -71,7 +73,7 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public async Task NotCompleteWithinAsync(
+        public async Task NotCompleteWithin(
             TimeSpan timeSpan, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -2030,14 +2030,14 @@ namespace FluentAssertions.Specialized
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrow(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactly<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
     public abstract class DelegateAssertionsBase<TDelegate, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TDelegate, FluentAssertions.Specialized.DelegateAssertionsBase<TDelegate, TAssertions>>
@@ -2108,9 +2108,9 @@ namespace FluentAssertions.Specialized
     {
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrow(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
     }
     public interface IExtractExceptions
     {
@@ -2130,8 +2130,8 @@ namespace FluentAssertions.Specialized
     {
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotCompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -2030,14 +2030,14 @@ namespace FluentAssertions.Specialized
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrow(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactly<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
     public abstract class DelegateAssertionsBase<TDelegate, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TDelegate, FluentAssertions.Specialized.DelegateAssertionsBase<TDelegate, TAssertions>>
@@ -2108,9 +2108,9 @@ namespace FluentAssertions.Specialized
     {
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrow(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
     }
     public interface IExtractExceptions
     {
@@ -2130,8 +2130,8 @@ namespace FluentAssertions.Specialized
     {
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotCompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -2030,14 +2030,14 @@ namespace FluentAssertions.Specialized
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrow(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactly<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
     public abstract class DelegateAssertionsBase<TDelegate, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TDelegate, FluentAssertions.Specialized.DelegateAssertionsBase<TDelegate, TAssertions>>
@@ -2108,9 +2108,9 @@ namespace FluentAssertions.Specialized
     {
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrow(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
     }
     public interface IExtractExceptions
     {
@@ -2130,8 +2130,8 @@ namespace FluentAssertions.Specialized
     {
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotCompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1983,14 +1983,14 @@ namespace FluentAssertions.Specialized
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrow(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactly<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
     public abstract class DelegateAssertionsBase<TDelegate, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TDelegate, FluentAssertions.Specialized.DelegateAssertionsBase<TDelegate, TAssertions>>
@@ -2061,9 +2061,9 @@ namespace FluentAssertions.Specialized
     {
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrow(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
     }
     public interface IExtractExceptions
     {
@@ -2083,8 +2083,8 @@ namespace FluentAssertions.Specialized
     {
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotCompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -2030,14 +2030,14 @@ namespace FluentAssertions.Specialized
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public AsyncFunctionAssertions(System.Func<TTask> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
         protected override string Identifier { get; }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrow(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrow<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.AndConstraint<TAssertions>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> Throw<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
-        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactlyAsync<TException>(string because = "", params object[] becauseArgs)
+        public System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> ThrowExactly<TException>(string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
     }
     public abstract class DelegateAssertionsBase<TDelegate, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TDelegate, FluentAssertions.Specialized.DelegateAssertionsBase<TDelegate, TAssertions>>
@@ -2108,9 +2108,9 @@ namespace FluentAssertions.Specialized
     {
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor) { }
         public GenericAsyncFunctionAssertions(System.Func<System.Threading.Tasks.Task<TResult>> subject, FluentAssertions.Specialized.IExtractExceptions extractor, FluentAssertions.Common.IClock clock) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfterAsync(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAsync(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrow(string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.GenericAsyncFunctionAssertions<TResult>, TResult>> NotThrowAfter(System.TimeSpan waitTime, System.TimeSpan pollInterval, string because = "", params object[] becauseArgs) { }
     }
     public interface IExtractExceptions
     {
@@ -2130,8 +2130,8 @@ namespace FluentAssertions.Specialized
     {
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs) { }
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
-        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
-        public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+        public System.Threading.Tasks.Task NotCompleteWithin(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/FluentAssertions.Specs/.editorconfig
+++ b/Tests/FluentAssertions.Specs/.editorconfig
@@ -94,8 +94,6 @@ dotnet_diagnostic.AV1704.severity = none
 dotnet_diagnostic.AV1706.severity = none
 # AV1710: Property contains the name of its containing type
 dotnet_diagnostic.AV1710.severity = none
-# AV1755: Name of async method should end with Async or TaskAsync
-dotnet_diagnostic.AV1755.severity = none
 
 # SA1001: XML comment analysis is disabled due to project configuration
 dotnet_diagnostic.SA1001.severity = none

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -34,11 +34,11 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> action = null;
 
             // Act
-            Func<Task> testAction = () => action.Should().ThrowAsync<ArgumentException>(
+            Func<Task> testAction = () => action.Should().Throw<ArgumentException>(
                 "because we want to test the failure {0}", "message");
 
             // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
+            await testAction.Should().Throw<XunitException>()
                 .WithMessage("*because we want to test the failure message*found <null>*");
         }
 
@@ -49,11 +49,11 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> action = null;
 
             // Act
-            Func<Task> testAction = () => action.Should().NotThrowAsync<ArgumentException>(
+            Func<Task> testAction = () => action.Should().NotThrow<ArgumentException>(
                 "because we want to test the failure {0}", "message");
 
             // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
+            await testAction.Should().Throw<XunitException>()
                 .WithMessage("*because we want to test the failure message*found <null>*");
         }
 
@@ -64,11 +64,11 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> action = null;
 
             // Act
-            Func<Task> testAction = () => action.Should().NotThrowAsync(
+            Func<Task> testAction = () => action.Should().NotThrow(
                 "because we want to test the failure {0}", "message");
 
             // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
+            await testAction.Should().Throw<XunitException>()
                 .WithMessage("*because we want to test the failure message*found <null>*");
         }
 
@@ -79,10 +79,10 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> act = () => throw new AggregateException();
 
             // Act
-            Func<Task> act2 = () => act.Should().NotThrowAsync();
+            Func<Task> act2 = () => act.Should().NotThrow();
 
             // Assert
-            await act2.Should().ThrowAsync<XunitException>();
+            await act2.Should().Throw<XunitException>();
         }
 
         [UIFact]
@@ -92,10 +92,10 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> act = () => throw new AggregateException();
 
             // Act
-            Func<Task> act2 = () => act.Should().NotThrowAsync();
+            Func<Task> act2 = () => act.Should().NotThrow();
 
             // Assert
-            await act2.Should().ThrowAsync<XunitException>();
+            await act2.Should().Throw<XunitException>();
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> act = () => throw new AggregateException(new ArgumentException("That was wrong."));
 
             // Act & Assert
-            await act.Should().ThrowAsync<ArgumentException>().WithMessage("That was wrong.");
+            await act.Should().Throw<ArgumentException>().WithMessage("That was wrong.");
         }
 
         [UIFact]
@@ -115,7 +115,7 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> act = () => throw new AggregateException(new ArgumentException("That was wrong."));
 
             // Act & Assert
-            await act.Should().ThrowAsync<ArgumentException>().WithMessage("That was wrong.");
+            await act.Should().Throw<ArgumentException>().WithMessage("That was wrong.");
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> act = () => throw new AggregateException("That was wrong as well.");
 
             // Act & Assert
-            await act.Should().ThrowAsync<AggregateException>().WithMessage("That was wrong as well.");
+            await act.Should().Throw<AggregateException>().WithMessage("That was wrong as well.");
         }
 
         [Fact]
@@ -135,7 +135,7 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> act = () => throw new AggregateException(new ArgumentException("That was wrong."));
 
             // Act & Assert
-            await act.Should().ThrowAsync<ArgumentException>()
+            await act.Should().Throw<ArgumentException>()
                 .Where(i => i.Message == "That was wrong.");
         }
 
@@ -146,7 +146,7 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> act = () => throw new AggregateException("That was wrong as well.");
 
             // Act & Assert
-            await act.Should().ThrowAsync<AggregateException>()
+            await act.Should().Throw<AggregateException>()
                 .Where(i => i.Message == "That was wrong as well.");
         }
 
@@ -157,7 +157,7 @@ namespace FluentAssertions.Specs.Exceptions
             where T : Exception
         {
             // Act/Assert
-            await action.Should().ThrowAsync<T>();
+            await action.Should().Throw<T>();
         }
 
         [UITheory]
@@ -166,7 +166,7 @@ namespace FluentAssertions.Specs.Exceptions
             where T : Exception
         {
             // Act/Assert
-            await action.Should().ThrowAsync<T>();
+            await action.Should().Throw<T>();
         }
 
         [Theory]
@@ -175,10 +175,10 @@ namespace FluentAssertions.Specs.Exceptions
             where T : Exception
         {
             // Act
-            Func<Task> act2 = () => action.Should().NotThrowAsync<T>();
+            Func<Task> act2 = () => action.Should().NotThrow<T>();
 
             // Assert
-            await act2.Should().ThrowAsync<XunitException>();
+            await act2.Should().Throw<XunitException>();
         }
 
         [UITheory]
@@ -187,10 +187,10 @@ namespace FluentAssertions.Specs.Exceptions
             where T : Exception
         {
             // Act
-            Func<Task> act2 = () => action.Should().NotThrowAsync<T>();
+            Func<Task> act2 = () => action.Should().NotThrow<T>();
 
             // Assert
-            await act2.Should().ThrowAsync<XunitException>();
+            await act2.Should().Throw<XunitException>();
         }
 #pragma warning restore xUnit1026 // Theory methods should use all of their parameters
 
@@ -257,10 +257,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.ThrowAsync<ArgumentNullException>())
-                .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+                .Should().ThrowExactly<ArgumentException>("because {0} should do that", "IFoo.Do");
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.ArgumentNullException.");
         }
 
@@ -273,10 +273,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.ThrowAsyncValueTask<ArgumentNullException>())
-                .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+                .Should().ThrowExactly<ArgumentException>("because {0} should do that", "IFoo.Do");
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.ArgumentNullException.");
         }
 
@@ -289,10 +289,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.ThrowAggregateExceptionAsync<ArgumentException>())
-                .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+                .Should().ThrowExactly<ArgumentException>("because {0} should do that", "IFoo.Do");
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.AggregateException.");
         }
 
@@ -305,10 +305,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.ThrowAggregateExceptionAsyncValueTask<ArgumentException>())
-                .Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+                .Should().ThrowExactly<ArgumentException>("because {0} should do that", "IFoo.Do");
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Expected type to be System.ArgumentException because IFoo.Do should do that, but found System.AggregateException.");
         }
 
@@ -321,7 +321,7 @@ namespace FluentAssertions.Specs.Exceptions
             // Act / Assert
             await asyncObject
                 .Awaiting(x => x.ThrowAsync<ArgumentNullException>())
-                .Should().ThrowExactlyAsync<ArgumentNullException>();
+                .Should().ThrowExactly<ArgumentNullException>();
         }
 
         [Fact]
@@ -333,7 +333,7 @@ namespace FluentAssertions.Specs.Exceptions
             // Act / Assert
             await asyncObject
                 .Awaiting(x => x.ThrowAsyncValueTask<ArgumentNullException>())
-                .Should().ThrowExactlyAsync<ArgumentNullException>();
+                .Should().ThrowExactly<ArgumentNullException>();
         }
 
         [Fact]
@@ -345,10 +345,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.ThrowAsync<ArgumentException>())
-                .Should().ThrowAsync<ArgumentException>();
+                .Should().Throw<ArgumentException>();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -360,10 +360,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
-                .Should().ThrowAsync<ArgumentException>();
+                .Should().Throw<ArgumentException>();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -373,10 +373,10 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> subject = null;
 
             // Act
-            Func<Task> action = () => subject.Should().NotThrowAsync();
+            Func<Task> action = () => subject.Should().NotThrow();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("*found <null>*");
         }
 
@@ -390,7 +390,7 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
 
             // Assert
-            await action.Should().ThrowAsync<ArgumentException>();
+            await action.Should().Throw<ArgumentException>();
         }
 
         [Fact]
@@ -402,10 +402,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.SucceedAsync())
-                .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
+                .Should().Throw<InvalidOperationException>("because {0} should do that", "IFoo.Do");
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but no exception was thrown.");
         }
 
@@ -418,10 +418,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.SucceedAsyncValueTask())
-                .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
+                .Should().Throw<InvalidOperationException>("because {0} should do that", "IFoo.Do");
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but no exception was thrown.");
         }
 
@@ -434,10 +434,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.ThrowAsync<ArgumentException>())
-                .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
+                .Should().Throw<InvalidOperationException>("because {0} should do that", "IFoo.Do");
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but found <System.ArgumentException>*");
         }
 
@@ -450,10 +450,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
-                .Should().ThrowAsync<InvalidOperationException>("because {0} should do that", "IFoo.Do");
+                .Should().Throw<InvalidOperationException>("because {0} should do that", "IFoo.Do");
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Expected a <System.InvalidOperationException> to be thrown because IFoo.Do should do that, but found <System.ArgumentException>*");
         }
 
@@ -466,10 +466,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.SucceedAsync())
-                .Should().NotThrowAsync();
+                .Should().NotThrow();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -481,10 +481,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.SucceedAsyncValueTask())
-                .Should().NotThrowAsync();
+                .Should().NotThrow();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -497,7 +497,7 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> action = () => asyncObject.SucceedAsync();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [UIFact]
@@ -510,7 +510,7 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> action = () => asyncObject.SucceedAsync();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -523,7 +523,7 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> action = () => asyncObject.ThrowAsync<ArgumentNullException>();
 
             // Assert
-            await action.Should().ThrowAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+            await action.Should().Throw<ArgumentException>("because {0} should do that", "IFoo.Do");
         }
 
         [Fact]
@@ -534,7 +534,7 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task<int>> f = () => asyncObject.ThrowTaskIntAsync<ArgumentNullException>(true);
 
             // Act / Assert
-            await f.Should().ThrowAsync<ArgumentNullException>();
+            await f.Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -545,7 +545,7 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task<int>> f = () => asyncObject.ThrowTaskIntAsync<InvalidOperationException>(true);
 
             // Act / Assert
-            await f.Should().NotThrowAsync<ArgumentNullException>();
+            await f.Should().NotThrow<ArgumentNullException>();
         }
 
         [Fact]
@@ -555,11 +555,11 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> action = null;
 
             // Act
-            Func<Task> testAction = () => action.Should().ThrowExactlyAsync<ArgumentException>(
+            Func<Task> testAction = () => action.Should().ThrowExactly<ArgumentException>(
                 "because we want to test the failure {0}", "message");
 
             // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
+            await testAction.Should().Throw<XunitException>()
                 .WithMessage("*because we want to test the failure message*found <null>*");
         }
 
@@ -571,10 +571,10 @@ namespace FluentAssertions.Specs.Exceptions
 
             // Act
             Func<Task> action = () => asyncObject.ThrowAsync<ArgumentNullException>();
-            Func<Task> testAction = () => action.Should().ThrowExactlyAsync<ArgumentException>("ABCDE");
+            Func<Task> testAction = () => action.Should().ThrowExactly<ArgumentException>("ABCDE");
 
             // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
+            await testAction.Should().Throw<XunitException>()
                 .WithMessage("*ArgumentException*ABCDE*ArgumentNullException*");
         }
 
@@ -586,10 +586,10 @@ namespace FluentAssertions.Specs.Exceptions
 
             // Act
             Func<Task> action = () => asyncObject.ThrowAggregateExceptionAsync<ArgumentException>();
-            Func<Task> testAction = () => action.Should().ThrowExactlyAsync<ArgumentException>("ABCDE");
+            Func<Task> testAction = () => action.Should().ThrowExactly<ArgumentException>("ABCDE");
 
             // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
+            await testAction.Should().Throw<XunitException>()
                 .WithMessage("*ArgumentException*ABCDE*AggregateException*");
         }
 
@@ -603,7 +603,7 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
 
             // Assert
-            await action.Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+            await action.Should().ThrowExactly<ArgumentException>("because {0} should do that", "IFoo.Do");
         }
 
         [UIFact]
@@ -616,7 +616,7 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
 
             // Assert
-            await action.Should().ThrowExactlyAsync<ArgumentException>("because {0} should do that", "IFoo.Do");
+            await action.Should().ThrowExactly<ArgumentException>("because {0} should do that", "IFoo.Do");
         }
 
         [Fact]
@@ -628,10 +628,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.ThrowAsync<ArgumentException>())
-                .Should().NotThrowAsync();
+                .Should().NotThrow();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Did not expect any exception, but found System.ArgumentException*");
         }
 
@@ -644,10 +644,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
-                .Should().NotThrowAsync();
+                .Should().NotThrow();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Did not expect any exception, but found System.ArgumentException*");
         }
 
@@ -660,10 +660,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.ThrowAsync<ArgumentException>())
-                .Should().NotThrowAsync<InvalidOperationException>();
+                .Should().NotThrow<InvalidOperationException>();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -675,10 +675,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
-                .Should().NotThrowAsync<InvalidOperationException>();
+                .Should().NotThrow<InvalidOperationException>();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -691,7 +691,7 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> action = () => asyncObject.ThrowAsync<ArgumentException>();
 
             // Assert
-            await action.Should().NotThrowAsync<InvalidOperationException>();
+            await action.Should().NotThrow<InvalidOperationException>();
         }
 
         [Fact]
@@ -703,10 +703,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(_ => asyncObject.SucceedAsync())
-                .Should().NotThrowAsync<InvalidOperationException>();
+                .Should().NotThrow<InvalidOperationException>();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -718,10 +718,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(_ => asyncObject.SucceedAsyncValueTask())
-                .Should().NotThrowAsync<InvalidOperationException>();
+                .Should().NotThrow<InvalidOperationException>();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -733,10 +733,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.ThrowAsync<ArgumentException>())
-                .Should().NotThrowAsync<ArgumentException>();
+                .Should().NotThrow<ArgumentException>();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Did not expect System.ArgumentException, but found*");
         }
 
@@ -749,10 +749,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.ThrowAsyncValueTask<ArgumentException>())
-                .Should().NotThrowAsync<ArgumentException>();
+                .Should().NotThrow<ArgumentException>();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Did not expect System.ArgumentException, but found*");
         }
 
@@ -765,10 +765,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(_ => asyncObject.ReturnTaskInt())
-                .Should().NotThrowAsync<InvalidOperationException>();
+                .Should().NotThrow<InvalidOperationException>();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -780,10 +780,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(_ => asyncObject.ReturnValueTaskInt())
-                .Should().NotThrowAsync<InvalidOperationException>();
+                .Should().NotThrow<InvalidOperationException>();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -795,10 +795,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.ThrowTaskIntAsync<ArgumentException>(true))
-                .Should().NotThrowAsync<ArgumentException>();
+                .Should().NotThrow<ArgumentException>();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Did not expect System.ArgumentException, but found System.ArgumentException*");
         }
 
@@ -811,10 +811,10 @@ namespace FluentAssertions.Specs.Exceptions
             // Act
             Func<Task> action = () => asyncObject
                 .Awaiting(x => x.ThrowValueTaskIntAsync<ArgumentException>(true))
-                .Should().NotThrowAsync<ArgumentException>();
+                .Should().NotThrow<ArgumentException>();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Did not expect System.ArgumentException, but found System.ArgumentException*");
         }
 
@@ -826,11 +826,11 @@ namespace FluentAssertions.Specs.Exceptions
 
             // Act
             Func<Task> action = () => task
-                .Should().ThrowAsync<AggregateException>()
+                .Should().Throw<AggregateException>()
                 .WithInnerException<AggregateException, InvalidOperationException>();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -841,10 +841,10 @@ namespace FluentAssertions.Specs.Exceptions
 
             // Act
             Func<Task> action = () => task
-                .Should().ThrowAsync<InvalidOperationException>();
+                .Should().Throw<InvalidOperationException>();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -855,10 +855,10 @@ namespace FluentAssertions.Specs.Exceptions
 
             // Act
             Func<Task> action = () => task
-                .Should().ThrowAsync<InvalidOperationException>();
+                .Should().Throw<InvalidOperationException>();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -869,11 +869,11 @@ namespace FluentAssertions.Specs.Exceptions
 
             // Act
             Func<Task> action = () => task
-                .Should().ThrowAsync<AggregateException>()
+                .Should().Throw<AggregateException>()
                 .WithInnerException<AggregateException, InvalidOperationException>();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
+            await action.Should().Throw<XunitException>().WithMessage("*InvalidOperation*Argument*");
         }
 
         [Fact]
@@ -884,10 +884,10 @@ namespace FluentAssertions.Specs.Exceptions
 
             // Act
             Func<Task> action = () => task
-                .Should().ThrowAsync<InvalidOperationException>();
+                .Should().Throw<InvalidOperationException>();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
+            await action.Should().Throw<XunitException>().WithMessage("*InvalidOperation*Argument*");
         }
 
         [Fact]
@@ -954,11 +954,11 @@ namespace FluentAssertions.Specs.Exceptions
 
             // Act
             Func<Task> act = () =>
-                task.Should().ThrowAsync<ArgumentException>()
+                task.Should().Throw<ArgumentException>()
                     .WithParameterName("someParameter");
 
             // Assert
-            await act.Should().NotThrowAsync();
+            await act.Should().NotThrow();
         }
 
         [Fact]
@@ -969,15 +969,15 @@ namespace FluentAssertions.Specs.Exceptions
 
             // Act
             Func<Task> act = () =>
-                task.Should().ThrowAsync<ArgumentException>()
+                task.Should().Throw<ArgumentException>()
                     .WithParameterName("someParameter", "we want to test the failure {0}", "message");
 
             // Assert
-            await act.Should().ThrowAsync<XunitException>()
+            await act.Should().Throw<XunitException>()
                 .WithMessage("*with parameter name \"someParameter\"*we want to test the failure message*\"someOtherParameter\"*");
         }
 
-        #region NotThrowAfterAsync
+        #region NotThrowAfter
         [Fact]
         public async Task When_wait_time_is_zero_for_async_func_executed_with_wait_it_should_not_throw()
         {
@@ -990,10 +990,10 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> someFunc = () => asyncObject.SucceedAsync();
 
             // Act
-            Func<Task> act = () => someFunc.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
+            Func<Task> act = () => someFunc.Should(clock).NotThrowAfter(waitTime, pollInterval);
 
             // Assert
-            await act.Should().NotThrowAsync();
+            await act.Should().NotThrow();
         }
 
         [Fact]
@@ -1008,10 +1008,10 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> someFunc = () => asyncObject.SucceedAsync();
 
             // Act
-            Func<Task> act = () => someFunc.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
+            Func<Task> act = () => someFunc.Should(clock).NotThrowAfter(waitTime, pollInterval);
 
             // Assert
-            await act.Should().NotThrowAsync();
+            await act.Should().NotThrow();
         }
 
         [Fact]
@@ -1023,11 +1023,11 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> action = null;
 
             // Act
-            Func<Task> testAction = () => action.Should().NotThrowAfterAsync(
+            Func<Task> testAction = () => action.Should().NotThrowAfter(
                 waitTime, pollInterval, "because we want to test the failure {0}", "message");
 
             // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
+            await testAction.Should().Throw<XunitException>()
                 .WithMessage("*because we want to test the failure message*found <null>*");
         }
 
@@ -1042,10 +1042,10 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> someFunc = () => asyncObject.SucceedAsync();
 
             // Act
-            Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
+            Func<Task> act = () => someFunc.Should().NotThrowAfter(waitTime, pollInterval);
 
             // Assert
-            await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
+            await act.Should().Throw<ArgumentOutOfRangeException>()
                 .WithMessage("* value of waitTime must be non-negative*");
         }
 
@@ -1060,10 +1060,10 @@ namespace FluentAssertions.Specs.Exceptions
             Func<Task> someFunc = () => asyncObject.SucceedAsync();
 
             // Act
-            Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
+            Func<Task> act = () => someFunc.Should().NotThrowAfter(waitTime, pollInterval);
 
             // Assert
-            await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
+            await act.Should().Throw<ArgumentOutOfRangeException>()
                 .WithMessage("* value of pollInterval must be non-negative*");
         }
 
@@ -1078,10 +1078,10 @@ namespace FluentAssertions.Specs.Exceptions
 
             // Act
             Func<Task> action = () => func.Should()
-                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+                .NotThrowAfter(waitTime, pollInterval, "we passed valid arguments");
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("*but found <null>*");
         }
 
@@ -1108,10 +1108,10 @@ namespace FluentAssertions.Specs.Exceptions
 
             // Act
             Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
-                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+                .NotThrowAfter(waitTime, pollInterval, "we passed valid arguments");
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
         }
 
@@ -1138,10 +1138,10 @@ namespace FluentAssertions.Specs.Exceptions
 
             // Act
             Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
-                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+                .NotThrowAfter(waitTime, pollInterval, "we passed valid arguments");
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
         }
 
@@ -1167,10 +1167,10 @@ namespace FluentAssertions.Specs.Exceptions
             };
 
             // Act
-            Func<Task> act = () => throwShorterThanWaitTime.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
+            Func<Task> act = () => throwShorterThanWaitTime.Should(clock).NotThrowAfter(waitTime, pollInterval);
 
             // Assert
-            await act.Should().NotThrowAsync();
+            await act.Should().NotThrow();
         }
 
         [UIFact]
@@ -1195,10 +1195,10 @@ namespace FluentAssertions.Specs.Exceptions
             };
 
             // Act
-            Func<Task> act = () => throwShorterThanWaitTime.Should(clock).NotThrowAfterAsync(waitTime, pollInterval);
+            Func<Task> act = () => throwShorterThanWaitTime.Should(clock).NotThrowAfter(waitTime, pollInterval);
 
             // Assert
-            await act.Should().NotThrowAsync();
+            await act.Should().NotThrow();
         }
         #endregion
     }

--- a/Tests/FluentAssertions.Specs/Extensions/FluentActionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Extensions/FluentActionsSpecs.cs
@@ -28,14 +28,14 @@ namespace FluentAssertions.Specs.Extensions
         public async Task Awaiting_works_with_action()
         {
             // Arrange / Act / Assert
-            await Awaiting(() => ThrowsAsync()).Should().ThrowAsync<InvalidOperationException>();
+            await Awaiting(() => ThrowsAsync()).Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
         public async Task Awaiting_works_with_func()
         {
             // Arrange / Act / Assert
-            await Awaiting(() => ThrowsAsync(0)).Should().ThrowAsync<InvalidOperationException>();
+            await Awaiting(() => ThrowsAsync(0)).Should().Throw<InvalidOperationException>();
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskAssertionSpecs.cs
@@ -31,11 +31,11 @@ namespace FluentAssertions.Specs.Specialized
             Func<Task> action = null;
 
             // Act
-            Func<Task> testAction = () => action.Should().CompleteWithinAsync(
+            Func<Task> testAction = () => action.Should().CompleteWithin(
                 timeSpan, "because we want to test the failure {0}", "message");
 
             // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
+            await testAction.Should().Throw<XunitException>()
                 .WithMessage("*because we want to test the failure message*found <null>*");
         }
 
@@ -47,12 +47,12 @@ namespace FluentAssertions.Specs.Specialized
             var taskFactory = new TaskCompletionSource<bool>();
 
             // Act
-            Func<Task> action = () => taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
+            Func<Task> action = () => taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithin(100.Milliseconds());
             taskFactory.SetResult(true);
             timer.Complete();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [UIFact]
@@ -63,12 +63,12 @@ namespace FluentAssertions.Specs.Specialized
             var taskFactory = new TaskCompletionSource<bool>();
 
             // Act
-            Func<Task> action = () => taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
+            Func<Task> action = () => taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithin(100.Milliseconds());
             taskFactory.SetResult(true);
             timer.Complete();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -79,11 +79,11 @@ namespace FluentAssertions.Specs.Specialized
             var taskFactory = new TaskCompletionSource<bool>();
 
             // Act
-            Func<Task> action = () => taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
+            Func<Task> action = () => taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithin(100.Milliseconds());
             timer.Complete();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>();
+            await action.Should().Throw<XunitException>();
         }
 
         [UIFact]
@@ -94,11 +94,11 @@ namespace FluentAssertions.Specs.Specialized
             var taskFactory = new TaskCompletionSource<bool>();
 
             // Act
-            Func<Task> action = () => taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithinAsync(100.Milliseconds());
+            Func<Task> action = () => taskFactory.Awaiting(t => (Task)t.Task).Should(timer).CompleteWithin(100.Milliseconds());
             timer.Complete();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>();
+            await action.Should().Throw<XunitException>();
         }
 
         [UIFact]
@@ -108,10 +108,10 @@ namespace FluentAssertions.Specs.Specialized
             Func<Task> task = CheckContextAsync;
 
             // Act
-            Func<Task> action = () => this.Awaiting(x => task()).Should().CompleteWithinAsync(1.Seconds());
+            Func<Task> action = () => this.Awaiting(x => task()).Should().CompleteWithin(1.Seconds());
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
 
             async Task CheckContextAsync()
             {

--- a/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
@@ -17,12 +17,12 @@ namespace FluentAssertions.Specs.Specialized
             var timer = new FakeClock();
 
             // Act
-            Func<Task> action = () => subject.Should(timer).CompleteWithinAsync(1.Seconds());
+            Func<Task> action = () => subject.Should(timer).CompleteWithin(1.Seconds());
             subject.SetResult(true);
             timer.Complete();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -33,12 +33,12 @@ namespace FluentAssertions.Specs.Specialized
             var timer = new FakeClock();
 
             // Act
-            Func<Task> action = async () => (await subject.Should(timer).CompleteWithinAsync(1.Seconds())).Which.Should().Be(42);
+            Func<Task> action = async () => (await subject.Should(timer).CompleteWithin(1.Seconds())).Which.Should().Be(42);
             subject.SetResult(42);
             timer.Complete();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -49,12 +49,12 @@ namespace FluentAssertions.Specs.Specialized
             var timer = new FakeClock();
 
             // Act
-            Func<Task> action = async () => (await subject.Should(timer).CompleteWithinAsync(1.Seconds())).Which.Should().Be(42);
+            Func<Task> action = async () => (await subject.Should(timer).CompleteWithin(1.Seconds())).Which.Should().Be(42);
             subject.SetResult(99);
             timer.Complete();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Expected * to be 42, but found 99.");
         }
 
@@ -66,11 +66,11 @@ namespace FluentAssertions.Specs.Specialized
             var timer = new FakeClock();
 
             // Act
-            Func<Task> action = () => subject.Should(timer).CompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
+            Func<Task> action = () => subject.Should(timer).CompleteWithin(1.Seconds(), "test {0}", "testArg");
             timer.Complete();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Expected subject to complete within 1s because test testArg.");
         }
 
@@ -82,10 +82,10 @@ namespace FluentAssertions.Specs.Specialized
             TaskCompletionSource<bool> subject = null;
 
             // Act
-            Func<Task> action = () => subject.Should().CompleteWithinAsync(1.Seconds());
+            Func<Task> action = () => subject.Should().CompleteWithin(1.Seconds());
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Expected subject to complete within 1s, but found <null>.");
         }
 
@@ -97,12 +97,12 @@ namespace FluentAssertions.Specs.Specialized
             var timer = new FakeClock();
 
             // Act
-            Func<Task> action = () => subject.Should(timer).NotCompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
+            Func<Task> action = () => subject.Should(timer).NotCompleteWithin(1.Seconds(), "test {0}", "testArg");
             subject.SetResult(true);
             timer.Complete();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>().WithMessage("*to not complete within*because test testArg*");
+            await action.Should().Throw<XunitException>().WithMessage("*to not complete within*because test testArg*");
         }
 
         [Fact]
@@ -113,11 +113,11 @@ namespace FluentAssertions.Specs.Specialized
             var timer = new FakeClock();
 
             // Act
-            Func<Task> action = () => subject.Should(timer).NotCompleteWithinAsync(1.Seconds());
+            Func<Task> action = () => subject.Should(timer).NotCompleteWithin(1.Seconds());
             timer.Complete();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -128,10 +128,10 @@ namespace FluentAssertions.Specs.Specialized
             TaskCompletionSource<bool> subject = null;
 
             // Act
-            Func<Task> action = () => subject.Should().NotCompleteWithinAsync(1.Seconds(), "test {0}", "testArg");
+            Func<Task> action = () => subject.Should().NotCompleteWithin(1.Seconds(), "test {0}", "testArg");
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Expected subject to not complete within 1s because test testArg, but found <null>.");
         }
     }

--- a/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -14,7 +14,7 @@ namespace FluentAssertions.Specs.Specialized
     [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
     public class TaskOfTAssertionSpecs
     {
-        #region CompleteWithinAsync
+        #region CompleteWithin
         [Fact]
         public async Task When_subject_is_null_when_expecting_to_complete_async_it_should_throw()
         {
@@ -23,11 +23,11 @@ namespace FluentAssertions.Specs.Specialized
             Func<Task<int>> action = null;
 
             // Act
-            Func<Task> testAction = () => action.Should().CompleteWithinAsync(
+            Func<Task> testAction = () => action.Should().CompleteWithin(
                 timeSpan, "because we want to test the failure {0}", "message");
 
             // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
+            await testAction.Should().Throw<XunitException>()
                 .WithMessage("*because we want to test the failure message*found <null>*");
         }
 
@@ -43,7 +43,7 @@ namespace FluentAssertions.Specs.Specialized
             {
                 Func<Task<int>> func = () => taskFactory.Task;
 
-                (await func.Should(timer).CompleteWithinAsync(100.Milliseconds()))
+                (await func.Should(timer).CompleteWithin(100.Milliseconds()))
                     .Which.Should().Be(42);
             };
 
@@ -51,7 +51,7 @@ namespace FluentAssertions.Specs.Specialized
             timer.Complete();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -66,17 +66,17 @@ namespace FluentAssertions.Specs.Specialized
             {
                 Func<Task<int>> func = () => taskFactory.Task;
 
-                return func.Should(timer).CompleteWithinAsync(100.Milliseconds());
+                return func.Should(timer).CompleteWithin(100.Milliseconds());
             };
 
             timer.Complete();
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>();
+            await action.Should().Throw<XunitException>();
         }
         #endregion
 
-        #region NotThrowAfterAsync
+        #region NotThrowAfter
         [Fact]
         public async Task When_subject_is_null_when_expecting_to_not_throw_async_it_should_throw()
         {
@@ -84,11 +84,11 @@ namespace FluentAssertions.Specs.Specialized
             Func<Task<int>> action = null;
 
             // Act
-            Func<Task> testAction = () => action.Should().NotThrowAsync(
+            Func<Task> testAction = () => action.Should().NotThrow(
                 "because we want to test the failure {0}", "message");
 
             // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
+            await testAction.Should().Throw<XunitException>()
                 .WithMessage("*because we want to test the failure message*found <null>*");
         }
 
@@ -104,7 +104,7 @@ namespace FluentAssertions.Specs.Specialized
             {
                 Func<Task<int>> func = () => taskFactory.Task;
 
-                (await func.Should(timer).NotThrowAsync())
+                (await func.Should(timer).NotThrow())
                     .Which.Should().Be(42);
             };
 
@@ -112,7 +112,7 @@ namespace FluentAssertions.Specs.Specialized
             timer.Complete();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [UIFact]
@@ -127,7 +127,7 @@ namespace FluentAssertions.Specs.Specialized
             {
                 Func<Task<int>> func = () => taskFactory.Task;
 
-                (await func.Should(timer).NotThrowAsync())
+                (await func.Should(timer).NotThrow())
                     .Which.Should().Be(42);
             };
 
@@ -135,7 +135,7 @@ namespace FluentAssertions.Specs.Specialized
             timer.Complete();
 
             // Assert
-            await action.Should().NotThrowAsync();
+            await action.Should().NotThrow();
         }
 
         [Fact]
@@ -149,11 +149,11 @@ namespace FluentAssertions.Specs.Specialized
             {
                 Func<Task<int>> func = () => throw new AggregateException();
 
-                return func.Should(timer).NotThrowAsync();
+                return func.Should(timer).NotThrow();
             };
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>();
+            await action.Should().Throw<XunitException>();
         }
 
         [UIFact]
@@ -167,11 +167,11 @@ namespace FluentAssertions.Specs.Specialized
             {
                 Func<Task<int>> func = () => throw new AggregateException();
 
-                return func.Should(timer).NotThrowAsync();
+                return func.Should(timer).NotThrow();
             };
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>();
+            await action.Should().Throw<XunitException>();
         }
 
         [Fact]
@@ -183,11 +183,11 @@ namespace FluentAssertions.Specs.Specialized
             Func<Task<int>> action = null;
 
             // Act
-            Func<Task> testAction = () => action.Should().NotThrowAfterAsync(
+            Func<Task> testAction = () => action.Should().NotThrowAfter(
                 waitTime, pollInterval, "because we want to test the failure {0}", "message");
 
             // Assert
-            await testAction.Should().ThrowAsync<XunitException>()
+            await testAction.Should().Throw<XunitException>()
                 .WithMessage("*because we want to test the failure message*found <null>*");
         }
 
@@ -202,10 +202,10 @@ namespace FluentAssertions.Specs.Specialized
             Func<Task<int>> someFunc = () => asyncObject.ReturnTaskInt();
 
             // Act
-            Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
+            Func<Task> act = () => someFunc.Should().NotThrowAfter(waitTime, pollInterval);
 
             // Assert
-            await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
+            await act.Should().Throw<ArgumentOutOfRangeException>()
                 .WithMessage("* value of waitTime must be non-negative*");
         }
 
@@ -220,10 +220,10 @@ namespace FluentAssertions.Specs.Specialized
             Func<Task<int>> someFunc = () => asyncObject.ReturnTaskInt();
 
             // Act
-            Func<Task> act = () => someFunc.Should().NotThrowAfterAsync(waitTime, pollInterval);
+            Func<Task> act = () => someFunc.Should().NotThrowAfter(waitTime, pollInterval);
 
             // Assert
-            await act.Should().ThrowAsync<ArgumentOutOfRangeException>()
+            await act.Should().Throw<ArgumentOutOfRangeException>()
                 .WithMessage("* value of pollInterval must be non-negative*");
         }
 
@@ -238,10 +238,10 @@ namespace FluentAssertions.Specs.Specialized
 
             // Act
             Func<Task> action = () => func.Should()
-                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+                .NotThrowAfter(waitTime, pollInterval, "we passed valid arguments");
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("*but found <null>*");
         }
 
@@ -269,10 +269,10 @@ namespace FluentAssertions.Specs.Specialized
 
             // Act
             Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
-                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+                .NotThrowAfter(waitTime, pollInterval, "we passed valid arguments");
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
         }
 
@@ -300,10 +300,10 @@ namespace FluentAssertions.Specs.Specialized
 
             // Act
             Func<Task> action = () => throwLongerThanWaitTime.Should(clock)
-                .NotThrowAfterAsync(waitTime, pollInterval, "we passed valid arguments");
+                .NotThrowAfter(waitTime, pollInterval, "we passed valid arguments");
 
             // Assert
-            await action.Should().ThrowAsync<XunitException>()
+            await action.Should().Throw<XunitException>()
                 .WithMessage("Did not expect any exceptions after 2s because we passed valid arguments*");
         }
 
@@ -332,12 +332,12 @@ namespace FluentAssertions.Specs.Specialized
             // Act
             Func<Task> act = async () =>
             {
-                (await throwShorterThanWaitTime.Should(clock).NotThrowAfterAsync(waitTime, pollInterval))
+                (await throwShorterThanWaitTime.Should(clock).NotThrowAfter(waitTime, pollInterval))
                     .Which.Should().Be(42);
             };
 
             // Assert
-            await act.Should().NotThrowAsync();
+            await act.Should().NotThrow();
         }
 
         [UIFact]
@@ -365,12 +365,12 @@ namespace FluentAssertions.Specs.Specialized
             // Act
             Func<Task> act = async () =>
             {
-                (await throwShorterThanWaitTime.Should(clock).NotThrowAfterAsync(waitTime, pollInterval))
+                (await throwShorterThanWaitTime.Should(clock).NotThrowAfter(waitTime, pollInterval))
                     .Which.Should().Be(42);
             };
 
             // Assert
-            await act.Should().NotThrowAsync();
+            await act.Should().NotThrow();
         }
         #endregion
     }

--- a/docs/_pages/executiontime.md
+++ b/docs/_pages/executiontime.md
@@ -51,7 +51,7 @@ If you're dealing with a `Task`, you can also assert that it completed within a 
 
 ```csharp
 Func<Task> someAsyncWork = () => SomethingReturningATask();
-await someAsyncWork.Should().CompleteWithinAsync(100.Milliseconds());
+await someAsyncWork.Should().CompleteWithin(100.Milliseconds());
 ```
 
 If the `Task` is generic and returns a value, you can use that to write a continuing assertion:
@@ -59,7 +59,7 @@ If the `Task` is generic and returns a value, you can use that to write a contin
 ```csharp
 Func<Task<int>> someAsyncFunc;
 
-(await someAsyncFunc.Should().CompleteWithinAsync(100.Milliseconds())).Which.Should().Be(42);
+(await someAsyncFunc.Should().CompleteWithin(100.Milliseconds())).Which.Should().Be(42);
 ```
 
 A fully `async` version is available as well.

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -21,6 +21,7 @@ sidebar:
 **Breaking Changes**
 * Changed `becauseArgs` of `[Not]Reference(Assembly)` from `string[]` to `object[]` - [#1459](https://github.com/fluentassertions/fluentassertions/pull/1459)
 * Major overhaul on how enums are handled, see the [Migration Guide](/upgradingtov6) for more details - [#1479](https://github.com/fluentassertions/fluentassertions/pull/1479).
+* Removed `Async` postfix from all assertions on asynchronous operations (`Task`, `Task<T>`, `TaskCompletionSource<T>`) - [#1490](https://github.com/fluentassertions/fluentassertions/pull/1490)
 
 **Breaking Changes (Extensibility)**
 * Pascal cased `CallerIdentifier.logger` - [#1458](https://github.com/fluentassertions/fluentassertions/pull/1458).

--- a/docs/_pages/specialized.md
+++ b/docs/_pages/specialized.md
@@ -12,19 +12,19 @@ The following assertions helps to check that the result is available within spec
 
 ```csharp
 var tcs = new TaskCompletionSource<bool>();
-await tcs.Should().CompleteWithinAsync(1.Seconds());
+await tcs.Should().CompleteWithin(1.Seconds());
 ```
 
 The assertion returns the result for subsequent value assertions.
 
 ```csharp
 var tcs = new TaskCompletionSource<bool>();
-(await tcs.Should().CompleteWithinAsync(1.Seconds())).Which.Should().BeTrue();
+(await tcs.Should().CompleteWithin(1.Seconds())).Which.Should().BeTrue();
 ```
 
 Additionally it is possible to assert that the task will *not* complete within specific time.
 
 ```csharp
 var tcs = new TaskCompletionSource<bool>();
-await tcs.Should().NotCompleteWithinAsync(1.Seconds());
+await tcs.Should().NotCompleteWithin(1.Seconds());
 ```


### PR DESCRIPTION
As discussed on slack we should remove `Async` postfix from all assertions to get better **fluent** api.