### PR TITLE
Avoid boxing when comparing for equality

### DIFF
--- a/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
@@ -49,7 +49,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.IsSameOrEqualTo(expected))
+                .ForCondition(Equals(Subject, expected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:object} to be equal to {0}{reason}, but found {1}.", expected, Subject);
 
@@ -138,7 +138,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.IsSameOrEqualTo(unexpected))
+                .ForCondition(!Equals(Subject, unexpected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:object} to be equal to {0}{reason}.", unexpected);
 

--- a/Src/FluentAssertions/Primitives/ObjectAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ObjectAssertions.cs
@@ -43,7 +43,7 @@ namespace FluentAssertions.Primitives
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.IsSameOrEqualTo(expected))
+                .ForCondition(ObjectExtensions.GetComparer<TSubject>()(Subject, expected))
                 .WithDefaultIdentifier(Identifier)
                 .FailWith("Expected {context} to be {0}{reason}, but found {1}.", expected,
                     Subject);
@@ -65,7 +65,7 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotBe(TSubject unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Subject.IsSameOrEqualTo(unexpected))
+                .ForCondition(!ObjectExtensions.GetComparer<TSubject>()(Subject, unexpected))
                 .BecauseOf(because, becauseArgs)
                 .WithDefaultIdentifier(Identifier)
                 .FailWith("Did not expect {context} to be equal to {0}{reason}.", unexpected);

--- a/Tests/Benchmarks/Benchmarks.csproj
+++ b/Tests/Benchmarks/Benchmarks.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFrameworks>net5;net472</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Src\FluentAssertions\FluentAssertions.snk</AssemblyOriginatorKeyFile>

