### PR TITLE
Add CreateXmlElement and CreateXmlDocument

### DIFF
--- a/Tests/FluentAssertions.Specs/Xml/XmlElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XmlElementAssertionSpecs.cs
@@ -17,12 +17,8 @@ namespace FluentAssertions.Specs.Xml
             // XmlElementAssertions inherits XmlNodeAssertions.
 
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml("<user>grega</user>");
-            var element = xmlDoc.DocumentElement;
-            var expectedDoc = new XmlDocument();
-            expectedDoc.LoadXml("<user>grega</user>");
-            var expected = expectedDoc.DocumentElement;
+            XmlElement element = CreateXmlElement("<user>grega</user>");
+            XmlElement expected = CreateXmlElement("<user>grega</user>");
 
             // Act
             Action act = () =>
@@ -40,9 +36,7 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_xml_element_has_a_specific_inner_text_and_it_does_it_should_succeed()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml("<user>grega</user>");
-            var element = xmlDoc.DocumentElement;
+            XmlElement element = CreateXmlElement("<user>grega</user>");
 
             // Act
             Action act = () =>
@@ -56,9 +50,7 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_xml_element_has_a_specific_inner_text_but_it_has_a_different_inner_text_it_should_throw()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml("<user>grega</user>");
-            var element = xmlDoc.DocumentElement;
+            XmlElement element = CreateXmlElement("<user>grega</user>");
 
             // Act
             Action act = () =>
