### PR TITLE
Update minimum .NET SDK to support OR_GREATER

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 See https://www.fluentassertions.com for background information, usage documentation, an extensibility guide, support information and more tips & tricks.
 
 # How do I build this?
-Install Visual Studio 2019 or JetBrains Rider 2017.1 and Build Tools 2017 and run
+Install Visual Studio 2019 16.9+ or JetBrains Rider 2017.1 and Build Tools 2017 and run.
+You will also need to have .NET Framework 4.7 SDK and .NET 5.0 SDK installed - check [global.json](global.json) for the current minimum required version.
 
 # What are these Approval.Tests?
 This is a special set of tests that use the [Verify](https://github.com/VerifyTests/Verify) project to verify whether you've introduced any breaking changes in the public API of the library.

--- a/docs/_pages/about.md
+++ b/docs/_pages/about.md
@@ -82,6 +82,6 @@ The version numbers of Fluent Assertions releases comply to the [Semantic Versio
 
 ## What do you need to compile the solution?
 
-* Visual Studio 2019 or Jetbrains Rider and Build Tools 2017
+* Visual Studio 2019 16.9+ or Jetbrains Rider and Build Tools 2017
 * Windows 10
-* .NET Core SDK 3.0
+* .NET Framework 4.7 SDK and .NET 5.0 SDK (check [global.json](https://github.com/fluentassertions/fluentassertions/tree/develop/global.json) for the current minimum required version)

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "5.0.100",
+        "version": "5.0.200",
         "rollForward": "latestFeature"
     }
 }


### PR DESCRIPTION
.NET SDK 5.0.200 added support for OR_GREATER preprocessor directives
to simplify multi-targeting.
https://github.com/dotnet/core/blob/main/release-notes/5.0/5.0.3/5.0.200-sdk.md#notable-changes

Is "current minimum required version" correct grammar ❓ 