### PR TITLE
Ignore the namespace if it is not specified

### DIFF
--- a/Src/FluentAssertions/Xml/XmlElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XmlElementAssertions.cs
@@ -113,7 +113,7 @@ namespace FluentAssertions.Xml
 
         /// <summary>
         /// Asserts that the current <see cref="XmlElement"/> has a direct child element with the specified
-        /// <paramref name="expectedName"/> name.
+        /// <paramref name="expectedName"/> name, ignoring the namespace.
         /// </summary>
         /// <param name="expectedName">The name of the expected child element</param>
         /// <param name="because">
@@ -128,7 +128,7 @@ namespace FluentAssertions.Xml
             string because = "",
             params object[] becauseArgs)
         {
-            return HaveElementWithNamespace(expectedName, string.Empty, because, becauseArgs);
+            return HaveElementWithNamespace(expectedName, null, because, becauseArgs);
         }
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace FluentAssertions.Xml
             string because = "",
             params object[] becauseArgs)
         {
-            XmlElement element = Subject[expectedName, expectedNamespace];
+            XmlElement element = expectedNamespace == null ? Subject[expectedName] : Subject[expectedName, expectedNamespace];
 
             string expectedFormattedName =
                 (string.IsNullOrEmpty(expectedNamespace) ? string.Empty : $"{{{expectedNamespace}}}")

--- a/Tests/FluentAssertions.Specs/Xml/XmlElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XmlElementAssertionSpecs.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Xml;
-using FluentAssertions.Formatting;
 using Xunit;
 using Xunit.Sdk;
 
@@ -417,6 +416,44 @@ namespace FluentAssertions.Specs.Xml
             matchedElement.Should().BeOfType<XmlElement>()
                 .And.HaveAttribute("attr", "1");
             matchedElement.Name.Should().Be("child");
+        }
+
+        [Fact]
+        public void When_asserting_xml_element_with_ns_has_child_element_and_it_does_it_should_succeed()
+        {
+            // Arrange
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(
+                @"<parent xmlns=""test"">
+                    <child>value</child>
+                </parent>");
+            var element = xmlDoc.DocumentElement;
+
+            // Act
+            Action act = () =>
+                element.Should().HaveElement("child");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_xml_element_has_child_element_and_it_does_with_ns_it_should_succeed2()
+        {
+            // Arrange
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(
+                @"<parent>
+                    <child xmlns=""test"">value</child>
+                </parent>");
+            var element = xmlDoc.DocumentElement;
+
+            // Act
+            Action act = () =>
+                element.Should().HaveElement("child");
+
+            // Assert
+            act.Should().NotThrow();
         }
 
         #endregion

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -24,6 +24,7 @@ sidebar:
 * Sometimes `BeEquivalentTo` reported an incorrect message when a dictionary was missing a key - [#1454](https://github.com/fluentassertions/fluentassertions/pull/1454)
 * Some dictionary failures did not honor the user-provided reason - [#1456](https://github.com/fluentassertions/fluentassertions/pull/1456)
 * Restrict what types `WhenTypeIs<T>` can use and how `Using<T>` handles non-nullable types, see the [Migration Guide](/upgradingtov6#using) for more details - [#1494](https://github.com/fluentassertions/fluentassertions/pull/1494).
+* `HaveElement` did not ignore the xml namespace - [#1541](https://github.com/fluentassertions/fluentassertions/pull/1541)
 
 **Breaking Changes**
 * Changed `becauseArgs` of `[Not]Reference(Assembly)` from `string[]` to `object[]` - [#1459](https://github.com/fluentassertions/fluentassertions/pull/1459)


### PR DESCRIPTION
If `HaveElement` is called without a namespace, ignore it when looking for a child element

Fixes #1523

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).