### PR TITLE
AssertionScope - allow reportables which are only calculated on failure

### DIFF
--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -170,7 +170,7 @@ namespace FluentAssertions.Execution
         /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a few
         /// specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as passed
         /// to <see cref="BecauseOf(FluentAssertions.Execution.Reason)"/>. Other named placeholders will be replaced with the <see cref="Current"/> scope data
-        /// passed through <see cref="AddNonReportable"/> and <see cref="AddReportable"/>. Finally, a description of the
+        /// passed through <see cref="AddNonReportable"/> and <see cref="AddReportable(string,string)"/>. Finally, a description of the
         /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
         /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
         /// Note that only 10 <paramref name="args"/> are supported in combination with a {reason}.
@@ -344,7 +344,7 @@ namespace FluentAssertions.Execution
         /// Adds some information to the assertion scope that will be included in the message
         /// that is emitted if an assertion fails. The value is only calculated on failure.
         /// </summary>
-        public void AddDeferredReportable(string key, Func<string> valueFunc)
+        public void AddReportable(string key, Func<string> valueFunc)
         {
             contextData.Add(new ContextDataItems.DataItem(key, new DeferredReportable(valueFunc), reportable: true, requiresFormatting: false));
         }

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -29,6 +29,18 @@ namespace FluentAssertions.Execution
         private string fallbackIdentifier = "object";
         private bool? succeeded;
 
+        private sealed class DeferredReportable
+        {
+            private readonly Lazy<string> lazyValue;
+
+            public DeferredReportable(Func<string> valueFunc)
+            {
+                this.lazyValue = new(valueFunc);
+            }
+
+            public override string ToString() => lazyValue.Value;
+        }
+
         #endregion
 
         /// <summary>
@@ -326,6 +338,15 @@ namespace FluentAssertions.Execution
         public void AddReportable(string key, string value)
         {
             contextData.Add(new ContextDataItems.DataItem(key, value, reportable: true, requiresFormatting: false));
+        }
+
+        /// <summary>
+        /// Adds some information to the assertion scope that will be included in the message
+        /// that is emitted if an assertion fails. The value is only calculated on failure.
+        /// </summary>
+        public void AddDeferredReportable(string key, Func<string> valueFunc)
+        {
+            contextData.Add(new ContextDataItems.DataItem(key, new DeferredReportable(valueFunc), reportable: true, requiresFormatting: false));
         }
 
         public string[] Discard()

--- a/Src/FluentAssertions/Execution/FailReason.cs
+++ b/Src/FluentAssertions/Execution/FailReason.cs
@@ -10,7 +10,7 @@
     /// to BecauseOf. Other named placeholders will be replaced with
     /// the <see cref="FluentAssertions.Execution.AssertionScope.Current"/> scope data passed through
     /// <see cref="FluentAssertions.Execution.AssertionScope.AddNonReportable"/> and
-    /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable"/>. Finally, a description of the
+    /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable(string,string)"/>. Finally, a description of the
     /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
     /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
     /// Note that only 10 arguments are supported in combination with a {reason}.

--- a/Src/FluentAssertions/Execution/GivenSelector.cs
+++ b/Src/FluentAssertions/Execution/GivenSelector.cs
@@ -85,7 +85,7 @@ namespace FluentAssertions.Execution
         /// to <see cref="AssertionScope.BecauseOf(FluentAssertions.Execution.Reason)"/>. Other named placeholders will be replaced with
         /// the <see cref="FluentAssertions.Execution.AssertionScope.Current"/> scope data passed through
         /// <see cref="FluentAssertions.Execution.AssertionScope.AddNonReportable"/> and
-        /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable"/>. Finally, a description of the current subject
+        /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable(string,string)"/>. Finally, a description of the current subject
         /// can be passed through the {context:description} placeholder. This is used in the message if no explicit context
         /// is specified through the <see cref="AssertionScope"/> constructor.
         /// Note that only 10 <paramref name="args"/> are supported in combination with a {reason}.
