### PR TITLE
Fix sticky footer overlapping content

### DIFF
--- a/docs/_sass/minimal-mistakes/_footer.scss
+++ b/docs/_sass/minimal-mistakes/_footer.scss
@@ -9,11 +9,6 @@
   margin-right: 0;
   width: 100%;
   clear: both;
-  /* sticky footer fix start */
-  position: absolute;
-  bottom: 0;
-  height: auto;
-  /* sticky footer fix end */
   margin-top: 3em;
   color: $muted-text-color;
   -webkit-animation: $intro-transition;

--- a/docs/_sass/minimal-mistakes/_page.scss
+++ b/docs/_sass/minimal-mistakes/_page.scss
@@ -20,6 +20,22 @@
   }
 }
 
+body {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 100vh;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-direction: column;
+          flex-direction: column;
+}
+
+.initial-content,
+.search-content {
+  flex: 1;
+}
+
 .page {
   @include breakpoint($large) {
     float: right;

--- a/docs/_sass/minimal-mistakes/_page.scss
+++ b/docs/_sass/minimal-mistakes/_page.scss
@@ -33,7 +33,7 @@ body {
 
 .initial-content,
 .search-content {
-  flex: 1;
+  flex: 1 0 auto;
 }
 
 .page {


### PR DESCRIPTION
The sticky footer overlaps and conceals content on nearly every page.

There are [several ways to make sticky footers][1]. Replace the current one with a grid variant. It's not strictly necessary to fix the footer's position in the grid as long as the DOM has the desired element order.

[1]: https://css-tricks.com/couple-takes-sticky-footer/

This makes

![before](https://user-images.githubusercontent.com/603326/117569259-1f977e80-b0c5-11eb-97db-03f23eb069ed.png)

look more like

![after](https://user-images.githubusercontent.com/603326/117569260-20301500-b0c5-11eb-802f-843ad865ec33.png)

I've checked

* wide screens
* narrow screens
* short content
* long content
* search box (which I'm not sure does anything...?)
