### PR TITLE
Simplify code with C# 9 features

### DIFF
--- a/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingSolver.cs
+++ b/Src/FluentAssertions/Collections/MaximumMatching/MaximumMatchingSolver.cs
@@ -110,7 +110,7 @@ namespace FluentAssertions.Collections.MaximumMatching
             public Predicate<TValue> GetMatchedPredicate(Element<TValue> element)
             {
                 return matchesByElement[element].Predicate;
-            }                
+            }
 
             public bool Contains(Element<TValue> element) => matchesByElement.ContainsKey(element);
 

--- a/Src/FluentAssertions/Common/StringExtensions.cs
+++ b/Src/FluentAssertions/Common/StringExtensions.cs
@@ -27,7 +27,7 @@ namespace FluentAssertions.Common
 
         private static Func<char, char, bool> GetCharComparer(StringComparison stringComparison) =>
             stringComparison == StringComparison.Ordinal
-                ? (Func<char, char, bool>)((x, y) => x == y)
+                ? ((x, y) => x == y)
                 : (x, y) => char.ToUpperInvariant(x) == char.ToUpperInvariant(y);
 
         /// <summary>

--- a/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
+++ b/Src/FluentAssertions/Equivalency/EnumEqualityStep.cs
@@ -110,7 +110,7 @@ namespace FluentAssertions.Equivalency
 
         private static decimal? ExtractDecimal(object o)
         {
-            return o is not null ? Convert.ToDecimal(o, CultureInfo.InvariantCulture) : (decimal?)null;
+            return o is not null ? Convert.ToDecimal(o, CultureInfo.InvariantCulture) : null;
         }
     }
 }

--- a/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
@@ -16,13 +16,13 @@ namespace FluentAssertions.Equivalency.Matching
             if (config.IncludeProperties)
             {
                 PropertyInfo propertyInfo = subject.GetType().FindProperty(expectedMember.Name, expectedMember.Type);
-                subjectMember = (propertyInfo is not null) && !propertyInfo.IsIndexer() ? (IMember)new Property(propertyInfo, parent) : null;
+                subjectMember = (propertyInfo is not null) && !propertyInfo.IsIndexer() ? new Property(propertyInfo, parent) : null;
             }
 
             if ((subjectMember is null) && config.IncludeFields)
             {
                 FieldInfo fieldInfo = subject.GetType().FindField(expectedMember.Name, expectedMember.Type);
-                subjectMember = (fieldInfo is not null) ? (IMember)new Field(fieldInfo, parent) : null;
+                subjectMember = (fieldInfo is not null) ? new Field(fieldInfo, parent) : null;
             }
 
             if ((subjectMember is null || !config.UseRuntimeTyping) && ExpectationImplementsMemberExplicitly(subject, expectedMember))

--- a/Src/FluentAssertions/Equivalency/Matching/TryMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/TryMatchByNameRule.cs
@@ -17,7 +17,7 @@ namespace FluentAssertions.Equivalency.Matching
             }
 
             FieldInfo field = subject.GetType().FindField(expectedMember.Name, expectedMember.Type);
-            return (field is not null) ? (IMember)new Field(field, parent) : null;
+            return (field is not null) ? new Field(field, parent) : null;
         }
 
         /// <inheritdoc />

--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -210,7 +210,7 @@ namespace FluentAssertions.Execution
 
         public GivenSelector<T> Given<T>(Func<T> selector)
         {
-            return new GivenSelector<T>(selector, this, continueAsserting: !succeeded.HasValue || succeeded.Value);
+            return new GivenSelector<T>(selector, this, continueAsserting: succeeded != false);
         }
 
         public AssertionScope ForCondition(bool condition)
