### PR TITLE
Make [Not]HaveSameCount generic only

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -1452,7 +1451,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> HaveSameCount(IEnumerable otherCollection, string because = "",
+        public AndConstraint<TAssertions> HaveSameCount<TExpectation>(IEnumerable<TExpectation> otherCollection, string because = "",
             params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot verify count against a <null> collection.");
@@ -1467,7 +1466,7 @@ namespace FluentAssertions.Collections
             }
 
             int actualCount = Subject.Count();
-            int expectedCount = (otherCollection as ICollection)?.Count ?? otherCollection.Cast<object>().Count();
+            int expectedCount = otherCollection.Count();
 
             Execute.Assertion
                 .ForCondition(actualCount == expectedCount)
@@ -2390,7 +2389,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotHaveSameCount(IEnumerable otherCollection, string because = "",
+        public AndConstraint<TAssertions> NotHaveSameCount<TExpectation>(IEnumerable<TExpectation> otherCollection, string because = "",
             params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot verify count against a <null> collection.");
@@ -2414,7 +2413,7 @@ namespace FluentAssertions.Collections
             }
 
             int actualCount = Subject.Count();
-            int expectedCount = otherCollection.Cast<object>().Count();
+            int expectedCount = otherCollection.Count();
 
             Execute.Assertion
                 .ForCondition(actualCount != expectedCount)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -377,7 +377,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndWhichConstraint<TAssertions, T> HaveElementAt(int index, T element, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(T successor, T expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(T predecessor, T expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> unexpected, string because = "", params object[] becauseArgs) { }
@@ -406,7 +406,7 @@ namespace FluentAssertions.Collections
             where TKey :  class { }
         public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotIntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> OnlyContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -377,7 +377,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndWhichConstraint<TAssertions, T> HaveElementAt(int index, T element, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(T successor, T expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(T predecessor, T expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> unexpected, string because = "", params object[] becauseArgs) { }
@@ -406,7 +406,7 @@ namespace FluentAssertions.Collections
             where TKey :  class { }
         public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotIntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> OnlyContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -377,7 +377,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndWhichConstraint<TAssertions, T> HaveElementAt(int index, T element, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(T successor, T expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(T predecessor, T expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> unexpected, string because = "", params object[] becauseArgs) { }
@@ -406,7 +406,7 @@ namespace FluentAssertions.Collections
             where TKey :  class { }
         public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotIntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> OnlyContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -370,7 +370,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndWhichConstraint<TAssertions, T> HaveElementAt(int index, T element, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(T successor, T expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(T predecessor, T expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> unexpected, string because = "", params object[] becauseArgs) { }
@@ -399,7 +399,7 @@ namespace FluentAssertions.Collections
             where TKey :  class { }
         public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotIntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> OnlyContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -377,7 +377,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndWhichConstraint<TAssertions, T> HaveElementAt(int index, T element, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(T successor, T expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(T predecessor, T expectation, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveSameCount<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> IntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEquivalentTo<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> unexpected, string because = "", params object[] becauseArgs) { }
@@ -406,7 +406,7 @@ namespace FluentAssertions.Collections
             where TKey :  class { }
         public FluentAssertions.AndConstraint<TAssertions> NotEqual(System.Collections.Generic.IEnumerable<T> unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount(System.Collections.IEnumerable otherCollection, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveSameCount<TExpectation>(System.Collections.Generic.IEnumerable<TExpectation> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotIntersectWith(System.Collections.Generic.IEnumerable<T> otherCollection, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> OnlyContain(System.Linq.Expressions.Expression<System.Func<T, bool>> predicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs) { }

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
@@ -615,7 +615,7 @@ namespace FluentAssertions.Specs.Collections
                 [2] = "Two",
                 [3] = "Three"
             };
-            IEnumerable collection = new[] { 4, 5, 6 };
+            var collection = new[] { 4, 5, 6 };
 
             // Act / Assert
             dictionary.Should().HaveSameCount(collection);
@@ -631,7 +631,7 @@ namespace FluentAssertions.Specs.Collections
                 [2] = "Two",
                 [3] = "Three"
             };
-            IEnumerable collection = new[] { 4, 6 };
+            var collection = new[] { 4, 6 };
 
             // Act
             Action act = () => dictionary.Should().HaveSameCount(collection);
@@ -651,7 +651,7 @@ namespace FluentAssertions.Specs.Collections
                 [2] = "Two",
                 [3] = "Three"
             };
-            IEnumerable collection = new[] { 4, 6 };
+            var collection = new[] { 4, 6 };
 
             // Act
             Action act = () => dictionary.Should().HaveSameCount(collection, "we want to test the {0}", "reason");
@@ -666,7 +666,7 @@ namespace FluentAssertions.Specs.Collections
         {
             // Arrange
             Dictionary<string, int> dictionary = null;
-            IEnumerable collection = new[] { 1, 2, 3 };
+            var collection = new[] { 1, 2, 3 };
 
             // Act
             Action act = () => dictionary.Should().HaveSameCount(collection,
@@ -687,7 +687,7 @@ namespace FluentAssertions.Specs.Collections
                 [2] = "Two",
                 [3] = "Three"
             };
-            IEnumerable collection = null;
+            int[] collection = null;
 
             // Act
             Action act = () => dictionary.Should().HaveSameCount(collection);
@@ -711,7 +711,7 @@ namespace FluentAssertions.Specs.Collections
                 [2] = "Two",
                 [3] = "Three"
             };
-            IEnumerable collection = new[] { 4, 6 };
+            var collection = new[] { 4, 6 };
 
             // Act / Assert
             dictionary.Should().NotHaveSameCount(collection);
@@ -727,7 +727,7 @@ namespace FluentAssertions.Specs.Collections
                 [2] = "Two",
                 [3] = "Three"
             };
-            IEnumerable collection = new[] { 4, 5, 6 };
+            var collection = new[] { 4, 5, 6 };
 
             // Act
             Action act = () => dictionary.Should().NotHaveSameCount(collection);
@@ -747,7 +747,7 @@ namespace FluentAssertions.Specs.Collections
                 [2] = "Two",
                 [3] = "Three"
             };
-            IEnumerable collection = new[] { 4, 5, 6 };
+            var collection = new[] { 4, 5, 6 };
 
             // Act
             Action act = () => dictionary.Should().NotHaveSameCount(collection, "we want to test the {0}", "reason");
@@ -762,7 +762,7 @@ namespace FluentAssertions.Specs.Collections
         {
             // Arrange
             Dictionary<int, string> dictionary = null;
-            IEnumerable collection = new[] { 1, 2, 3 };
+            var collection = new[] { 1, 2, 3 };
 
             // Act
             Action act = () => dictionary.Should().NotHaveSameCount(collection,
@@ -783,7 +783,7 @@ namespace FluentAssertions.Specs.Collections
                 [2] = "Two",
                 [3] = "Three"
             };
-            IEnumerable collection = null;
+            int[] collection = null;
 
             // Act
             Action act = () => dictionary.Should().NotHaveSameCount(collection);
@@ -803,7 +803,7 @@ namespace FluentAssertions.Specs.Collections
                 [2] = "Two",
                 [3] = "Three"
             };
-            IEnumerable collection = dictionary;
+            var collection = dictionary;
 
             // Act
             Action act = () => dictionary.Should().NotHaveSameCount(collection,


### PR DESCRIPTION
In #1529 I missed removing non-generics from `[Not]HaveSameCount`.