@@ -73,9 +65,7 @@ namespace FluentAssertions.Specs.Xml
             When_asserting_xml_element_has_a_specific_inner_text_but_it_has_a_different_inner_text_it_should_throw_with_descriptive_message()
         {
             // Arrange
-            var document = new XmlDocument();
-            document.LoadXml("<user>grega</user>");
-            var theElement = document.DocumentElement;
+            XmlElement theElement = CreateXmlElement("<user>grega</user>");
 
             // Act
             Action act = () =>
@@ -94,9 +84,7 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_xml_element_has_attribute_with_specific_value_and_it_does_it_should_succeed()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(@"<user name=""martin"" />");
-            var element = xmlDoc.DocumentElement;
+            XmlElement element = CreateXmlElement(@"<user name=""martin"" />");
 
             // Act
             Action act = () =>
@@ -110,9 +98,7 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_xml_element_has_attribute_with_ns_and_specific_value_and_it_does_it_should_succeed()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
-            var element = xmlDoc.DocumentElement;
+            XmlElement element = CreateXmlElement(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
 
             // Act
             Action act = () =>
@@ -126,9 +112,7 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(@"<user name=""martin"" />");
-            var element = xmlDoc.DocumentElement;
+            XmlElement element = CreateXmlElement(@"<user name=""martin"" />");
 
             // Act
             Action act = () =>
@@ -143,9 +127,7 @@ namespace FluentAssertions.Specs.Xml
             When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
-            var element = xmlDoc.DocumentElement;
+            XmlElement element = CreateXmlElement(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
 
             // Act
             Action act = () =>
@@ -160,9 +142,7 @@ namespace FluentAssertions.Specs.Xml
             When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var document = new XmlDocument();
-            document.LoadXml(@"<user name=""martin"" />");
-            var theElement = document.DocumentElement;
+            XmlElement theElement = CreateXmlElement(@"<user name=""martin"" />");
 
             // Act
             Action act = () =>
@@ -180,9 +160,7 @@ namespace FluentAssertions.Specs.Xml
             When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_does_not_exist_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var document = new XmlDocument();
-            document.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
-            var theElement = document.DocumentElement;
+            XmlElement theElement = CreateXmlElement(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
 
             // Act
             Action act = () =>
@@ -202,9 +180,7 @@ namespace FluentAssertions.Specs.Xml
             When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(@"<user name=""martin"" />");
-            var element = xmlDoc.DocumentElement;
+            XmlElement element = CreateXmlElement(@"<user name=""martin"" />");
 
             // Act
             Action act = () =>
@@ -219,9 +195,7 @@ namespace FluentAssertions.Specs.Xml
             When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
-            var element = xmlDoc.DocumentElement;
+            XmlElement element = CreateXmlElement(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
 
             // Act
             Action act = () =>
@@ -236,9 +210,7 @@ namespace FluentAssertions.Specs.Xml
             When_asserting_xml_element_has_attribute_with_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var document = new XmlDocument();
-            document.LoadXml(@"<user name=""martin"" />");
-            var theElement = document.DocumentElement;
+            XmlElement theElement = CreateXmlElement(@"<user name=""martin"" />");
 
             // Act
             Action act = () =>
@@ -256,9 +228,7 @@ namespace FluentAssertions.Specs.Xml
             When_asserting_xml_element_has_attribute_with_ns_and_specific_value_but_attribute_has_different_value_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var document = new XmlDocument();
-            document.LoadXml(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
-            var theElement = document.DocumentElement;
+            XmlElement theElement = CreateXmlElement(@"<user xmlns:a=""http://www.example.com/2012/test"" a:name=""martin"" />");
 
             // Act
             Action act = () =>
@@ -281,12 +251,10 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_xml_element_has_child_element_and_it_does_it_should_succeed()
         {
             // Arrange
-            var xml = new XmlDocument();
-            xml.LoadXml(
+            XmlElement element = CreateXmlElement(
                 @"<parent>
                     <child />
                   </parent>");
-            var element = xml.DocumentElement;
 
             // Act
             Action act = () =>
@@ -300,12 +268,10 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_xml_element_has_child_element_with_ns_and_it_does_it_should_succeed()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(
+            XmlElement element = CreateXmlElement(
                 @"<parent xmlns:c='http://www.example.com/2012/test'>
                     <c:child />
                   </parent>");
-            var element = xmlDoc.DocumentElement;
 
             // Act
             Action act = () =>
@@ -319,12 +285,10 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_xml_element_has_child_element_but_it_does_not_it_should_fail()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(
+            XmlElement element = CreateXmlElement(
                 @"<parent>
                     <child />
                   </parent>");
-            var element = xmlDoc.DocumentElement;
 
             // Act
             Action act = () =>
@@ -338,12 +302,10 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_xml_element_has_child_element_with_ns_but_it_does_not_it_should_fail()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(
+            XmlElement element = CreateXmlElement(
                 @"<parent>
                     <child />
                   </parent>");
-            var element = xmlDoc.DocumentElement;
 
             // Act
             Action act = () =>
@@ -357,12 +319,10 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_xml_element_has_child_element_but_it_does_not_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var document = new XmlDocument();
-            document.LoadXml(
+            XmlElement theElement = CreateXmlElement(
                 @"<parent>
                     <child />
                   </parent>");
-            var theElement = document.DocumentElement;
 
             // Act
             Action act = () =>
@@ -379,12 +339,10 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_xml_element_has_child_element_with_ns_but_it_does_not_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var document = new XmlDocument();
-            document.LoadXml(
+            XmlElement theElement = CreateXmlElement(
                 @"<parent>
                     <child />
                   </parent>");
-            var theElement = document.DocumentElement;
 
             // Act
             Action act = () =>
@@ -402,12 +360,10 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_xml_element_has_child_element_it_should_return_the_matched_element_in_the_which_property()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(
+            XmlElement element = CreateXmlElement(
                 @"<parent>
                     <child attr='1' />
                   </parent>");
-            var element = xmlDoc.DocumentElement;
 
             // Act
             var matchedElement = element.Should().HaveElement("child").Subject;
@@ -422,12 +378,10 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_xml_element_with_ns_has_child_element_and_it_does_it_should_succeed()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(
+            XmlElement element = CreateXmlElement(
                 @"<parent xmlns=""test"">
                     <child>value</child>
                 </parent>");
-            var element = xmlDoc.DocumentElement;
 
             // Act
             Action act = () =>
@@ -441,12 +395,10 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_xml_element_has_child_element_and_it_does_with_ns_it_should_succeed2()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(
+            XmlElement element = CreateXmlElement(
                 @"<parent>
                     <child xmlns=""test"">value</child>
                 </parent>");
-            var element = xmlDoc.DocumentElement;
 
             // Act
             Action act = () =>
@@ -457,5 +409,12 @@ namespace FluentAssertions.Specs.Xml
         }
 
         #endregion
+
+        private static XmlElement CreateXmlElement(string xml)
+        {
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(xml);
+            return xmlDoc.DocumentElement;
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Xml/XmlNodeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XmlNodeAssertionSpecs.cs
@@ -27,10 +27,8 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_same_as_a_different_xml_node_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<doc/>");
-            var otherNode = new XmlDocument();
-            otherNode.LoadXml("<otherDoc/>");
+            XmlDocument theDocument = CreateXmlDocument("<doc/>");
+            XmlDocument otherNode = CreateXmlDocument("<otherDoc/>");
 
             // Act
             Action act = () =>
@@ -46,10 +44,8 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_same_as_a_different_xml_node_it_should_fail_with_descriptive_message_and_truncate_xml()
         {
             // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<doc>Some very long text that should be truncated.</doc>");
-            var otherNode = new XmlDocument();
-            otherNode.LoadXml("<otherDoc/>");
+            XmlDocument theDocument = CreateXmlDocument("<doc>Some very long text that should be truncated.</doc>");
+            XmlDocument otherNode = CreateXmlDocument("<otherDoc/>");
 
             // Act
             Action act = () =>
@@ -66,8 +62,7 @@ namespace FluentAssertions.Specs.Xml
         {
             // Arrange
             XmlDocument theDocument = null;
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml/>");
+            XmlDocument expected = CreateXmlDocument("<xml/>");
 
             // Act
             Action act = () => theDocument.Should().BeSameAs(expected);
@@ -99,8 +94,7 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_null_but_it_is_not_it_should_fail()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml("<xml/>");
+            XmlDocument xmlDoc = CreateXmlDocument("<xml/>");
 
             // Act
             Action act = () =>
@@ -114,8 +108,7 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_null_but_it_is_not_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml/>");
+            XmlDocument theDocument = CreateXmlDocument("<xml/>");
 
             // Act
             Action act = () =>
@@ -131,8 +124,7 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_a_non_null_xml_node_is_not_null_it_should_succeed()
         {
             // Arrange
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml("<xml/>");
+            XmlDocument xmlDoc = CreateXmlDocument("<xml/>");
 
             // Act
             Action act = () =>
@@ -193,10 +185,8 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_not_equivalent_to_som_other_xml_node_it_should_succeed()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml>a</xml>");
-            var unexpected = new XmlDocument();
-            unexpected.LoadXml("<xml>b</xml>");
+            XmlDocument subject = CreateXmlDocument("<xml>a</xml>");
+            XmlDocument unexpected = CreateXmlDocument("<xml>b</xml>");
 
             // Act
             Action act = () =>
@@ -210,8 +200,7 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_not_equivalent_to_same_xml_node_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml>a</xml>");
+            XmlDocument theDocument = CreateXmlDocument("<xml>a</xml>");
 
             // Act
             Action act = () =>
@@ -227,10 +216,8 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_with_other_contents_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<subject/>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<expected/>");
+            XmlDocument theDocument = CreateXmlDocument("<subject/>");
+            XmlDocument expected = CreateXmlDocument("<expected/>");
 
             // Act
             Action act = () =>
@@ -248,10 +235,8 @@ namespace FluentAssertions.Specs.Xml
             // Arrange
             var xml = "<root><a xmlns=\"urn:a\"><data>data</data></a><ns:b xmlns:ns=\"urn:b\"><data>data</data></ns:b></root>";
 
-            var subject = new XmlDocument();
-            subject.LoadXml(xml);
-            var expected = new XmlDocument();
-            expected.LoadXml(xml);
+            XmlDocument subject = CreateXmlDocument(xml);
+            XmlDocument expected = CreateXmlDocument(xml);
 
             // Act
             Action act = () =>
@@ -265,10 +250,8 @@ namespace FluentAssertions.Specs.Xml
         public void When_assertion_an_xml_node_is_equivalent_to_a_different_xml_node_with_different_namespace_prefix_it_should_succeed()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml xmlns=\"urn:a\"/>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<a:xml xmlns:a=\"urn:a\"/>");
+            XmlDocument subject = CreateXmlDocument("<xml xmlns=\"urn:a\"/>");
+            XmlDocument expected = CreateXmlDocument("<a:xml xmlns:a=\"urn:a\"/>");
 
             // Act
             Action act = () =>
@@ -282,10 +265,8 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_which_differs_only_on_unused_namespace_declaration_it_should_succeed()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml xmlns:a=\"urn:a\"/>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml/>");
+            XmlDocument subject = CreateXmlDocument("<xml xmlns:a=\"urn:a\"/>");
+            XmlDocument expected = CreateXmlDocument("<xml/>");
 
             // Act
             Action act = () =>
@@ -299,10 +280,8 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_equivalent_to_a_different_XmlDocument_which_differs_on_a_child_element_name_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml><child><subject/></child></xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><child><expected/></child></xml>");
+            XmlDocument theDocument = CreateXmlDocument("<xml><child><subject/></child></xml>");
+            XmlDocument expected = CreateXmlDocument("<xml><child><expected/></child></xml>");
 
             // Act
             Action act = () =>
@@ -318,10 +297,8 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_equivalent_to_a_different_xml_node_which_differs_on_a_child_element_namespace_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<a:xml xmlns:a=\"urn:a\"><a:child><a:data/></a:child></a:xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml xmlns=\"urn:a\"><child><data xmlns=\"urn:b\"/></child></xml>");
+            XmlDocument theDocument = CreateXmlDocument("<a:xml xmlns:a=\"urn:a\"><a:child><a:data/></a:child></a:xml>");
+            XmlDocument expected = CreateXmlDocument("<xml xmlns=\"urn:a\"><child><data xmlns=\"urn:b\"/></child></xml>");
 
             // Act
             Action act = () =>
@@ -337,10 +314,8 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_contains_an_unexpected_node_type_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml>data</xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><data/></xml>");
+            XmlDocument theDocument = CreateXmlDocument("<xml>data</xml>");
+            XmlDocument expected = CreateXmlDocument("<xml><data/></xml>");
 
             // Act
             Action act = () =>
@@ -356,10 +331,8 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_contains_extra_elements_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml><data/></xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml/>");
+            XmlDocument theDocument = CreateXmlDocument("<xml><data/></xml>");
+            XmlDocument expected = CreateXmlDocument("<xml/>");
 
             // Act
             Action act = () =>
@@ -375,10 +348,8 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_lacks_elements_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml/>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><data/></xml>");
+            XmlDocument theDocument = CreateXmlDocument("<xml/>");
+            XmlDocument expected = CreateXmlDocument("<xml><data/></xml>");
 
             // Act
             Action act = () =>
@@ -394,10 +365,8 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_lacks_attributes_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml><element b=\"1\"/></xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><element a=\"b\" b=\"1\"/></xml>");
+            XmlDocument theDocument = CreateXmlDocument("<xml><element b=\"1\"/></xml>");
+            XmlDocument expected = CreateXmlDocument("<xml><element a=\"b\" b=\"1\"/></xml>");
 
             // Act
             Action act = () =>
@@ -413,10 +382,8 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_extra_attributes_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml><element a=\"b\"/></xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><element/></xml>");
+            XmlDocument theDocument = CreateXmlDocument("<xml><element a=\"b\"/></xml>");
+            XmlDocument expected = CreateXmlDocument("<xml><element/></xml>");
 
             // Act
             Action act = () =>
@@ -432,10 +399,8 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_different_attribute_values_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml><element a=\"b\"/></xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><element a=\"c\"/></xml>");
+            XmlDocument theDocument = CreateXmlDocument("<xml><element a=\"b\"/></xml>");
+            XmlDocument expected = CreateXmlDocument("<xml><element a=\"c\"/></xml>");
 
             // Act
             Action act = () =>
@@ -451,10 +416,8 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_attribute_with_different_namespace_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><element a=\"b\"/></xml>");
+            XmlDocument theDocument = CreateXmlDocument("<xml><element xmlns:ns=\"urn:a\" ns:a=\"b\"/></xml>");
+            XmlDocument expected = CreateXmlDocument("<xml><element a=\"b\"/></xml>");
 
             // Act
             Action act = () =>
@@ -470,10 +433,8 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_which_has_different_text_contents_it_should_fail_with_descriptive_message()
         {
             // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml>a</xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml>b</xml>");
+            XmlDocument theDocument = CreateXmlDocument("<xml>a</xml>");
+            XmlDocument expected = CreateXmlDocument("<xml>b</xml>");
 
             // Act
             Action act = () =>
@@ -489,10 +450,8 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_equivalent_to_different_xml_node_with_different_comments_it_should_succeed()
         {
             // Arrange
-            var subject = new XmlDocument();
-            subject.LoadXml("<xml><!--Comment--><a/></xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><a/><!--Comment--></xml>");
+            XmlDocument subject = CreateXmlDocument("<xml><!--Comment--><a/></xml>");
+            XmlDocument expected = CreateXmlDocument("<xml><a/><!--Comment--></xml>");
 
             // Act
             Action act = () => subject.Should().BeEquivalentTo(expected);
@@ -521,8 +480,7 @@ namespace FluentAssertions.Specs.Xml
         public void When_asserting_an_xml_node_is_equivalent_that_contains_an_unsupported_node_it_should_throw_a_descriptive_message()
         {
             // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml><![CDATA[Text]]></xml>");
+            XmlDocument theDocument = CreateXmlDocument("<xml><![CDATA[Text]]></xml>");
 
             // Act
             Action act = () => theDocument.Should().BeEquivalentTo(theDocument);
@@ -537,10 +495,8 @@ namespace FluentAssertions.Specs.Xml
             When_asserting_an_xml_node_is_equivalent_that_isnt_it_should_include_the_right_location_in_the_descriptive_message()
         {
             // Arrange
-            var theDocument = new XmlDocument();
-            theDocument.LoadXml("<xml><a/><b c=\"d\"/></xml>");
-            var expected = new XmlDocument();
-            expected.LoadXml("<xml><a/><b c=\"e\"/></xml>");
+            XmlDocument theDocument = CreateXmlDocument("<xml><a/><b c=\"d\"/></xml>");
+            XmlDocument expected = CreateXmlDocument("<xml><a/><b c=\"e\"/></xml>");
 
             // Act
             Action act = () => theDocument.Should().BeEquivalentTo(expected);
@@ -551,5 +507,12 @@ namespace FluentAssertions.Specs.Xml
         }
 
         #endregion
+
+        private static XmlDocument CreateXmlDocument(string xml)
+        {
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(xml);
+            return xmlDoc;
+        }
     }
 }


### PR DESCRIPTION
Every time I see the `new XmlDocument()` + `XmlDocument.LoadXml()` combo I wonder why `static XmlDocument XmlDocument.LoadFromXml(string xml)` does not exist in BCL.