### PR TITLE
Scan AppDomain to detect nspec assembly

### DIFF
--- a/Src/FluentAssertions/Execution/NSpecFramework.cs
+++ b/Src/FluentAssertions/Execution/NSpecFramework.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection;
 
 namespace FluentAssertions.Execution
@@ -11,23 +12,18 @@ namespace FluentAssertions.Execution
         {
             get
             {
-                try
-                {
-                    assembly = Assembly.Load(new AssemblyName("nspec"));
+                assembly = AppDomain.CurrentDomain
+                    .GetAssemblies()
+                    .FirstOrDefault(a => a.FullName.StartsWith("nspec,", StringComparison.OrdinalIgnoreCase));
 
-                    if (assembly is null)
-                    {
-                        return false;
-                    }
-
-                    int majorVersion = assembly.GetName().Version.Major;
-
-                    return majorVersion >= 2;
-                }
-                catch
+                if (assembly is null)
                 {
                     return false;
                 }
+
+                int majorVersion = assembly.GetName().Version.Major;
+
+                return majorVersion >= 2;
             }
         }
 

--- a/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
+++ b/Src/FluentAssertions/Execution/TestFrameworkProvider.cs
@@ -15,7 +15,7 @@ namespace FluentAssertions.Execution
             ["nspec3"] = new NSpecFramework(),
             ["nunit"] = new NUnitTestFramework(),
             ["mstestv2"] = new MSTestFrameworkV2(),
-            ["xunit2"] = new XUnit2TestFramework()
+            ["xunit2"] = new XUnit2TestFramework() // Keep this the last one as it uses a try/catch approach
         };
 
         private static ITestFramework testFramework;

--- a/Src/FluentAssertions/Execution/XUnit2TestFramework.cs
+++ b/Src/FluentAssertions/Execution/XUnit2TestFramework.cs
@@ -13,6 +13,7 @@ namespace FluentAssertions.Execution
             {
                 try
                 {
+                    // For netfx the assembly is not in AppDomain by default, so we can't just scan AppDomain.CurrentDomain
                     assembly = Assembly.Load(new AssemblyName("xunit.assert"));
 
                     return assembly is not null;

--- a/Tests/TestFrameworks/XUnit2.Specs/XUnit2.Specs.csproj
+++ b/Tests/TestFrameworks/XUnit2.Specs/XUnit2.Specs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net47;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>XUnit2.Specs</RootNamespace>
     <AssemblyName>XUnit2.Specs</AssemblyName>
     <CodeAnalysisRuleSet>..\..\..\TestRules.ruleset</CodeAnalysisRuleSet>


### PR DESCRIPTION
A colleague who had "Just My Code"  in VS disabled wondered why he saw an assembly not found exception for nspec.
When I implemented this in #702 I probably just copied the xunit approach, but it _needs_ to use `Assembly.Load` for netfx #384.
For nspec this does not seems necessary and we can use the non-throwing from `LateBoundTestFramework`

I've checked the build pipeline locally that both targets of xunit are run.