@@ -115,7 +115,7 @@ namespace FluentAssertions.Execution
         /// passed to <see cref="AssertionScope.BecauseOf(FluentAssertions.Execution.Reason)"/>. Other named placeholders will be
         /// replaced with the <see cref="FluentAssertions.Execution.AssertionScope.Current"/> scope data passed through
         /// <see cref="FluentAssertions.Execution.AssertionScope.AddNonReportable"/> and
-        /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable"/>. Finally, a description of the
+        /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable(string,string)"/>. Finally, a description of the
         /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
         /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
         /// Note that only 10 <paramref name="args"/> are supported in combination with a {reason}.

--- a/Src/FluentAssertions/Execution/IAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/IAssertionScope.cs
@@ -38,7 +38,7 @@ namespace FluentAssertions.Execution
         /// to <see cref="AssertionScope.BecauseOf(FluentAssertions.Execution.Reason)"/>. Other named placeholders will be replaced with
         /// the <see cref="FluentAssertions.Execution.AssertionScope.Current"/> scope data passed through
         /// <see cref="FluentAssertions.Execution.AssertionScope.AddNonReportable"/> and
-        /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable"/>. Finally, a description of the
+        /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable(string,string)"/>. Finally, a description of the
         /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
         /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
         /// Note that only 10 <paramref name="args"/> are supported in combination with a {reason}.
@@ -77,7 +77,7 @@ namespace FluentAssertions.Execution
         /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a few
         /// specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as passed
         /// to <see cref="AssertionScope.BecauseOf(FluentAssertions.Execution.Reason)"/>. Other named placeholders will be replaced with the <see cref="AssertionScope.Current"/> scope data
-        /// passed through <see cref="AssertionScope.AddNonReportable"/> and <see cref="AssertionScope.AddReportable"/>. Finally, a description of the
+        /// passed through <see cref="AssertionScope.AddNonReportable"/> and <see cref="AssertionScope.AddReportable(string,string)"/>. Finally, a description of the
         /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
         /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
         /// Note that only 10 <paramref name="args"/> are supported in combination with a {reason}.

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1199,6 +1199,7 @@ namespace FluentAssertions.Execution
         public static FluentAssertions.Execution.AssertionScope Current { get; }
         public void AddNonReportable(string key, object value) { }
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, System.Func<string> valueFunc) { }
         public void AddReportable(string key, string value) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(FluentAssertions.Execution.Reason reason) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1197,9 +1197,9 @@ namespace FluentAssertions.Execution
         public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
-        public void AddDeferredReportable(string key, System.Func<string> valueFunc) { }
         public void AddNonReportable(string key, object value) { }
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, System.Func<string> valueFunc) { }
         public void AddReportable(string key, string value) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(FluentAssertions.Execution.Reason reason) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1197,6 +1197,7 @@ namespace FluentAssertions.Execution
         public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
+        public void AddDeferredReportable(string key, System.Func<string> valueFunc) { }
         public void AddNonReportable(string key, object value) { }
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
         public void AddReportable(string key, string value) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1197,9 +1197,9 @@ namespace FluentAssertions.Execution
         public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
-        public void AddDeferredReportable(string key, System.Func<string> valueFunc) { }
         public void AddNonReportable(string key, object value) { }
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, System.Func<string> valueFunc) { }
         public void AddReportable(string key, string value) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(FluentAssertions.Execution.Reason reason) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1197,6 +1197,7 @@ namespace FluentAssertions.Execution
         public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
+        public void AddDeferredReportable(string key, System.Func<string> valueFunc) { }
         public void AddNonReportable(string key, object value) { }
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
         public void AddReportable(string key, string value) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1150,6 +1150,7 @@ namespace FluentAssertions.Execution
         public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
+        public void AddDeferredReportable(string key, System.Func<string> valueFunc) { }
         public void AddNonReportable(string key, object value) { }
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
         public void AddReportable(string key, string value) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1150,9 +1150,9 @@ namespace FluentAssertions.Execution
         public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
-        public void AddDeferredReportable(string key, System.Func<string> valueFunc) { }
         public void AddNonReportable(string key, object value) { }
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, System.Func<string> valueFunc) { }
         public void AddReportable(string key, string value) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(FluentAssertions.Execution.Reason reason) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1197,9 +1197,9 @@ namespace FluentAssertions.Execution
         public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