@@ -255,7 +255,7 @@ namespace FluentAssertions.Execution
         {
             try
             {
-                bool failed = !succeeded.HasValue || !succeeded.Value;
+                bool failed = succeeded != true;
                 if (failed)
                 {
                     string result = failReasonFunc();

--- a/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -29,7 +29,7 @@ namespace FluentAssertions.Formatting
 
         /// <summary>
         /// This step simplifies the lambda expression by replacing parts of it which do not depend on the lambda parameters
-        /// with the actual values of these sub-expressions. The simplified expression is much easier to read. 
+        /// with the actual values of these sub-expressions. The simplified expression is much easier to read.
         /// E.g. "(_.Text == "two") AndAlso (_.Number == 3)"
         /// Instead of "(_.Text == value(FluentAssertions.Specs.Collections.GenericCollectionAssertionsSpecs+c__DisplayClass122_0).twoText) AndAlso (_.Number == 3)".
         /// </summary>

--- a/Src/FluentAssertions/Primitives/BooleanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/BooleanAssertions.cs
@@ -87,7 +87,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> Be(bool expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && Subject.Value == expected)
+                .ForCondition(Subject == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:boolean} to be {0}{reason}, but found {1}.", expected, Subject);
 
@@ -108,7 +108,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotBe(bool unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.HasValue || (Subject.Value != unexpected))
+                .ForCondition(Subject != unexpected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:boolean} not to be {0}{reason}, but found {1}.", unexpected, Subject);
 

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -60,7 +60,7 @@ namespace FluentAssertions.Primitives
                 .ForCondition(Subject == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} to be {0}{reason}, but found {1}.",
-                    expected, Subject ?? default(DateTime?));
+                    expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -82,7 +82,7 @@ namespace FluentAssertions.Primitives
                 .ForCondition(Subject == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} to be {0}{reason}, but found {1}.",
-                    expected, Subject ?? default(DateTime?));
+                    expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -171,7 +171,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be within {0} from {1}{reason}, but found {2}.",
                     precision,
-                    nearbyTime, Subject ?? default(DateTime?));
+                    nearbyTime, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -217,7 +217,7 @@ namespace FluentAssertions.Primitives
                 .FailWith(
                     "Did not expect {context:the date and time} to be within {0} from {1}{reason}, but it was {2}.",
                     precision,
-                    distantTime, Subject ?? default(DateTime?));
+                    distantTime, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -240,7 +240,7 @@ namespace FluentAssertions.Primitives
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) < 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be before {0}{reason}, but found {1}.", expected,
-                    Subject ?? default(DateTime?));
+                    Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -280,7 +280,7 @@ namespace FluentAssertions.Primitives
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) <= 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be on or before {0}{reason}, but found {1}.", expected,
-                    Subject ?? default(DateTime?));
+                    Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -320,7 +320,7 @@ namespace FluentAssertions.Primitives
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) > 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be after {0}{reason}, but found {1}.", expected,
-                    Subject ?? default(DateTime?));
+                    Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -360,7 +360,7 @@ namespace FluentAssertions.Primitives
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) >= 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be on or after {0}{reason}, but found {1}.", expected,
-                    Subject ?? default(DateTime?));
+                    Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeAssertions.cs
@@ -57,7 +57,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> Be(DateTime expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && (Subject.Value == expected))
+                .ForCondition(Subject == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} to be {0}{reason}, but found {1}.",
                     expected, Subject ?? default(DateTime?));
@@ -102,7 +102,7 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.HasValue || (Subject.Value != unexpected))
+                .ForCondition(Subject != unexpected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} not to be {0}{reason}, but it is.", unexpected);
 
@@ -124,9 +124,7 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(
-                    (!Subject.HasValue == unexpected.HasValue) ||
-                    (Subject.HasValue && unexpected.HasValue && Subject.Value != unexpected))
+                .ForCondition(Subject != unexpected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:date and time} not to be {0}{reason}, but it is.", unexpected);
 
@@ -169,7 +167,7 @@ namespace FluentAssertions.Primitives
             DateTime maximumValue = nearbyTime.AddTicks(Math.Min(precision.Ticks, distanceToMaxInTicks));
 
             Execute.Assertion
