### PR TITLE
Create SourceLink-Enabled and Deterministic nupkg

### DIFF
--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -24,9 +24,7 @@ class Build : NukeBuild
        - Microsoft VSCode           https://nuke.build/vscode
     */
 
-    public static int Main() => Execute<Build>(
-        x => x.UnitTests,
-        x => x.Pack);
+    public static int Main() => Execute<Build>(x => x.Pack);
 
     [Solution(GenerateProjects = true)] readonly Solution Solution;
     [GitVersion] readonly GitVersion GitVersion;
@@ -35,13 +33,13 @@ class Build : NukeBuild
     AbsolutePath ArtifactsDirectory => RootDirectory / "Artifacts";
 
     Target Clean => _ => _
-        .Before(Restore)
         .Executes(() =>
         {
             EnsureCleanDirectory(ArtifactsDirectory);
         });
 
     Target Restore => _ => _
+        .DependsOn(Clean)
         .Executes(() =>
         {
             DotNetRestore(s => s
@@ -119,6 +117,7 @@ class Build : NukeBuild
                 .SetProject(Solution.Core.FluentAssertions)
                 .SetOutputDirectory(ArtifactsDirectory)
                 .SetConfiguration("Release")
+                .EnableContinuousIntegrationBuild() // Necessary for deterministic builds
                 .SetVersion(GitVersion.NuGetVersionV2));
         });
 }

--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -10,6 +10,7 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <CodeAnalysisRuleSet>..\..\Rules.ruleset</CodeAnalysisRuleSet>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <OutputPath>..\..\Artifacts\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
@@ -45,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <None Include="..\FluentAssertions.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">


### PR DESCRIPTION
Enable SourceLink and Deterministic builds:
* Two more green badges in Nuget Package Explorer
* Size reduction (1.50 MB -> 1.14 MB) since pdb files are no longer embedded in nupkg, but only downloaded on demand.

Possible downsides/caveats:
* Only nuget.org has a symbol server (this might not be true anymore), this is only a problem if we want to switch/add provider.
* You can't step through FA while being offline (unless the symbols are cached somewhere locally)
* Your IDE is too old to have support for symbols servers (before Visual Studio 2017 version 15.9)
* Your IDE isn't set up to download symbols from the nuget symbol server (before Visual Studio 2019 version 16.1)

The limitations of snupkg in contrast to pdb

> * They do not currently support Windows PDBs (generated by VC++, or for managed projects that set build property `DebugType` to `full`)
> * They require the library to be built by newer C#/VB compiler (Visual Studio 2017 Update 9).
> * The consumer of the package also needs Visual Studio 2017 Update 9 debugger.
> * Not supported by [Azure DevOps Artifacts](https://azure.microsoft.com/en-us/services/devops/artifacts) service.

https://github.com/dotnet/sourcelink#alternative-pdb-distribution

A thing that talks in favor of snupkg is that there in an active [issue](https://github.com/dotnet/sdk/issues/1458) with applications targeting .net core 3.0 and symbols from pdb files.
I tested this with Newtonsoft.Json in VS to see when I could step into the source of `JsonConvert`.
12.0.1 and 12.0.2 both have sourcelink, but the former includes symbols in pdb files and the latter publishes a snupkg.

|               | 12.0.1/pdb | 12.0.2/snupkg |
|---------------|:----------:|:-------------:|
| netcoreapp2.1 |     OK     |       OK      |
| netcoreapp3.1 |    FAIL    |       OK      |

Links:
* https://github.com/dotnet/sourcelink
* https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink
* https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/nuget#symbol-packages

Before
![image](https://user-images.githubusercontent.com/919634/114305682-926b0500-9ad9-11eb-8208-038d3dd0735b.png)

After
![image](https://user-images.githubusercontent.com/919634/114306244-a6176b00-9adb-11eb-9265-84402fda2bd1.png)