-        public void AddDeferredReportable(string key, System.Func<string> valueFunc) { }
         public void AddNonReportable(string key, object value) { }
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
+        public void AddReportable(string key, System.Func<string> valueFunc) { }
         public void AddReportable(string key, string value) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(FluentAssertions.Execution.Reason reason) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1197,6 +1197,7 @@ namespace FluentAssertions.Execution
         public bool Succeeded { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
         public static FluentAssertions.Execution.AssertionScope Current { get; }
+        public void AddDeferredReportable(string key, System.Func<string> valueFunc) { }
         public void AddNonReportable(string key, object value) { }
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
         public void AddReportable(string key, string value) { }

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -643,6 +643,52 @@ namespace FluentAssertions.Specs.Execution
                 .WithMessage("*SomeValue*AnotherValue*");
         }
 
+        [Fact]
+        public void When_using_a_deferred_reportable_value_it_is_not_calculated_if_there_are_no_failures()
+        {
+            // Arrange
+            var scope = new AssertionScope();
+            var deferredValueInvoked = false;
+
+            scope.AddDeferredReportable("MyKey", () =>
+            {
+                deferredValueInvoked = true;
+
+                return "MyValue";
+            });
+
+            // Act
+            scope.Dispose();
+
+            // Assert
+            deferredValueInvoked.Should().BeFalse();
+        }
+
+        [Fact]
+        public void When_using_a_deferred_reportable_value_it_is_calculated_if_there_is_a_failure()
+        {
+            // Arrange
+            var scope = new AssertionScope();
+            var deferredValueInvoked = false;
+
+            scope.AddDeferredReportable("MyKey", () =>
+            {
+                deferredValueInvoked = true;
+
+                return "MyValue";
+            });
+
+            AssertionScope.Current.FailWith("{MyKey}");
+
+            // Act
+            Action act = scope.Dispose;
+
+            // Assert
+            act.Should().ThrowExactly<XunitException>()
+                .WithMessage("*MyValue*");
+            deferredValueInvoked.Should().BeTrue();
+        }
+
         #endregion
 
         #region Chaining API

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -650,7 +650,7 @@ namespace FluentAssertions.Specs.Execution
             var scope = new AssertionScope();
             var deferredValueInvoked = false;
 
-            scope.AddDeferredReportable("MyKey", () =>
+            scope.AddReportable("MyKey", () =>
             {
                 deferredValueInvoked = true;
 
@@ -671,7 +671,7 @@ namespace FluentAssertions.Specs.Execution
             var scope = new AssertionScope();
             var deferredValueInvoked = false;
 
-            scope.AddDeferredReportable("MyKey", () =>
+            scope.AddReportable("MyKey", () =>
             {
                 deferredValueInvoked = true;
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -16,6 +16,7 @@ sidebar:
 * Added `WithResult` extension method to `CompleteWithinAsync` assertions for `Task<T>` and `TaskCompletionSource<T>` - [#1478](https://github.com/fluentassertions/fluentassertions/pull/1478).
 * Added `Satisfy` to be able to compare a collection with a set of predicates in any order - [#1500](https://github.com/fluentassertions/fluentassertions/pull/1500).
 * Added milliseconds formatting for error messages including `TimeSpan` - [#1504](https://github.com/fluentassertions/fluentassertions/pull/1504).
+* Added `AddReportable` overload to `AssertionScope` for deferring reportable value calculation only on a test failure - [#1515](https://github.com/fluentassertions/fluentassertions/pull/1515).
 
 **Fixes**
 * Sometimes `BeEquivalentTo` reported an incorrect message when a dictionary was missing a key - [#1454](https://github.com/fluentassertions/fluentassertions/pull/1454)


### PR DESCRIPTION
Discussed [here](https://github.com/fluentassertions/fluentassertions/discussions/1509) - I thought I'd contribute a potential solution.

My personal use case is that I've got some costly calculations to display user-friendly failure info, and I'd like to avoid doing this for the 99% case where the tests run successfully.

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).