### PR TITLE
Add assertions for (Buffered)Stream

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
+using System.IO;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -16,6 +17,7 @@ using FluentAssertions.Numeric;
 using FluentAssertions.Primitives;
 using FluentAssertions.Reflection;
 using FluentAssertions.Specialized;
+using FluentAssertions.Streams;
 using FluentAssertions.Types;
 using FluentAssertions.Xml;
 using JetBrains.Annotations;
@@ -178,6 +180,26 @@ namespace FluentAssertions
         public static XAttributeAssertions Should(this XAttribute actualValue)
         {
             return new XAttributeAssertions(actualValue);
+        }
+
+        /// <summary>
+        /// Returns an <see cref="StreamAssertions"/> object that can be used to assert the
+        /// current <see cref="Stream"/>.
+        /// </summary>
+        [Pure]
+        public static StreamAssertions Should(this Stream actualValue)
+        {
+            return new StreamAssertions(actualValue);
+        }
+
+        /// <summary>
+        /// Returns an <see cref="BufferedStreamAssertions"/> object that can be used to assert the
+        /// current <see cref="BufferedStream"/>.
+        /// </summary>
+        [Pure]
+        public static BufferedStreamAssertions Should(this BufferedStream actualValue)
+        {
+            return new BufferedStreamAssertions(actualValue);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Streams/BufferedStreamAssertions.cs
+++ b/Src/FluentAssertions/Streams/BufferedStreamAssertions.cs
@@ -1,0 +1,86 @@
+﻿using System.Diagnostics;
+using System.IO;
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1
+using FluentAssertions.Execution;
+#endif
+
+namespace FluentAssertions.Streams
+{
+    /// <summary>
+    /// Contains a number of methods to assert that an <see cref="Stream"/> is in the expected state.
+    /// </summary>
+    ///
+    [DebuggerNonUserCode]
+    public class BufferedStreamAssertions : BufferedStreamAssertions<BufferedStreamAssertions>
+    {
+        public BufferedStreamAssertions(BufferedStream stream)
+            : base(stream)
+        {
+        }
+    }
+
+    public class BufferedStreamAssertions<TAssertions> : StreamAssertions<BufferedStream, TAssertions>
+        where TAssertions : BufferedStreamAssertions<TAssertions>
+    {
+        public BufferedStreamAssertions(BufferedStream stream)
+            : base(stream)
+        {
+        }
+
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1
+        /// <summary>
+        /// Asserts that the current <see cref="BufferedStream"/> has the <paramref name="expected"/> buffer size.
+        /// </summary>
+        /// <param name="expected">The expected buffer size of the current stream.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> HaveBufferSize(int expected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected the {context:stream} buffer size to be {0}{reason}, ", expected)
+                .ForCondition(Subject is not null)
+                .FailWith("but found a <null> BufferedStream.")
+                .Then
+                .ForCondition(Subject.BufferSize == expected)
+                .FailWith("but it was {0}.", Subject.BufferSize)
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="BufferedStream"/> has not the <paramref name="unexpected"/> buffer size.
+        /// </summary>
+        /// <param name="unexpected">The not expected buffer size of the current stream.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotHaveBufferSize(int unexpected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected the {context:stream} buffer size not to be {0}{reason}, ", unexpected)
+                .ForCondition(Subject is not null)
+                .FailWith("but found a <null> BufferedStream.")
+                .Then
+                .ForCondition(Subject.BufferSize != unexpected)
+                .FailWith("but it was {0}.", Subject.BufferSize)
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+#endif
+    }
+}

--- a/Src/FluentAssertions/Streams/BufferedStreamAssertions.cs
+++ b/Src/FluentAssertions/Streams/BufferedStreamAssertions.cs
@@ -43,9 +43,9 @@ namespace FluentAssertions.Streams
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected the {context:stream} buffer size to be {0}{reason}, ", expected)
+                .WithExpectation("Expected the buffer size of {context:stream} to be {0}{reason}, ", expected)
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> BufferedStream.")
+                .FailWith("but found a <null> reference.")
                 .Then
                 .ForCondition(Subject.BufferSize == expected)
                 .FailWith("but it was {0}.", Subject.BufferSize)
@@ -56,9 +56,9 @@ namespace FluentAssertions.Streams
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="BufferedStream"/> has not the <paramref name="unexpected"/> buffer size.
+        /// Asserts that the current <see cref="BufferedStream"/> does not have a buffer size of <paramref name="unexpected"/>.
         /// </summary>
-        /// <param name="unexpected">The not expected buffer size of the current stream.</param>
+        /// <param name="unexpected">The unexpected buffer size of the current stream.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -70,9 +70,9 @@ namespace FluentAssertions.Streams
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected the {context:stream} buffer size not to be {0}{reason}, ", unexpected)
+                .WithExpectation("Expected the buffer size of {context:stream} not to be {0}{reason}, ", unexpected)
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> BufferedStream.")
+                .FailWith("but found a <null> reference.")
                 .Then
                 .ForCondition(Subject.BufferSize != unexpected)
                 .FailWith("but it was {0}.", Subject.BufferSize)

--- a/Src/FluentAssertions/Streams/StreamAssertions.cs
+++ b/Src/FluentAssertions/Streams/StreamAssertions.cs
@@ -47,7 +47,7 @@ namespace FluentAssertions.Streams
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:stream} to be writable{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> Stream.")
+                .FailWith("but found a <null> reference.")
                 .Then
                 .ForCondition(Subject.CanWrite)
                 .FailWith("but it was not.")
@@ -73,7 +73,7 @@ namespace FluentAssertions.Streams
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:stream} not to be writable{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> Stream.")
+                .FailWith("but found a <null> reference.")
                 .Then
                 .ForCondition(!Subject.CanWrite)
                 .FailWith("but it was.")
@@ -99,7 +99,7 @@ namespace FluentAssertions.Streams
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:stream} to be seekable{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> Stream.")
+                .FailWith("but found a <null> reference.")
                 .Then
                 .ForCondition(Subject.CanSeek)
                 .FailWith("but it was not.")
@@ -125,7 +125,7 @@ namespace FluentAssertions.Streams
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:stream} not to be seekable{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> Stream.")
+                .FailWith("but found a <null> reference.")
                 .Then
                 .ForCondition(!Subject.CanSeek)
                 .FailWith("but it was.")
@@ -151,7 +151,7 @@ namespace FluentAssertions.Streams
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:stream} to be readable{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> Stream.")
+                .FailWith("but found a <null> reference.")
                 .Then
                 .ForCondition(Subject.CanRead)
                 .FailWith("but it was not.")
@@ -177,7 +177,7 @@ namespace FluentAssertions.Streams
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:stream} not to be readable{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> Stream.")
+                .FailWith("but found a <null> reference.")
                 .Then
                 .ForCondition(!Subject.CanRead)
                 .FailWith("but it was.")
@@ -198,13 +198,13 @@ namespace FluentAssertions.Streams
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> HavePosition(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HavePosition(long expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the position of {context:stream} to be {0}{reason}, ", expected)
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> Stream.")
+                .FailWith("but found a <null> reference.")
                 .Then
                 .ForCondition(Subject.CanSeek)
                 .FailWith("but found a non-seekable stream.")
@@ -218,9 +218,9 @@ namespace FluentAssertions.Streams
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Stream"/> has not the <paramref name="unexpected"/> position.
+        /// Asserts that the current <see cref="Stream"/> does not have an <paramref name="unexpected"/> position.
         /// </summary>
-        /// <param name="unexpected">The not expected position of the current stream.</param>
+        /// <param name="unexpected">The unexpected position of the current stream.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -228,13 +228,13 @@ namespace FluentAssertions.Streams
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotHavePosition(int unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotHavePosition(long unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the position of {context:stream} not to be {0}{reason}, ", unexpected)
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> Stream.")
+                .FailWith("but found a <null> reference.")
                 .Then
                 .ForCondition(Subject.CanSeek)
                 .FailWith("but found a non-seekable stream.")
@@ -258,13 +258,13 @@ namespace FluentAssertions.Streams
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveLength(long expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the length of {context:stream} to be {0}{reason}, ", expected)
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> Stream.")
+                .FailWith("but found a <null> reference.")
                 .Then
                 .ForCondition(Subject.CanSeek)
                 .FailWith("but found a non-seekable stream.")
@@ -278,9 +278,9 @@ namespace FluentAssertions.Streams
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Stream"/> has not the <paramref name="unexpected"/> length.
+        /// Asserts that the current <see cref="Stream"/> does not have an <paramref name="unexpected"/> length.
         /// </summary>
-        /// <param name="unexpected">The not expected length of the current stream.</param>
+        /// <param name="unexpected">The unexpected length of the current stream.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -288,13 +288,13 @@ namespace FluentAssertions.Streams
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> NotHaveLength(int unexpected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> NotHaveLength(long unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected the length of {context:stream} not to be {0}{reason}, ", unexpected)
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> Stream.")
+                .FailWith("but found a <null> reference.")
                 .Then
                 .ForCondition(Subject.CanSeek)
                 .FailWith("but found a non-seekable stream.")
@@ -308,7 +308,7 @@ namespace FluentAssertions.Streams
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Stream"/> is read only.
+        /// Asserts that the current <see cref="Stream"/> is read-only.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -321,9 +321,9 @@ namespace FluentAssertions.Streams
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:stream} to be read only{reason}, ")
+                .WithExpectation("Expected {context:stream} to be read-only{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> Stream.")
+                .FailWith("but found a <null> reference.")
                 .Then
                 .ForCondition(!Subject.CanWrite && Subject.CanRead)
                 .FailWith("but it was writable or not readable.")
@@ -334,7 +334,7 @@ namespace FluentAssertions.Streams
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Stream"/> is not read only.
+        /// Asserts that the current <see cref="Stream"/> is not read-only.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -347,9 +347,9 @@ namespace FluentAssertions.Streams
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:stream} not to be read only{reason}, ")
+                .WithExpectation("Expected {context:stream} not to be read-only{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> Stream.")
+                .FailWith("but found a <null> reference.")
                 .Then
                 .ForCondition(Subject.CanWrite || !Subject.CanRead)
                 .FailWith("but it was.")
@@ -360,7 +360,7 @@ namespace FluentAssertions.Streams
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Stream"/> is write only.
+        /// Asserts that the current <see cref="Stream"/> is write-only.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -373,9 +373,9 @@ namespace FluentAssertions.Streams
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:stream} to be write only{reason}, ")
+                .WithExpectation("Expected {context:stream} to be write-only{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> Stream.")
+                .FailWith("but found a <null> reference.")
                 .Then
                 .ForCondition(Subject.CanWrite && !Subject.CanRead)
                 .FailWith("but it was readable or not writable.")
@@ -386,7 +386,7 @@ namespace FluentAssertions.Streams
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Stream"/> is not write only.
+        /// Asserts that the current <see cref="Stream"/> is not write-only.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -399,9 +399,9 @@ namespace FluentAssertions.Streams
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:stream} not to be write only{reason}, ")
+                .WithExpectation("Expected {context:stream} not to be write-only{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> Stream.")
+                .FailWith("but found a <null> reference.")
                 .Then
                 .ForCondition(!Subject.CanWrite || Subject.CanRead)
                 .FailWith("but it was.")

--- a/Src/FluentAssertions/Streams/StreamAssertions.cs
+++ b/Src/FluentAssertions/Streams/StreamAssertions.cs
@@ -1,0 +1,414 @@
+﻿using System.Diagnostics;
+using System.IO;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+
+namespace FluentAssertions.Streams
+{
+    /// <summary>
+    /// Contains a number of methods to assert that an <see cref="Stream"/> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
+    public class StreamAssertions : StreamAssertions<Stream, StreamAssertions>
+    {
+        public StreamAssertions(Stream stream)
+            : base(stream)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Contains a number of methods to assert that a <typeparamref name="TSubject"/> is in the expected state.
+    /// </summary>
+    public class StreamAssertions<TSubject, TAssertions> : ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : Stream
+        where TAssertions : StreamAssertions<TSubject, TAssertions>
+    {
+        public StreamAssertions(TSubject stream)
+            : base(stream)
+        {
+        }
+
+        protected override string Identifier => "stream";
+
+        /// <summary>
+        /// Asserts that the current <see cref="Stream"/> is writable.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> BeWritable(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:stream} to be writable{reason}, ")
+                .ForCondition(Subject is not null)
+                .FailWith("but found a <null> Stream.")
+                .Then
+                .ForCondition(Subject.CanWrite)
+                .FailWith("but it was not.")
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Stream"/> is not writable.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotBeWritable(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:stream} not to be writable{reason}, ")
+                .ForCondition(Subject is not null)
+                .FailWith("but found a <null> Stream.")
+                .Then
+                .ForCondition(!Subject.CanWrite)
+                .FailWith("but it was.")
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Stream"/> is seekable.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> BeSeekable(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:stream} to be seekable{reason}, ")
+                .ForCondition(Subject is not null)
+                .FailWith("but found a <null> Stream.")
+                .Then
+                .ForCondition(Subject.CanSeek)
+                .FailWith("but it was not.")
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Stream"/> is not seekable.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotBeSeekable(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:stream} not to be seekable{reason}, ")
+                .ForCondition(Subject is not null)
+                .FailWith("but found a <null> Stream.")
+                .Then
+                .ForCondition(!Subject.CanSeek)
+                .FailWith("but it was.")
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Stream"/> is readable.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> BeReadable(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:stream} to be readable{reason}, ")
+                .ForCondition(Subject is not null)
+                .FailWith("but found a <null> Stream.")
+                .Then
+                .ForCondition(Subject.CanRead)
+                .FailWith("but it was not.")
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Stream"/> is not readable.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotBeReadable(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:stream} not to be readable{reason}, ")
+                .ForCondition(Subject is not null)
+                .FailWith("but found a <null> Stream.")
+                .Then
+                .ForCondition(!Subject.CanRead)
+                .FailWith("but it was.")
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Stream"/> has the <paramref name="expected"/> position.
+        /// </summary>
+        /// <param name="expected">The expected position of the current stream.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> HavePosition(int expected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected the position of {context:stream} to be {0}{reason}, ", expected)
+                .ForCondition(Subject is not null)
+                .FailWith("but found a <null> Stream.")
+                .Then
+                .ForCondition(Subject.CanSeek)
+                .FailWith("but found a non-seekable stream.")
+                .Then
+                .ForCondition(Subject.Position == expected)
+                .FailWith("but it was {0}.", Subject.Position)
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Stream"/> has not the <paramref name="unexpected"/> position.
+        /// </summary>
+        /// <param name="unexpected">The not expected position of the current stream.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotHavePosition(int unexpected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected the position of {context:stream} not to be {0}{reason}, ", unexpected)
+                .ForCondition(Subject is not null)
+                .FailWith("but found a <null> Stream.")
+                .Then
+                .ForCondition(Subject.CanSeek)
+                .FailWith("but found a non-seekable stream.")
+                .Then
+                .ForCondition(Subject.Position != unexpected)
+                .FailWith("but it was.")
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Stream"/> has the <paramref name="expected"/> length.
+        /// </summary>
+        /// <param name="expected">The expected length of the current stream.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected the length of {context:stream} to be {0}{reason}, ", expected)
+                .ForCondition(Subject is not null)
+                .FailWith("but found a <null> Stream.")
+                .Then
+                .ForCondition(Subject.CanSeek)
+                .FailWith("but found a non-seekable stream.")
+                .Then
+                .ForCondition(Subject.Length == expected)
+                .FailWith("but it was {0}.", Subject.Length)
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Stream"/> has not the <paramref name="unexpected"/> length.
+        /// </summary>
+        /// <param name="unexpected">The not expected length of the current stream.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotHaveLength(int unexpected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected the length of {context:stream} not to be {0}{reason}, ", unexpected)
+                .ForCondition(Subject is not null)
+                .FailWith("but found a <null> Stream.")
+                .Then
+                .ForCondition(Subject.CanSeek)
+                .FailWith("but found a non-seekable stream.")
+                .Then
+                .ForCondition(Subject.Length != unexpected)
+                .FailWith("but it was.")
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Stream"/> is read only.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> BeReadOnly(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:stream} to be read only{reason}, ")
+                .ForCondition(Subject is not null)
+                .FailWith("but found a <null> Stream.")
+                .Then
+                .ForCondition(!Subject.CanWrite && Subject.CanRead)
+                .FailWith("but it was writable or not readable.")
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Stream"/> is not read only.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotBeReadOnly(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:stream} not to be read only{reason}, ")
+                .ForCondition(Subject is not null)
+                .FailWith("but found a <null> Stream.")
+                .Then
+                .ForCondition(Subject.CanWrite || !Subject.CanRead)
+                .FailWith("but it was.")
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Stream"/> is write only.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> BeWriteOnly(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:stream} to be write only{reason}, ")
+                .ForCondition(Subject is not null)
+                .FailWith("but found a <null> Stream.")
+                .Then
+                .ForCondition(Subject.CanWrite && !Subject.CanRead)
+                .FailWith("but it was readable or not writable.")
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="Stream"/> is not write only.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotBeWriteOnly(string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:stream} not to be write only{reason}, ")
+                .ForCondition(Subject is not null)
+                .FailWith("but found a <null> Stream.")
+                .Then
+                .ForCondition(!Subject.CanWrite || Subject.CanRead)
+                .FailWith("but it was.")
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+    }
+}

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -52,6 +52,8 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
+        public static FluentAssertions.Streams.BufferedStreamAssertions Should(this System.IO.BufferedStream actualValue) { }
+        public static FluentAssertions.Streams.StreamAssertions Should(this System.IO.Stream actualValue) { }
         public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
         public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
         public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
