### PR TITLE
Improve `Using<TMember>`

### DIFF
--- a/Src/FluentAssertions/Equivalency/AssertionContext.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionContext.cs
@@ -24,12 +24,10 @@ namespace FluentAssertions.Equivalency
 
         internal static AssertionContext<TSubject> CreateFromEquivalencyValidationContext(IEquivalencyValidationContext context)
         {
-            TSubject expectation = (context.Expectation is not null) ? (TSubject)context.Expectation : default;
-
             return new AssertionContext<TSubject>(
                 context.CurrentNode,
                 (TSubject)context.Subject,
-                expectation,
+                (TSubject)context.Expectation,
                 context.Reason.FormattedMessage,
                 context.Reason.Arguments);
         }

--- a/Src/FluentAssertions/Equivalency/AssertionRuleEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/AssertionRuleEquivalencyStep.cs
@@ -83,12 +83,19 @@ namespace FluentAssertions.Equivalency
 
             if (subjectIsValidType && expectationIsValidType)
             {
+                if ((subjectIsNull || expectationIsNull) && !CanBeNull<TSubject>())
+                {
+                    return false;
+                }
+
                 assertion(AssertionContext<TSubject>.CreateFromEquivalencyValidationContext(context));
                 return true;
             }
 
             return false;
         }
+
+        private static bool CanBeNull<T>() => !typeof(T).IsValueType || Nullable.GetUnderlyingType(typeof(T)) is not null;
 
         /// <summary>
         /// Returns a string that represents the current object.

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -698,6 +698,7 @@ namespace FluentAssertions.Equivalency
             /// <typeparamref name="TMemberType" />
             /// </summary>
             public TSelf WhenTypeIs<TMemberType>()
+                where TMemberType : TMember
             {
                 When(info => info.RuntimeType.IsSameOrInherits(typeof(TMemberType)));
                 return options;

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -1073,7 +1073,8 @@ namespace FluentAssertions.Equivalency
         {
             public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
             public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }
-            public TSelf WhenTypeIs<TMemberType>() { }
+            public TSelf WhenTypeIs<TMemberType>()
+                where TMemberType : TMember { }
         }
     }
     public class SimpleEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -1073,7 +1073,8 @@ namespace FluentAssertions.Equivalency
         {
             public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
             public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }
-            public TSelf WhenTypeIs<TMemberType>() { }
+            public TSelf WhenTypeIs<TMemberType>()
+                where TMemberType : TMember { }
         }
     }
     public class SimpleEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -1073,7 +1073,8 @@ namespace FluentAssertions.Equivalency
         {
             public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
             public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }
-            public TSelf WhenTypeIs<TMemberType>() { }
+            public TSelf WhenTypeIs<TMemberType>()
+                where TMemberType : TMember { }
         }
     }
     public class SimpleEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -1066,7 +1066,8 @@ namespace FluentAssertions.Equivalency
         {
             public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
             public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }
-            public TSelf WhenTypeIs<TMemberType>() { }
+            public TSelf WhenTypeIs<TMemberType>()
+                where TMemberType : TMember { }
         }
     }
     public class SimpleEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -1073,7 +1073,8 @@ namespace FluentAssertions.Equivalency
         {
             public Restriction(TSelf options, System.Action<FluentAssertions.Equivalency.IAssertionContext<TMember>> action) { }
             public TSelf When(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IObjectInfo, bool>> predicate) { }
-            public TSelf WhenTypeIs<TMemberType>() { }
+            public TSelf WhenTypeIs<TMemberType>()
+                where TMemberType : TMember { }
         }
     }
     public class SimpleEqualityEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep

--- a/Tests/FluentAssertions.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
@@ -431,6 +431,78 @@ namespace FluentAssertions.Specs.Equivalency
             act.Should().NotThrow();
         }
 
