### PR TITLE
Fix links

### DIFF
--- a/docs/_pages/basicassertions.md
+++ b/docs/_pages/basicassertions.md
@@ -70,7 +70,7 @@ theObject.Should().BeBinarySerializable();
 theObject.Should().BeDataContractSerializable();
 ```
 
-Internally, `BeBinarySerializable` uses the [Object graph comparison](#object-graph-comparison) API, so if you are in need of excluding certain properties from the comparison (for instance, because its backing field is `[NonSerializable]`, you can do this:
+Internally, `BeBinarySerializable` uses the [Object graph comparison](objectgraphs.md) API, so if you are in need of excluding certain properties from the comparison (for instance, because its backing field is `[NonSerializable]`, you can do this:
 
 ```csharp
 theObject.Should().BeBinarySerializable<MyClass>(

--- a/docs/_pages/collections.md
+++ b/docs/_pages/collections.md
@@ -91,7 +91,7 @@ stringCollection.Should().ContainMatch("* failed");
 stringCollection.Should().AllBe("build succeeded");
 ```
 
-In order to assert presence of an equivalent item in a collection applying [Object graph comparison](/objectgraphs) rules, use this:
+In order to assert presence of an equivalent item in a collection applying [Object graph comparison](objectgraphs.md) rules, use this:
 
 ```csharp
 collection.Should().ContainEquivalentOf(boxedValue);

--- a/docs/_pages/tips.md
+++ b/docs/_pages/tips.md
@@ -40,7 +40,7 @@ If you see something missing, please consider submitting a pull request.
 {% include assertion-comparison.html header1="MSTest" header2="Fluent Assertions" idPrefix="mstest-" caption="Exceptions"        examples=site.data.mstest-migration.exceptions %}
 
 ## Using global AssertionOptions
-The `AssertionOptions` class allows you to globally configure how `Should().BeEquivalentTo()` works, see also [Object graph comparison](/objectgraphs). Setting up the global configuration multiple times can lead to multi-threading issues when tests are run in parallel.
+The `AssertionOptions` class allows you to globally configure how `Should().BeEquivalentTo()` works, see also [Object graph comparison](objectgraphs.md). Setting up the global configuration multiple times can lead to multi-threading issues when tests are run in parallel.
 
 In order to ensure the global AssertionOptions are configured exactly once, a test framework specific solution is required.
 


### PR DESCRIPTION
Maybe your engine also allows links with the `.md`, but there is actually one place that has a non-working link (https://fluentassertions.com/basicassertions/).

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).