### PR TITLE
Add because/becauseArgs to `Contain(IEnumerable<T>)`

### DIFF
--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -652,7 +652,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> Contain(IEnumerable<KeyValuePair<TKey, TValue>> expected,
+        public new AndConstraint<TAssertions> Contain(IEnumerable<KeyValuePair<TKey, TValue>> expected,
             string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare dictionary with <null>.");
@@ -809,7 +809,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotContain(IEnumerable<KeyValuePair<TKey, TValue>> items,
+        public new AndConstraint<TAssertions> NotContain(IEnumerable<KeyValuePair<TKey, TValue>> items,
             string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(items, nameof(items), "Cannot compare dictionary with <null>.");

--- a/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/SelfReferencingCollectionAssertions.cs
@@ -439,15 +439,17 @@ namespace FluentAssertions.Collections
         /// <summary>
         /// Asserts that the collection contains some extra items in addition to the original items.
         /// </summary>
-        /// <param name="expectedItemsList">An <see cref="IEnumerable{T}"/> of expectation items.</param>
-        /// <param name="additionalExpectedItems">Additional items that are expectation to be contained by the collection.</param>
-        public AndConstraint<TAssertions> Contain(IEnumerable<T> expectedItemsList,
-            params T[] additionalExpectedItems)
+        /// <param name="expected">An <see cref="IEnumerable{T}"/> of expectation items.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndConstraint<TAssertions> Contain(IEnumerable<T> expected, string because = "", params object[] becauseArgs)
         {
-            var list = new List<T>(expectedItemsList);
-            list.AddRange(additionalExpectedItems);
-
-            return Contain((IEnumerable)list);
+            return Contain((IEnumerable)expected, because, becauseArgs);
         }
 
         /// <summary>
@@ -555,13 +557,17 @@ namespace FluentAssertions.Collections
         /// <summary>
         /// Asserts that the collection does not contain some extra items in addition to the original items.
         /// </summary>
-        /// <param name="unexpectedItemsList">An <see cref="IEnumerable{T}"/> of unexpected items.</param>
-        /// <param name="additionalUnexpectedItems">Additional items that are not expected to be contained by the collection.</param>
-        public AndConstraint<TAssertions> NotContain(IEnumerable<T> unexpectedItemsList, params T[] additionalUnexpectedItems)
+        /// <param name="unexpected">An <see cref="IEnumerable{T}"/> of unexpected items.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
+        /// </param>
+        public AndConstraint<TAssertions> NotContain(IEnumerable<T> unexpected, string because = "", params object[] becauseArgs)
         {
-            var list = new List<T>(unexpectedItemsList);
-            list.AddRange(additionalUnexpectedItems);
-            return NotContain((IEnumerable)list);
+            return NotContain((IEnumerable)unexpected, because, becauseArgs);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -262,42 +262,6 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
-        /// Expects the current collection to contain the specified elements in any order. Elements are compared
-        /// using their <see cref="object.Equals(object)" /> implementation.
-        /// </summary>
-        /// <param name="expected">An <see cref="IEnumerable{T}" /> with the expected elements.</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-        /// </param>
-        public AndConstraint<TAssertions> Contain(IEnumerable<string> expected, string because = null,
-            params object[] becauseArgs)
-        {
-            return base.Contain(expected, because, becauseArgs);
-        }
-
-        /// <summary>
-        /// Asserts that the current collection does not contain the supplied items. Elements are compared
-        /// using their <see cref="object.Equals(object)" /> implementation.
-        /// </summary>
-        /// <param name="unexpected">An <see cref="IEnumerable{T}"/> with the unexpected elements.</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
-        /// </param>
-        public AndConstraint<TAssertions> NotContain(IEnumerable<string> unexpected, string because = null,
-            params object[] becauseArgs)
-        {
-            return base.NotContain(unexpected, because, becauseArgs);
-        }
-
-        /// <summary>
         /// Asserts that the collection contains at least one string that matches a wildcard pattern.
         /// </summary>
         /// <param name="wildcardPattern">

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.approved.txt
@@ -471,7 +471,7 @@ namespace FluentAssertions.Collections
         where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, T, TAssertions>
     {
         public SelfReferencingCollectionAssertions(TCollection actualValue) { }
-        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] becauseArgs) { }
@@ -486,7 +486,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpectedItemsList, params T[] additionalUnexpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
@@ -517,13 +517,11 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params string[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<TAssertions> Equal(params string[] expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params string[] unexpected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.Generic.IEnumerable<string> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.approved.txt
@@ -471,7 +471,7 @@ namespace FluentAssertions.Collections
         where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, T, TAssertions>
     {
         public SelfReferencingCollectionAssertions(TCollection actualValue) { }
-        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] becauseArgs) { }
@@ -486,7 +486,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpectedItemsList, params T[] additionalUnexpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
@@ -517,13 +517,11 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params string[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<TAssertions> Equal(params string[] expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params string[] unexpected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.Generic.IEnumerable<string> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.approved.txt
@@ -471,7 +471,7 @@ namespace FluentAssertions.Collections
         where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, T, TAssertions>
     {
         public SelfReferencingCollectionAssertions(TCollection actualValue) { }
-        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] becauseArgs) { }
@@ -486,7 +486,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpectedItemsList, params T[] additionalUnexpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
@@ -517,13 +517,11 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params string[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<TAssertions> Equal(params string[] expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params string[] unexpected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.Generic.IEnumerable<string> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.approved.txt
@@ -464,7 +464,7 @@ namespace FluentAssertions.Collections
         where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, T, TAssertions>
     {
         public SelfReferencingCollectionAssertions(TCollection actualValue) { }
-        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] becauseArgs) { }
@@ -479,7 +479,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpectedItemsList, params T[] additionalUnexpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
@@ -510,13 +510,11 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params string[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<TAssertions> Equal(params string[] expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params string[] unexpected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.Generic.IEnumerable<string> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.approved.txt
@@ -471,7 +471,7 @@ namespace FluentAssertions.Collections
         where TAssertions : FluentAssertions.Collections.SelfReferencingCollectionAssertions<TCollection, T, TAssertions>
     {
         public SelfReferencingCollectionAssertions(TCollection actualValue) { }
-        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expectedItemsList, params T[] additionalExpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<T> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] becauseArgs) { }
@@ -486,7 +486,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpectedItemsList, params T[] additionalUnexpectedItems) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
@@ -517,13 +517,11 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo(System.Collections.Generic.IEnumerable<string> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<string>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<string> expected, string because = null, params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(params string[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainInOrder(System.Collections.Generic.IEnumerable<string> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, string> ContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Equal(System.Collections.Generic.IEnumerable<string> expected) { }
         public FluentAssertions.AndConstraint<TAssertions> Equal(params string[] expected) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotContain(System.Collections.Generic.IEnumerable<string> unexpected, string because = null, params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(params string[] unexpected) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainInOrder(System.Collections.Generic.IEnumerable<string> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotContainMatch(string wildcardPattern, string because = "", params object[] becauseArgs) { }

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
@@ -103,17 +103,18 @@ namespace FluentAssertions.Specs.Collections
         }
 
         [Fact]
-        public void When_a_collection_does_not_contain_the_combination_of_a_collection_and_a_single_item_it_should_throw()
+        public void When_a_collection_does_not_contain_the_collection_it_should_throw()
         {
             // Arrange
-            IEnumerable<object> strings = new[] { "string1", "string2" };
+            IEnumerable<object> subject = new[] { "string1", "string2" };
+            IEnumerable<object> expectation = new[] { "string1", "string2", "string3" };
 
             // Act
-            Action act = () => strings.Should().Contain(strings, new object[] { "string3" });
+            Action act = () => subject.Should().Contain(expectation, "some {0}", "argument");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected strings {\"string1\", \"string2\"} to contain {\"string1\", \"string2\", \"string3\"}, but could not find {\"string3\"}.");
+                "Expected subject {\"string1\", \"string2\"} to contain {\"string1\", \"string2\", \"string3\"}*some argument*but could not find {\"string3\"}.");
         }
 
         [Fact]
@@ -175,17 +176,18 @@ namespace FluentAssertions.Specs.Collections
         }
 
         [Fact]
-        public void When_a_collection_does_contain_the_combination_of_a_collection_and_a_single_item_it_should_throw()
+        public void When_a_collection_does_contain_the_collection_it_should_throw()
         {
             // Arrange
-            IEnumerable<object> strings = new[] { "string1", "string2" };
+            IEnumerable<object> subject = new[] { "string1", "string2" };
+            IEnumerable<object> expectation = new[] { "string3", "string4", "string2" };
 
             // Act
-            Action act = () => strings.Should().NotContain(new[] { "string3", "string4" }, new object[] { "string2" });
+            Action act = () => subject.Should().NotContain(expectation, "some {0}", "argument");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected strings {\"string1\", \"string2\"} to not contain {\"string3\", \"string4\", \"string2\"}, but found {\"string2\"}.");
+                "Expected subject {\"string1\", \"string2\"} to not contain {\"string3\", \"string4\", \"string2\"}*some argument*but found {\"string2\"}.");
         }
 
         [Fact]

--- a/docs/_pages/collections.md
+++ b/docs/_pages/collections.md
@@ -49,7 +49,7 @@ collection.Should().Contain(8)
   .And.NotBeSubsetOf(new[] {11, 56});
 
 collection.Should().Contain(x => x > 3);
-collection.Should().Contain(collection, "", 5, 6); // It should contain the original items, plus 5 and 6.
+collection.Should().Contain(collection);
 
 collection.Should().OnlyContain(x => x < 10);
 collection.Should().ContainItemsAssignableTo<int>();

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -19,10 +19,12 @@ sidebar:
 * Sometimes `BeEquivalentTo` reported an incorrect message when a dictionary was missing a key - [#1454](https://github.com/fluentassertions/fluentassertions/pull/1454)
 * Some dictionary failures did not honor the user-provided reason - [#1456](https://github.com/fluentassertions/fluentassertions/pull/1456)
 * Restrict what types `WhenTypeIs<T>` can use and how `Using<T>` handles non-nullable types, see the [Migration Guide](/upgradingtov6#using) for more details - [#1494](https://github.com/fluentassertions/fluentassertions/pull/1494).
+* Added missing `[Not]Contain(IEnumerable<T> expected, string because, params object[] becauseArgs)` - [#1499](https://github.com/fluentassertions/fluentassertions/pull/1499).
 
 **Breaking Changes**
 * Changed `becauseArgs` of `[Not]Reference(Assembly)` from `string[]` to `object[]` - [#1459](https://github.com/fluentassertions/fluentassertions/pull/1459)
 * Major overhaul on how enums are handled, see the [Migration Guide](/upgradingtov6#enums) for more details - [#1479](https://github.com/fluentassertions/fluentassertions/pull/1479).
+* Removed `[Not]Contain(IEnumerable<T> expected, params T[] additionalExpectedItems)` - [#1499](https://github.com/fluentassertions/fluentassertions/pull/1499).
 
 **Breaking Changes (Extensibility)**
 * Pascal cased `CallerIdentifier.logger` - [#1458](https://github.com/fluentassertions/fluentassertions/pull/1458).


### PR DESCRIPTION
fb7c6970 added `Contain(IEnumerable<T> originalItems, params T[] additionalItems)`
which left out the ability to provide `because` and `becauseArgs`.

This fixes #806 