-                .ForCondition(Subject.HasValue && (Subject.Value >= minimumValue) && (Subject.Value <= maximumValue))
+                .ForCondition((Subject >= minimumValue) && (Subject.Value <= maximumValue))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be within {0} from {1}{reason}, but found {2}.",
                     precision,
@@ -214,7 +212,7 @@ namespace FluentAssertions.Primitives
             DateTime maximumValue = distantTime.AddTicks(Math.Min(precision.Ticks, distanceToMaxInTicks));
 
             Execute.Assertion
-                .ForCondition(Subject.HasValue && ((Subject.Value < minimumValue) || (Subject.Value > maximumValue)))
+                .ForCondition((Subject < minimumValue) || (Subject > maximumValue))
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Did not expect {context:the date and time} to be within {0} from {1}{reason}, but it was {2}.",

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -62,7 +62,7 @@ namespace FluentAssertions.Primitives
                 .ForCondition(Subject == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be {0}{reason}, but it was {1}.",
-                    expected, Subject ?? default(DateTimeOffset?));
+                    expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -85,7 +85,7 @@ namespace FluentAssertions.Primitives
                 .ForCondition(Subject == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be {0}{reason}, but it was {1}.",
-                    expected, Subject ?? default(DateTimeOffset?));
+                    expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -221,7 +221,7 @@ namespace FluentAssertions.Primitives
                 .FailWith(
                     "Did not expect {context:the date and time} to be within {0} from {1}{reason}, but it was {2}.",
                     precision,
-                    distantTime, Subject ?? default(DateTimeOffset?));
+                    distantTime, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -244,7 +244,7 @@ namespace FluentAssertions.Primitives
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) < 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be before {0}{reason}, but it was {1}.", expected,
-                    Subject ?? default(DateTimeOffset?));
+                    Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -284,7 +284,7 @@ namespace FluentAssertions.Primitives
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) <= 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be on or before {0}{reason}, but it was {1}.", expected,
-                    Subject ?? default(DateTimeOffset?));
+                    Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -324,7 +324,7 @@ namespace FluentAssertions.Primitives
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) > 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be after {0}{reason}, but it was {1}.", expected,
-                    Subject ?? default(DateTimeOffset?));
+                    Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -364,7 +364,7 @@ namespace FluentAssertions.Primitives
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) >= 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be on or after {0}{reason}, but it was {1}.", expected,
-                    Subject ?? default(DateTimeOffset?));
+                    Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -59,7 +59,7 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && (Subject.Value == expected))
+                .ForCondition(Subject == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be {0}{reason}, but it was {1}.",
                     expected, Subject ?? default(DateTimeOffset?));
@@ -105,7 +105,7 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.HasValue || (Subject.Value != unexpected))
+                .ForCondition(Subject != unexpected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:the date and time} to be {0}{reason}, but it was.", unexpected);
 
@@ -127,8 +127,7 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition((!Subject.HasValue == unexpected.HasValue) ||
-                (Subject.HasValue && unexpected.HasValue && Subject.Value != unexpected))
+                .ForCondition(Subject != unexpected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:the date and time} to be {0}{reason}, but it was.", unexpected);
 
@@ -172,7 +171,7 @@ namespace FluentAssertions.Primitives
             DateTimeOffset maximumValue = nearbyTime.AddTicks(Math.Min(precision.Ticks, distanceToMaxInTicks));
 
             Execute.Assertion
-                .ForCondition(Subject.HasValue && (Subject.Value >= minimumValue) && (Subject.Value <= maximumValue))
+                .ForCondition(Subject >= minimumValue && (Subject <= maximumValue))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:the date and time} to be within {0} from {1}{reason}, but it was {2}.",
                     precision,
@@ -217,7 +216,7 @@ namespace FluentAssertions.Primitives
             DateTimeOffset maximumValue = distantTime.AddTicks(Math.Min(precision.Ticks, distanceToMaxInTicks));
 
             Execute.Assertion