+        [InlineData(null, 0)]
+        [InlineData(0, null)]
+        [Theory]
+        public void When_subject_or_expectation_is_null_it_should_not_match_a_non_nullable_type(int? subjectValue, int? expectedValue)
+        {
+            // Arrange
+            var actual = new { Value = subjectValue };
+            var expected = new { Value = expectedValue };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected, opt => opt
+                .Using<int>(c => c.Subject.Should().NotBe(c.Expectation))
+                .WhenTypeIs<int>());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [InlineData(null, 0)]
+        [InlineData(0, null)]
+        [Theory]
+        public void When_subject_or_expectation_is_null_it_should_match_a_nullable_type(int? subjectValue, int? expectedValue)
+        {
+            // Arrange
+            var actual = new { Value = subjectValue };
+            var expected = new { Value = expectedValue };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected, opt => opt
+                .Using<int?>(c => c.Subject.Should().NotBe(c.Expectation))
+                .WhenTypeIs<int?>());
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [InlineData(null, null)]
+        [InlineData(0, 0)]
+        [Theory]
+        public void When_types_are_nullable_it_should_match_a_nullable_type(int? subjectValue, int? expectedValue)
+        {
+            // Arrange
+            var actual = new { Value = subjectValue };
+            var expected = new { Value = expectedValue };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected, opt => opt
+                .Using<int?>(c => c.Subject.Should().NotBe(c.Expectation))
+                .WhenTypeIs<int?>());
+
+            // Assert
+            act.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void When_overriding_with_custom_assertion_it_should_be_chainable()
+        {
+            // Arrange
+            var actual = new { Nullable = (int?)1, NonNullable = 2 };
+            var expected = new { Nullable = (int?)3, NonNullable = 3 };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected, opt => opt
+                .Using<int>(c => c.Subject.Should().BeCloseTo(c.Expectation, 1))
+                .WhenTypeIs<int>()
+                .Using<int?>(c => c.Subject.Should().NotBe(c.Expectation))
+                .WhenTypeIs<int?>());
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
         [Fact]
         public void When_a_nullable_property_is_overriden_with_a_custom_assertion_it_should_use_it()
         {
@@ -447,8 +519,9 @@ namespace FluentAssertions.Specs.Equivalency
             };
 
             // Act / Assert
-            actual.Should().BeEquivalentTo(expected,
-                opt => opt.Using<long>(c => c.Subject.Should().BeInRange(0, 10)).WhenTypeIs<long?>());
+            actual.Should().BeEquivalentTo(expected, opt => opt
+                .Using<long?>(c => c.Subject.Should().BeInRange(0, 10))
+                .WhenTypeIs<long?>());
         }
 
         internal class SimpleWithNullable

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -17,10 +17,11 @@ sidebar:
 **Fixes**
 * Sometimes `BeEquivalentTo` reported an incorrect message when a dictionary was missing a key - [#1454](https://github.com/fluentassertions/fluentassertions/pull/1454)
 * Some dictionary failures did not honor the user-provided reason - [#1456](https://github.com/fluentassertions/fluentassertions/pull/1456)
+* Restrict what types `WhenTypeIs<T>` can use and how `Using<T>` handles non-nullable types, see the [Migration Guide](/upgradingtov6#using) for more details - [#1494](https://github.com/fluentassertions/fluentassertions/pull/1494).
 
 **Breaking Changes**
 * Changed `becauseArgs` of `[Not]Reference(Assembly)` from `string[]` to `object[]` - [#1459](https://github.com/fluentassertions/fluentassertions/pull/1459)
-* Major overhaul on how enums are handled, see the [Migration Guide](/upgradingtov6) for more details - [#1479](https://github.com/fluentassertions/fluentassertions/pull/1479).
+* Major overhaul on how enums are handled, see the [Migration Guide](/upgradingtov6#enums) for more details - [#1479](https://github.com/fluentassertions/fluentassertions/pull/1479).
 
 **Breaking Changes (Extensibility)**
 * Pascal cased `CallerIdentifier.logger` - [#1458](https://github.com/fluentassertions/fluentassertions/pull/1458).


### PR DESCRIPTION
Restrict `WhenTypeIs<TMemberType>` to types assignable to `TMember`.
This should catch `NullReferenceException` or `InvalidCastException` in `CreateFromEquivalencyValidationContext` at compile-time.
![image](https://user-images.githubusercontent.com/919634/107850489-1f0f8480-6e03-11eb-9e37-dfaabd315eab.png)

The snippet below might have worked, but it assumes that the subject and expectation are both non-null.
```cs
.Using<int>()
.WhenTypeIs<int?>()
```

Instead, you now have to make this assumption more explicit by using `Nullable<int>.Value` 
```cs
Using<int?>(e => e.Subject.Value.Should().Be(e.Subject.Value))
```


Make `WhenTypeIs<TMemberType>` optional unless when chaining further.
For the most cases `TMemberType` is exactly `TMember` and in those cases `WhereTypeIs<>()` is noisy.
By adding an implicit cast operator we can avoid that.
The exception being when we need more chaining after `Using<>`, see the added `When_overriding_with_custom_assertion_it_should_be_chainable`.


Avoid trying to cast null to non-nullable type.
This handles when subject or expectation is null, but `Using<int>` would either:
* cast `null` to `int` leading to a NullReferenceException`, or
* use `default(int)` when `Expectation` is `null`, which would make `null` and `0` equal.

As far as I can read from #33 the changes in `When_a_nullable_property_is_overriden_with_a_custom_assertion_it_should_use_it` are fine, as the original bug report was about `using<long?>` didn't match a non-null `long?`

This fixes #799 