### PR TITLE
Fix context pattern in error message when implementing multiple interfaces

### DIFF
--- a/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/GenericDictionaryEquivalencyStep.cs
@@ -83,7 +83,7 @@ namespace FluentAssertions.Equivalency
             }
 
             AssertionScope.Current.FailWith(
-                "{{context:Expectation}} implements multiple dictionary types.  "
+                "{context:Expectation} implements multiple dictionary types.  "
              + $"It is not known which type should be use for equivalence.{Environment.NewLine}"
              + $"The following IDictionary interfaces are implemented: {string.Join(", ", (IEnumerable<Type>)interfaces)}");
 

--- a/Tests/FluentAssertions.Specs/Equivalency/DictionaryEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DictionaryEquivalencySpecs.cs
@@ -527,14 +527,15 @@ namespace FluentAssertions.Specs.Equivalency
         public void When_an_object_implements_two_IDictionary_interfaces_it_should_fail_descriptively()
         {
             // Arrange
-            var object1 = new ClassWithTwoDictionaryImplementations();
-            var object2 = new ClassWithTwoDictionaryImplementations();
+            var object1 = (object)new ClassWithTwoDictionaryImplementations();
+            var object2 = (object)new ClassWithTwoDictionaryImplementations();
 
             // Act
             Action act = () => object1.Should().BeEquivalentTo(object2);
 
             // Assert
-            act.Should().NotThrow();
+            act.Should().Throw<XunitException>()
+                .WithMessage("*Object1*implements multiple dictionary types*");
         }
 
         [Fact]


### PR DESCRIPTION
In c847f3cc `When_an_object_implements_two_IDictionary_interfaces_it_should_fail_descriptively` was changed to asserting that it didn't throw an exception.
It looks as a mistake to me.

The error in the context pattern was introduced in d2e61fc5 but `When_an_object_implements_two_IDictionary_interfaces_it_should_fail_descriptively` no longer caught the error.

 