-                .ForCondition(Subject.HasValue && ((Subject.Value < minimumValue) || (Subject.Value > maximumValue)))
+                .ForCondition((Subject < minimumValue) || (Subject > maximumValue))
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Did not expect {context:the date and time} to be within {0} from {1}{reason}, but it was {2}.",

--- a/Src/FluentAssertions/Primitives/GuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/GuidAssertions.cs
@@ -48,7 +48,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && (Subject.Value == Guid.Empty))
+                .ForCondition(Subject == Guid.Empty)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:Guid} to be empty{reason}, but found {0}.", Subject);
 
@@ -110,7 +110,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> Be(Guid expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.HasValue && Subject.Value == expected)
+                .ForCondition(Subject == expected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:Guid} to be {0}{reason}, but found {1}.", expected, Subject);
 
@@ -131,7 +131,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotBe(Guid unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.HasValue || Subject.Value != unexpected)
+                .ForCondition(Subject != unexpected)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:Guid} to be {0}{reason}.", Subject);
 

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -281,7 +281,7 @@ namespace FluentAssertions.Primitives
             TimeSpan maximumValue = nearbyTime + precision;
 
             Execute.Assertion
-                .ForCondition(Subject.HasValue && (Subject.Value >= minimumValue) && (Subject.Value <= maximumValue))
+                .ForCondition((Subject >= minimumValue) && (Subject.Value <= maximumValue))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:time} to be within {0} from {1}{reason}, but found {2}.",
                     precision,
@@ -323,7 +323,7 @@ namespace FluentAssertions.Primitives
             TimeSpan maximumValue = distantTime + precision;
 
             Execute.Assertion
-                .ForCondition(Subject.HasValue && !((Subject.Value >= minimumValue) && (Subject.Value <= maximumValue)))
+                .ForCondition(Subject < minimumValue || Subject > maximumValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:time} to not be within {0} from {1}{reason}, but found {2}.",
                     precision,

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -285,7 +285,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:time} to be within {0} from {1}{reason}, but found {2}.",
                     precision,
-                    nearbyTime, Subject ?? default(TimeSpan?));
+                    nearbyTime, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -327,7 +327,7 @@ namespace FluentAssertions.Primitives
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:time} to not be within {0} from {1}{reason}, but found {2}.",
                     precision,
-                    distantTime, Subject ?? default(TimeSpan?));
+                    distantTime, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Tests/FluentAssertions.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
@@ -150,7 +150,7 @@ namespace FluentAssertions.Specs.Equivalency
                 }
 
                 PropertyInfo runtimeProperty = subject.GetType().GetRuntimeProperty(name);
-                return (runtimeProperty is not null) ? (IMember)new Property(runtimeProperty, parent) : null;
+                return (runtimeProperty is not null) ? new Property(runtimeProperty, parent) : null;
             }
         }
 

--- a/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Events/EventAssertionSpecs.cs
@@ -837,9 +837,9 @@ namespace FluentAssertions.Specs.Events
 
             public int SomeOtherProperty { get; set; }
 
-            public event PropertyChangedEventHandler PropertyChanged = (_, __) => { };
+            public event PropertyChangedEventHandler PropertyChanged = (_, _) => { };
 
-            public event Action<string, int, string> NonConventionalEvent = (_, __, ___) => { };
+            public event Action<string, int, string> NonConventionalEvent = (_, _, _) => { };
 
             public void RaiseNonConventionalEvent(string first, int second, string third)
             {

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -352,7 +352,7 @@ namespace FluentAssertions.Specs.Exceptions
         }
 
         [Fact]