@@ -2126,6 +2128,43 @@ namespace FluentAssertions.Specialized
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Streams
+{
+    public class BufferedStreamAssertions : FluentAssertions.Streams.BufferedStreamAssertions<FluentAssertions.Streams.BufferedStreamAssertions>
+    {
+        public BufferedStreamAssertions(System.IO.BufferedStream stream) { }
+    }
+    public class BufferedStreamAssertions<TAssertions> : FluentAssertions.Streams.StreamAssertions<System.IO.BufferedStream, TAssertions>
+        where TAssertions : FluentAssertions.Streams.BufferedStreamAssertions<TAssertions>
+    {
+        public BufferedStreamAssertions(System.IO.BufferedStream stream) { }
+    }
+    public class StreamAssertions : FluentAssertions.Streams.StreamAssertions<System.IO.Stream, FluentAssertions.Streams.StreamAssertions>
+    {
+        public StreamAssertions(System.IO.Stream stream) { }
+    }
+    public class StreamAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.IO.Stream
+        where TAssertions : FluentAssertions.Streams.StreamAssertions<TSubject, TAssertions>
+    {
+        public StreamAssertions(TSubject stream) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeReadOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSeekable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeWriteOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HavePosition(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeReadOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSeekable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeWriteOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveLength(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHavePosition(int unexpected, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2156,15 +2156,15 @@ namespace FluentAssertions.Streams
         public FluentAssertions.AndConstraint<TAssertions> BeSeekable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeWriteOnly(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HavePosition(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLength(long expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HavePosition(long expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeReadOnly(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSeekable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeWriteOnly(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveLength(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHavePosition(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveLength(long unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHavePosition(long unexpected, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -2158,15 +2158,15 @@ namespace FluentAssertions.Streams
         public FluentAssertions.AndConstraint<TAssertions> BeSeekable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeWriteOnly(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HavePosition(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLength(long expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HavePosition(long expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeReadOnly(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSeekable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeWriteOnly(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveLength(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHavePosition(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveLength(long unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHavePosition(long unexpected, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -52,6 +52,8 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
+        public static FluentAssertions.Streams.BufferedStreamAssertions Should(this System.IO.BufferedStream actualValue) { }
+        public static FluentAssertions.Streams.StreamAssertions Should(this System.IO.Stream actualValue) { }
         public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
         public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
         public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
@@ -2126,6 +2128,45 @@ namespace FluentAssertions.Specialized
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Streams
+{
+    public class BufferedStreamAssertions : FluentAssertions.Streams.BufferedStreamAssertions<FluentAssertions.Streams.BufferedStreamAssertions>
+    {
+        public BufferedStreamAssertions(System.IO.BufferedStream stream) { }
+    }
+    public class BufferedStreamAssertions<TAssertions> : FluentAssertions.Streams.StreamAssertions<System.IO.BufferedStream, TAssertions>
+        where TAssertions : FluentAssertions.Streams.BufferedStreamAssertions<TAssertions>
+    {
+        public BufferedStreamAssertions(System.IO.BufferedStream stream) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveBufferSize(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveBufferSize(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class StreamAssertions : FluentAssertions.Streams.StreamAssertions<System.IO.Stream, FluentAssertions.Streams.StreamAssertions>
+    {
+        public StreamAssertions(System.IO.Stream stream) { }
+    }
+    public class StreamAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.IO.Stream
+        where TAssertions : FluentAssertions.Streams.StreamAssertions<TSubject, TAssertions>
+    {
+        public StreamAssertions(TSubject stream) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeReadOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSeekable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeWriteOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HavePosition(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeReadOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSeekable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeWriteOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveLength(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHavePosition(int unexpected, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -2158,15 +2158,15 @@ namespace FluentAssertions.Streams
         public FluentAssertions.AndConstraint<TAssertions> BeSeekable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeWriteOnly(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HavePosition(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLength(long expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HavePosition(long expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeReadOnly(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSeekable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeWriteOnly(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveLength(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHavePosition(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveLength(long unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHavePosition(long unexpected, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -52,6 +52,8 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
+        public static FluentAssertions.Streams.BufferedStreamAssertions Should(this System.IO.BufferedStream actualValue) { }
+        public static FluentAssertions.Streams.StreamAssertions Should(this System.IO.Stream actualValue) { }
         public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
         public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
         public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
@@ -2126,6 +2128,45 @@ namespace FluentAssertions.Specialized
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Streams
+{
+    public class BufferedStreamAssertions : FluentAssertions.Streams.BufferedStreamAssertions<FluentAssertions.Streams.BufferedStreamAssertions>
+    {
+        public BufferedStreamAssertions(System.IO.BufferedStream stream) { }
+    }
+    public class BufferedStreamAssertions<TAssertions> : FluentAssertions.Streams.StreamAssertions<System.IO.BufferedStream, TAssertions>
+        where TAssertions : FluentAssertions.Streams.BufferedStreamAssertions<TAssertions>
+    {
+        public BufferedStreamAssertions(System.IO.BufferedStream stream) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveBufferSize(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveBufferSize(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class StreamAssertions : FluentAssertions.Streams.StreamAssertions<System.IO.Stream, FluentAssertions.Streams.StreamAssertions>
+    {
+        public StreamAssertions(System.IO.Stream stream) { }
+    }
+    public class StreamAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.IO.Stream
+        where TAssertions : FluentAssertions.Streams.StreamAssertions<TSubject, TAssertions>
+    {
+        public StreamAssertions(TSubject stream) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeReadOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSeekable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeWriteOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HavePosition(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeReadOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSeekable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeWriteOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveLength(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHavePosition(int unexpected, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2109,15 +2109,15 @@ namespace FluentAssertions.Streams
         public FluentAssertions.AndConstraint<TAssertions> BeSeekable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeWriteOnly(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HavePosition(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLength(long expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HavePosition(long expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeReadOnly(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSeekable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeWriteOnly(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveLength(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHavePosition(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveLength(long unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHavePosition(long unexpected, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -51,6 +51,8 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
+        public static FluentAssertions.Streams.BufferedStreamAssertions Should(this System.IO.BufferedStream actualValue) { }
+        public static FluentAssertions.Streams.StreamAssertions Should(this System.IO.Stream actualValue) { }
         public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
         public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
         public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
@@ -2079,6 +2081,43 @@ namespace FluentAssertions.Specialized
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Streams
+{
+    public class BufferedStreamAssertions : FluentAssertions.Streams.BufferedStreamAssertions<FluentAssertions.Streams.BufferedStreamAssertions>
+    {
+        public BufferedStreamAssertions(System.IO.BufferedStream stream) { }
+    }
+    public class BufferedStreamAssertions<TAssertions> : FluentAssertions.Streams.StreamAssertions<System.IO.BufferedStream, TAssertions>
+        where TAssertions : FluentAssertions.Streams.BufferedStreamAssertions<TAssertions>
+    {
+        public BufferedStreamAssertions(System.IO.BufferedStream stream) { }
+    }
+    public class StreamAssertions : FluentAssertions.Streams.StreamAssertions<System.IO.Stream, FluentAssertions.Streams.StreamAssertions>
+    {
+        public StreamAssertions(System.IO.Stream stream) { }
+    }
+    public class StreamAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.IO.Stream
+        where TAssertions : FluentAssertions.Streams.StreamAssertions<TSubject, TAssertions>
+    {
+        public StreamAssertions(TSubject stream) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeReadOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSeekable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeWriteOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HavePosition(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeReadOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSeekable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeWriteOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveLength(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHavePosition(int unexpected, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2158,15 +2158,15 @@ namespace FluentAssertions.Streams
         public FluentAssertions.AndConstraint<TAssertions> BeSeekable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeWriteOnly(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> HavePosition(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLength(long expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HavePosition(long expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeReadOnly(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSeekable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeWriteOnly(string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHaveLength(int unexpected, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.AndConstraint<TAssertions> NotHavePosition(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveLength(long unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHavePosition(long unexpected, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -52,6 +52,8 @@ namespace FluentAssertions
         public static FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions Should(this System.Func<System.Threading.Tasks.Task> action) { }
         public static FluentAssertions.Primitives.GuidAssertions Should(this System.Guid actualValue) { }
         public static FluentAssertions.Primitives.NullableGuidAssertions Should(this System.Guid? actualValue) { }
+        public static FluentAssertions.Streams.BufferedStreamAssertions Should(this System.IO.BufferedStream actualValue) { }
+        public static FluentAssertions.Streams.StreamAssertions Should(this System.IO.Stream actualValue) { }
         public static FluentAssertions.Reflection.AssemblyAssertions Should(this System.Reflection.Assembly assembly) { }
         public static FluentAssertions.Types.ConstructorInfoAssertions Should(this System.Reflection.ConstructorInfo constructorInfo) { }
         public static FluentAssertions.Types.MethodInfoAssertions Should(this System.Reflection.MethodInfo methodInfo) { }
@@ -2126,6 +2128,45 @@ namespace FluentAssertions.Specialized
         public TaskCompletionSourceAssertions(System.Threading.Tasks.TaskCompletionSource<T> tcs, FluentAssertions.Common.IClock clock) { }
         public System.Threading.Tasks.Task<FluentAssertions.AndWhichConstraint<FluentAssertions.Specialized.TaskCompletionSourceAssertions<T>, T>> CompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
         public System.Threading.Tasks.Task NotCompleteWithinAsync(System.TimeSpan timeSpan, string because = "", params object[] becauseArgs) { }
+    }
+}
+namespace FluentAssertions.Streams
+{
+    public class BufferedStreamAssertions : FluentAssertions.Streams.BufferedStreamAssertions<FluentAssertions.Streams.BufferedStreamAssertions>
+    {
+        public BufferedStreamAssertions(System.IO.BufferedStream stream) { }
+    }
+    public class BufferedStreamAssertions<TAssertions> : FluentAssertions.Streams.StreamAssertions<System.IO.BufferedStream, TAssertions>
+        where TAssertions : FluentAssertions.Streams.BufferedStreamAssertions<TAssertions>
+    {
+        public BufferedStreamAssertions(System.IO.BufferedStream stream) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveBufferSize(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveBufferSize(int unexpected, string because = "", params object[] becauseArgs) { }
+    }
+    public class StreamAssertions : FluentAssertions.Streams.StreamAssertions<System.IO.Stream, FluentAssertions.Streams.StreamAssertions>
+    {
+        public StreamAssertions(System.IO.Stream stream) { }
+    }
+    public class StreamAssertions<TSubject, TAssertions> : FluentAssertions.Primitives.ReferenceTypeAssertions<TSubject, TAssertions>
+        where TSubject : System.IO.Stream
+        where TAssertions : FluentAssertions.Streams.StreamAssertions<TSubject, TAssertions>
+    {
+        public StreamAssertions(TSubject stream) { }
+        protected override string Identifier { get; }
+        public FluentAssertions.AndConstraint<TAssertions> BeReadOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeSeekable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeWriteOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HavePosition(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeReadOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeReadable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeSeekable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeWritable(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeWriteOnly(string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHaveLength(int unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotHavePosition(int unexpected, string because = "", params object[] becauseArgs) { }
     }
 }
 namespace FluentAssertions.Types

--- a/Tests/FluentAssertions.Specs/Streams/BufferedStreamAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Streams/BufferedStreamAssertionSpecs.cs
@@ -10,11 +10,10 @@ namespace FluentAssertions.Specs.Streams
     public class BufferedStreamAssertionSpecs
     {
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1
-
         #region HaveBufferSize / NotHaveBufferSize
 
         [Fact]
-        public void When_asserting_a_stream_should_have_buffer_size_with_the_same_value_it_should_succeed()
+        public void When_a_stream_has_the_expected_buffer_size_it_should_succeed()
         {
             // Arrange
             using var stream = new BufferedStream(new MemoryStream(), 10);
@@ -28,37 +27,37 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_stream_should_have_buffer_size_with_a_different_value_it_should_throw()
+        public void When_a_stream_has_an_unexpected_buffer_size_should_fail()
         {
             // Arrange
             using var stream = new BufferedStream(new MemoryStream(), 1);
 
             // Act
             Action act = () =>
-                stream.Should().HaveBufferSize(10);
+                stream.Should().HaveBufferSize(10, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the stream buffer size to be 10, but it was 1.");
+                .WithMessage("Expected the buffer size of stream to be 10 *failure message*, but it was 1.");
         }
 
         [Fact]
-        public void When_asserting_null_stream_should_have_buffer_size_should_throw()
+        public void When_null_have_buffer_size_should_fail()
         {
             // Arrange
             BufferedStream stream = null;
 
             // Act
             Action act = () =>
-                stream.Should().HaveBufferSize(10);
+                stream.Should().HaveBufferSize(10, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the stream buffer size to be 10, but found a <null> BufferedStream.");
+                .WithMessage("Expected the buffer size of stream to be 10 *failure message*, but found a <null> reference.");
         }
 
         [Fact]
-        public void When_asserting_a_stream_should_not_have_buffer_size_with_a_different_value_it_should_succeed()
+        public void When_a_stream_does_not_have_an_unexpected_buffer_size_it_should_succeed()
         {
             // Arrange
             using var stream = new BufferedStream(new MemoryStream(), 1);
@@ -72,33 +71,33 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_stream_should_not_have_buffer_size_with_the_same_value_it_should_throw()
+        public void When_a_stream_does_have_the_unexpected_buffer_size_it_should_fail()
         {
             // Arrange
             using var stream = new BufferedStream(new MemoryStream(), 10);
 
             // Act
             Action act = () =>
-                stream.Should().NotHaveBufferSize(10);
+                stream.Should().NotHaveBufferSize(10, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the stream buffer size not to be 10, but it was 10.");
+                .WithMessage("Expected the buffer size of stream not to be 10 *failure message*, but it was 10.");
         }
 
         [Fact]
-        public void When_asserting_null_stream_not_should_have_buffer_size_should_throw()
+        public void When_null_not_have_buffer_size_should_fail()
         {
             // Arrange
             BufferedStream stream = null;
 
             // Act
             Action act = () =>
-                stream.Should().NotHaveBufferSize(10);
+                stream.Should().NotHaveBufferSize(10, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the stream buffer size not to be 10, but found a <null> BufferedStream.");
+                .WithMessage("Expected the buffer size of stream not to be 10 *failure message*, but found a <null> reference.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Streams/BufferedStreamAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Streams/BufferedStreamAssertionSpecs.cs
@@ -1,0 +1,107 @@
+﻿#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1
+using System;
+using System.IO;
+using Xunit;
+using Xunit.Sdk;
+#endif
+
+namespace FluentAssertions.Specs.Streams
+{
+    public class BufferedStreamAssertionSpecs
+    {
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1
+
+        #region HaveBufferSize / NotHaveBufferSize
+
+        [Fact]
+        public void When_asserting_a_stream_should_have_buffer_size_with_the_same_value_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new BufferedStream(new MemoryStream(), 10);
+
+            // Act
+            Action act = () =>
+                stream.Should().HaveBufferSize(10);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_stream_should_have_buffer_size_with_a_different_value_it_should_throw()
+        {
+            // Arrange
+            using var stream = new BufferedStream(new MemoryStream(), 1);
+
+            // Act
+            Action act = () =>
+                stream.Should().HaveBufferSize(10);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the stream buffer size to be 10, but it was 1.");
+        }
+
+        [Fact]
+        public void When_asserting_null_stream_should_have_buffer_size_should_throw()
+        {
+            // Arrange
+            BufferedStream stream = null;
+
+            // Act
+            Action act = () =>
+                stream.Should().HaveBufferSize(10);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the stream buffer size to be 10, but found a <null> BufferedStream.");
+        }
+
+        [Fact]
+        public void When_asserting_a_stream_should_not_have_buffer_size_with_a_different_value_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new BufferedStream(new MemoryStream(), 1);
+
+            // Act
+            Action act = () =>
+                stream.Should().NotHaveBufferSize(10);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_stream_should_not_have_buffer_size_with_the_same_value_it_should_throw()
+        {
+            // Arrange
+            using var stream = new BufferedStream(new MemoryStream(), 10);
+
+            // Act
+            Action act = () =>
+                stream.Should().NotHaveBufferSize(10);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the stream buffer size not to be 10, but it was 10.");
+        }
+
+        [Fact]
+        public void When_asserting_null_stream_not_should_have_buffer_size_should_throw()
+        {
+            // Arrange
+            BufferedStream stream = null;
+
+            // Act
+            Action act = () =>
+                stream.Should().NotHaveBufferSize(10);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the stream buffer size not to be 10, but found a <null> BufferedStream.");
+        }
+
+        #endregion
+#endif
+    }
+}

--- a/Tests/FluentAssertions.Specs/Streams/StreamAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Streams/StreamAssertionSpecs.cs
@@ -10,7 +10,7 @@ namespace FluentAssertions.Specs.Streams
         #region BeWritable / NotBeWritable
 
         [Fact]
-        public void When_asserting_a_writeable_stream_is_writable_it_should_succeed()
+        public void When_having_a_writable_stream_be_writable_should_succeed()
         {
             // Arrange
             using var stream = new TestStream { Writable = true };
@@ -24,7 +24,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_non_writeable_stream_is_writable_it_should_fail()
+        public void When_having_a_non_writable_stream_be_writable_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Writable = false };
@@ -39,7 +39,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_null_stream_should_be_writable_should_throw()
+        public void When_null_be_writable_should_fail()
         {
             // Arrange
             TestStream stream = null;
@@ -50,11 +50,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be writable *failure message*, but found a <null> Stream.");
+                .WithMessage("Expected stream to be writable *failure message*, but found a <null> reference.");
         }
 
         [Fact]
-        public void When_asserting_a_non_writeable_stream_is_not_writable_it_should_succeed()
+        public void When_having_a_non_writable_stream_be_not_writable_should_succeed()
         {
             // Arrange
             using var stream = new TestStream { Writable = false };
@@ -68,7 +68,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_writeable_stream_is_not_writable_it_should_fail()
+        public void When_having_a_writable_stream_be_not_writable_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Writable = true };
@@ -83,7 +83,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_null_stream_should_not_be_writable_should_throw()
+        public void When_null_not_be_writable_should_fail()
         {
             // Arrange
             TestStream stream = null;
@@ -94,7 +94,7 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be writable *failure message*, but found a <null> Stream.");
+                .WithMessage("Expected stream not to be writable *failure message*, but found a <null> reference.");
         }
 
         #endregion
@@ -102,7 +102,7 @@ namespace FluentAssertions.Specs.Streams
         #region BeSeekable / NotBeSeekable
 
         [Fact]
-        public void When_asserting_a_seekable_stream_is_seekable_it_should_succeed()
+        public void When_having_a_seekable_stream_be_seekable_should_succeed()
         {
             // Arrange
             using var stream = new TestStream { Seekable = true };
@@ -116,7 +116,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_non_seekable_stream_is_seekable_it_should_fail()
+        public void When_having_a_non_seekable_stream_be_seekable_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Seekable = false };
@@ -131,7 +131,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_null_stream_should_be_seekable_should_throw()
+        public void When_null_be_seekable_should_fail()
         {
             // Arrange
             TestStream stream = null;
@@ -142,11 +142,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be seekable *failure message*, but found a <null> Stream.");
+                .WithMessage("Expected stream to be seekable *failure message*, but found a <null> reference.");
         }
 
         [Fact]
-        public void When_asserting_a_non_seekable_stream_is_not_seekable_it_should_succeed()
+        public void When_having_a_non_seekable_stream_be_not_seekable_should_succeed()
         {
             // Arrange
             using var stream = new TestStream { Seekable = false };
@@ -160,7 +160,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_seekable_stream_is_not_seekable_it_should_fail()
+        public void When_having_a_seekable_stream_be_not_seekable_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Seekable = true };
@@ -175,7 +175,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_null_stream_should_not_be_seekable_should_throw()
+        public void When_null_not_be_seekable_should_fail()
         {
             // Arrange
             TestStream stream = null;
@@ -186,7 +186,7 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be seekable *failure message*, but found a <null> Stream.");
+                .WithMessage("Expected stream not to be seekable *failure message*, but found a <null> reference.");
         }
 
         #endregion
@@ -194,7 +194,7 @@ namespace FluentAssertions.Specs.Streams
         #region BeReadable / NotBeReadable
 
         [Fact]
-        public void When_asserting_a_readable_stream_is_readable_it_should_succeed()
+        public void When_having_a_readable_stream_be_readable_should_succeed()
         {
             // Arrange
             using var stream = new TestStream { Readable = true };
@@ -208,7 +208,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_non_readable_stream_is_readable_it_should_fail()
+        public void When_having_a_non_readable_stream_be_readable_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Readable = false };
@@ -223,7 +223,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_null_stream_should_be_readable_should_throw()
+        public void When_null_be_readable_should_fail()
         {
             // Arrange
             TestStream stream = null;
@@ -234,11 +234,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be readable *failure message*, but found a <null> Stream.");
+                .WithMessage("Expected stream to be readable *failure message*, but found a <null> reference.");
         }
 
         [Fact]
-        public void When_asserting_a_non_readable_stream_is_not_readable_it_should_succeed()
+        public void When_having_a_non_readable_stream_be_not_readable_should_succeed()
         {
             // Arrange
             using var stream = new TestStream { Readable = false };
@@ -252,7 +252,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_readable_stream_is_not_readable_it_should_fail()
+        public void When_having_a_readable_stream_be_not_readable_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Readable = true };
@@ -267,7 +267,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_null_stream_should_not_be_readable_should_throw()
+        public void When_null_not_be_readable_should_fail()
         {
             // Arrange
             TestStream stream = null;
@@ -278,7 +278,7 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be readable *failure message*, but found a <null> Stream.");
+                .WithMessage("Expected stream not to be readable *failure message*, but found a <null> reference.");
         }
 
         #endregion
@@ -286,7 +286,7 @@ namespace FluentAssertions.Specs.Streams
         #region HavePosition / NotHavePosition
 
         [Fact]
-        public void When_asserting_a_stream_should_have_position_with_the_same_value_it_should_succeed()
+        public void When_a_stream_has_the_expected_position_it_should_succeed()
         {
             // Arrange
             using var stream = new TestStream { Seekable = true, Position = 10 };
@@ -300,7 +300,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_stream_should_have_position_with_a_different_value_it_should_throw()
+        public void When_a_stream_has_the_unexpected_position_it_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Seekable = true, Position = 1 };
@@ -311,11 +311,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream to be 10 *failure message*, but it was 1*.");
+                .WithMessage("Expected the position of stream to be 10* *failure message*, but it was 1*.");
         }
 
         [Fact]
-        public void When_asserting_a_non_seekable_stream_should_have_position_should_throw()
+        public void When_having_a_non_seekable_stream_have_position_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Seekable = false };
@@ -326,11 +326,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream to be 10 *failure message*, but found a non-seekable stream.");
+                .WithMessage("Expected the position of stream to be 10* *failure message*, but found a non-seekable stream.");
         }
 
         [Fact]
-        public void When_asserting_a_null_stream_should_have_position_should_throw()
+        public void When_null_have_position_should_fail()
         {
             // Arrange
             TestStream stream = null;
@@ -341,11 +341,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream to be 10 *failure message*, but found a <null> Stream.");
+                .WithMessage("Expected the position of stream to be 10* *failure message*, but found a <null> reference.");
         }
 
         [Fact]
-        public void When_asserting_a_stream_should_not_have_position_with_a_different_it_should_succeed()
+        public void When_a_stream_does_not_have_an_unexpected_position_it_should_succeed()
         {
             // Arrange
             using var stream = new TestStream { Seekable = true, Position = 1 };
@@ -359,7 +359,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_stream_should_not_have_position_with_the_same_value_it_should_throw()
+        public void When_a_stream_does_have_the_unexpected_position_it_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Seekable = true, Position = 10 };
@@ -370,11 +370,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream not to be 10 *failure message*, but it was.");
+                .WithMessage("Expected the position of stream not to be 10* *failure message*, but it was.");
         }
 
         [Fact]
-        public void When_asserting_a_non_seekable_stream_should_not_have_position_should_throw()
+        public void When_having_a_non_seekable_stream_not_have_position_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Seekable = false };
@@ -385,11 +385,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream not to be 10 *failure message*, but found a non-seekable stream.");
+                .WithMessage("Expected the position of stream not to be 10* *failure message*, but found a non-seekable stream.");
         }
 
         [Fact]
-        public void When_asserting_a_null_stream_should_not_have_position_should_throw()
+        public void When_null_not_have_position_should_fail()
         {
             // Arrange
             TestStream stream = null;
@@ -400,7 +400,7 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the position of stream not to be 10 *failure message*, but found a <null> Stream.");
+                .WithMessage("Expected the position of stream not to be 10* *failure message*, but found a <null> reference.");
         }
 
         #endregion
@@ -408,10 +408,10 @@ namespace FluentAssertions.Specs.Streams
         #region HaveLength / NotHaveLength
 
         [Fact]
-        public void When_asserting_a_stream_should_have_length_with_the_same_value_it_should_succeed()
+        public void When_a_stream_has_the_expected_length_it_should_succeed()
         {
             // Arrange
-            using var stream = new TestStream { Seekable = true, WithLentgh = 10 };
+            using var stream = new TestStream { Seekable = true, WithLength = 10 };
 
             // Act
             Action act = () =>
@@ -422,10 +422,10 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_stream_should_have_length_with_a_different_value_it_should_throw()
+        public void When_a_stream_has_an_unexpected_length_it_should_fail()
         {
             // Arrange
-            using var stream = new TestStream { Seekable = true, WithLentgh = 1 };
+            using var stream = new TestStream { Seekable = true, WithLength = 1 };
 
             // Act
             Action act = () =>
@@ -433,11 +433,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream to be 10 *failure message*, but it was 1*.");
+                .WithMessage("Expected the length of stream to be 10* *failure message*, but it was 1*.");
         }
 
         [Fact]
-        public void When_asserting_a_non_seekable_stream_should_have_length_should_throw()
+        public void When_having_a_non_seekable_stream_have_length_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Seekable = false };
@@ -448,11 +448,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream to be 10 *failure message*, but found a non-seekable stream.");
+                .WithMessage("Expected the length of stream to be 10* *failure message*, but found a non-seekable stream.");
         }
 
         [Fact]
-        public void When_asserting_a_null_stream_should_have_length_should_throw()
+        public void When_null_have_length_should_fail()
         {
             // Arrange
             TestStream stream = null;
@@ -463,14 +463,14 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream to be 10 *failure message*, but found a <null> Stream.");
+                .WithMessage("Expected the length of stream to be 10* *failure message*, but found a <null> reference.");
         }
 
         [Fact]
-        public void When_asserting_a_stream_should_not_have_length_with_a_different_it_should_succeed()
+        public void When_a_stream_does_not_have_an_unexpected_length_it_should_succeed()
         {
             // Arrange
-            using var stream = new TestStream { Seekable = true, WithLentgh = 1 };
+            using var stream = new TestStream { Seekable = true, WithLength = 1 };
 
             // Act
             Action act = () =>
@@ -481,10 +481,10 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_stream_should_not_have_length_with_the_same_value_it_should_throw()
+        public void When_a_stream_does_have_the_unexpected_length_it_should_fail()
         {
             // Arrange
-            using var stream = new TestStream { Seekable = true, WithLentgh = 10 };
+            using var stream = new TestStream { Seekable = true, WithLength = 10 };
 
             // Act
             Action act = () =>
@@ -492,11 +492,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream not to be 10 *failure message*, but it was.");
+                .WithMessage("Expected the length of stream not to be 10* *failure message*, but it was.");
         }
 
         [Fact]
-        public void When_asserting_a_non_seekable_stream_should_not_have_length_should_throw()
+        public void When_having_a_non_seekable_stream_not_have_length_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Seekable = false };
@@ -507,11 +507,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream not to be 10 *failure message*, but found a non-seekable stream.");
+                .WithMessage("Expected the length of stream not to be 10* *failure message*, but found a non-seekable stream.");
         }
 
         [Fact]
-        public void When_asserting_a_null_stream_should_not_have_length_should_throw()
+        public void When_null_not_have_length_should_fail()
         {
             // Arrange
             TestStream stream = null;
@@ -522,7 +522,7 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the length of stream not to be 10 *failure message*, but found a <null> Stream.");
+                .WithMessage("Expected the length of stream not to be 10* *failure message*, but found a <null> reference.");
         }
 
         #endregion
@@ -530,7 +530,7 @@ namespace FluentAssertions.Specs.Streams
         #region BeReadOnly / NotBeReadOnly
 
         [Fact]
-        public void When_asserting_a_readonly_stream_is_readonly_it_should_succeed()
+        public void When_having_a_readonly_stream_be_read_only_should_succeed()
         {
             // Arrange
             using var stream = new TestStream { Readable = true, Writable = false };
@@ -544,7 +544,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_writable_stream_is_readonly_it_should_fail()
+        public void When_having_a_writable_stream_be_read_only_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Readable = true, Writable = true };
@@ -555,11 +555,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be read only *failure message*, but it was writable or not readable.");
+                .WithMessage("Expected stream to be read-only *failure message*, but it was writable or not readable.");
         }
 
         [Fact]
-        public void When_asserting_a_non_readable_stream_is_readonly_it_should_fail()
+        public void When_having_a_non_readable_stream_be_read_only_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Readable = false, Writable = false };
@@ -570,11 +570,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be read only *failure message*, but it was writable or not readable.");
+                .WithMessage("Expected stream to be read-only *failure message*, but it was writable or not readable.");
         }
 
         [Fact]
-        public void When_asserting_a_null_stream_should_be_readonly_should_throw()
+        public void When_null_be_read_only_should_fail()
         {
             // Arrange
             TestStream stream = null;
@@ -585,11 +585,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be read only *failure message*, but found a <null> Stream.");
+                .WithMessage("Expected stream to be read-only *failure message*, but found a <null> reference.");
         }
 
         [Fact]
-        public void When_asserting_a_non_readable_stream_is_not_readonly_it_should_succeed()
+        public void When_having_a_non_readable_stream_be_not_read_only_should_succeed()
         {
             // Arrange
             using var stream = new TestStream { Readable = false, Writable = false };
@@ -603,7 +603,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_writable_stream_is_not_readonly_it_should_succeed()
+        public void When_having_a_writable_stream_be_not_read_only_should_succeed()
         {
             // Arrange
             using var stream = new TestStream { Readable = true, Writable = true };
@@ -617,7 +617,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_readonly_stream_is_not_readonly_it_should_fail()
+        public void When_having_a_readonly_stream_be_not_read_only_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Readable = true, Writable = false };
@@ -628,11 +628,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be read only *failure message*, but it was.");
+                .WithMessage("Expected stream not to be read-only *failure message*, but it was.");
         }
 
         [Fact]
-        public void When_asserting_a_null_stream_should_not_be_readonly_should_throw()
+        public void When_null_not_be_read_only_should_fail()
         {
             // Arrange
             TestStream stream = null;
@@ -643,7 +643,7 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be read only *failure message*, but found a <null> Stream.");
+                .WithMessage("Expected stream not to be read-only *failure message*, but found a <null> reference.");
         }
 
         #endregion
@@ -651,7 +651,7 @@ namespace FluentAssertions.Specs.Streams
         #region BeWriteOnly / NotBeWriteOnly
 
         [Fact]
-        public void When_asserting_a_writeonly_stream_is_writeonly_it_should_succeed()
+        public void When_having_a_writeonly_stream_be_write_only_should_succeed()
         {
             // Arrange
             using var stream = new TestStream { Readable = false, Writable = true };
@@ -665,7 +665,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_readable_stream_is_writeonly_it_should_fail()
+        public void When_having_a_readable_stream_be_write_only_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Readable = true, Writable = true };
@@ -676,11 +676,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be write only *failure message*, but it was readable or not writable.");
+                .WithMessage("Expected stream to be write-only *failure message*, but it was readable or not writable.");
         }
 
         [Fact]
-        public void When_asserting_a_non_wrtieable_stream_is_writeonly_it_should_fail()
+        public void When_having_a_non_writable_stream_be_write_only_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Readable = false, Writable = false };
@@ -691,11 +691,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be write only *failure message*, but it was readable or not writable.");
+                .WithMessage("Expected stream to be write-only *failure message*, but it was readable or not writable.");
         }
 
         [Fact]
-        public void When_asserting_a_null_stream_should_be_writeonly_should_throw()
+        public void When_null_be_write_only_should_fail()
         {
             // Arrange
             TestStream stream = null;
@@ -706,11 +706,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream to be write only *failure message*, but found a <null> Stream.");
+                .WithMessage("Expected stream to be write-only *failure message*, but found a <null> reference.");
         }
 
         [Fact]
-        public void When_asserting_a_non_writable_stream_is_not_writeonly_it_should_succeed()
+        public void When_having_a_non_writable_stream_be_not_write_only_should_succeed()
         {
             // Arrange
             using var stream = new TestStream { Readable = false, Writable = false };
@@ -724,7 +724,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_readable_stream_is_not_writeonly_it_should_succeed()
+        public void When_having_a_readable_stream_be_not_write_only_should_succeed()
         {
             // Arrange
             using var stream = new TestStream { Readable = true, Writable = true };
@@ -738,7 +738,7 @@ namespace FluentAssertions.Specs.Streams
         }
 
         [Fact]
-        public void When_asserting_a_writeonly_stream_is_not_writeonly_it_should_fail()
+        public void When_having_a_writeonly_stream_be_not_write_only_should_fail()
         {
             // Arrange
             using var stream = new TestStream { Readable = false, Writable = true };
@@ -749,11 +749,11 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be write only *failure message*, but it was.");
+                .WithMessage("Expected stream not to be write-only *failure message*, but it was.");
         }
 
         [Fact]
-        public void When_asserting_a_null_stream_should_not_be_writeonly_should_throw()
+        public void When_null_not_be_write_only_should_fail()
         {
             // Arrange
             TestStream stream = null;
@@ -764,7 +764,7 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected stream not to be write only *failure message*, but found a <null> Stream.");
+                .WithMessage("Expected stream not to be write-only *failure message*, but found a <null> reference.");
         }
 
         #endregion
@@ -778,7 +778,7 @@ namespace FluentAssertions.Specs.Streams
 
         public bool Writable { private get; set; }
 
-        public long WithLentgh { private get; set; }
+        public long WithLength { private get; set; }
 
         public override bool CanRead => Readable;
 
@@ -786,7 +786,7 @@ namespace FluentAssertions.Specs.Streams
 
         public override bool CanWrite => Writable;
 
-        public override long Length => WithLentgh;
+        public override long Length => WithLength;
 
         public override long Position { get; set; }
 

--- a/Tests/FluentAssertions.Specs/Streams/StreamAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Streams/StreamAssertionSpecs.cs
@@ -1,0 +1,803 @@
+﻿using System;
+using System.IO;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Streams
+{
+    public class StreamAssertionSpecs
+    {
+        #region BeWritable / NotBeWritable
+
+        [Fact]
+        public void When_asserting_a_writeable_stream_is_writable_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new TestStream { Writable = true };
+
+            // Act
+            Action act = () =>
+                stream.Should().BeWritable();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_non_writeable_stream_is_writable_it_should_fail()
+        {
+            // Arrange
+            using var stream = new TestStream { Writable = false };
+
+            // Act
+            Action act = () =>
+                stream.Should().BeWritable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream to be writable *failure message*, but it was not.");
+        }
+
+        [Fact]
+        public void When_asserting_a_null_stream_should_be_writable_should_throw()
+        {
+            // Arrange
+            TestStream stream = null;
+
+            // Act
+            Action act = () =>
+                stream.Should().BeWritable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream to be writable *failure message*, but found a <null> Stream.");
+        }
+
+        [Fact]
+        public void When_asserting_a_non_writeable_stream_is_not_writable_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new TestStream { Writable = false };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotBeWritable();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_writeable_stream_is_not_writable_it_should_fail()
+        {
+            // Arrange
+            using var stream = new TestStream { Writable = true };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotBeWritable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream not to be writable *failure message*, but it was.");
+        }
+
+        [Fact]
+        public void When_asserting_a_null_stream_should_not_be_writable_should_throw()
+        {
+            // Arrange
+            TestStream stream = null;
+
+            // Act
+            Action act = () =>
+                stream.Should().NotBeWritable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream not to be writable *failure message*, but found a <null> Stream.");
+        }
+
+        #endregion
+
+        #region BeSeekable / NotBeSeekable
+
+        [Fact]
+        public void When_asserting_a_seekable_stream_is_seekable_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new TestStream { Seekable = true };
+
+            // Act
+            Action act = () =>
+                stream.Should().BeSeekable();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_non_seekable_stream_is_seekable_it_should_fail()
+        {
+            // Arrange
+            using var stream = new TestStream { Seekable = false };
+
+            // Act
+            Action act = () =>
+                stream.Should().BeSeekable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream to be seekable *failure message*, but it was not.");
+        }
+
+        [Fact]
+        public void When_asserting_a_null_stream_should_be_seekable_should_throw()
+        {
+            // Arrange
+            TestStream stream = null;
+
+            // Act
+            Action act = () =>
+                stream.Should().BeSeekable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream to be seekable *failure message*, but found a <null> Stream.");
+        }
+
+        [Fact]
+        public void When_asserting_a_non_seekable_stream_is_not_seekable_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new TestStream { Seekable = false };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotBeSeekable();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_seekable_stream_is_not_seekable_it_should_fail()
+        {
+            // Arrange
+            using var stream = new TestStream { Seekable = true };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotBeSeekable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream not to be seekable *failure message*, but it was.");
+        }
+
+        [Fact]
+        public void When_asserting_a_null_stream_should_not_be_seekable_should_throw()
+        {
+            // Arrange
+            TestStream stream = null;
+
+            // Act
+            Action act = () =>
+                stream.Should().NotBeSeekable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream not to be seekable *failure message*, but found a <null> Stream.");
+        }
+
+        #endregion
+
+        #region BeReadable / NotBeReadable
+
+        [Fact]
+        public void When_asserting_a_readable_stream_is_readable_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new TestStream { Readable = true };
+
+            // Act
+            Action act = () =>
+                stream.Should().BeReadable();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_non_readable_stream_is_readable_it_should_fail()
+        {
+            // Arrange
+            using var stream = new TestStream { Readable = false };
+
+            // Act
+            Action act = () =>
+                stream.Should().BeReadable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream to be readable *failure message*, but it was not.");
+        }
+
+        [Fact]
+        public void When_asserting_a_null_stream_should_be_readable_should_throw()
+        {
+            // Arrange
+            TestStream stream = null;
+
+            // Act
+            Action act = () =>
+                stream.Should().BeReadable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream to be readable *failure message*, but found a <null> Stream.");
+        }
+
+        [Fact]
+        public void When_asserting_a_non_readable_stream_is_not_readable_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new TestStream { Readable = false };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotBeReadable();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_readable_stream_is_not_readable_it_should_fail()
+        {
+            // Arrange
+            using var stream = new TestStream { Readable = true };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotBeReadable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream not to be readable *failure message*, but it was.");
+        }
+
+        [Fact]
+        public void When_asserting_a_null_stream_should_not_be_readable_should_throw()
+        {
+            // Arrange
+            TestStream stream = null;
+
+            // Act
+            Action act = () =>
+                stream.Should().NotBeReadable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream not to be readable *failure message*, but found a <null> Stream.");
+        }
+
+        #endregion
+
+        #region HavePosition / NotHavePosition
+
+        [Fact]
+        public void When_asserting_a_stream_should_have_position_with_the_same_value_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new TestStream { Seekable = true, Position = 10 };
+
+            // Act
+            Action act = () =>
+                stream.Should().HavePosition(10);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_stream_should_have_position_with_a_different_value_it_should_throw()
+        {
+            // Arrange
+            using var stream = new TestStream { Seekable = true, Position = 1 };
+
+            // Act
+            Action act = () =>
+                stream.Should().HavePosition(10, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the position of stream to be 10 *failure message*, but it was 1*.");
+        }
+
+        [Fact]
+        public void When_asserting_a_non_seekable_stream_should_have_position_should_throw()
+        {
+            // Arrange
+            using var stream = new TestStream { Seekable = false };
+
+            // Act
+            Action act = () =>
+                stream.Should().HavePosition(10, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the position of stream to be 10 *failure message*, but found a non-seekable stream.");
+        }
+
+        [Fact]
+        public void When_asserting_a_null_stream_should_have_position_should_throw()
+        {
+            // Arrange
+            TestStream stream = null;
+
+            // Act
+            Action act = () =>
+                stream.Should().HavePosition(10, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the position of stream to be 10 *failure message*, but found a <null> Stream.");
+        }
+
+        [Fact]
+        public void When_asserting_a_stream_should_not_have_position_with_a_different_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new TestStream { Seekable = true, Position = 1 };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotHavePosition(10);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_stream_should_not_have_position_with_the_same_value_it_should_throw()
+        {
+            // Arrange
+            using var stream = new TestStream { Seekable = true, Position = 10 };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotHavePosition(10, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the position of stream not to be 10 *failure message*, but it was.");
+        }
+
+        [Fact]
+        public void When_asserting_a_non_seekable_stream_should_not_have_position_should_throw()
+        {
+            // Arrange
+            using var stream = new TestStream { Seekable = false };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotHavePosition(10, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the position of stream not to be 10 *failure message*, but found a non-seekable stream.");
+        }
+
+        [Fact]
+        public void When_asserting_a_null_stream_should_not_have_position_should_throw()
+        {
+            // Arrange
+            TestStream stream = null;
+
+            // Act
+            Action act = () =>
+                stream.Should().NotHavePosition(10, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the position of stream not to be 10 *failure message*, but found a <null> Stream.");
+        }
+
+        #endregion
+
+        #region HaveLength / NotHaveLength
+
+        [Fact]
+        public void When_asserting_a_stream_should_have_length_with_the_same_value_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new TestStream { Seekable = true, WithLentgh = 10 };
+
+            // Act
+            Action act = () =>
+                stream.Should().HaveLength(10);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_stream_should_have_length_with_a_different_value_it_should_throw()
+        {
+            // Arrange
+            using var stream = new TestStream { Seekable = true, WithLentgh = 1 };
+
+            // Act
+            Action act = () =>
+                stream.Should().HaveLength(10, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the length of stream to be 10 *failure message*, but it was 1*.");
+        }
+
+        [Fact]
+        public void When_asserting_a_non_seekable_stream_should_have_length_should_throw()
+        {
+            // Arrange
+            using var stream = new TestStream { Seekable = false };
+
+            // Act
+            Action act = () =>
+                stream.Should().HaveLength(10, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the length of stream to be 10 *failure message*, but found a non-seekable stream.");
+        }
+
+        [Fact]
+        public void When_asserting_a_null_stream_should_have_length_should_throw()
+        {
+            // Arrange
+            TestStream stream = null;
+
+            // Act
+            Action act = () =>
+                stream.Should().HaveLength(10, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the length of stream to be 10 *failure message*, but found a <null> Stream.");
+        }
+
+        [Fact]
+        public void When_asserting_a_stream_should_not_have_length_with_a_different_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new TestStream { Seekable = true, WithLentgh = 1 };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotHaveLength(10);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_stream_should_not_have_length_with_the_same_value_it_should_throw()
+        {
+            // Arrange
+            using var stream = new TestStream { Seekable = true, WithLentgh = 10 };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotHaveLength(10, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the length of stream not to be 10 *failure message*, but it was.");
+        }
+
+        [Fact]
+        public void When_asserting_a_non_seekable_stream_should_not_have_length_should_throw()
+        {
+            // Arrange
+            using var stream = new TestStream { Seekable = false };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotHaveLength(10, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the length of stream not to be 10 *failure message*, but found a non-seekable stream.");
+        }
+
+        [Fact]
+        public void When_asserting_a_null_stream_should_not_have_length_should_throw()
+        {
+            // Arrange
+            TestStream stream = null;
+
+            // Act
+            Action act = () =>
+                stream.Should().NotHaveLength(10, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the length of stream not to be 10 *failure message*, but found a <null> Stream.");
+        }
+
+        #endregion
+
+        #region BeReadOnly / NotBeReadOnly
+
+        [Fact]
+        public void When_asserting_a_readonly_stream_is_readonly_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new TestStream { Readable = true, Writable = false };
+
+            // Act
+            Action act = () =>
+                stream.Should().BeReadOnly();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_writable_stream_is_readonly_it_should_fail()
+        {
+            // Arrange
+            using var stream = new TestStream { Readable = true, Writable = true };
+
+            // Act
+            Action act = () =>
+                stream.Should().BeReadOnly("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream to be read only *failure message*, but it was writable or not readable.");
+        }
+
+        [Fact]
+        public void When_asserting_a_non_readable_stream_is_readonly_it_should_fail()
+        {
+            // Arrange
+            using var stream = new TestStream { Readable = false, Writable = false };
+
+            // Act
+            Action act = () =>
+                stream.Should().BeReadOnly("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream to be read only *failure message*, but it was writable or not readable.");
+        }
+
+        [Fact]
+        public void When_asserting_a_null_stream_should_be_readonly_should_throw()
+        {
+            // Arrange
+            TestStream stream = null;
+
+            // Act
+            Action act = () =>
+                stream.Should().BeReadOnly("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream to be read only *failure message*, but found a <null> Stream.");
+        }
+
+        [Fact]
+        public void When_asserting_a_non_readable_stream_is_not_readonly_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new TestStream { Readable = false, Writable = false };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotBeReadOnly();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_writable_stream_is_not_readonly_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new TestStream { Readable = true, Writable = true };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotBeReadOnly();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_readonly_stream_is_not_readonly_it_should_fail()
+        {
+            // Arrange
+            using var stream = new TestStream { Readable = true, Writable = false };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotBeReadOnly("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream not to be read only *failure message*, but it was.");
+        }
+
+        [Fact]
+        public void When_asserting_a_null_stream_should_not_be_readonly_should_throw()
+        {
+            // Arrange
+            TestStream stream = null;
+
+            // Act
+            Action act = () =>
+                stream.Should().NotBeReadOnly("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream not to be read only *failure message*, but found a <null> Stream.");
+        }
+
+        #endregion
+
+        #region BeWriteOnly / NotBeWriteOnly
+
+        [Fact]
+        public void When_asserting_a_writeonly_stream_is_writeonly_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new TestStream { Readable = false, Writable = true };
+
+            // Act
+            Action act = () =>
+                stream.Should().BeWriteOnly();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_readable_stream_is_writeonly_it_should_fail()
+        {
+            // Arrange
+            using var stream = new TestStream { Readable = true, Writable = true };
+
+            // Act
+            Action act = () =>
+                stream.Should().BeWriteOnly("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream to be write only *failure message*, but it was readable or not writable.");
+        }
+
+        [Fact]
+        public void When_asserting_a_non_wrtieable_stream_is_writeonly_it_should_fail()
+        {
+            // Arrange
+            using var stream = new TestStream { Readable = false, Writable = false };
+
+            // Act
+            Action act = () =>
+                stream.Should().BeWriteOnly("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream to be write only *failure message*, but it was readable or not writable.");
+        }
+
+        [Fact]
+        public void When_asserting_a_null_stream_should_be_writeonly_should_throw()
+        {
+            // Arrange
+            TestStream stream = null;
+
+            // Act
+            Action act = () =>
+                stream.Should().BeWriteOnly("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream to be write only *failure message*, but found a <null> Stream.");
+        }
+
+        [Fact]
+        public void When_asserting_a_non_writable_stream_is_not_writeonly_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new TestStream { Readable = false, Writable = false };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotBeWriteOnly();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_readable_stream_is_not_writeonly_it_should_succeed()
+        {
+            // Arrange
+            using var stream = new TestStream { Readable = true, Writable = true };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotBeWriteOnly();
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_writeonly_stream_is_not_writeonly_it_should_fail()
+        {
+            // Arrange
+            using var stream = new TestStream { Readable = false, Writable = true };
+
+            // Act
+            Action act = () =>
+                stream.Should().NotBeWriteOnly("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream not to be write only *failure message*, but it was.");
+        }
+
+        [Fact]
+        public void When_asserting_a_null_stream_should_not_be_writeonly_should_throw()
+        {
+            // Arrange
+            TestStream stream = null;
+
+            // Act
+            Action act = () =>
+                stream.Should().NotBeWriteOnly("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected stream not to be write only *failure message*, but found a <null> Stream.");
+        }
+
+        #endregion
+    }
+
+    internal class TestStream : Stream
+    {
+        public bool Readable { private get; set; }
+
+        public bool Seekable { private get; set; }
+
+        public bool Writable { private get; set; }
+
+        public long WithLentgh { private get; set; }
+
+        public override bool CanRead => Readable;
+
+        public override bool CanSeek => Seekable;
+
+        public override bool CanWrite => Writable;
+
+        public override long Length => WithLentgh;
+
+        public override long Position { get; set; }
+
+        public override void Flush() => throw new NotImplementedException();
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
+
+        public override void SetLength(long value) => throw new NotImplementedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+    }
+}

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -19,6 +19,7 @@ sidebar:
 * Added `AddReportable` overload to `AssertionScope` for deferring reportable value calculation only on a test failure - [#1515](https://github.com/fluentassertions/fluentassertions/pull/1515).
 * Added the possibility to set the maximum depth and other formatting settings either globally or per `AssertionScope` - [#1469](https://github.com/fluentassertions/fluentassertions/pull/1469).
 * Added `BeInAscendingOrder` and `BeInDescendingOrder` for collections taking a lambda expression - [#1526](https://github.com/fluentassertions/fluentassertions/pull/1526)
+* Added `[Not]BeWritable`, `[Not]BeSeekable`, `[Not]BeReadable`, `[Not]BeReadOnly`, `[Not]BeWriteOnly`, `[Not]HaveLength` , `[Not]HavePosition` for Stream and `[Not]HaveBufferSize` for BufferedStream - [#1543](https://github.com/fluentassertions/fluentassertions/pull/1543)
 
 **Fixes**
 * Sometimes `BeEquivalentTo` reported an incorrect message when a dictionary was missing a key - [#1454](https://github.com/fluentassertions/fluentassertions/pull/1454)

--- a/docs/_pages/streams.md
+++ b/docs/_pages/streams.md
@@ -1,0 +1,32 @@
+---
+title: Streams
+permalink: /streams/
+layout: single
+classes: wide
+sidebar:
+  nav: "sidebar"
+---
+
+## Streams ##
+
+```csharp
+var stream = new MemoryStream(new byte[1024], writable: false);
+
+stream.Should().NotBeWritable();
+stream.Should().BeReadable();
+stream.Should().BeReadOnly();
+stream.Should().BeSeekable();
+
+stream.Should().HaveLength(1024);
+stream.Should().HavePosition(0);
+
+```
+
+There are also additional assertions for `BufferedStream`.
+
+```csharp
+var stream = new BufferedStream(new MemoryStream(), 1024)
+
+subject.Should().HaveBufferSize(1024);
+subject.Should().NotHaveBufferSize(2048);
+```


### PR DESCRIPTION
Added for `Stream`
* `[Not]BeWritable`
* `[Not]BeSeekable`
* `[Not]BeReadable`
* `[Not]BeReadOnly`
* `[Not]BeWriteOnly`
* `[Not]HaveLength`
* `[Not]HavePosition`
 
Added for `BufferedStream`

* `[Not]HaveBufferSize` 

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).