--- a/Tests/Benchmarks/CollectionEqual.cs
+++ b/Tests/Benchmarks/CollectionEqual.cs
@@ -1,15 +1,18 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 using FluentAssertions;
 using FluentAssertions.Common;
 
 namespace Benchmarks
 {
     [MemoryDiagnoser]
-    [RyuJitX86Job]
+    [SimpleJob(RuntimeMoniker.Net472)]
+    [SimpleJob(RuntimeMoniker.NetCoreApp50)]
     public class CollectionEqualBenchmarks
     {
-        private int[] collection1;
-        private int[] collection2;
+        private IEnumerable<int> collection1;
+        private IEnumerable<int> collection2;
 
         [Params(10, 100, 1_000, 5_000, 10_000)]
         public int N { get; set; }
@@ -28,13 +31,13 @@ namespace Benchmarks
         }
 
         [Benchmark]
-        public void CollectionEqual_Generic_IsSameOrEqualTo()
+        public void CollectionEqual_Optimized()
         {
-            collection1.Should().Equal(collection2, (s, e) => ((object)s).IsSameOrEqualTo(e));
+            collection1.Should().Equal(collection2, ObjectExtensions.GetComparer<int>());
         }
 
         [Benchmark]
-        public void CollectionEqual_Generic_Equality()
+        public void CollectionEqual_CustomComparer()
         {
             collection1.Should().Equal(collection2, (a, b) => a == b);
         }

--- a/Tests/Benchmarks/Program.cs
+++ b/Tests/Benchmarks/Program.cs
@@ -6,7 +6,7 @@ namespace Benchmarks
     {
         public static void Main()
         {
-            _ = BenchmarkRunner.Run<LargeDataTableEquivalencyBenchmarks>();
+            _ = BenchmarkRunner.Run<CollectionEqualBenchmarks>();
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/AndWhichConstraintSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AndWhichConstraintSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-
 using FluentAssertions.Collections;
 using Xunit;
 using Xunit.Sdk;

--- a/Tests/FluentAssertions.Specs/Extensions/ObjectExtensionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Extensions/ObjectExtensionsSpecs.cs
@@ -12,7 +12,14 @@ namespace FluentAssertions.Specs.Extensions
         [MemberData(nameof(GetNonEquivalentNumericData))]
         public void When_comparing_non_equivalent_boxed_numerics_it_should_fail(object actual, object expected)
         {
-            actual.IsSameOrEqualTo(expected).Should().BeFalse();
+            // Arrange
+            Func<object, object, bool> comparer = ObjectExtensions.GetComparer<object>();
+
+            // Act
+            bool success = comparer(actual, expected);
+
+            // Assert
+            success.Should().BeFalse();
         }
 
         public static IEnumerable<object[]> GetNonEquivalentNumericData()
@@ -39,7 +46,14 @@ namespace FluentAssertions.Specs.Extensions
         [MemberData(nameof(GetNumericAndNumericData))]
         public void When_comparing_a_numeric_to_a_numeric_it_should_succeed(object actual, object expected)
         {
-            actual.IsSameOrEqualTo(expected).Should().BeTrue();
+            // Arrange
+            Func<object, object, bool> comparer = ObjectExtensions.GetComparer<object>();
+
+            // Act
+            bool success = comparer(actual, expected);
+
+            // Assert
+            success.Should().BeTrue();
         }
 
         public static IEnumerable<object[]> GetNumericAndNumericData()
@@ -53,11 +67,14 @@ namespace FluentAssertions.Specs.Extensions
         [MemberData(nameof(GetNonNumericAndNumericData))]
         public void When_comparing_a_non_numeric_to_a_numeric_it_should_fail(object actual, object unexpected)
         {
+            // Arrange
+            Func<object, object, bool> comparer = ObjectExtensions.GetComparer<object>();
+
             // Act
-            bool isSameOrEquals = actual.IsSameOrEqualTo(unexpected);
+            bool success = comparer(actual, unexpected);
 
             // Assert
-            isSameOrEquals.Should().BeFalse();
+            success.Should().BeFalse();
         }
 
         public static IEnumerable<object[]> GetNonNumericAndNumericData()
@@ -71,11 +88,14 @@ namespace FluentAssertions.Specs.Extensions
         [MemberData(nameof(GetNumericAndNonNumericData))]
         public void When_comparing_a_numeric_to_a_non_numeric_it_should_fail(object actual, object unexpected)
         {
+            // Arrange
+            Func<object, object, bool> comparer = ObjectExtensions.GetComparer<object>();
+
             // Act
-            bool isSameOrEquals = actual.IsSameOrEqualTo(unexpected);
+            bool success = comparer(actual, unexpected);
 
             // Assert
-            isSameOrEquals.Should().BeFalse();
+            success.Should().BeFalse();
         }
 
         public static IEnumerable<object[]> GetNumericAndNonNumericData()
@@ -89,11 +109,14 @@ namespace FluentAssertions.Specs.Extensions
         [MemberData(nameof(GetNonNumericAndNonNumericData))]
         public void When_comparing_a_non_numeric_to_a_non_numeric_it_should_fail(object actual, object unexpected)
         {
+            // Arrange
+            Func<object, object, bool> comparer = ObjectExtensions.GetComparer<object>();
+
             // Act
-            bool isSameOrEquals = actual.IsSameOrEqualTo(unexpected);
+            bool success = comparer(actual, unexpected);
 
             // Assert
-            isSameOrEquals.Should().BeFalse();
+            success.Should().BeFalse();
         }
 
         public static IEnumerable<object[]> GetNonNumericAndNonNumericData()


### PR DESCRIPTION
In #840 I did some optimizations for `Equal` to avoid some boxing value types, but we can do even better!

This PR does two things:
* Avoid all boxing for value types in the comparison method.
* Only perform `CompareNumerics` when `T` is `object`.
  *  This is a generous fallback for comparing boxed numerics.

I picked `net472` as the worst case TFM we support and `net5` as the best case.

`Develop` 
```cs
collection1.Should().Equal(collection2)
```

`Develop_CustomComparer` 
```cs
collection1.Should().Equal(collection2, (a, b) => a == b)
```

`PR`
```cs
collection1.Should().Equal(collection2, ObjectExtensions.GetComparer<int>())
```

```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-10750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.300-preview.21180.15
  [Host]        : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT
  .NET 4.7.2    : .NET Framework 4.8 (4.8.4300.0), X64 RyuJIT
  .NET Core 5.0 : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT
  
|                 Method |       Runtime |     N |         Mean |       Error |      StdDev | Ratio |   Gen 0 | Allocated |
|----------------------- |-------------- |------ |-------------:|------------:|------------:|------:|--------:|----------:|
|                Develop |    .NET 4.7.2 |    10 |   1,376.9 ns |    22.60 ns |    20.04 ns |  1.00 |  0.7076 |   4.35 KB |
| Develop_CustomComparer |    .NET 4.7.2 |    10 |   1,369.5 ns |    17.40 ns |    16.28 ns |  0.99 |  0.6294 |   3.88 KB |
|                     PR |    .NET 4.7.2 |    10 |   1,362.7 ns |    20.73 ns |    19.39 ns |  0.99 |  0.6294 |   3.88 KB |
|                        |               |       |              |             |             |       |         |           |
|                Develop | .NET Core 5.0 |    10 |   1,062.8 ns |    12.98 ns |    12.14 ns |  1.00 |  0.6599 |   4.05 KB |
| Develop_CustomComparer | .NET Core 5.0 |    10 |     940.6 ns |     8.04 ns |     7.13 ns |  0.89 |  0.5836 |   3.58 KB |
|                     PR | .NET Core 5.0 |    10 |     957.3 ns |    19.01 ns |    35.70 ns |  0.94 |  0.5836 |   3.58 KB |
|                        |               |       |              |             |             |       |         |           |
|                Develop |    .NET 4.7.2 |   100 |   3,199.9 ns |    37.26 ns |    34.85 ns |  1.00 |  1.3962 |   8.58 KB |
| Develop_CustomComparer |    .NET 4.7.2 |   100 |   2,245.8 ns |    21.31 ns |    19.94 ns |  0.70 |  0.6294 |   3.88 KB |
|                     PR |    .NET 4.7.2 |   100 |   2,658.9 ns |    52.59 ns |    66.50 ns |  0.84 |  0.6294 |   3.88 KB |
|                        |               |       |              |             |             |       |         |           |
|                Develop | .NET Core 5.0 |   100 |   2,515.3 ns |    32.34 ns |    30.25 ns |  1.00 |  1.3466 |   8.27 KB |
| Develop_CustomComparer | .NET Core 5.0 |   100 |   1,660.8 ns |    23.86 ns |    22.32 ns |  0.66 |  0.5836 |   3.58 KB |
|                     PR | .NET Core 5.0 |   100 |   1,682.4 ns |    16.42 ns |    14.56 ns |  0.67 |  0.5836 |   3.58 KB |
|                        |               |       |              |             |             |       |         |           |
|                Develop |    .NET 4.7.2 |  1000 |  18,743.7 ns |   365.32 ns |   375.16 ns |  1.00 |  8.2703 |  50.89 KB |
| Develop_CustomComparer |    .NET 4.7.2 |  1000 |  11,381.5 ns |   218.45 ns |   233.74 ns |  0.61 |  0.6256 |   3.88 KB |
|                     PR |    .NET 4.7.2 |  1000 |  14,460.0 ns |   245.39 ns |   229.54 ns |  0.77 |  0.6256 |   3.88 KB |
|                        |               |       |              |             |             |       |         |           |
|                Develop | .NET Core 5.0 |  1000 |  17,893.6 ns |   127.90 ns |   119.64 ns |  1.00 |  8.2092 |  50.45 KB |
| Develop_CustomComparer | .NET Core 5.0 |  1000 |   9,247.5 ns |    94.39 ns |    88.30 ns |  0.52 |  0.5798 |   3.58 KB |
|                     PR | .NET Core 5.0 |  1000 |   8,941.7 ns |    97.65 ns |    91.34 ns |  0.50 |  0.5798 |   3.58 KB |
|                        |               |       |              |             |             |       |         |           |
|                Develop |    .NET 4.7.2 |  5000 |  86,172.4 ns | 1,647.57 ns | 1,618.13 ns |  1.00 | 38.8184 | 238.94 KB |
| Develop_CustomComparer |    .NET 4.7.2 |  5000 |  51,771.7 ns |   868.98 ns |   812.85 ns |  0.60 |  0.6104 |   3.88 KB |
|                     PR |    .NET 4.7.2 |  5000 |  67,685.7 ns |   456.88 ns |   381.52 ns |  0.78 |  0.6104 |   3.88 KB |
|                        |               |       |              |             |             |       |         |           |
|                Develop | .NET Core 5.0 |  5000 |  87,125.4 ns | 1,385.73 ns | 1,296.21 ns |  1.00 | 38.8184 | 237.95 KB |
| Develop_CustomComparer | .NET Core 5.0 |  5000 |  42,355.4 ns |   607.94 ns |   507.65 ns |  0.49 |  0.5493 |   3.58 KB |
|                     PR | .NET Core 5.0 |  5000 |  43,113.3 ns |   558.00 ns |   521.95 ns |  0.49 |  0.5493 |   3.58 KB |
|                        |               |       |              |             |             |       |         |           |
|                Develop |    .NET 4.7.2 | 10000 | 171,523.5 ns | 2,120.72 ns | 1,983.72 ns |  1.00 | 77.1484 | 474.01 KB |
| Develop_CustomComparer |    .NET 4.7.2 | 10000 | 107,674.6 ns | 1,374.55 ns | 1,147.81 ns |  0.63 |  0.6104 |   3.88 KB |
|                     PR |    .NET 4.7.2 | 10000 | 158,831.2 ns | 1,656.97 ns | 1,468.86 ns |  0.93 |  0.4883 |   3.88 KB |
|                        |               |       |              |             |             |       |         |           |
|                Develop | .NET Core 5.0 | 10000 | 167,779.2 ns | 2,584.25 ns | 2,417.31 ns |  1.00 | 76.9043 | 472.33 KB |
| Develop_CustomComparer | .NET Core 5.0 | 10000 |  90,068.3 ns | 1,541.58 ns | 1,713.46 ns |  0.54 |  0.4883 |   3.58 KB |
|                     PR | .NET Core 5.0 | 10000 |  85,530.9 ns | 1,134.58 ns | 1,061.28 ns |  0.51 |  0.4883 |   3.58 KB |
```