-        public async Task When_async_method_throws_expected_exception__through_ValueTask_it_should_succeed()
+        public async Task When_async_method_throws_expected_exception_through_ValueTask_it_should_succeed()
         {
             // Arrange
             var asyncObject = new AsyncClass();

--- a/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
@@ -301,7 +301,7 @@ namespace FluentAssertions.Specs.Numeric
         #region NotBeInRange
 
         [Fact]
-        public void When_assertion_an_instance_to_not_be_in_a_certain_range_and_it_is_not__it_should_succeed()
+        public void When_assertion_an_instance_to_not_be_in_a_certain_range_and_it_is_not_it_should_succeed()
         {
             // Arrange
             var subject = new ComparableOfInt(3);

--- a/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
@@ -116,7 +116,7 @@ namespace FluentAssertions.Specs.Specialized
         }
 
         [Fact]
-        public void When_the_execution_time_of_an_action_is_not_less_than_a_limit__it_should_throw()
+        public void When_the_execution_time_of_an_action_is_not_less_than_a_limit_it_should_throw()
         {
             // Arrange
             Action someAction = () => Thread.Sleep(510);
@@ -130,7 +130,7 @@ namespace FluentAssertions.Specs.Specialized
         }
 
         [Fact]
-        public void When_the_execution_time_of_an_async_action_is_not_less_than_a_limit__it_should_throw()
+        public void When_the_execution_time_of_an_async_action_is_not_less_than_a_limit_it_should_throw()
         {
             // Arrange
             Func<Task> someAction = () => Task.Delay(TimeSpan.FromMilliseconds(150));
@@ -294,7 +294,7 @@ namespace FluentAssertions.Specs.Specialized
         }
 
         [Fact]
-        public void When_the_execution_time_of_an_action_is_not_greater_than_a_limit__it_should_throw()
+        public void When_the_execution_time_of_an_action_is_not_greater_than_a_limit_it_should_throw()
         {
             // Arrange
             Action someAction = () => Thread.Sleep(100);
@@ -386,7 +386,7 @@ namespace FluentAssertions.Specs.Specialized
         }
 
         [Fact]
-        public void When_the_execution_time_of_an_action_is_not_close_to_a_limit__it_should_throw()
+        public void When_the_execution_time_of_an_action_is_not_close_to_a_limit_it_should_throw()
         {
             // Arrange
             Action someAction = () => Thread.Sleep(200);

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
@@ -266,7 +266,7 @@ namespace FluentAssertions.Specs.Types
     internal class TestClassForMethodSelector
     {
 #pragma warning disable 67 // "event is never used"
-        public event EventHandler SomethingChanged = (_, __) => { };
+        public event EventHandler SomethingChanged = (_, _) => { };
 #pragma warning restore 67
 
         public virtual void PublicVirtualVoidMethod()


### PR DESCRIPTION
C# 9.0 brought two new features we can use to simplify the code a bit.
* [Target-Typed Conditional Expression
](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/target-typed-conditional-expression)
* [Lambda discard parameters
](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/lambda-discard-parameters)

For three-valued boolean logic in C# we can utilize [lifted operators](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/nullable-value-types#lifted-operators) to simplify the expressions.
For IL/ASM interested [sharplab.io](https://sharplab.io/#v2:EYLgtghglgdgNAFxBAzmAPgAQMwAJMCMAbLvgEy4DCuAsAFADe9ppA9K7gMYCuATrwFMYCZixz5iuYAHtpAG1wA5aQgBCAynOkoBAFWkAKWAgD8uCHFzHcWgO4Del69wAOLhwEpcAXgB8tOhYg8wA6AAlUADUIOW4BXAAyBNwDCBDo2PiAHhtpe15cdHRQjLjcf1d3Xg8AblFSetx2XBdBBAQoARQRQLE8QhIZeSUVdU1tPWkyI2EzCythXPynRcrPH39GoIhcHLsHQuKdircHOt6Gi6aOOQFUBHMUHTBgOQBPXBAPRvEBqVkFMo1BotDp9NgZqZzCsHvtHAsHmtqhsAsEWGkIihSvEkik0gBxAQIbEAeV4ABEBAAzCDcOQIAxePZ5A5FUKE4kxOJkyk0ukMrwnKq1egAXyAA===)

I have not dug into why we have expressions such as `Subject ?? default(DateTime?)` when `Subject` itself was of type `DateTime?`, but it's redundant to return another empty nullable. 