### PR TITLE
Make type assertions more robust

### DIFF
--- a/Src/FluentAssertions/Common/Guard.cs
+++ b/Src/FluentAssertions/Common/Guard.cs
@@ -36,6 +36,24 @@ namespace FluentAssertions.Common
             }
         }
 
+        public static void ThrowIfArgumentIsOutOfRange<T>([ValidatedNotNull] T value, string paramName)
+            where T : Enum
+        {
+            if (!Enum.IsDefined(typeof(T), value))
+            {
+                throw new ArgumentOutOfRangeException(paramName);
+            }
+        }
+
+        public static void ThrowIfArgumentIsOutOfRange<T>([ValidatedNotNull] T value, string paramName, string message)
+            where T : Enum
+        {
+            if (!Enum.IsDefined(typeof(T), value))
+            {
+                throw new ArgumentOutOfRangeException(paramName, message);
+            }
+        }
+
         /// <summary>
         /// Workaround to make dotnet_code_quality.null_check_validation_methods work
         /// https://github.com/dotnet/roslyn-analyzers/issues/3451#issuecomment-606690452

--- a/Src/FluentAssertions/Types/MethodInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoAssertions.cs
@@ -226,7 +226,12 @@ namespace FluentAssertions.Types
 
         internal static string GetDescriptionFor(MethodInfo method)
         {
-            string returnTypeName = method.ReturnType.Name;
+            if (method is null)
+            {
+                return string.Empty;
+            }
+
+            var returnTypeName = method.ReturnType.Name;
 
             return $"{returnTypeName} {method.DeclaringType}.{method.Name}";
         }

--- a/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
@@ -269,7 +269,13 @@ namespace FluentAssertions.Types
 
         internal static string GetDescriptionFor(PropertyInfo property)
         {
-            string propTypeName = property.PropertyType.Name;
+            if (property is null)
+            {
+                return string.Empty;
+            }
+
+            var propTypeName = property.PropertyType.Name;
+
             return $"{propTypeName} {property.DeclaringType}.{property.Name}";
         }
 

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -11,7 +11,7 @@ using FluentAssertions.Primitives;
 namespace FluentAssertions.Types
 {
     /// <summary>
-    /// Contains a number of methods to assert that a <see cref="System.Type"/> meets certain expectations.
+    /// Contains a number of methods to assert that a <see cref="Type"/> meets certain expectations.
     /// </summary>
     [DebuggerNonUserCode]
     public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
@@ -25,7 +25,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type is equal to the specified <typeparamref name="TExpected"/> type.
+        /// Asserts that the current <see cref="Type"/> is equal to the specified <typeparamref name="TExpected"/> type.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -40,7 +40,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type is equal to the specified <paramref name="expected"/> type.
+        /// Asserts that the current <see cref="Type"/> is equal to the specified <paramref name="expected"/> type.
         /// </summary>
         /// <param name="expected">The expected type</param>
         /// <param name="because">
@@ -422,7 +422,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> implements Interface <paramref name="interfaceType"/>.
+        /// Asserts that the current <see cref="Type"/> implements <paramref name="interfaceType"/>.
         /// </summary>
         /// <param name="interfaceType">The interface that should be implemented.</param>
         /// <param name="because">
@@ -454,7 +454,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> implements Interface <typeparamref name="TInterface"/>.
+        /// Asserts that the current <see cref="Type"/> implements interface <typeparamref name="TInterface"/>.
         /// </summary>
         /// <typeparam name="TInterface">The interface that should be implemented.</typeparam>
         /// <param name="because">
@@ -471,7 +471,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> does not implement Interface <paramref name="interfaceType"/>.
+        /// Asserts that the current <see cref="Type"/> does not implement <paramref name="interfaceType"/>.
         /// </summary>
         /// <param name="interfaceType">The interface that should be not implemented.</param>
         /// <param name="because">
@@ -503,7 +503,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> does not implement Interface <typeparamref name="TInterface"/>.
+        /// Asserts that the current <see cref="Type"/> does not implement interface <typeparamref name="TInterface"/>.
         /// </summary>
         /// <typeparam name="TInterface">The interface that should not be implemented.</typeparam>
         /// <param name="because">
@@ -520,9 +520,9 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> is derived from <see cref="System.Type"/> <paramref name="baseType"/>.
+        /// Asserts that the current <see cref="Type"/> is derived from <paramref name="baseType"/>.
         /// </summary>
-        /// <param name="baseType">The Type that should be derived from.</param>
+        /// <param name="baseType">The type that should be derived from.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -552,9 +552,9 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> is derived from <typeparamref name="TBaseClass"/>.
+        /// Asserts that the current <see cref="Type"/> is derived from <typeparamref name="TBaseClass"/>.
         /// </summary>
-        /// <typeparam name="TBaseClass">The Type that should be derived from.</typeparam>
+        /// <typeparam name="TBaseClass">The type that should be derived from.</typeparam>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -569,9 +569,9 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> is not derived from <see cref="System.Type"/> <paramref name="baseType"/>.
+        /// Asserts that the current <see cref="Type"/> is not derived from <paramref name="baseType"/>.
         /// </summary>
-        /// <param name="baseType">The Type that should not be derived from.</param>
+        /// <param name="baseType">The type that should not be derived from.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -601,9 +601,9 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> is not derived from <typeparamref name="TBaseClass"/>.
+        /// Asserts that the current <see cref="Type"/> is not derived from <typeparamref name="TBaseClass"/>.
         /// </summary>
-        /// <typeparam name="TBaseClass">The Type that should not be derived from.</typeparam>
+        /// <typeparam name="TBaseClass">The type that should not be derived from.</typeparam>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -618,7 +618,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> is sealed.
+        /// Asserts that the current <see cref="Type"/> is sealed.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -646,7 +646,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> is not sealed.
+        /// Asserts that the current <see cref="Type"/> is not sealed.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -674,7 +674,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> is abstract.
+        /// Asserts that the current <see cref="Type"/> is abstract.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -702,7 +702,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> is not abstract.
+        /// Asserts that the current <see cref="Type"/> is not abstract.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -730,7 +730,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> is static.
+        /// Asserts that the current <see cref="Type"/> is static.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -758,7 +758,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> is not static.
+        /// Asserts that the current <see cref="Type"/> is not static.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -786,7 +786,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type has a property of type <paramref name="propertyType"/> named <paramref name="name"/>.
+        /// Asserts that the current <see cref="Type"/> has a property of type <paramref name="propertyType"/> named <paramref name="name"/>.
         /// </summary>
         /// <param name="propertyType">The type of the property.</param>
         /// <param name="name">The name of the property.</param>
@@ -824,7 +824,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type has a property of type <typeparamref name="TProperty"/> named <paramref name="name"/>.
+        /// Asserts that the current <see cref="Type"/> has a property of type <typeparamref name="TProperty"/> named <paramref name="name"/>.
         /// </summary>
         /// <typeparam name="TProperty">The type of the property.</typeparam>
         /// <param name="name">The name of the property.</param>
@@ -842,7 +842,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type does not have a property named <paramref name="name"/>.
+        /// Asserts that the current <see cref="Type"/> does not have a property named <paramref name="name"/>.
         /// </summary>
         /// <param name="name">The name of the property.</param>
         /// <param name="because">
@@ -874,7 +874,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type explicitly implements a property named
+        /// Asserts that the current <see cref="Type"/> explicitly implements a property named
         /// <paramref name="name"/> from interface <paramref name="interfaceType" />.
         /// </summary>
         /// <param name="interfaceType">The type of the interface.</param>
@@ -911,7 +911,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type explicitly implements a property named
+        /// Asserts that the current <see cref="Type"/> explicitly implements a property named
         /// <paramref name="name"/> from interface <typeparamref name="TInterface"/>.
         /// </summary>
         /// <typeparam name="TInterface">The interface whose member is being explicitly implemented.</typeparam>
@@ -931,7 +931,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type does not explicitly implement a property named
+        /// Asserts that the current <see cref="Type"/> does not explicitly implement a property named
         /// <paramref name="name"/> from interface <paramref name="interfaceType" />.
         /// </summary>
         /// <param name="interfaceType">The type of the interface.</param>
@@ -968,7 +968,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type does not explicitly implement a property named
+        /// Asserts that the current <see cref="Type"/> does not explicitly implement a property named
         /// <paramref name="name"/> from interface <typeparamref name="TInterface"/>.
         /// </summary>
         /// <typeparam name="TInterface">The interface whose member is not being explicitly implemented.</typeparam>
@@ -988,7 +988,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type explicitly implements a method named <paramref name="name"/>
+        /// Asserts that the current <see cref="Type"/> explicitly implements a method named <paramref name="name"/>
         /// from interface <paramref name="interfaceType" />.
         /// </summary>
         /// <param name="interfaceType">The type of the interface.</param>
@@ -1028,7 +1028,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type explicitly implements a method named <paramref name="name"/>
+        /// Asserts that the current <see cref="Type"/> explicitly implements a method named <paramref name="name"/>
         /// from interface  <typeparamref name="TInterface"/>.
         /// </summary>
         /// <typeparam name="TInterface">The interface whose member is being explicitly implemented.</typeparam>
@@ -1050,7 +1050,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type does not explicitly implement a method named <paramref name="name"/>
+        /// Asserts that the current <see cref="Type"/> does not explicitly implement a method named <paramref name="name"/>
         /// from interface <paramref name="interfaceType" />.
         /// </summary>
         /// <param name="interfaceType">The type of the interface.</param>
@@ -1090,7 +1090,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type does not explicitly implement a method named <paramref name="name"/>
+        /// Asserts that the current <see cref="Type"/> does not explicitly implement a method named <paramref name="name"/>
         /// from interface <typeparamref name="TInterface"/>.
         /// </summary>
         /// <typeparam name="TInterface">The interface whose member is not being explicitly implemented.</typeparam>
@@ -1112,7 +1112,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type has an indexer of type <paramref name="indexerType"/>.
+        /// Asserts that the current <see cref="Type"/> has an indexer of type <paramref name="indexerType"/>.
         /// with parameter types <paramref name="parameterTypes"/>.
         /// </summary>
         /// <param name="indexerType">The type of the indexer.</param>
@@ -1151,7 +1151,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type does not have an indexer that takes parameter types <paramref name="parameterTypes"/>.
+        /// Asserts that the current <see cref="Type"/> does not have an indexer that takes parameter types <paramref name="parameterTypes"/>.
         /// </summary>
         /// <param name="parameterTypes">The expected indexer's parameter types.</param>
         /// <param name="because">
@@ -1182,7 +1182,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type has a method named <paramref name="name"/>with parameter types <paramref name="parameterTypes"/>.
+        /// Asserts that the current <see cref="Type"/> has a method named <paramref name="name"/> with parameter types <paramref name="parameterTypes"/>.
         /// </summary>
         /// <param name="name">The name of the method.</param>
         /// <param name="parameterTypes">The parameter types for the indexer.</param>
@@ -1216,7 +1216,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type does not expose a method named <paramref name="name"/>
+        /// Asserts that the current <see cref="Type"/> does not expose a method named <paramref name="name"/>
         /// with parameter types <paramref name="parameterTypes"/>.
         /// </summary>
         /// <param name="name">The name of the method.</param>
@@ -1252,7 +1252,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type has a constructor with parameter types <paramref name="parameterTypes"/>.
+        /// Asserts that the current <see cref="Type"/> has a constructor with <paramref name="parameterTypes"/>.
         /// </summary>
         /// <param name="parameterTypes">The parameter types for the indexer.</param>
         /// <param name="because">
@@ -1283,7 +1283,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type has a default constructor.
+        /// Asserts that the current <see cref="Type"/> has a default constructor.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -1298,7 +1298,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type does not have a constructor with parameter types <paramref name="parameterTypes"/>.
+        /// Asserts that the current <see cref="Type"/> does not have a constructor with <paramref name="parameterTypes"/>.
         /// </summary>
         /// <param name="parameterTypes">The parameter types for the indexer.</param>
         /// <param name="because">
@@ -1329,7 +1329,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type does not have a default constructor.
+        /// Asserts that the current <see cref="Type"/> does not have a default constructor.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -1349,7 +1349,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the selected type has the specified C# <paramref name="accessModifier"/>.
+        /// Asserts that the current <see cref="Type"/> has the specified C# <paramref name="accessModifier"/>.
         /// </summary>
         /// <param name="accessModifier">The expected C# access modifier.</param>
         /// <param name="because">
@@ -1381,7 +1381,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the selected type does not have the specified C# <paramref name="accessModifier"/>.
+        /// Asserts that the current <see cref="Type"/> does not have the specified C# <paramref name="accessModifier"/>.
         /// </summary>
         /// <param name="accessModifier">The unexpected C# access modifier.</param>
         /// <param name="because">
@@ -1413,7 +1413,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type has an implicit conversion operator that converts <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
+        /// Asserts that the current <see cref="Type"/> has an implicit conversion operator that converts <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
@@ -1430,7 +1430,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type has an implicit conversion operator that converts <paramref name="sourceType"/> into <paramref name="targetType"/>.
+        /// Asserts that the current <see cref="Type"/> has an implicit conversion operator that converts <paramref name="sourceType"/> into <paramref name="targetType"/>.
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
@@ -1464,7 +1464,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type does not have an implicit conversion operator that converts <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
+        /// Asserts that the current <see cref="Type"/> does not have an implicit conversion operator that converts <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
@@ -1481,7 +1481,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type does not have an implicit conversion operator that converts <paramref name="sourceType"/> into <paramref name="targetType"/>.
+        /// Asserts that the current <see cref="Type"/> does not have an implicit conversion operator that converts <paramref name="sourceType"/> into <paramref name="targetType"/>.
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
@@ -1515,7 +1515,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type has an explicit conversion operator that converts <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
+        /// Asserts that the current <see cref="Type"/> has an explicit conversion operator that converts <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
@@ -1532,7 +1532,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type has an explicit conversion operator that converts <paramref name="sourceType"/> into <paramref name="targetType"/>.
+        /// Asserts that the current <see cref="Type"/> has an explicit conversion operator that converts <paramref name="sourceType"/> into <paramref name="targetType"/>.
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
@@ -1566,7 +1566,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type does not have an explicit conversion operator that converts <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
+        /// Asserts that the current <see cref="Type"/> does not have an explicit conversion operator that converts <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
@@ -1583,7 +1583,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current type does not have an explicit conversion operator that converts <paramref name="sourceType"/> into <paramref name="targetType"/>.
+        /// Asserts that the current <see cref="Type"/> does not have an explicit conversion operator that converts <paramref name="sourceType"/> into <paramref name="targetType"/>.
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -654,17 +654,20 @@ namespace FluentAssertions.Types
         /// is not a class.</exception>
         public AndConstraint<TypeAssertions> BeSealed(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
-               .BecauseOf(because, becauseArgs)
-               .ForCondition(Subject is not null)
-               .FailWith("Expected type to be sealed{reason}, but {context:type} is <null>.");
-
-            AssertThatSubjectIsClass();
-
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.IsCSharpSealed())
-                .FailWith("Expected type {0} to be sealed{reason}.", Subject);
+                .ForCondition(Subject is not null)
+                .FailWith("Expected type to be sealed{reason}, but {context:type} is <null>.");
+
+            if (success)
+            {
+                AssertThatSubjectIsClass();
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.IsCSharpSealed())
+                    .FailWith("Expected type {0} to be sealed{reason}.", Subject);
+            }
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -683,17 +686,20 @@ namespace FluentAssertions.Types
         /// is not a class.</exception>
         public AndConstraint<TypeAssertions> NotBeSealed(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
-               .BecauseOf(because, becauseArgs)
-               .ForCondition(Subject is not null)
-               .FailWith("Expected type not to be sealed{reason}, but {context:type} is <null>.");
-
-            AssertThatSubjectIsClass();
-
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(!Subject.IsCSharpSealed())
-                .FailWith("Expected type {0} not to be sealed{reason}.", Subject);
+                .ForCondition(Subject is not null)
+                .FailWith("Expected type not to be sealed{reason}, but {context:type} is <null>.");
+
+            if (success)
+            {
+                AssertThatSubjectIsClass();
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(!Subject.IsCSharpSealed())
+                    .FailWith("Expected type {0} not to be sealed{reason}.", Subject);
+            }
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -712,17 +718,20 @@ namespace FluentAssertions.Types
         /// is not a class.</exception>
         public AndConstraint<TypeAssertions> BeAbstract(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
-               .BecauseOf(because, becauseArgs)
-               .ForCondition(Subject is not null)
-               .FailWith("Expected type to be abstract{reason}, but {context:type} is <null>.");
-
-            AssertThatSubjectIsClass();
-
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.IsCSharpAbstract())
-                .FailWith("Expected {context:type} {0} to be abstract{reason}.", Subject);
+                .ForCondition(Subject is not null)
+                .FailWith("Expected type to be abstract{reason}, but {context:type} is <null>.");
+
+            if (success)
+            {
+                AssertThatSubjectIsClass();
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.IsCSharpAbstract())
+                    .FailWith("Expected {context:type} {0} to be abstract{reason}.", Subject);
+            }
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -741,17 +750,20 @@ namespace FluentAssertions.Types
         /// is not a class.</exception>
         public AndConstraint<TypeAssertions> NotBeAbstract(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
-               .BecauseOf(because, becauseArgs)
-               .ForCondition(Subject is not null)
-               .FailWith("Expected type not to be abstract{reason}, but {context:type} is <null>.");
-
-            AssertThatSubjectIsClass();
-
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(!Subject.IsCSharpAbstract())
-                .FailWith("Expected type {0} not to be abstract{reason}.", Subject);
+                .ForCondition(Subject is not null)
+                .FailWith("Expected type not to be abstract{reason}, but {context:type} is <null>.");
+
+            if (success)
+            {
+                AssertThatSubjectIsClass();
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(!Subject.IsCSharpAbstract())
+                    .FailWith("Expected type {0} not to be abstract{reason}.", Subject);
+            }
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -770,17 +782,20 @@ namespace FluentAssertions.Types
         /// is not a class.</exception>
         public AndConstraint<TypeAssertions> BeStatic(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                .BecauseOf(because, becauseArgs)
                .ForCondition(Subject is not null)
                .FailWith("Expected type to be static{reason}, but {context:type} is <null>.");
 
-            AssertThatSubjectIsClass();
+            if (success)
+            {
+                AssertThatSubjectIsClass();
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(Subject.IsCSharpStatic())
-                .FailWith("Expected type {0} to be static{reason}.", Subject);
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.IsCSharpStatic())
+                    .FailWith("Expected type {0} to be static{reason}.", Subject);
+            }
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -799,17 +814,20 @@ namespace FluentAssertions.Types
         /// is not a class.</exception>
         public AndConstraint<TypeAssertions> NotBeStatic(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
-               .BecauseOf(because, becauseArgs)
-               .ForCondition(Subject is not null)
-               .FailWith("Expected type not to be static{reason}, but {context:type} is <null>.");
-
-            AssertThatSubjectIsClass();
-
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(!Subject.IsCSharpStatic())
-                .FailWith("Expected type {0} not to be static{reason}.", Subject);
+                .ForCondition(Subject is not null)
+                .FailWith("Expected type not to be static{reason}, but {context:type} is <null>.");
+
+            if (success)
+            {
+                AssertThatSubjectIsClass();
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(!Subject.IsCSharpStatic())
+                    .FailWith("Expected type {0} not to be static{reason}.", Subject);
+            }
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -835,22 +853,27 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNull(propertyType, nameof(propertyType));
             Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
                 .FailWith(
                     $"Expected {propertyType.Name} {{context:type}}.{name} to exist{{reason}}, but {{context:type}} is <null>.");
 
-            PropertyInfo propertyInfo = Subject.GetPropertyByName(name);
-            var propertyInfoDescription = PropertyInfoAssertions.GetDescriptionFor(propertyInfo);
+            PropertyInfo propertyInfo = null;
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(propertyInfo is not null)
-                .FailWith($"Expected {propertyType.Name} {Subject.FullName}.{name} to exist{{reason}}, but it does not.")
-                .Then
-                .ForCondition(propertyInfo.PropertyType == propertyType)
-                .FailWith($"Expected {propertyInfoDescription} to be of type {propertyType}{{reason}}, but it is not.");
+            if (success)
+            {
+                propertyInfo = Subject.GetPropertyByName(name);
+                var propertyInfoDescription = PropertyInfoAssertions.GetDescriptionFor(propertyInfo);
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(propertyInfo is not null)
+                    .FailWith($"Expected {propertyType.Name} {Subject}.{name} to exist{{reason}}, but it does not.")
+                    .Then
+                    .ForCondition(propertyInfo.PropertyType == propertyType)
+                    .FailWith($"Expected {propertyInfoDescription} to be of type {propertyType}{{reason}}, but it is not.");
+            }
 
             return new AndWhichConstraint<TypeAssertions, PropertyInfo>(this, propertyInfo);
         }
@@ -891,18 +914,21 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
                 .FailWith($"Expected {{context:type}}.{name} to not exist{{reason}}, but {{context:type}} is <null>.");
 
-            PropertyInfo propertyInfo = Subject.GetPropertyByName(name);
-            var propertyInfoDescription = PropertyInfoAssertions.GetDescriptionFor(propertyInfo);
+            if (success)
+            {
+                PropertyInfo propertyInfo = Subject.GetPropertyByName(name);
+                var propertyInfoDescription = PropertyInfoAssertions.GetDescriptionFor(propertyInfo);
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(propertyInfo is null)
-                .FailWith($"Expected {propertyInfoDescription} to not exist{{reason}}, but it does.");
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(propertyInfo is null)
+                    .FailWith($"Expected {propertyInfoDescription} to not exist{{reason}}, but it does.");
+            }
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -928,23 +954,25 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNull(interfaceType, nameof(interfaceType));
             Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
                 .FailWith(
-                    $"Expected {{context:type}} to explicitly implement {interfaceType.FullName}.{name}{{reason}}" +
+                    $"Expected {{context:type}} to explicitly implement {interfaceType}.{name}{{reason}}" +
                     $", but {{context:type}} is <null>.");
 
-            Subject.Should().Implement(interfaceType, because, becauseArgs);
+            if (success)
+            {
+                Subject.Should().Implement(interfaceType, because, becauseArgs);
 
-            var explicitlyImplementsProperty = Subject.HasExplicitlyImplementedProperty(interfaceType, name);
+                var explicitlyImplementsProperty = Subject.HasExplicitlyImplementedProperty(interfaceType, name);
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(explicitlyImplementsProperty)
-                .FailWith(
-                    $"Expected {Subject.FullName} to explicitly implement {interfaceType.FullName}.{name}{{reason}}" +
-                    $", but it does not.");
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(explicitlyImplementsProperty)
+                    .FailWith(
+                        $"Expected {Subject} to explicitly implement {interfaceType}.{name}{{reason}}, but it does not.");
+            }
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -991,23 +1019,26 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNull(interfaceType, nameof(interfaceType));
             Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
                 .FailWith(
-                    $"Expected {{context:type}} to not explicitly implement {interfaceType.FullName}.{name}{{reason}}" +
+                    $"Expected {{context:type}} to not explicitly implement {interfaceType}.{name}{{reason}}" +
                     $", but {{context:type}} is <null>.");
 
-            Subject.Should().Implement(interfaceType, because, becauseArgs);
+            if (success)
+            {
+                Subject.Should().Implement(interfaceType, because, becauseArgs);
 
-            var explicitlyImplementsProperty = Subject.HasExplicitlyImplementedProperty(interfaceType, name);
+                var explicitlyImplementsProperty = Subject.HasExplicitlyImplementedProperty(interfaceType, name);
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(!explicitlyImplementsProperty)
-                .FailWith(
-                    $"Expected {Subject.FullName} to not explicitly implement {interfaceType.FullName}.{name}{{reason}}" +
-                    $", but it does.");
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(!explicitlyImplementsProperty)
+                    .FailWith(
+                        $"Expected {Subject} to not explicitly implement {interfaceType}.{name}{{reason}}" +
+                        $", but it does.");
+            }
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1057,23 +1088,26 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));
             Guard.ThrowIfArgumentIsNull(parameterTypes, nameof(parameterTypes));
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
                 .FailWith(
-                    $"Expected {{context:type}} to explicitly implement {interfaceType.FullName}.{name}" +
+                    $"Expected {{context:type}} to explicitly implement {interfaceType}.{name}" +
                     $"({GetParameterString(parameterTypes)}){{reason}}, but {{context:type}} is <null>.");
 
-            Subject.Should().Implement(interfaceType, because, becauseArgs);
+            if (success)
+            {
+                Subject.Should().Implement(interfaceType, because, becauseArgs);
 
-            var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType.FullName}.{name}", parameterTypes);
+                var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType}.{name}", parameterTypes);
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(explicitlyImplementsMethod)
-                .FailWith(
-                    $"Expected {Subject.FullName} to explicitly implement {interfaceType.FullName}.{name}" +
-                    $"({GetParameterString(parameterTypes)}){{reason}}, but it does not.");
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(explicitlyImplementsMethod)
+                    .FailWith(
+                        $"Expected {Subject} to explicitly implement {interfaceType}.{name}" +
+                        $"({GetParameterString(parameterTypes)}){{reason}}, but it does not.");
+            }
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1125,23 +1159,26 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));
             Guard.ThrowIfArgumentIsNull(parameterTypes, nameof(parameterTypes));
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
                 .FailWith(
-                    $"Expected {{context:type}} to not explicitly implement {interfaceType.FullName}.{name}" +
+                    $"Expected {{context:type}} to not explicitly implement {interfaceType}.{name}" +
                     $"({GetParameterString(parameterTypes)}){{reason}}, but {{context:type}} is <null>.");
 
-            Subject.Should().Implement(interfaceType, because, becauseArgs);
+            if (success)
+            {
+                Subject.Should().Implement(interfaceType, because, becauseArgs);
 
-            var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType.FullName}.{name}", parameterTypes);
+                var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType}.{name}", parameterTypes);
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(!explicitlyImplementsMethod)
-                .FailWith(
-                    $"Expected {Subject.FullName} to not explicitly implement {interfaceType.FullName}.{name}" +
-                    $"({GetParameterString(parameterTypes)}){{reason}}, but it does.");
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(!explicitlyImplementsMethod)
+                    .FailWith(
+                        $"Expected {Subject} to not explicitly implement {interfaceType}.{name}" +
+                        $"({GetParameterString(parameterTypes)}){{reason}}, but it does.");
+            }
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1190,25 +1227,30 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNull(indexerType, nameof(indexerType));
             Guard.ThrowIfArgumentIsNull(parameterTypes, nameof(parameterTypes));
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
                 .FailWith(
                     $"Expected {indexerType.Name} {{context:type}}[{GetParameterString(parameterTypes)}] to exist{{reason}}" +
                     $", but {{context:type}} is <null>.");
 
-            PropertyInfo propertyInfo = Subject.GetIndexerByParameterTypes(parameterTypes);
-            var propertyInfoDescription = PropertyInfoAssertions.GetDescriptionFor(propertyInfo);
+            PropertyInfo propertyInfo = null;
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(propertyInfo is not null)
-                .FailWith(
-                    $"Expected {indexerType.Name} {Subject.FullName}[{GetParameterString(parameterTypes)}] to exist{{reason}}" +
-                    $", but it does not.")
-                .Then
-                .ForCondition(propertyInfo.PropertyType == indexerType)
-                .FailWith($"Expected {propertyInfoDescription} to be of type {indexerType}{{reason}}, but it is not.");
+            if (success)
+            {
+                propertyInfo = Subject.GetIndexerByParameterTypes(parameterTypes);
+                var propertyInfoDescription = PropertyInfoAssertions.GetDescriptionFor(propertyInfo);
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(propertyInfo is not null)
+                    .FailWith(
+                        $"Expected {indexerType.Name} {Subject}[{GetParameterString(parameterTypes)}] to exist{{reason}}" +
+                        $", but it does not.")
+                    .Then
+                    .ForCondition(propertyInfo.PropertyType == indexerType)
+                    .FailWith($"Expected {propertyInfoDescription} to be of type {indexerType}{{reason}}, but it is not.");
+            }
 
             return new AndWhichConstraint<TypeAssertions, PropertyInfo>(this, propertyInfo);
         }
@@ -1231,21 +1273,24 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsNull(parameterTypes, nameof(parameterTypes));
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
                 .FailWith(
                     $"Expected indexer {{context:type}}[{GetParameterString(parameterTypes)}] to not exist{{reason}}" +
                     $", but {{context:type}} is <null>.");
 
-            PropertyInfo propertyInfo = Subject.GetIndexerByParameterTypes(parameterTypes);
+            if (success)
+            {
+                PropertyInfo propertyInfo = Subject.GetIndexerByParameterTypes(parameterTypes);
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(propertyInfo is null)
-                .FailWith(
-                    $"Expected indexer {Subject.FullName}[{GetParameterString(parameterTypes)}] to not exist{{reason}}" +
-                    $", but it does.");
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(propertyInfo is null)
+                    .FailWith(
+                        $"Expected indexer {Subject}[{GetParameterString(parameterTypes)}] to not exist{{reason}}" +
+                        $", but it does.");
+            }
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1271,21 +1316,26 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));
             Guard.ThrowIfArgumentIsNull(parameterTypes, nameof(parameterTypes));
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
                 .FailWith(
                     $"Expected method {{context:type}}.{name}({GetParameterString(parameterTypes)}) to exist{{reason}}" +
                     $", but {{context:type}} is <null>.");
 
-            MethodInfo methodInfo = Subject.GetMethod(name, parameterTypes);
+            MethodInfo methodInfo = null;
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(methodInfo is not null)
-                .FailWith(
-                    $"Expected method {Subject.FullName}.{name}({GetParameterString(parameterTypes)}) to exist{{reason}}" +
-                    $", but it does not.");
+            if (success)
+            {
+                methodInfo = Subject.GetMethod(name, parameterTypes);
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(methodInfo is not null)
+                    .FailWith(
+                        $"Expected method {Subject}.{name}({GetParameterString(parameterTypes)}) to exist{{reason}}" +
+                        $", but it does not.");
+            }
 
             return new AndWhichConstraint<TypeAssertions, MethodInfo>(this, methodInfo);
         }
@@ -1311,22 +1361,25 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));
             Guard.ThrowIfArgumentIsNull(parameterTypes, nameof(parameterTypes));
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
                 .FailWith(
                     $"Expected method {{context:type}}.{name}({GetParameterString(parameterTypes)}) to not exist{{reason}}" +
                     $", but {{context:type}} is <null>.");
 
-            MethodInfo methodInfo = Subject.GetMethod(name, parameterTypes);
-            var methodInfoDescription = MethodInfoAssertions.GetDescriptionFor(methodInfo);
+            if (success)
+            {
+                MethodInfo methodInfo = Subject.GetMethod(name, parameterTypes);
+                var methodInfoDescription = MethodInfoAssertions.GetDescriptionFor(methodInfo);
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(methodInfo is null)
-                .FailWith(
-                    $"Expected method {methodInfoDescription}({GetParameterString(parameterTypes)}) to not exist{{reason}}" +
-                    $", but it does.");
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(methodInfo is null)
+                    .FailWith(
+                        $"Expected method {methodInfoDescription}({GetParameterString(parameterTypes)}) to not exist{{reason}}" +
+                        $", but it does.");
+            }
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1348,21 +1401,26 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsNull(parameterTypes, nameof(parameterTypes));
 
-            Execute.Assertion
-               .BecauseOf(because, becauseArgs)
-               .ForCondition(Subject is not null)
-               .FailWith(
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith(
                     $"Expected constructor {{context:type}}({GetParameterString(parameterTypes)}) to exist{{reason}}" +
                     $", but {{context:type}} is <null>.");
 
-            ConstructorInfo constructorInfo = Subject.GetConstructor(parameterTypes);
+            ConstructorInfo constructorInfo = null;
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(constructorInfo is not null)
-                .FailWith(
-                    $"Expected constructor {Subject.FullName}({GetParameterString(parameterTypes)}) to exist{{reason}}" +
-                    $", but it does not.");
+            if (success)
+            {
+                constructorInfo = Subject.GetConstructor(parameterTypes);
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(constructorInfo is not null)
+                    .FailWith(
+                        $"Expected constructor {Subject}({GetParameterString(parameterTypes)}) to exist{{reason}}" +
+                        $", but it does not.");
+            }
 
             return new AndWhichConstraint<TypeAssertions, ConstructorInfo>(this, constructorInfo);
         }
@@ -1400,21 +1458,26 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsNull(parameterTypes, nameof(parameterTypes));
 
-            Execute.Assertion
-               .BecauseOf(because, becauseArgs)
-               .ForCondition(Subject is not null)
-               .FailWith(
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith(
                     $"Expected constructor {{context:type}}({GetParameterString(parameterTypes)}) not to exist{{reason}}" +
                     $", but {{context:type}} is <null>.");
 
-            ConstructorInfo constructorInfo = Subject.GetConstructor(parameterTypes);
+            ConstructorInfo constructorInfo = null;
 
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(constructorInfo is null)
-                .FailWith(
-                    $"Expected constructor {Subject.FullName}({GetParameterString(parameterTypes)}) not to exist{{reason}}" +
-                    $", but it does.");
+            if (success)
+            {
+                constructorInfo = Subject.GetConstructor(parameterTypes);
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(constructorInfo is null)
+                    .FailWith(
+                        $"Expected constructor {Subject}({GetParameterString(parameterTypes)}) not to exist{{reason}}" +
+                        $", but it does.");
+            }
 
             return new AndWhichConstraint<TypeAssertions, ConstructorInfo>(this, constructorInfo);
         }
@@ -1458,19 +1521,22 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsOutOfRange(accessModifier, nameof(accessModifier));
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                .BecauseOf(because, becauseArgs)
                .ForCondition(Subject is not null)
                .FailWith($"Expected {{context:type}} to be {accessModifier}{{reason}}, but {{context:type}} is <null>.");
 
-            CSharpAccessModifier subjectAccessModifier = Subject.GetCSharpAccessModifier();
+            if (success)
+            {
+                CSharpAccessModifier subjectAccessModifier = Subject.GetCSharpAccessModifier();
 
-            Execute.Assertion.ForCondition(accessModifier == subjectAccessModifier)
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(accessModifier == subjectAccessModifier)
-                .FailWith(
-                    $"Expected {{context:type}} {Subject.Name} to be {accessModifier}{{reason}}" +
-                    $", but it is {subjectAccessModifier}.");
+                Execute.Assertion.ForCondition(accessModifier == subjectAccessModifier)
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(accessModifier == subjectAccessModifier)
+                    .FailWith(
+                        $"Expected {{context:type}} {Subject.Name} to be {accessModifier}{{reason}}" +
+                        $", but it is {subjectAccessModifier}.");
+            }
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1493,18 +1559,21 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsOutOfRange(accessModifier, nameof(accessModifier));
 
-            Execute.Assertion
-               .BecauseOf(because, becauseArgs)
-               .ForCondition(Subject is not null)
-               .FailWith($"Expected {{context:type}} not to be {accessModifier}{{reason}}, but {{context:type}} is <null>.");
-
-            CSharpAccessModifier subjectAccessModifier = Subject.GetCSharpAccessModifier();
-
-            Execute.Assertion
-                .ForCondition(accessModifier != subjectAccessModifier)
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(accessModifier != subjectAccessModifier)
-                .FailWith($"Expected {{context:type}} {Subject.Name} not to be {accessModifier}{{reason}}, but it is.");
+                .ForCondition(Subject is not null)
+                .FailWith($"Expected {{context:type}} not to be {accessModifier}{{reason}}, but {{context:type}} is <null>.");
+
+            if (success)
+            {
+                CSharpAccessModifier subjectAccessModifier = Subject.GetCSharpAccessModifier();
+
+                Execute.Assertion
+                    .ForCondition(accessModifier != subjectAccessModifier)
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(accessModifier != subjectAccessModifier)
+                    .FailWith($"Expected {{context:type}} {Subject.Name} not to be {accessModifier}{{reason}}, but it is.");
+            }
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1549,21 +1618,24 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNull(sourceType, nameof(sourceType));
             Guard.ThrowIfArgumentIsNull(targetType, nameof(targetType));
 
-            Execute.Assertion
-               .BecauseOf(because, becauseArgs)
-               .ForCondition(Subject is not null)
-               .FailWith(
-                    $"Expected public static implicit {targetType.FullName}({sourceType.FullName}) to exist{{reason}}" +
-                    $", but {{context:type}} is <null>.");
-
-            MethodInfo methodInfo = Subject.GetImplicitConversionOperator(sourceType, targetType);
-
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(methodInfo is not null)
-                .FailWith(
-                    $"Expected public static implicit {targetType.FullName}({sourceType.FullName}) to exist{{reason}}" +
-                    $", but it does not.");
+                .ForCondition(Subject is not null)
+                .FailWith("Expected public static implicit {0}({1}) to exist{reason}, but {context:type} is <null>.",
+                    targetType, sourceType);
+
+            MethodInfo methodInfo = null;
+
+            if (success)
+            {
+                methodInfo = Subject.GetImplicitConversionOperator(sourceType, targetType);
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(methodInfo is not null)
+                    .FailWith("Expected public static implicit {0}({1}) to exist{reason}, but it does not.",
+                        targetType, sourceType);
+            }
 
             return new AndWhichConstraint<TypeAssertions, MethodInfo>(this, methodInfo);
         }
@@ -1608,21 +1680,22 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNull(sourceType, nameof(sourceType));
             Guard.ThrowIfArgumentIsNull(targetType, nameof(targetType));
 
-            Execute.Assertion
-               .BecauseOf(because, becauseArgs)
-               .ForCondition(Subject is not null)
-               .FailWith(
-                    $"Expected public static implicit {targetType.FullName}({sourceType.FullName}) to not exist{{reason}}" +
-                    $", but {{context:type}} is <null>.");
-
-            MethodInfo methodInfo = Subject.GetImplicitConversionOperator(sourceType, targetType);
-
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(methodInfo is null)
-                .FailWith(
-                    $"Expected public static implicit {targetType.FullName}({sourceType.FullName}) to not exist{{reason}}" +
-                    $", but it does.");
+                .ForCondition(Subject is not null)
+                .FailWith("Expected public static implicit {0}({1}) to not exist{reason}, but {context:type} is <null>.",
+                    targetType, sourceType);
+
+            if (success)
+            {
+                MethodInfo methodInfo = Subject.GetImplicitConversionOperator(sourceType, targetType);
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(methodInfo is null)
+                    .FailWith("Expected public static implicit {0}({1}) to not exist{reason}, but it does.",
+                        targetType, sourceType);
+            }
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1667,21 +1740,24 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNull(sourceType, nameof(sourceType));
             Guard.ThrowIfArgumentIsNull(targetType, nameof(targetType));
 
-            Execute.Assertion
-               .BecauseOf(because, becauseArgs)
-               .ForCondition(Subject is not null)
-               .FailWith(
-                    $"Expected public static explicit {targetType.FullName}({sourceType.FullName}) to exist{{reason}}" +
-                    $", but {{context:type}} is <null>.");
-
-            MethodInfo methodInfo = Subject.GetExplicitConversionOperator(sourceType, targetType);
-
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(methodInfo is not null)
-                .FailWith(
-                    $"Expected public static explicit {targetType.FullName}({sourceType.FullName}) to exist{{reason}}" +
-                    $", but it does not.");
+                .ForCondition(Subject is not null)
+                .FailWith("Expected public static explicit {0}({1}) to exist{reason}, but {context:type} is <null>.",
+                    targetType, sourceType);
+
+            MethodInfo methodInfo = null;
+
+            if (success)
+            {
+                methodInfo = Subject.GetExplicitConversionOperator(sourceType, targetType);
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(methodInfo is not null)
+                    .FailWith("Expected public static explicit {0}({1}) to exist{reason}, but it does not.",
+                        targetType, sourceType);
+            }
 
             return new AndWhichConstraint<TypeAssertions, MethodInfo>(this, methodInfo);
         }
@@ -1726,21 +1802,22 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNull(sourceType, nameof(sourceType));
             Guard.ThrowIfArgumentIsNull(targetType, nameof(targetType));
 
-            Execute.Assertion
-               .BecauseOf(because, becauseArgs)
-               .ForCondition(Subject is not null)
-               .FailWith(
-                    $"Expected public static explicit {targetType.FullName}({sourceType.FullName}) to not exist{{reason}}" +
-                    $", but {{context:type}} is <null>.");
-
-            MethodInfo methodInfo = Subject.GetExplicitConversionOperator(sourceType, targetType);
-
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(methodInfo is null)
-                .FailWith(
-                    $"Expected public static explicit {targetType.FullName}({sourceType.FullName}) to not exist{{reason}}" +
-                    $", but it does.");
+                .ForCondition(Subject is not null)
+                .FailWith("Expected public static explicit {0}({1}) to not exist{reason}, but {context:type} is <null>.",
+                    targetType, sourceType);
+
+            if (success)
+            {
+                MethodInfo methodInfo = Subject.GetExplicitConversionOperator(sourceType, targetType);
+
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(methodInfo is null)
+                    .FailWith("Expected public static explicit {0}({1}) to not exist{reason}, but it does.",
+                        targetType, sourceType);
+            }
 
             return new AndConstraint<TypeAssertions>(this);
         }

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -1294,7 +1294,7 @@ namespace FluentAssertions.Types
         /// </param>
         public AndWhichConstraint<TypeAssertions, ConstructorInfo> HaveDefaultConstructor(string because = "", params object[] becauseArgs)
         {
-            return HaveConstructor(new Type[] { }, because, becauseArgs);
+            return HaveConstructor(new Type[0], because, becauseArgs);
         }
 
         /// <summary>
@@ -1340,7 +1340,7 @@ namespace FluentAssertions.Types
         /// </param>
         public AndWhichConstraint<TypeAssertions, ConstructorInfo> NotHaveDefaultConstructor(string because = "", params object[] becauseArgs)
         {
-            return NotHaveConstructor(new Type[] { }, because, becauseArgs);
+            return NotHaveConstructor(new Type[0], because, becauseArgs);
         }
 
         private static string GetParameterString(IEnumerable<Type> parameterTypes)

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -93,7 +93,9 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsNull(type, nameof(type));
 
-            bool isAssignable = type.IsGenericTypeDefinition ? Subject.IsAssignableToOpenGeneric(type) : type.IsAssignableFrom(Subject);
+            bool isAssignable = type.IsGenericTypeDefinition
+                ? Subject.IsAssignableToOpenGeneric(type)
+                : type.IsAssignableFrom(Subject);
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -136,7 +138,9 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsNull(type, nameof(type));
 
-            bool isAssignable = type.IsGenericTypeDefinition ? Subject.IsAssignableToOpenGeneric(type) : type.IsAssignableFrom(Subject);
+            bool isAssignable = type.IsGenericTypeDefinition
+                ? Subject.IsAssignableToOpenGeneric(type)
+                : type.IsAssignableFrom(Subject);
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -212,7 +216,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> is decorated with the specified <typeparamref name="TAttribute"/>.
+        /// Asserts that the current <see cref="Type"/> is decorated with the specified <typeparamref name="TAttribute"/>.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -221,7 +225,8 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndWhichConstraint<TypeAssertions, TAttribute> BeDecoratedWith<TAttribute>(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<TypeAssertions, TAttribute> BeDecoratedWith<TAttribute>(
+            string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
             IEnumerable<TAttribute> attributes = Subject.GetMatchingAttributes<TAttribute>();
@@ -236,7 +241,7 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> is decorated with an attribute of type <typeparamref name="TAttribute"/>
+        /// Asserts that the current <see cref="Type"/> is decorated with an attribute of type <typeparamref name="TAttribute"/>
         /// that matches the specified <paramref name="isMatchingAttributePredicate"/>.
         /// </summary>
         /// <param name="isMatchingAttributePredicate">
@@ -262,7 +267,8 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(attributes.Any())
-                .FailWith("Expected type {0} to be decorated with {1} that matches {2}{reason}, but no matching attribute was found.",
+                .FailWith(
+                    "Expected type {0} to be decorated with {1} that matches {2}{reason}, but no matching attribute was found.",
                     Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
 
             return new AndWhichConstraint<TypeAssertions, TAttribute>(this, attributes);
@@ -278,7 +284,8 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndWhichConstraint<TypeAssertions, TAttribute> BeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<TypeAssertions, TAttribute> BeDecoratedWithOrInherit<TAttribute>(
+            string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
             IEnumerable<TAttribute> attributes = Subject.GetMatchingOrInheritedAttributes<TAttribute>();
@@ -286,7 +293,8 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(attributes.Any())
-                .FailWith("Expected type {0} to be decorated with or inherit {1}{reason}, but the attribute was not found.", Subject, typeof(TAttribute));
+                .FailWith("Expected type {0} to be decorated with or inherit {1}{reason}, but the attribute was not found.",
+                    Subject, typeof(TAttribute));
 
             return new AndWhichConstraint<TypeAssertions, TAttribute>(this, attributes);
         }
@@ -318,13 +326,15 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(attributes.Any())
-                .FailWith("Expected type {0} to be decorated with or inherit {1} that matches {2}{reason}, but no matching attribute was found.", Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
+                .FailWith(
+                    "Expected type {0} to be decorated with or inherit {1} that matches {2}{reason}" +
+                    ", but no matching attribute was found.", Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
 
             return new AndWhichConstraint<TypeAssertions, TAttribute>(this, attributes);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> is not decorated with the specified <typeparamref name="TAttribute"/>.
+        /// Asserts that the current <see cref="Type"/> is not decorated with the specified <typeparamref name="TAttribute"/>.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -339,14 +349,15 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(!Subject.IsDecoratedWith<TAttribute>())
-                .FailWith("Expected type {0} to not be decorated with {1}{reason}, but the attribute was found.", Subject, typeof(TAttribute));
+                .FailWith("Expected type {0} to not be decorated with {1}{reason}, but the attribute was found.",
+                    Subject, typeof(TAttribute));
 
             return new AndConstraint<TypeAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> is not decorated with an attribute of type <typeparamref name="TAttribute"/>
-        /// that matches the specified <paramref name="isMatchingAttributePredicate"/>.
+        /// Asserts that the current <see cref="Type"/> is not decorated with an attribute of type
+        /// <typeparamref name="TAttribute"/> that matches the specified <paramref name="isMatchingAttributePredicate"/>.
         /// </summary>
         /// <param name="isMatchingAttributePredicate">
         /// The predicate that the attribute must match.
@@ -367,13 +378,16 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(!Subject.IsDecoratedWith(isMatchingAttributePredicate))
-                .FailWith("Expected type {0} to not be decorated with {1} that matches {2}{reason}, but a matching attribute was found.", Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
+                .FailWith(
+                    "Expected type {0} to not be decorated with {1} that matches {2}{reason}, but a matching attribute was found.",
+                    Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
 
             return new AndConstraint<TypeAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> is not decorated with and does not inherit from a parent class,  the specified <typeparamref name="TAttribute"/>.
+        /// Asserts that the current <see cref="Type"/> is not decorated with and does not inherit from a parent class,
+        /// the specified <typeparamref name="TAttribute"/>.
         /// </summary>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -382,20 +396,23 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(string because = "", params object[] becauseArgs)
+        public AndConstraint<TypeAssertions> NotBeDecoratedWithOrInherit<TAttribute>(
+            string because = "", params object[] becauseArgs)
             where TAttribute : Attribute
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(!Subject.IsDecoratedWithOrInherit<TAttribute>())
-                .FailWith("Expected type {0} to not be decorated with or inherit {1}{reason}, but the attribute was found.", Subject, typeof(TAttribute));
+                .FailWith("Expected type {0} to not be decorated with or inherit {1}{reason}, but the attribute was found.",
+                    Subject, typeof(TAttribute));
 
             return new AndConstraint<TypeAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="System.Type"/> is not decorated with and does not inherit from a parent class, an attribute of type <typeparamref name="TAttribute"/>
-        /// that matches the specified <paramref name="isMatchingAttributePredicate"/>.
+        /// Asserts that the current <see cref="Type"/> is not decorated with and does not inherit from a parent class, an
+        /// attribute of type <typeparamref name="TAttribute"/> that matches the specified 
+        /// <paramref name="isMatchingAttributePredicate"/>.
         /// </summary>
         /// <param name="isMatchingAttributePredicate">
         /// The predicate that the attribute must match.
@@ -416,7 +433,9 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(!Subject.IsDecoratedWithOrInherit(isMatchingAttributePredicate))
-                .FailWith("Expected type {0} to not be decorated with or inherit {1} that matches {2}{reason}, but a matching attribute was found.", Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
+                .FailWith(
+                    "Expected type {0} to not be decorated with or inherit {1} that matches {2}{reason}" +
+                    ", but a matching attribute was found.", Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -535,7 +554,9 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsNull(baseType, nameof(baseType));
 
-            bool isDerivedFrom = baseType.IsGenericTypeDefinition ? Subject.IsDerivedFromOpenGeneric(baseType) : Subject.IsSubclassOf(baseType);
+            bool isDerivedFrom = baseType.IsGenericTypeDefinition
+                ? Subject.IsDerivedFromOpenGeneric(baseType)
+                : Subject.IsSubclassOf(baseType);
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -584,7 +605,9 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsNull(baseType, nameof(baseType));
 
-            bool isDerivedFrom = baseType.IsGenericTypeDefinition ? Subject.IsDerivedFromOpenGeneric(baseType) : Subject.IsSubclassOf(baseType);
+            bool isDerivedFrom = baseType.IsGenericTypeDefinition
+                ? Subject.IsDerivedFromOpenGeneric(baseType)
+                : Subject.IsSubclassOf(baseType);
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -627,7 +650,8 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        /// <exception cref="InvalidOperationException"><see cref="ReferenceTypeAssertions{Type, TypeAssertions}.Subject"/> is not a class.</exception>
+        /// <exception cref="InvalidOperationException"><see cref="ReferenceTypeAssertions{Type, TypeAssertions}.Subject"/>
+        /// is not a class.</exception>
         public AndConstraint<TypeAssertions> BeSealed(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
@@ -655,7 +679,8 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        /// <exception cref="InvalidOperationException"><see cref="ReferenceTypeAssertions{Type, TypeAssertions}.Subject"/> is not a class.</exception>
+        /// <exception cref="InvalidOperationException"><see cref="ReferenceTypeAssertions{Type, TypeAssertions}.Subject"/>
+        /// is not a class.</exception>
         public AndConstraint<TypeAssertions> NotBeSealed(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
@@ -683,7 +708,8 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        /// <exception cref="InvalidOperationException"><see cref="ReferenceTypeAssertions{Type, TypeAssertions}.Subject"/> is not a class.</exception>
+        /// <exception cref="InvalidOperationException"><see cref="ReferenceTypeAssertions{Type, TypeAssertions}.Subject"/>
+        /// is not a class.</exception>
         public AndConstraint<TypeAssertions> BeAbstract(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
@@ -711,7 +737,8 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        /// <exception cref="InvalidOperationException"><see cref="ReferenceTypeAssertions{Type, TypeAssertions}.Subject"/> is not a class.</exception>
+        /// <exception cref="InvalidOperationException"><see cref="ReferenceTypeAssertions{Type, TypeAssertions}.Subject"/>
+        /// is not a class.</exception>
         public AndConstraint<TypeAssertions> NotBeAbstract(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
@@ -739,7 +766,8 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        /// <exception cref="InvalidOperationException"><see cref="ReferenceTypeAssertions{Type, TypeAssertions}.Subject"/> is not a class.</exception>
+        /// <exception cref="InvalidOperationException"><see cref="ReferenceTypeAssertions{Type, TypeAssertions}.Subject"/>
+        /// is not a class.</exception>
         public AndConstraint<TypeAssertions> BeStatic(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
@@ -767,7 +795,8 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        /// <exception cref="InvalidOperationException"><see cref="ReferenceTypeAssertions{Type, TypeAssertions}.Subject"/> is not a class.</exception>
+        /// <exception cref="InvalidOperationException"><see cref="ReferenceTypeAssertions{Type, TypeAssertions}.Subject"/>
+        /// is not a class.</exception>
         public AndConstraint<TypeAssertions> NotBeStatic(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
@@ -786,7 +815,8 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Type"/> has a property of type <paramref name="propertyType"/> named <paramref name="name"/>.
+        /// Asserts that the current <see cref="Type"/> has a property of type <paramref name="propertyType"/> named
+        /// <paramref name="name"/>.
         /// </summary>
         /// <param name="propertyType">The type of the property.</param>
         /// <param name="name">The name of the property.</param>
@@ -799,7 +829,8 @@ namespace FluentAssertions.Types
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="propertyType"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
-        public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveProperty(Type propertyType, string name, string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveProperty(
+            Type propertyType, string name, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(propertyType, nameof(propertyType));
             Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));
@@ -807,7 +838,8 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
-                .FailWith($"Expected {propertyType.Name} {{context:type}}.{name} to exist{{reason}}, but {{context:type}} is <null>.");
+                .FailWith(
+                    $"Expected {propertyType.Name} {{context:type}}.{name} to exist{{reason}}, but {{context:type}} is <null>.");
 
             PropertyInfo propertyInfo = Subject.GetPropertyByName(name);
             var propertyInfoDescription = PropertyInfoAssertions.GetDescriptionFor(propertyInfo);
@@ -824,7 +856,8 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Type"/> has a property of type <typeparamref name="TProperty"/> named <paramref name="name"/>.
+        /// Asserts that the current <see cref="Type"/> has a property of type <typeparamref name="TProperty"/> named
+        /// <paramref name="name"/>.
         /// </summary>
         /// <typeparam name="TProperty">The type of the property.</typeparam>
         /// <param name="name">The name of the property.</param>
@@ -836,7 +869,8 @@ namespace FluentAssertions.Types
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
-        public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveProperty<TProperty>(string name, string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveProperty<TProperty>(
+            string name, string because = "", params object[] becauseArgs)
         {
             return HaveProperty(typeof(TProperty), name, because, becauseArgs);
         }
@@ -888,7 +922,8 @@ namespace FluentAssertions.Types
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="interfaceType"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
-        public AndConstraint<TypeAssertions> HaveExplicitProperty(Type interfaceType, string name, string because = "", params object[] becauseArgs)
+        public AndConstraint<TypeAssertions> HaveExplicitProperty(
+            Type interfaceType, string name, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(interfaceType, nameof(interfaceType));
             Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));
@@ -896,7 +931,9 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
-                .FailWith($"Expected {{context:type}} to explicitly implement {interfaceType.FullName}.{name}{{reason}}, but {{context:type}} is <null>.");
+                .FailWith(
+                    $"Expected {{context:type}} to explicitly implement {interfaceType.FullName}.{name}{{reason}}" +
+                    $", but {{context:type}} is <null>.");
 
             Subject.Should().Implement(interfaceType, because, becauseArgs);
 
@@ -905,7 +942,9 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(explicitlyImplementsProperty)
-                .FailWith($"Expected {Subject.FullName} to explicitly implement {interfaceType.FullName}.{name}{{reason}}, but it does not.");
+                .FailWith(
+                    $"Expected {Subject.FullName} to explicitly implement {interfaceType.FullName}.{name}{{reason}}" +
+                    $", but it does not.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -924,7 +963,8 @@ namespace FluentAssertions.Types
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
-        public AndConstraint<TypeAssertions> HaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+        public AndConstraint<TypeAssertions> HaveExplicitProperty<TInterface>(
+            string name, string because = "", params object[] becauseArgs)
             where TInterface : class
         {
             return HaveExplicitProperty(typeof(TInterface), name, because, becauseArgs);
@@ -945,7 +985,8 @@ namespace FluentAssertions.Types
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="interfaceType"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
-        public AndConstraint<TypeAssertions> NotHaveExplicitProperty(Type interfaceType, string name, string because = "", params object[] becauseArgs)
+        public AndConstraint<TypeAssertions> NotHaveExplicitProperty(
+            Type interfaceType, string name, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(interfaceType, nameof(interfaceType));
             Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));
@@ -953,7 +994,9 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
-                .FailWith($"Expected {{context:type}} to not explicitly implement {interfaceType.FullName}.{name}{{reason}}, but {{context:type}} is <null>.");
+                .FailWith(
+                    $"Expected {{context:type}} to not explicitly implement {interfaceType.FullName}.{name}{{reason}}" +
+                    $", but {{context:type}} is <null>.");
 
             Subject.Should().Implement(interfaceType, because, becauseArgs);
 
@@ -962,7 +1005,9 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(!explicitlyImplementsProperty)
-                .FailWith($"Expected {Subject.FullName} to not explicitly implement {interfaceType.FullName}.{name}{{reason}}, but it does.");
+                .FailWith(
+                    $"Expected {Subject.FullName} to not explicitly implement {interfaceType.FullName}.{name}{{reason}}" +
+                    $", but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -981,7 +1026,8 @@ namespace FluentAssertions.Types
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
-        public AndConstraint<TypeAssertions> NotHaveExplicitProperty<TInterface>(string name, string because = "", params object[] becauseArgs)
+        public AndConstraint<TypeAssertions> NotHaveExplicitProperty<TInterface>(
+            string name, string because = "", params object[] becauseArgs)
             where TInterface : class
         {
             return NotHaveExplicitProperty(typeof(TInterface), name, because, becauseArgs);
@@ -1004,7 +1050,8 @@ namespace FluentAssertions.Types
         /// <exception cref="ArgumentNullException"><paramref name="interfaceType"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
-        public AndConstraint<TypeAssertions> HaveExplicitMethod(Type interfaceType, string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
+        public AndConstraint<TypeAssertions> HaveExplicitMethod(
+            Type interfaceType, string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(interfaceType, nameof(interfaceType));
             Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));
@@ -1013,7 +1060,9 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
-                .FailWith($"Expected {{context:type}} to explicitly implement {interfaceType.FullName}.{name}({GetParameterString(parameterTypes)}){{reason}}, but {{context:type}} is <null>.");
+                .FailWith(
+                    $"Expected {{context:type}} to explicitly implement {interfaceType.FullName}.{name}" +
+                    $"({GetParameterString(parameterTypes)}){{reason}}, but {{context:type}} is <null>.");
 
             Subject.Should().Implement(interfaceType, because, becauseArgs);
 
@@ -1022,7 +1071,9 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(explicitlyImplementsMethod)
-                .FailWith($"Expected {Subject.FullName} to explicitly implement {interfaceType.FullName}.{name}({GetParameterString(parameterTypes)}){{reason}}, but it does not.");
+                .FailWith(
+                    $"Expected {Subject.FullName} to explicitly implement {interfaceType.FullName}.{name}" +
+                    $"({GetParameterString(parameterTypes)}){{reason}}, but it does not.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1043,7 +1094,8 @@ namespace FluentAssertions.Types
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
-        public AndConstraint<TypeAssertions> HaveExplicitMethod<TInterface>(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
+        public AndConstraint<TypeAssertions> HaveExplicitMethod<TInterface>(
+            string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
             where TInterface : class
         {
             return HaveExplicitMethod(typeof(TInterface), name, parameterTypes, because, becauseArgs);
@@ -1066,7 +1118,8 @@ namespace FluentAssertions.Types
         /// <exception cref="ArgumentNullException"><paramref name="interfaceType"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
-        public AndConstraint<TypeAssertions> NotHaveExplicitMethod(Type interfaceType, string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
+        public AndConstraint<TypeAssertions> NotHaveExplicitMethod(
+            Type interfaceType, string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(interfaceType, nameof(interfaceType));
             Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));
@@ -1075,7 +1128,9 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
-                .FailWith($"Expected {{context:type}} to not explicitly implement {interfaceType.FullName}.{name}({GetParameterString(parameterTypes)}){{reason}}, but {{context:type}} is <null>.");
+                .FailWith(
+                    $"Expected {{context:type}} to not explicitly implement {interfaceType.FullName}.{name}" +
+                    $"({GetParameterString(parameterTypes)}){{reason}}, but {{context:type}} is <null>.");
 
             Subject.Should().Implement(interfaceType, because, becauseArgs);
 
@@ -1084,7 +1139,9 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(!explicitlyImplementsMethod)
-                .FailWith($"Expected {Subject.FullName} to not explicitly implement {interfaceType.FullName}.{name}({GetParameterString(parameterTypes)}){{reason}}, but it does.");
+                .FailWith(
+                    $"Expected {Subject.FullName} to not explicitly implement {interfaceType.FullName}.{name}" +
+                    $"({GetParameterString(parameterTypes)}){{reason}}, but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1105,7 +1162,8 @@ namespace FluentAssertions.Types
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
-        public AndConstraint<TypeAssertions> NotHaveExplicitMethod<TInterface>(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
+        public AndConstraint<TypeAssertions> NotHaveExplicitMethod<TInterface>(
+            string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
             where TInterface : class
         {
             return NotHaveExplicitMethod(typeof(TInterface), name, parameterTypes, because, becauseArgs);
@@ -1126,7 +1184,8 @@ namespace FluentAssertions.Types
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="indexerType"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
-        public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveIndexer(Type indexerType, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<TypeAssertions, PropertyInfo> HaveIndexer(
+            Type indexerType, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(indexerType, nameof(indexerType));
             Guard.ThrowIfArgumentIsNull(parameterTypes, nameof(parameterTypes));
@@ -1134,7 +1193,9 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
-                .FailWith($"Expected {indexerType.Name} {{context:type}}[{GetParameterString(parameterTypes)}] to exist{{reason}}, but {{context:type}} is <null>.");
+                .FailWith(
+                    $"Expected {indexerType.Name} {{context:type}}[{GetParameterString(parameterTypes)}] to exist{{reason}}" +
+                    $", but {{context:type}} is <null>.");
 
             PropertyInfo propertyInfo = Subject.GetIndexerByParameterTypes(parameterTypes);
             var propertyInfoDescription = PropertyInfoAssertions.GetDescriptionFor(propertyInfo);
@@ -1142,7 +1203,9 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(propertyInfo is not null)
-                .FailWith($"Expected {indexerType.Name} {Subject.FullName}[{GetParameterString(parameterTypes)}] to exist{{reason}}, but it does not.")
+                .FailWith(
+                    $"Expected {indexerType.Name} {Subject.FullName}[{GetParameterString(parameterTypes)}] to exist{{reason}}" +
+                    $", but it does not.")
                 .Then
                 .ForCondition(propertyInfo.PropertyType == indexerType)
                 .FailWith($"Expected {propertyInfoDescription} to be of type {indexerType}{{reason}}, but it is not.");
@@ -1151,7 +1214,8 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Type"/> does not have an indexer that takes parameter types <paramref name="parameterTypes"/>.
+        /// Asserts that the current <see cref="Type"/> does not have an indexer that takes parameter types
+        /// <paramref name="parameterTypes"/>.
         /// </summary>
         /// <param name="parameterTypes">The expected indexer's parameter types.</param>
         /// <param name="because">
@@ -1162,27 +1226,33 @@ namespace FluentAssertions.Types
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
-        public AndConstraint<TypeAssertions> NotHaveIndexer(IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
+        public AndConstraint<TypeAssertions> NotHaveIndexer(
+            IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(parameterTypes, nameof(parameterTypes));
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
-                .FailWith($"Expected indexer {{context:type}}[{GetParameterString(parameterTypes)}] to not exist{{reason}}, but {{context:type}} is <null>.");
+                .FailWith(
+                    $"Expected indexer {{context:type}}[{GetParameterString(parameterTypes)}] to not exist{{reason}}" +
+                    $", but {{context:type}} is <null>.");
 
             PropertyInfo propertyInfo = Subject.GetIndexerByParameterTypes(parameterTypes);
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(propertyInfo is null)
-                .FailWith($"Expected indexer {Subject.FullName}[{GetParameterString(parameterTypes)}] to not exist{{reason}}, but it does.");
+                .FailWith(
+                    $"Expected indexer {Subject.FullName}[{GetParameterString(parameterTypes)}] to not exist{{reason}}" +
+                    $", but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Type"/> has a method named <paramref name="name"/> with parameter types <paramref name="parameterTypes"/>.
+        /// Asserts that the current <see cref="Type"/> has a method named <paramref name="name"/> with parameter types
+        /// <paramref name="parameterTypes"/>.
         /// </summary>
         /// <param name="name">The name of the method.</param>
         /// <param name="parameterTypes">The parameter types for the indexer.</param>
@@ -1195,7 +1265,8 @@ namespace FluentAssertions.Types
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
-        public AndWhichConstraint<TypeAssertions, MethodInfo> HaveMethod(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<TypeAssertions, MethodInfo> HaveMethod(
+            string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));
             Guard.ThrowIfArgumentIsNull(parameterTypes, nameof(parameterTypes));
@@ -1203,14 +1274,18 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
-                .FailWith($"Expected method {{context:type}}.{name}({GetParameterString(parameterTypes)}) to exist{{reason}}, but {{context:type}} is <null>.");
+                .FailWith(
+                    $"Expected method {{context:type}}.{name}({GetParameterString(parameterTypes)}) to exist{{reason}}" +
+                    $", but {{context:type}} is <null>.");
 
             MethodInfo methodInfo = Subject.GetMethod(name, parameterTypes);
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(methodInfo is not null)
-                .FailWith($"Expected method {Subject.FullName}.{name}({GetParameterString(parameterTypes)}) to exist{{reason}}, but it does not.");
+                .FailWith(
+                    $"Expected method {Subject.FullName}.{name}({GetParameterString(parameterTypes)}) to exist{{reason}}" +
+                    $", but it does not.");
 
             return new AndWhichConstraint<TypeAssertions, MethodInfo>(this, methodInfo);
         }
@@ -1230,7 +1305,8 @@ namespace FluentAssertions.Types
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
-        public AndConstraint<TypeAssertions> NotHaveMethod(string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
+        public AndConstraint<TypeAssertions> NotHaveMethod(
+            string name, IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));
             Guard.ThrowIfArgumentIsNull(parameterTypes, nameof(parameterTypes));
@@ -1238,7 +1314,9 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
-                .FailWith($"Expected method {{context:type}}.{name}({GetParameterString(parameterTypes)}) to not exist{{reason}}, but {{context:type}} is <null>.");
+                .FailWith(
+                    $"Expected method {{context:type}}.{name}({GetParameterString(parameterTypes)}) to not exist{{reason}}" +
+                    $", but {{context:type}} is <null>.");
 
             MethodInfo methodInfo = Subject.GetMethod(name, parameterTypes);
             var methodInfoDescription = MethodInfoAssertions.GetDescriptionFor(methodInfo);
@@ -1246,7 +1324,9 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(methodInfo is null)
-                .FailWith($"Expected method {methodInfoDescription}({GetParameterString(parameterTypes)}) to not exist{{reason}}, but it does.");
+                .FailWith(
+                    $"Expected method {methodInfoDescription}({GetParameterString(parameterTypes)}) to not exist{{reason}}" +
+                    $", but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1263,21 +1343,26 @@ namespace FluentAssertions.Types
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
-        public AndWhichConstraint<TypeAssertions, ConstructorInfo> HaveConstructor(IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<TypeAssertions, ConstructorInfo> HaveConstructor(
+            IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(parameterTypes, nameof(parameterTypes));
 
             Execute.Assertion
                .BecauseOf(because, becauseArgs)
                .ForCondition(Subject is not null)
-               .FailWith($"Expected constructor {{context:type}}({GetParameterString(parameterTypes)}) to exist{{reason}}, but {{context:type}} is <null>.");
+               .FailWith(
+                    $"Expected constructor {{context:type}}({GetParameterString(parameterTypes)}) to exist{{reason}}" +
+                    $", but {{context:type}} is <null>.");
 
             ConstructorInfo constructorInfo = Subject.GetConstructor(parameterTypes);
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(constructorInfo is not null)
-                .FailWith($"Expected constructor {Subject.FullName}({GetParameterString(parameterTypes)}) to exist{{reason}}, but it does not.");
+                .FailWith(
+                    $"Expected constructor {Subject.FullName}({GetParameterString(parameterTypes)}) to exist{{reason}}" +
+                    $", but it does not.");
 
             return new AndWhichConstraint<TypeAssertions, ConstructorInfo>(this, constructorInfo);
         }
@@ -1292,7 +1377,8 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        public AndWhichConstraint<TypeAssertions, ConstructorInfo> HaveDefaultConstructor(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<TypeAssertions, ConstructorInfo> HaveDefaultConstructor(
+            string because = "", params object[] becauseArgs)
         {
             return HaveConstructor(new Type[0], because, becauseArgs);
         }
@@ -1309,21 +1395,26 @@ namespace FluentAssertions.Types
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="parameterTypes"/> is <c>null</c>.</exception>
-        public AndWhichConstraint<TypeAssertions, ConstructorInfo> NotHaveConstructor(IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<TypeAssertions, ConstructorInfo> NotHaveConstructor(
+            IEnumerable<Type> parameterTypes, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(parameterTypes, nameof(parameterTypes));
 
             Execute.Assertion
                .BecauseOf(because, becauseArgs)
                .ForCondition(Subject is not null)
-               .FailWith($"Expected constructor {{context:type}}({GetParameterString(parameterTypes)}) not to exist{{reason}}, but {{context:type}} is <null>.");
+               .FailWith(
+                    $"Expected constructor {{context:type}}({GetParameterString(parameterTypes)}) not to exist{{reason}}" +
+                    $", but {{context:type}} is <null>.");
 
             ConstructorInfo constructorInfo = Subject.GetConstructor(parameterTypes);
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(constructorInfo is null)
-                .FailWith($"Expected constructor {Subject.FullName}({GetParameterString(parameterTypes)}) not to exist{{reason}}, but it does.");
+                .FailWith(
+                    $"Expected constructor {Subject.FullName}({GetParameterString(parameterTypes)}) not to exist{{reason}}" +
+                    $", but it does.");
 
             return new AndWhichConstraint<TypeAssertions, ConstructorInfo>(this, constructorInfo);
         }
@@ -1338,7 +1429,8 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        public AndWhichConstraint<TypeAssertions, ConstructorInfo> NotHaveDefaultConstructor(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<TypeAssertions, ConstructorInfo> NotHaveDefaultConstructor(
+            string because = "", params object[] becauseArgs)
         {
             return NotHaveConstructor(new Type[0], because, becauseArgs);
         }
@@ -1359,7 +1451,8 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="accessModifier"/> is not a <see cref="CSharpAccessModifier"/> value.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="accessModifier"/>
+        /// is not a <see cref="CSharpAccessModifier"/> value.</exception>
         public AndConstraint<TypeAssertions> HaveAccessModifier(
             CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
         {
@@ -1375,7 +1468,9 @@ namespace FluentAssertions.Types
             Execute.Assertion.ForCondition(accessModifier == subjectAccessModifier)
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(accessModifier == subjectAccessModifier)
-                .FailWith($"Expected {{context:type}} {Subject.Name} to be {accessModifier}{{reason}}, but it is {subjectAccessModifier}.");
+                .FailWith(
+                    $"Expected {{context:type}} {Subject.Name} to be {accessModifier}{{reason}}" +
+                    $", but it is {subjectAccessModifier}.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1391,8 +1486,10 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="accessModifier"/> is not a <see cref="CSharpAccessModifier"/> value.</exception>
-        public AndConstraint<TypeAssertions> NotHaveAccessModifier(CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="accessModifier"/>
+        /// is not a <see cref="CSharpAccessModifier"/> value.</exception>
+        public AndConstraint<TypeAssertions> NotHaveAccessModifier(
+            CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsOutOfRange(accessModifier, nameof(accessModifier));
 
@@ -1413,7 +1510,8 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Type"/> has an implicit conversion operator that converts <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
+        /// Asserts that the current <see cref="Type"/> has an implicit conversion operator that converts
+        /// <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
@@ -1424,13 +1522,15 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        public AndWhichConstraint<TypeAssertions, MethodInfo> HaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<TypeAssertions, MethodInfo> HaveImplicitConversionOperator<TSource, TTarget>(
+            string because = "", params object[] becauseArgs)
         {
             return HaveImplicitConversionOperator(typeof(TSource), typeof(TTarget), because, becauseArgs);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Type"/> has an implicit conversion operator that converts <paramref name="sourceType"/> into <paramref name="targetType"/>.
+        /// Asserts that the current <see cref="Type"/> has an implicit conversion operator that converts
+        /// <paramref name="sourceType"/> into <paramref name="targetType"/>.
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
@@ -1443,7 +1543,8 @@ namespace FluentAssertions.Types
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="sourceType"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="targetType"/> is <c>null</c>.</exception>
-        public AndWhichConstraint<TypeAssertions, MethodInfo> HaveImplicitConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<TypeAssertions, MethodInfo> HaveImplicitConversionOperator(
+            Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(sourceType, nameof(sourceType));
             Guard.ThrowIfArgumentIsNull(targetType, nameof(targetType));
@@ -1451,20 +1552,25 @@ namespace FluentAssertions.Types
             Execute.Assertion
                .BecauseOf(because, becauseArgs)
                .ForCondition(Subject is not null)
-               .FailWith($"Expected public static implicit {targetType.FullName}({sourceType.FullName}) to exist{{reason}}, but {{context:type}} is <null>.");
+               .FailWith(
+                    $"Expected public static implicit {targetType.FullName}({sourceType.FullName}) to exist{{reason}}" +
+                    $", but {{context:type}} is <null>.");
 
             MethodInfo methodInfo = Subject.GetImplicitConversionOperator(sourceType, targetType);
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(methodInfo is not null)
-                .FailWith($"Expected public static implicit {targetType.FullName}({sourceType.FullName}) to exist{{reason}}, but it does not.");
+                .FailWith(
+                    $"Expected public static implicit {targetType.FullName}({sourceType.FullName}) to exist{{reason}}" +
+                    $", but it does not.");
 
             return new AndWhichConstraint<TypeAssertions, MethodInfo>(this, methodInfo);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Type"/> does not have an implicit conversion operator that converts <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
+        /// Asserts that the current <see cref="Type"/> does not have an implicit conversion operator that converts
+        /// <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
@@ -1475,13 +1581,15 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        public AndConstraint<TypeAssertions> NotHaveImplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
+        public AndConstraint<TypeAssertions> NotHaveImplicitConversionOperator<TSource, TTarget>(
+            string because = "", params object[] becauseArgs)
         {
             return NotHaveImplicitConversionOperator(typeof(TSource), typeof(TTarget), because, becauseArgs);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Type"/> does not have an implicit conversion operator that converts <paramref name="sourceType"/> into <paramref name="targetType"/>.
+        /// Asserts that the current <see cref="Type"/> does not have an implicit conversion operator that converts
+        /// <paramref name="sourceType"/> into <paramref name="targetType"/>.
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
@@ -1494,7 +1602,8 @@ namespace FluentAssertions.Types
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="sourceType"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="targetType"/> is <c>null</c>.</exception>
-        public AndConstraint<TypeAssertions> NotHaveImplicitConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
+        public AndConstraint<TypeAssertions> NotHaveImplicitConversionOperator(
+            Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(sourceType, nameof(sourceType));
             Guard.ThrowIfArgumentIsNull(targetType, nameof(targetType));
@@ -1502,20 +1611,25 @@ namespace FluentAssertions.Types
             Execute.Assertion
                .BecauseOf(because, becauseArgs)
                .ForCondition(Subject is not null)
-               .FailWith($"Expected public static implicit {targetType.FullName}({sourceType.FullName}) to not exist{{reason}}, but {{context:type}} is <null>.");
+               .FailWith(
+                    $"Expected public static implicit {targetType.FullName}({sourceType.FullName}) to not exist{{reason}}" +
+                    $", but {{context:type}} is <null>.");
 
             MethodInfo methodInfo = Subject.GetImplicitConversionOperator(sourceType, targetType);
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(methodInfo is null)
-                .FailWith($"Expected public static implicit {targetType.FullName}({sourceType.FullName}) to not exist{{reason}}, but it does.");
+                .FailWith(
+                    $"Expected public static implicit {targetType.FullName}({sourceType.FullName}) to not exist{{reason}}" +
+                    $", but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Type"/> has an explicit conversion operator that converts <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
+        /// Asserts that the current <see cref="Type"/> has an explicit conversion operator that converts
+        /// <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
@@ -1526,13 +1640,15 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        public AndWhichConstraint<TypeAssertions, MethodInfo> HaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<TypeAssertions, MethodInfo> HaveExplicitConversionOperator<TSource, TTarget>(
+            string because = "", params object[] becauseArgs)
         {
             return HaveExplicitConversionOperator(typeof(TSource), typeof(TTarget), because, becauseArgs);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Type"/> has an explicit conversion operator that converts <paramref name="sourceType"/> into <paramref name="targetType"/>.
+        /// Asserts that the current <see cref="Type"/> has an explicit conversion operator that converts
+        /// <paramref name="sourceType"/> into <paramref name="targetType"/>.
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
@@ -1545,7 +1661,8 @@ namespace FluentAssertions.Types
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="sourceType"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="targetType"/> is <c>null</c>.</exception>
-        public AndWhichConstraint<TypeAssertions, MethodInfo> HaveExplicitConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
+        public AndWhichConstraint<TypeAssertions, MethodInfo> HaveExplicitConversionOperator(
+            Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(sourceType, nameof(sourceType));
             Guard.ThrowIfArgumentIsNull(targetType, nameof(targetType));
@@ -1553,20 +1670,25 @@ namespace FluentAssertions.Types
             Execute.Assertion
                .BecauseOf(because, becauseArgs)
                .ForCondition(Subject is not null)
-               .FailWith($"Expected public static explicit {targetType.FullName}({sourceType.FullName}) to exist{{reason}}, but {{context:type}} is <null>.");
+               .FailWith(
+                    $"Expected public static explicit {targetType.FullName}({sourceType.FullName}) to exist{{reason}}" +
+                    $", but {{context:type}} is <null>.");
 
             MethodInfo methodInfo = Subject.GetExplicitConversionOperator(sourceType, targetType);
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(methodInfo is not null)
-                .FailWith($"Expected public static explicit {targetType.FullName}({sourceType.FullName}) to exist{{reason}}, but it does not.");
+                .FailWith(
+                    $"Expected public static explicit {targetType.FullName}({sourceType.FullName}) to exist{{reason}}" +
+                    $", but it does not.");
 
             return new AndWhichConstraint<TypeAssertions, MethodInfo>(this, methodInfo);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Type"/> does not have an explicit conversion operator that converts <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
+        /// Asserts that the current <see cref="Type"/> does not have an explicit conversion operator that converts
+        /// <typeparamref name="TSource"/> into <typeparamref name="TTarget"/>.
         /// </summary>
         /// <typeparam name="TSource">The type to convert from.</typeparam>
         /// <typeparam name="TTarget">The type to convert to.</typeparam>
@@ -1577,13 +1699,15 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        public AndConstraint<TypeAssertions> NotHaveExplicitConversionOperator<TSource, TTarget>(string because = "", params object[] becauseArgs)
+        public AndConstraint<TypeAssertions> NotHaveExplicitConversionOperator<TSource, TTarget>(
+            string because = "", params object[] becauseArgs)
         {
             return NotHaveExplicitConversionOperator(typeof(TSource), typeof(TTarget), because, becauseArgs);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="Type"/> does not have an explicit conversion operator that converts <paramref name="sourceType"/> into <paramref name="targetType"/>.
+        /// Asserts that the current <see cref="Type"/> does not have an explicit conversion operator that converts
+        /// <paramref name="sourceType"/> into <paramref name="targetType"/>.
         /// </summary>
         /// <param name="sourceType">The type to convert from.</param>
         /// <param name="targetType">The type to convert to.</param>
@@ -1596,7 +1720,8 @@ namespace FluentAssertions.Types
         /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="sourceType"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="targetType"/> is <c>null</c>.</exception>
-        public AndConstraint<TypeAssertions> NotHaveExplicitConversionOperator(Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
+        public AndConstraint<TypeAssertions> NotHaveExplicitConversionOperator(
+            Type sourceType, Type targetType, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(sourceType, nameof(sourceType));
             Guard.ThrowIfArgumentIsNull(targetType, nameof(targetType));
@@ -1604,14 +1729,18 @@ namespace FluentAssertions.Types
             Execute.Assertion
                .BecauseOf(because, becauseArgs)
                .ForCondition(Subject is not null)
-               .FailWith($"Expected public static explicit {targetType.FullName}({sourceType.FullName}) to not exist{{reason}}, but {{context:type}} is <null>.");
+               .FailWith(
+                    $"Expected public static explicit {targetType.FullName}({sourceType.FullName}) to not exist{{reason}}" +
+                    $", but {{context:type}} is <null>.");
 
             MethodInfo methodInfo = Subject.GetExplicitConversionOperator(sourceType, targetType);
 
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(methodInfo is null)
-                .FailWith($"Expected public static explicit {targetType.FullName}({sourceType.FullName}) to not exist{{reason}}, but it does.");
+                .FailWith(
+                    $"Expected public static explicit {targetType.FullName}({sourceType.FullName}) to not exist{{reason}}" +
+                    $", but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
         }

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -1013,7 +1013,7 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
-                .FailWith($"Expected {{context:type}} to explicitly implement {interfaceType.FullName}.{name}{{reason}}, but {{context:type}} is <null>.");
+                .FailWith($"Expected {{context:type}} to explicitly implement {interfaceType.FullName}.{name}({GetParameterString(parameterTypes)}){{reason}}, but {{context:type}} is <null>.");
 
             Subject.Should().Implement(interfaceType, because, becauseArgs);
 
@@ -1022,7 +1022,7 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(explicitlyImplementsMethod)
-                .FailWith($"Expected {Subject.FullName} to explicitly implement {interfaceType.FullName}.{name}{{reason}}, but it does not.");
+                .FailWith($"Expected {Subject.FullName} to explicitly implement {interfaceType.FullName}.{name}({GetParameterString(parameterTypes)}){{reason}}, but it does not.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1075,7 +1075,7 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
-                .FailWith($"Expected {{context:type}} to not explicitly implement {interfaceType.FullName}.{name}{{reason}}, but {{context:type}} is <null>.");
+                .FailWith($"Expected {{context:type}} to not explicitly implement {interfaceType.FullName}.{name}({GetParameterString(parameterTypes)}){{reason}}, but {{context:type}} is <null>.");
 
             Subject.Should().Implement(interfaceType, because, becauseArgs);
 
@@ -1084,7 +1084,7 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(!explicitlyImplementsMethod)
-                .FailWith($"Expected {Subject.FullName} to not explicitly implement {interfaceType.FullName}.{name}{{reason}}, but it does.");
+                .FailWith($"Expected {Subject.FullName} to not explicitly implement {interfaceType.FullName}.{name}({GetParameterString(parameterTypes)}){{reason}}, but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
         }

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -53,8 +53,8 @@ namespace FluentAssertions.Types
         public AndConstraint<TypeAssertions> Be(Type expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject == expected)
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject == expected)
                 .FailWith(GetFailureMessageIfTypesAreDifferent(Subject, expected));
 
             return new AndConstraint<TypeAssertions>(this);
@@ -96,8 +96,8 @@ namespace FluentAssertions.Types
             bool isAssignable = type.IsGenericTypeDefinition ? Subject.IsAssignableToOpenGeneric(type) : type.IsAssignableFrom(Subject);
 
             Execute.Assertion
-                .ForCondition(isAssignable)
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(isAssignable)
                 .FailWith("Expected {context:type} {0} to be assignable to {1}{reason}, but it is not.", Subject, type);
 
             return new AndConstraint<TypeAssertions>(this);
@@ -139,8 +139,8 @@ namespace FluentAssertions.Types
             bool isAssignable = type.IsGenericTypeDefinition ? Subject.IsAssignableToOpenGeneric(type) : type.IsAssignableFrom(Subject);
 
             Execute.Assertion
-                .ForCondition(!isAssignable)
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(!isAssignable)
                 .FailWith("Expected {context:type} {0} to not be assignable to {1}{reason}, but it is.", Subject, type);
 
             return new AndConstraint<TypeAssertions>(this);
@@ -204,8 +204,8 @@ namespace FluentAssertions.Types
             string nameOfUnexpectedType = (unexpected is not null) ? $"[{unexpected.AssemblyQualifiedName}]" : "<null>";
 
             Execute.Assertion
-                .ForCondition(Subject != unexpected)
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject != unexpected)
                 .FailWith("Expected type not to be " + nameOfUnexpectedType + "{reason}, but it is.");
 
             return new AndConstraint<TypeAssertions>(this);
@@ -227,8 +227,8 @@ namespace FluentAssertions.Types
             IEnumerable<TAttribute> attributes = Subject.GetMatchingAttributes<TAttribute>();
 
             Execute.Assertion
-                .ForCondition(attributes.Any())
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(attributes.Any())
                 .FailWith("Expected type {0} to be decorated with {1}{reason}, but the attribute was not found.",
                     Subject, typeof(TAttribute));
 
@@ -260,8 +260,8 @@ namespace FluentAssertions.Types
             IEnumerable<TAttribute> attributes = Subject.GetMatchingAttributes(isMatchingAttributePredicate);
 
             Execute.Assertion
-                .ForCondition(attributes.Any())
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(attributes.Any())
                 .FailWith("Expected type {0} to be decorated with {1} that matches {2}{reason}, but no matching attribute was found.",
                     Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
 
@@ -284,10 +284,9 @@ namespace FluentAssertions.Types
             IEnumerable<TAttribute> attributes = Subject.GetMatchingOrInheritedAttributes<TAttribute>();
 
             Execute.Assertion
-                .ForCondition(attributes.Any())
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected type {0} to be decorated with or inherit {1}{reason}, but the attribute was not found.",
-                    Subject, typeof(TAttribute));
+                .ForCondition(attributes.Any())
+                .FailWith("Expected type {0} to be decorated with or inherit {1}{reason}, but the attribute was not found.", Subject, typeof(TAttribute));
 
             return new AndWhichConstraint<TypeAssertions, TAttribute>(this, attributes);
         }
@@ -317,10 +316,9 @@ namespace FluentAssertions.Types
             IEnumerable<TAttribute> attributes = Subject.GetMatchingOrInheritedAttributes(isMatchingAttributePredicate);
 
             Execute.Assertion
-                .ForCondition(attributes.Any())
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected type {0} to be decorated with or inherit {1} that matches {2}{reason}, but no matching attribute was found.",
-                    Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
+                .ForCondition(attributes.Any())
+                .FailWith("Expected type {0} to be decorated with or inherit {1} that matches {2}{reason}, but no matching attribute was found.", Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
 
             return new AndWhichConstraint<TypeAssertions, TAttribute>(this, attributes);
         }
@@ -339,10 +337,9 @@ namespace FluentAssertions.Types
             where TAttribute : Attribute
         {
             Execute.Assertion
-                .ForCondition(!Subject.IsDecoratedWith<TAttribute>())
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected type {0} to not be decorated with {1}{reason}, but the attribute was found.",
-                    Subject, typeof(TAttribute));
+                .ForCondition(!Subject.IsDecoratedWith<TAttribute>())
+                .FailWith("Expected type {0} to not be decorated with {1}{reason}, but the attribute was found.", Subject, typeof(TAttribute));
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -368,10 +365,9 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate, nameof(isMatchingAttributePredicate));
 
             Execute.Assertion
-                .ForCondition(!Subject.IsDecoratedWith(isMatchingAttributePredicate))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected type {0} to not be decorated with {1} that matches {2}{reason}, but a matching attribute was found.",
-                    Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
+                .ForCondition(!Subject.IsDecoratedWith(isMatchingAttributePredicate))
+                .FailWith("Expected type {0} to not be decorated with {1} that matches {2}{reason}, but a matching attribute was found.", Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -390,10 +386,9 @@ namespace FluentAssertions.Types
             where TAttribute : Attribute
         {
             Execute.Assertion
-                .ForCondition(!Subject.IsDecoratedWithOrInherit<TAttribute>())
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected type {0} to not be decorated with or inherit {1}{reason}, but the attribute was found.",
-                    Subject, typeof(TAttribute));
+                .ForCondition(!Subject.IsDecoratedWithOrInherit<TAttribute>())
+                .FailWith("Expected type {0} to not be decorated with or inherit {1}{reason}, but the attribute was found.", Subject, typeof(TAttribute));
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -419,10 +414,9 @@ namespace FluentAssertions.Types
             Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate, nameof(isMatchingAttributePredicate));
 
             Execute.Assertion
-                .ForCondition(!Subject.IsDecoratedWithOrInherit(isMatchingAttributePredicate))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected type {0} to not be decorated with or inherit {1} that matches {2}{reason}, but a matching attribute was found.",
-                    Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
+                .ForCondition(!Subject.IsDecoratedWithOrInherit(isMatchingAttributePredicate))
+                .FailWith("Expected type {0} to not be decorated with or inherit {1} that matches {2}{reason}, but a matching attribute was found.", Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -644,8 +638,8 @@ namespace FluentAssertions.Types
             AssertThatSubjectIsClass();
 
             Execute.Assertion
-                .ForCondition(Subject.IsCSharpSealed())
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject.IsCSharpSealed())
                 .FailWith("Expected type {0} to be sealed{reason}.", Subject);
 
             return new AndConstraint<TypeAssertions>(this);
@@ -672,8 +666,8 @@ namespace FluentAssertions.Types
             AssertThatSubjectIsClass();
 
             Execute.Assertion
-                .ForCondition(!Subject.IsCSharpSealed())
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(!Subject.IsCSharpSealed())
                 .FailWith("Expected type {0} not to be sealed{reason}.", Subject);
 
             return new AndConstraint<TypeAssertions>(this);
@@ -700,9 +694,9 @@ namespace FluentAssertions.Types
             AssertThatSubjectIsClass();
 
             Execute.Assertion
-                .ForCondition(Subject.IsCSharpAbstract())
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected type {0} to be abstract{reason}.", Subject);
+                .ForCondition(Subject.IsCSharpAbstract())
+                .FailWith("Expected {context:type} {0} to be abstract{reason}.", Subject);
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -728,8 +722,8 @@ namespace FluentAssertions.Types
             AssertThatSubjectIsClass();
 
             Execute.Assertion
-                .ForCondition(!Subject.IsCSharpAbstract())
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(!Subject.IsCSharpAbstract())
                 .FailWith("Expected type {0} not to be abstract{reason}.", Subject);
 
             return new AndConstraint<TypeAssertions>(this);
@@ -756,8 +750,8 @@ namespace FluentAssertions.Types
             AssertThatSubjectIsClass();
 
             Execute.Assertion
-                .ForCondition(Subject.IsCSharpStatic())
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject.IsCSharpStatic())
                 .FailWith("Expected type {0} to be static{reason}.", Subject);
 
             return new AndConstraint<TypeAssertions>(this);
@@ -784,8 +778,8 @@ namespace FluentAssertions.Types
             AssertThatSubjectIsClass();
 
             Execute.Assertion
-                .ForCondition(!Subject.IsCSharpStatic())
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(!Subject.IsCSharpStatic())
                 .FailWith("Expected type {0} not to be static{reason}.", Subject);
 
             return new AndConstraint<TypeAssertions>(this);
@@ -871,8 +865,9 @@ namespace FluentAssertions.Types
             PropertyInfo propertyInfo = Subject.GetPropertyByName(name);
             var propertyInfoDescription = PropertyInfoAssertions.GetDescriptionFor(propertyInfo);
 
-            Execute.Assertion.ForCondition(propertyInfo is null)
+            Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(propertyInfo is null)
                 .FailWith($"Expected {propertyInfoDescription} to not exist{{reason}}, but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
@@ -907,8 +902,9 @@ namespace FluentAssertions.Types
 
             var explicitlyImplementsProperty = Subject.HasExplicitlyImplementedProperty(interfaceType, name);
 
-            Execute.Assertion.ForCondition(explicitlyImplementsProperty)
+            Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(explicitlyImplementsProperty)
                 .FailWith($"Expected {Subject.FullName} to explicitly implement {interfaceType.FullName}.{name}{{reason}}, but it does not.");
 
             return new AndConstraint<TypeAssertions>(this);
@@ -963,8 +959,9 @@ namespace FluentAssertions.Types
 
             var explicitlyImplementsProperty = Subject.HasExplicitlyImplementedProperty(interfaceType, name);
 
-            Execute.Assertion.ForCondition(!explicitlyImplementsProperty)
+            Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(!explicitlyImplementsProperty)
                 .FailWith($"Expected {Subject.FullName} to not explicitly implement {interfaceType.FullName}.{name}{{reason}}, but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
@@ -1022,8 +1019,9 @@ namespace FluentAssertions.Types
 
             var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType.FullName}.{name}", parameterTypes);
 
-            Execute.Assertion.ForCondition(explicitlyImplementsMethod)
+            Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(explicitlyImplementsMethod)
                 .FailWith($"Expected {Subject.FullName} to explicitly implement {interfaceType.FullName}.{name}{{reason}}, but it does not.");
 
             return new AndConstraint<TypeAssertions>(this);
@@ -1083,8 +1081,9 @@ namespace FluentAssertions.Types
 
             var explicitlyImplementsMethod = Subject.HasMethod($"{interfaceType.FullName}.{name}", parameterTypes);
 
-            Execute.Assertion.ForCondition(!explicitlyImplementsMethod)
+            Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(!explicitlyImplementsMethod)
                 .FailWith($"Expected {Subject.FullName} to not explicitly implement {interfaceType.FullName}.{name}{{reason}}, but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
@@ -1140,12 +1139,12 @@ namespace FluentAssertions.Types
             PropertyInfo propertyInfo = Subject.GetIndexerByParameterTypes(parameterTypes);
             var propertyInfoDescription = PropertyInfoAssertions.GetDescriptionFor(propertyInfo);
 
-            Execute.Assertion.ForCondition(propertyInfo is not null)
+            Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith($"Expected {indexerType.Name} {Subject.FullName}[{GetParameterString(parameterTypes)}] to exist{{reason}}, but it does not.");
-
-            Execute.Assertion.ForCondition(propertyInfo.PropertyType == indexerType)
-                .BecauseOf(because, becauseArgs)
+                .ForCondition(propertyInfo is not null)
+                .FailWith($"Expected {indexerType.Name} {Subject.FullName}[{GetParameterString(parameterTypes)}] to exist{{reason}}, but it does not.")
+                .Then
+                .ForCondition(propertyInfo.PropertyType == indexerType)
                 .FailWith($"Expected {propertyInfoDescription} to be of type {indexerType}{{reason}}, but it is not.");
 
             return new AndWhichConstraint<TypeAssertions, PropertyInfo>(this, propertyInfo);
@@ -1174,8 +1173,9 @@ namespace FluentAssertions.Types
 
             PropertyInfo propertyInfo = Subject.GetIndexerByParameterTypes(parameterTypes);
 
-            Execute.Assertion.ForCondition(propertyInfo is null)
+            Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(propertyInfo is null)
                 .FailWith($"Expected indexer {Subject.FullName}[{GetParameterString(parameterTypes)}] to not exist{{reason}}, but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
@@ -1207,8 +1207,9 @@ namespace FluentAssertions.Types
 
             MethodInfo methodInfo = Subject.GetMethod(name, parameterTypes);
 
-            Execute.Assertion.ForCondition(methodInfo is not null)
+            Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(methodInfo is not null)
                 .FailWith($"Expected method {Subject.FullName}.{name}({GetParameterString(parameterTypes)}) to exist{{reason}}, but it does not.");
 
             return new AndWhichConstraint<TypeAssertions, MethodInfo>(this, methodInfo);
@@ -1242,8 +1243,9 @@ namespace FluentAssertions.Types
             MethodInfo methodInfo = Subject.GetMethod(name, parameterTypes);
             var methodInfoDescription = MethodInfoAssertions.GetDescriptionFor(methodInfo);
 
-            Execute.Assertion.ForCondition(methodInfo is null)
+            Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(methodInfo is null)
                 .FailWith($"Expected method {methodInfoDescription}({GetParameterString(parameterTypes)}) to not exist{{reason}}, but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
@@ -1272,8 +1274,9 @@ namespace FluentAssertions.Types
 
             ConstructorInfo constructorInfo = Subject.GetConstructor(parameterTypes);
 
-            Execute.Assertion.ForCondition(constructorInfo is not null)
+            Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(constructorInfo is not null)
                 .FailWith($"Expected constructor {Subject.FullName}({GetParameterString(parameterTypes)}) to exist{{reason}}, but it does not.");
 
             return new AndWhichConstraint<TypeAssertions, ConstructorInfo>(this, constructorInfo);
@@ -1318,8 +1321,8 @@ namespace FluentAssertions.Types
             ConstructorInfo constructorInfo = Subject.GetConstructor(parameterTypes);
 
             Execute.Assertion
-                .ForCondition(constructorInfo is null)
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(constructorInfo is null)
                 .FailWith($"Expected constructor {Subject.FullName}({GetParameterString(parameterTypes)}) not to exist{{reason}}, but it does.");
 
             return new AndWhichConstraint<TypeAssertions, ConstructorInfo>(this, constructorInfo);
@@ -1371,8 +1374,8 @@ namespace FluentAssertions.Types
 
             Execute.Assertion.ForCondition(accessModifier == subjectAccessModifier)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected type " + Subject.Name + " to be " + accessModifier.ToString()
-                    + "{reason}, but it is " + subjectAccessModifier.ToString() + ".");
+                .ForCondition(accessModifier == subjectAccessModifier)
+                .FailWith($"Expected {{context:type}} {Subject.Name} to be {accessModifier}{{reason}}, but it is {subjectAccessModifier}.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1403,7 +1406,8 @@ namespace FluentAssertions.Types
             Execute.Assertion
                 .ForCondition(accessModifier != subjectAccessModifier)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected type " + Subject.Name + " not to be " + accessModifier.ToString() + "{reason}, but it is.");
+                .ForCondition(accessModifier != subjectAccessModifier)
+                .FailWith($"Expected {{context:type}} {Subject.Name} not to be {accessModifier}{{reason}}, but it is.");
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -1451,8 +1455,9 @@ namespace FluentAssertions.Types
 
             MethodInfo methodInfo = Subject.GetImplicitConversionOperator(sourceType, targetType);
 
-            Execute.Assertion.ForCondition(methodInfo is not null)
+            Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(methodInfo is not null)
                 .FailWith($"Expected public static implicit {targetType.FullName}({sourceType.FullName}) to exist{{reason}}, but it does not.");
 
             return new AndWhichConstraint<TypeAssertions, MethodInfo>(this, methodInfo);
@@ -1501,8 +1506,9 @@ namespace FluentAssertions.Types
 
             MethodInfo methodInfo = Subject.GetImplicitConversionOperator(sourceType, targetType);
 
-            Execute.Assertion.ForCondition(methodInfo is null)
+            Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(methodInfo is null)
                 .FailWith($"Expected public static implicit {targetType.FullName}({sourceType.FullName}) to not exist{{reason}}, but it does.");
 
             return new AndConstraint<TypeAssertions>(this);
@@ -1551,8 +1557,9 @@ namespace FluentAssertions.Types
 
             MethodInfo methodInfo = Subject.GetExplicitConversionOperator(sourceType, targetType);
 
-            Execute.Assertion.ForCondition(methodInfo is not null)
+            Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(methodInfo is not null)
                 .FailWith($"Expected public static explicit {targetType.FullName}({sourceType.FullName}) to exist{{reason}}, but it does not.");
 
             return new AndWhichConstraint<TypeAssertions, MethodInfo>(this, methodInfo);
@@ -1601,8 +1608,9 @@ namespace FluentAssertions.Types
 
             MethodInfo methodInfo = Subject.GetExplicitConversionOperator(sourceType, targetType);
 
-            Execute.Assertion.ForCondition(methodInfo is null)
+            Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(methodInfo is null)
                 .FailWith($"Expected public static explicit {targetType.FullName}({sourceType.FullName}) to not exist{{reason}}, but it does.");
 
             return new AndConstraint<TypeAssertions>(this);

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
@@ -42,7 +42,7 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().Be(differentType, "because we want to test the failure {0}", "message");
+                type.Should().Be(differentType, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -72,12 +72,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                nullType.Should().Be(someType, "because we want to test the error {0}", "message");
+                nullType.Should().Be(someType, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be FluentAssertions*ClassWithAttribute" +
-                    " because we want to test the error message, but found <null>.");
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to be *.ClassWithAttribute *failure message*, but found <null>.");
         }
 
         [Fact]
@@ -89,12 +88,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                someType.Should().Be(nullType, "because we want to test the error {0}", "message");
+                someType.Should().Be(nullType, "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be <null>" +
-                    " because we want to test the error message, but found FluentAssertions*ClassWithAttribute.");
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to be <null> *failure message*, but found *.ClassWithAttribute.");
         }
 
         [Fact]
@@ -112,16 +110,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                typeFromThisAssembly.Should().Be(typeFromOtherAssembly, "because we want to test the error {0}",
-                    "message");
+                typeFromThisAssembly.Should().Be(typeFromOtherAssembly, "we want to test the failure {0}", "message");
 
             // Assert
-            const string expectedMessage =
-                "Expected type to be [FluentAssertions.Primitives.ObjectAssertions, FluentAssertions*]" +
-                    " because we want to test the error message, but found " +
-                        "[FluentAssertions.Primitives.ObjectAssertions, FluentAssertions*].";
-
-            act.Should().Throw<XunitException>().WithMessage(expectedMessage);
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to be [*.ObjectAssertions, *] *failure message*, but found [*.ObjectAssertions, *].");
         }
 
         [Fact]
@@ -146,7 +139,7 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().Be<ClassWithoutAttribute>("because we want to test the failure {0}", "message");
+                type.Should().Be<ClassWithoutAttribute>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -181,7 +174,7 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotBe(sameType, "because we want to test the failure {0}", "message");
+                type.Should().NotBe(sameType, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -225,7 +218,7 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotBe<ClassWithAttribute>("because we want to test the failure {0}", "message");
+                type.Should().NotBe<ClassWithAttribute>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -262,11 +255,11 @@ namespace FluentAssertions.Specs.Types
         {
             // Arrange
             Type someType = typeof(DummyImplementingClass);
-            Action act = () => someType.Should().BeAssignableTo<DateTime>("because we want to test the failure {0}", "message");
+            Action act = () => someType.Should().BeAssignableTo<DateTime>("we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*{typeof(DummyImplementingClass)} to be assignable to {typeof(DateTime)}*failure message*");
+                .WithMessage("Expected someType *.DummyImplementingClass to be assignable to *.DateTime *failure message*, but it is not.");
         }
 
         [Fact]
@@ -298,7 +291,7 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                someType.Should().BeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
+                someType.Should().BeAssignableTo(typeof(DateTime), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -334,11 +327,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                someType.Should().BeAssignableTo(typeof(IDummyInterface<>), "because we want to test the failure {0}", "message");
+                someType.Should().BeAssignableTo(typeof(IDummyInterface<>), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*{typeof(IDummyInterface)} to be assignable to {typeof(IDummyInterface<>)}*failure message*");
+                .WithMessage("Expected someType *.IDummyInterface to be assignable to *.IDummyInterface`1[T] *failure message*, but it is not.");
         }
 
         [Fact]
@@ -346,11 +339,11 @@ namespace FluentAssertions.Specs.Types
         {
             // Arrange
             Type someType = typeof(ClassWithAttribute);
-            Action act = () => someType.Should().BeAssignableTo(typeof(DummyBaseType<>), "because we want to test the failure {0}", "message");
+            Action act = () => someType.Should().BeAssignableTo(typeof(DummyBaseType<>), "we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*{typeof(ClassWithAttribute)} to be assignable to {typeof(DummyBaseType<>)}*failure message*");
+                .WithMessage("*.ClassWithAttribute to be assignable to *.DummyBaseType* *failure message*");
         }
 
         [Fact]
@@ -383,33 +376,33 @@ namespace FluentAssertions.Specs.Types
         public void When_its_own_type_and_asserting_not_assignable_it_fails()
         {
             // Arrange
-            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo<DummyImplementingClass>("because we want to test the failure {0}", "message");
+            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo<DummyImplementingClass>("we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*{typeof(DummyImplementingClass)} to not be assignable to {typeof(DummyImplementingClass)}*failure message*");
+                .WithMessage("Expected typeof(DummyImplementingClass) *.DummyImplementingClass to not be assignable to *.DummyImplementingClass *failure message*");
         }
 
         [Fact]
         public void When_its_base_type_and_asserting_not_assignable_it_fails()
         {
             // Arrange
-            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo<DummyBaseClass>("because we want to test the failure {0}", "message");
+            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo<DummyBaseClass>("we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*{typeof(DummyImplementingClass)} to not be assignable to {typeof(DummyBaseClass)}*failure message*");
+                .WithMessage("Expected typeof(DummyImplementingClass) *.DummyImplementingClass to not be assignable to *.DummyBaseClass *failure message*, but it is.");
         }
 
         [Fact]
         public void When_implemented_interface_type_and_asserting_not_assignable_it_fails()
         {
             // Arrange
-            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo<IDisposable>("because we want to test the failure {0}", "message");
+            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo<IDisposable>("we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*{typeof(DummyImplementingClass)} to not be assignable to {typeof(IDisposable)}*failure message*");
+                .WithMessage("Expected typeof(DummyImplementingClass) *.DummyImplementingClass to not be assignable to *.IDisposable *failure message*, but it is.");
         }
 
         [Fact]
@@ -423,33 +416,33 @@ namespace FluentAssertions.Specs.Types
         public void When_its_own_type_instance_and_asserting_not_assignable_it_fails()
         {
             // Arrange
-            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(DummyImplementingClass), "because we want to test the failure {0}", "message");
+            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(DummyImplementingClass), "we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*{typeof(DummyImplementingClass)} to not be assignable to {typeof(DummyImplementingClass)}*failure message*");
+                .WithMessage("Expected typeof(DummyImplementingClass) *.DummyImplementingClass to not be assignable to *.DummyImplementingClass *failure message*, but it is.");
         }
 
         [Fact]
         public void When_its_base_type_instance_and_asserting_not_assignable_it_fails()
         {
             // Arrange
-            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(DummyBaseClass), "because we want to test the failure {0}", "message");
+            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(DummyBaseClass), "we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*{typeof(DummyImplementingClass)} to not be assignable to {typeof(DummyBaseClass)}*failure message*");
+                .WithMessage("Expected typeof(DummyImplementingClass) *.DummyImplementingClass to not be assignable to *.DummyBaseClass *failure message*, but it is.");
         }
 
         [Fact]
         public void When_an_implemented_interface_type_instance_and_asserting_not_assignable_it_fails()
         {
             // Arrange
-            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(IDisposable), "because we want to test the failure {0}", "message");
+            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(IDisposable), "we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*{typeof(DummyImplementingClass)} to not be assignable to {typeof(IDisposable)}*failure message*");
+                .WithMessage("Expected typeof(DummyImplementingClass) *.DummyImplementingClass to not be assignable to *.IDisposable *failure message*, but it is.");
         }
 
         [Fact]
@@ -478,11 +471,11 @@ namespace FluentAssertions.Specs.Types
         {
             // Arrange
             Type someType = typeof(ClassWithGenericBaseType);
-            Action act = () => someType.Should().NotBeAssignableTo(typeof(IDummyInterface<>), "because we want to test the failure {0}", "message");
+            Action act = () => someType.Should().NotBeAssignableTo(typeof(IDummyInterface<>), "we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*{typeof(ClassWithGenericBaseType)} to not be assignable to {typeof(IDummyInterface<>)}*failure message*");
+                .WithMessage("Expected someType *.ClassWithGenericBaseType to not be assignable to *.IDummyInterface`1[T] *failure message*, but it is.");
         }
 
         [Fact]
@@ -490,11 +483,11 @@ namespace FluentAssertions.Specs.Types
         {
             // Arrange
             Type someType = typeof(ClassWithGenericBaseType);
-            Action act = () => someType.Should().NotBeAssignableTo(typeof(IDummyInterface<>), "because we want to test the failure {0}", "message");
+            Action act = () => someType.Should().NotBeAssignableTo(typeof(IDummyInterface<>), "we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*{typeof(ClassWithGenericBaseType)} to not be assignable to {typeof(IDummyInterface<>)}*failure message*");
+                .WithMessage("Expected someType *.ClassWithGenericBaseType to not be assignable to *.IDummyInterface`1[T] *failure message*, but it is.");
         }
 
         [Fact]
@@ -538,12 +531,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().BeDerivedFrom(typeof(ClassWithMembers), "because we want to test the error {0}", "message");
+                type.Should().BeDerivedFrom(typeof(ClassWithMembers), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*DummyBaseClass to be derived from " +
-                             "FluentAssertions*ClassWithMembers because we want to test the error message, but it is not.");
+                .WithMessage("Expected type *.DummyBaseClass to be derived from *.ClassWithMembers *failure message*, but it is not.");
         }
 
         [Fact]
@@ -554,11 +546,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().BeDerivedFrom(typeof(IDummyInterface), "because we want to test the error {0}", "message");
+                type.Should().BeDerivedFrom(typeof(IDummyInterface), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"Expected type *.ClassThatImplementsInterface to be derived from *.IDummyInterface *error message*, but *.IDummyInterface is an interface.");
+                .WithMessage("Expected type *.ClassThatImplementsInterface to be derived from *.IDummyInterface *failure message*, but *.IDummyInterface is an interface.");
         }
 
         [Fact]
@@ -597,12 +589,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().BeDerivedFrom(typeof(DummyBaseType<>), "because we want to test the error {0}", "message");
+                type.Should().BeDerivedFrom(typeof(DummyBaseType<>), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"Expected type {typeof(ClassWithMembers)} to be derived from " +
-                             $"{typeof(DummyBaseType<>)} because we want to test the error message, but it is not.");
+                .WithMessage("Expected type *.ClassWithMembers to be derived from *.DummyBaseType`* *failure message*, but it is not.");
         }
 
         [Fact]
@@ -664,12 +655,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotBeDerivedFrom(typeof(DummyBaseClass), "because we want to test the error {0}", "message");
+                type.Should().NotBeDerivedFrom(typeof(DummyBaseClass), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type*DummyImplementingClass*not to be derived from*" +
-                             "DummyBaseClass*because we want to test the error message*but it is.");
+                .WithMessage("Expected type *.DummyImplementingClass not to be derived from *.DummyBaseClass *failure message*, but it is.");
         }
 
         [Fact]
@@ -680,11 +670,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotBeDerivedFrom(typeof(IDummyInterface), "because we want to test the error {0}", "message");
+                type.Should().NotBeDerivedFrom(typeof(IDummyInterface), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"Expected type *.ClassThatImplementsInterface not to be derived from *.IDummyInterface *error message*, but *.IDummyInterface is an interface.");
+                .WithMessage("Expected type *.ClassThatImplementsInterface not to be derived from *.IDummyInterface *failure message*, but *.IDummyInterface is an interface.");
         }
 
         [Fact]
@@ -723,12 +713,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotBeDerivedFrom(typeof(DummyBaseType<>), "because we want to test the error {0}", "message");
+                type.Should().NotBeDerivedFrom(typeof(DummyBaseType<>), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"Expected type*{typeof(DummyBaseType<ClassWithGenericBaseType>)}*not to be derived from*" +
-                             $"{typeof(DummyBaseType<>)}*because we want to test the error message*but it is.");
+                .WithMessage("Expected type *.DummyBaseType`1[*.ClassWithGenericBaseType] not to be derived from *.DummyBaseType`1[T] *failure message*, but it is.");
         }
 
         [Fact]
@@ -805,7 +794,7 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                typeWithoutAttribute.Should().BeDecoratedWith<DummyClassAttribute>("because we want to test the failure {0}", "message");
+                typeWithoutAttribute.Should().BeDecoratedWith<DummyClassAttribute>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -871,9 +860,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*ClassWithAttribute to be decorated with " +
-                    "FluentAssertions*DummyClassAttribute that matches ((a.Name == \"Unexpected\")*a.IsEnabled), " +
-                        "but no matching attribute was found.");
+                .WithMessage("Expected type *.ClassWithAttribute to be decorated with *.DummyClassAttribute that matches ((a.Name == \"Unexpected\")*a.IsEnabled), but no matching attribute was found.");
         }
 
         [Fact]
@@ -906,14 +893,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                types.Should().BeDecoratedWith<DummyClassAttribute>("because we do");
+                types.Should().BeDecoratedWith<DummyClassAttribute>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be decorated with *DummyClassAttribute*" +
-                    " because we do, but the attribute was not found on the following types:*" +
-                    "*ClassWithoutAttribute*" +
-                    "*OtherClassWithoutAttribute*.");
+                .WithMessage("Expected all types to be decorated with *.DummyClassAttribute *failure message*, but the attribute was not found on the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
         }
 
         [Fact]
@@ -945,15 +929,11 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 types.Should()
-                    .BeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled, "because we do");
+                    .BeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be decorated with *DummyClassAttribute*" +
-                    " that matches ((a.Name == \"Expected\")*a.IsEnabled) because we do," +
-                    " but no matching attribute was found on the following types:*" +
-                    "*ClassWithoutAttribute*" +
-                    "*OtherClassWithoutAttribute*.");
+                .WithMessage("Expected all types to be decorated with *.DummyClassAttribute that matches ((a.Name == \"Expected\") * a.IsEnabled) *failure message*, but no matching attribute was found on the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
         }
 
         #endregion
@@ -997,7 +977,7 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                typeWithoutAttribute.Should().BeDecoratedWithOrInherit<DummyClassAttribute>("because we want to test the failure {0}", "message");
+                typeWithoutAttribute.Should().BeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -1063,9 +1043,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*ClassWithInheritedAttribute to be decorated with or inherit " +
-                    "FluentAssertions*DummyClassAttribute that matches ((a.Name == \"Unexpected\")*a.IsEnabled), " +
-                        "but no matching attribute was found.");
+                .WithMessage("Expected type *.ClassWithInheritedAttribute to be decorated with or inherit *.DummyClassAttribute that matches ((a.Name == \"Unexpected\")*a.IsEnabled), but no matching attribute was found.");
         }
 
         [Fact]
@@ -1098,14 +1076,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                types.Should().BeDecoratedWithOrInherit<DummyClassAttribute>("because we do");
+                types.Should().BeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be decorated with or inherit *DummyClassAttribute*" +
-                    " because we do, but the attribute was not found on the following types:*" +
-                    "*ClassWithoutAttribute*" +
-                    "*OtherClassWithoutAttribute*.");
+                .WithMessage("Expected all types to be decorated with or inherit *.DummyClassAttribute *failure message*, but the attribute was not found on the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
         }
 
         [Fact]
@@ -1138,15 +1113,11 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 types.Should()
-                    .BeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled, "because we do");
+                    .BeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be decorated with or inherit *DummyClassAttribute*" +
-                    " that matches ((a.Name == \"Expected\")*a.IsEnabled) because we do," +
-                    " but no matching attribute was found on the following types:*" +
-                    "*ClassWithoutAttribute*" +
-                    "*OtherClassWithoutAttribute*.");
+                .WithMessage("Expected all types to be decorated with or inherit *.DummyClassAttribute that matches ((a.Name == \"Expected\")*a.IsEnabled) *failure message*, but no matching attribute was found on the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
         }
 
         #endregion
@@ -1175,12 +1146,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                typeWithAttribute.Should().NotBeDecoratedWith<DummyClassAttribute>("because we want to test the failure {0}", "message");
+                typeWithAttribute.Should().NotBeDecoratedWith<DummyClassAttribute>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type*ClassWithAttribute to not be decorated with" +
-                    "*DummyClassAttribute* *failure message* attribute was found.");
+                .WithMessage("Expected type *.ClassWithAttribute to not be decorated with *.DummyClassAttribute* *failure message*, but the attribute was found.");
         }
 
         [Fact]
@@ -1226,9 +1196,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type*ClassWithAttribute to not be decorated with" +
-                    "*DummyClassAttribute that matches ((a.Name == \"Expected\")*a.IsEnabled)" +
-                        "*matching attribute was found.");
+                .WithMessage("Expected type *.ClassWithAttribute to not be decorated with *.DummyClassAttribute that matches ((a.Name == \"Expected\") * a.IsEnabled), but a matching attribute was found.");
         }
 
         [Fact]
@@ -1261,12 +1229,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                types.Should().NotBeDecoratedWith<DummyClassAttribute>("because we do");
+                types.Should().NotBeDecoratedWith<DummyClassAttribute>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to not be decorated*DummyClassAttribute" +
-                    "*because we do*attribute was found*ClassWithAttribute*");
+                .WithMessage("Expected all types to not be decorated *.DummyClassAttribute *failure message*, but the attribute was found on the following types:*\"*.ClassWithAttribute\".");
         }
 
         [Fact]
@@ -1297,13 +1264,11 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 types.Should()
-                    .NotBeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled, "because we do");
+                    .NotBeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to not be decorated with *DummyClassAttribute" +
-                    "*((a.Name == \"Expected\")*a.IsEnabled) because we do" +
-                    "*matching attribute was found*ClassWithAttribute*.");
+                .WithMessage("Expected all types to not be decorated with *.DummyClassAttribute that matches ((a.Name == \"Expected\") * a.IsEnabled) *failure message*, but a matching attribute was found on the following types:*\"*.ClassWithAttribute\".");
         }
 
         #endregion
@@ -1332,7 +1297,7 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                typeWithAttribute.Should().NotBeDecoratedWithOrInherit<DummyClassAttribute>("because we want to test the failure {0}", "message");
+                typeWithAttribute.Should().NotBeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -1382,9 +1347,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type*ClassWithInheritedAttribute to not be decorated with or inherit" +
-                    "*DummyClassAttribute that matches ((a.Name == \"Expected\")*a.IsEnabled)" +
-                        "*matching attribute was found.");
+                .WithMessage("Expected type *.ClassWithInheritedAttribute to not be decorated with or inherit *.DummyClassAttribute that matches ((a.Name == \"Expected\") * a.IsEnabled), but a matching attribute was found.");
         }
 
         [Fact]
@@ -1417,12 +1380,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                types.Should().NotBeDecoratedWithOrInherit<DummyClassAttribute>("because we do");
+                types.Should().NotBeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to not be decorated with or inherit*DummyClassAttribute" +
-                    "*because we do*attribute was found*ClassWithInheritedAttribute*");
+                .WithMessage("Expected all types to not be decorated with or inherit *.DummyClassAttribute *failure message*, but the attribute was found on the following types:*\"*.ClassWithInheritedAttribute\".");
         }
 
         [Fact]
@@ -1433,15 +1395,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () => types.Should()
-                .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled,
-                    "because we {0}", "do");
+                .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to not be decorated with or inherit *DummyClassAttribute*" +
-                    " that matches ((a.Name == \"Expected\")*a.IsEnabled) because we do," +
-                    " but a matching attribute was found on the following types:*" +
-                    "*ClassWithInheritedAttribute*.");
+                .WithMessage("Expected all types to not be decorated with or inherit *.DummyClassAttribute that matches ((a.Name == \"Expected\") * a.IsEnabled) *failure message*, but a matching attribute was found on the following types:*\"*.ClassWithInheritedAttribute\".");
         }
 
         [Fact]
@@ -1452,8 +1410,7 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () => types.Should()
-                .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled,
-                    "because we {0}", "do");
+                .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled);
 
             // Assert
             act.Should().NotThrow();
@@ -1504,16 +1461,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                types.Should().BeInNamespace(nameof(DummyNamespace),
-                    "because we want to test the error {0}", "message");
+                types.Should().BeInNamespace(nameof(DummyNamespace), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be in namespace \"DummyNamespace\"" +
-                             " because we want to test the error message," +
-                             " but the following types are in a different namespace:*" +
-                             "*ClassNotInDummyNamespace*" +
-                             "*OtherClassNotInDummyNamespace*.");
+                .WithMessage("Expected all types to be in namespace \"DummyNamespace\" *failure message*, but the following types are in a different namespace:*\"*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
         }
 
         [Fact]
@@ -1540,8 +1492,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be in namespace \"DummyNamespace\"" +
-                             "*ClassInGlobalNamespace*");
+                .WithMessage("Expected all types to be in namespace \"DummyNamespace\", but the following types are in a different namespace:*\"ClassInGlobalNamespace\".");
         }
 
         [Fact]
@@ -1560,10 +1511,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be in namespace <null>" +
-                             "*ClassInDummyNamespace*" +
-                             "*ClassNotInDummyNamespace*" +
-                             "*OtherClassNotInDummyNamespace*");
+                .WithMessage("Expected all types to be in namespace <null>, but the following types are in a different namespace:*\"*.ClassInDummyNamespace*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
         }
 
         #endregion
@@ -1610,15 +1558,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                types.Should().NotBeInNamespace(nameof(DummyNamespace),
-                    "because we want to test the error {0}", "message");
+                types.Should().NotBeInNamespace(nameof(DummyNamespace), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected no types to be in namespace \"DummyNamespace\"" +
-                             " because we want to test the error message," +
-                             " but the following types are in the namespace:*" +
-                             "*DummyNamespace.ClassInDummyNamespace*.");
+                .WithMessage("Expected no types to be in namespace \"DummyNamespace\" *failure message*, but the following types are in the namespace:*\"DummyNamespace.ClassInDummyNamespace\".");
         }
 
         #endregion
@@ -1704,15 +1648,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                types.Should().BeUnderNamespace(nameof(DummyNamespace),
-                    "because we want to test the error {0}", "message");
+                types.Should().BeUnderNamespace(nameof(DummyNamespace), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                    .WithMessage("Expected the namespaces of all types to start with \"DummyNamespace\"" +
-                                 " because we want to test the error message," +
-                                 " but the namespaces of the following types do not start with it:*" +
-                                 "*ClassInDummyNamespaceTwo*");
+                    .WithMessage("Expected the namespaces of all types to start with \"DummyNamespace\" *failure message*, but the namespaces of the following types do not start with it:*\"*.ClassInDummyNamespaceTwo\".");
         }
 
         [Fact]
@@ -1731,8 +1671,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the namespaces of all types to start with \"DummyNamespace.InnerDummyNamespace\"" +
-                             "*ClassInDummyNamespace*");
+                .WithMessage("Expected the namespaces of all types to start with \"DummyNamespace.InnerDummyNamespace\", but the namespaces of the following types do not start with it:*\"*.ClassInDummyNamespace\".");
         }
 
         #endregion
@@ -1766,15 +1705,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                types.Should().NotBeUnderNamespace(nameof(DummyNamespace),
-                    "because we want to test the error {0}", "message");
+                types.Should().NotBeUnderNamespace(nameof(DummyNamespace), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the namespaces of all types to not start with \"DummyNamespace\"" +
-                             " because we want to test the error message," +
-                             " but the namespaces of the following types start with it:*" +
-                             "*ClassInDummyNamespace*");
+                .WithMessage("Expected the namespaces of all types to not start with \"DummyNamespace\" *failure message*, but the namespaces of the following types start with it:*\"*.ClassInDummyNamespace\".");
         }
 
         [Fact]
@@ -1789,8 +1724,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the namespaces of all types to not start with \"DummyNamespace.InnerDummyNamespace\"" +
-                             "*ClassInInnerDummyNamespace*");
+                .WithMessage("Expected the namespaces of all types to not start with \"DummyNamespace.InnerDummyNamespace\", but the namespaces of the following types start with it:*\"*.ClassInInnerDummyNamespace\".");
         }
 
         [Fact]
@@ -1804,8 +1738,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the namespaces of all types to not start with \"DummyNamespace\"" +
-                             "*ClassInInnerDummyNamespace*");
+                .WithMessage("Expected the namespaces of all types to not start with \"DummyNamespace\", but the namespaces of the following types start with it:*\"*.ClassInInnerDummyNamespace\".");
         }
 
         [Fact]
@@ -1819,8 +1752,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the namespaces of all types to not start with <null>" +
-                             "*ClassInGlobalNamespace*");
+                .WithMessage("Expected the namespaces of all types to not start with <null>, but the namespaces of the following types start with it:*\"ClassInGlobalNamespace\".");
         }
 
         [Fact]
@@ -1839,10 +1771,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the namespaces of all types to not start with <null>" +
-                             "*ClassInDummyNamespace*" +
-                             "*ClassNotInDummyNamespace*." +
-                             "*OtherClassNotInDummyNamespace*.");
+                .WithMessage("Expected the namespaces of all types to not start with <null>, but the namespaces of the following types start with it:*\"*.ClassInDummyNamespace*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
         }
 
         [Fact]
@@ -1870,9 +1799,9 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Theory]
-        [InlineData(typeof(ClassWithoutMembers), "Expected type FluentAssertions*ClassWithoutMembers to be sealed.")]
-        [InlineData(typeof(Abstract), "Expected type FluentAssertions*Abstract to be sealed.")]
-        [InlineData(typeof(Static), "Expected type FluentAssertions*Static to be sealed.")]
+        [InlineData(typeof(ClassWithoutMembers), "Expected type *.ClassWithoutMembers to be sealed.")]
+        [InlineData(typeof(Abstract), "Expected type *.Abstract to be sealed.")]
+        [InlineData(typeof(Static), "Expected type *.Static to be sealed.")]
         public void When_type_is_not_sealed_it_fails(Type type, string exceptionMessage)
         {
             // Act
@@ -1890,17 +1819,17 @@ namespace FluentAssertions.Specs.Types
             var type = typeof(ClassWithoutMembers);
 
             // Act
-            Action act = () => type.Should().BeSealed("it's {0} important", "very");
+            Action act = () => type.Should().BeSealed("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*ClassWithoutMembers to be sealed because it's very important.");
+                .WithMessage("Expected type *.ClassWithoutMembers to be sealed *failure message*.");
         }
 
         [Theory]
-        [InlineData(typeof(IDummyInterface), "FluentAssertions*IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "FluentAssertions*Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "FluentAssertions*ExampleDelegate must be a class.")]
+        [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "*.Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
         public void When_type_is_not_valid_for_BeSealed_it_throws_exception(Type type, string exceptionMessage)
         {
             // Act
@@ -1935,13 +1864,11 @@ namespace FluentAssertions.Specs.Types
             });
 
             // Act
-            Action act = () => types.Should().BeSealed("it's {0} important", "very");
+            Action act = () => types.Should().BeSealed("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be sealed because it's very important, but the following types are not:"
-                             + "*Abstract*"
-                             + ".");
+                .WithMessage("Expected all types to be sealed *failure message*, but the following types are not:*\"*.Abstract\".");
         }
 
         [Fact]
@@ -1984,7 +1911,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*Sealed not to be sealed.");
+                .WithMessage("Expected type *.Sealed not to be sealed.");
         }
 
         [Fact]
@@ -1994,17 +1921,17 @@ namespace FluentAssertions.Specs.Types
             var type = typeof(Sealed);
 
             // Act
-            Action act = () => type.Should().NotBeSealed("it's {0} important", "very");
+            Action act = () => type.Should().NotBeSealed("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*Sealed not to be sealed because it's very important.");
+                .WithMessage("Expected type *.Sealed not to be sealed *failure message*.");
         }
 
         [Theory]
-        [InlineData(typeof(IDummyInterface), "FluentAssertions*IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "FluentAssertions*Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "FluentAssertions*ExampleDelegate must be a class.")]
+        [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "*.Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
         public void When_type_is_not_valid_for_NotBeSealed_it_throws_exception(Type type, string exceptionMessage)
         {
             // Act
@@ -2039,13 +1966,11 @@ namespace FluentAssertions.Specs.Types
             });
 
             // Act
-            Action act = () => types.Should().NotBeSealed("it's {0} important", "very");
+            Action act = () => types.Should().NotBeSealed("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types not to be sealed because it's very important, but the following types are:"
-                             + "*Sealed*"
-                             + ".");
+                .WithMessage("Expected all types not to be sealed *failure message*, but the following types are:*\"*.Sealed\".");
         }
 
         [Fact]
@@ -2075,9 +2000,9 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Theory]
-        [InlineData(typeof(ClassWithoutMembers), "Expected type FluentAssertions*ClassWithoutMembers to be abstract.")]
-        [InlineData(typeof(Sealed), "Expected type FluentAssertions*Sealed to be abstract.")]
-        [InlineData(typeof(Static), "Expected type FluentAssertions*Static to be abstract.")]
+        [InlineData(typeof(ClassWithoutMembers), "Expected type *.ClassWithoutMembers to be abstract.")]
+        [InlineData(typeof(Sealed), "Expected type *.Sealed to be abstract.")]
+        [InlineData(typeof(Static), "Expected type *.Static to be abstract.")]
         public void When_type_is_not_abstract_it_fails(Type type, string exceptionMessage)
         {
             // Act
@@ -2095,17 +2020,17 @@ namespace FluentAssertions.Specs.Types
             var type = typeof(ClassWithoutMembers);
 
             // Act
-            Action act = () => type.Should().BeAbstract("it's {0} important", "very");
+            Action act = () => type.Should().BeAbstract("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*ClassWithoutMembers to be abstract because it's very important.");
+                .WithMessage("Expected type *.ClassWithoutMembers to be abstract *failure message*.");
         }
 
         [Theory]
-        [InlineData(typeof(IDummyInterface), "FluentAssertions*IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "FluentAssertions*Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "FluentAssertions*ExampleDelegate must be a class.")]
+        [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "*.Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
         public void When_type_is_not_valid_for_BeAbstract_it_throws_exception(Type type, string exceptionMessage)
         {
             // Act
@@ -2156,7 +2081,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*Abstract not to be abstract.");
+                .WithMessage("Expected type *.Abstract not to be abstract.");
         }
 
         [Fact]
@@ -2166,17 +2091,17 @@ namespace FluentAssertions.Specs.Types
             var type = typeof(Abstract);
 
             // Act
-            Action act = () => type.Should().NotBeAbstract("it's {0} important", "very");
+            Action act = () => type.Should().NotBeAbstract("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*Abstract not to be abstract because it's very important.");
+                .WithMessage("Expected type *.Abstract not to be abstract *failure message*.");
         }
 
         [Theory]
-        [InlineData(typeof(IDummyInterface), "FluentAssertions*IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "FluentAssertions*Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "FluentAssertions*ExampleDelegate must be a class.")]
+        [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "*.Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
         public void When_type_is_not_valid_for_NotBeAbstract_it_throws_exception(Type type, string exceptionMessage)
         {
             // Act
@@ -2214,9 +2139,9 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Theory]
-        [InlineData(typeof(ClassWithoutMembers), "Expected type FluentAssertions*ClassWithoutMembers to be static.")]
-        [InlineData(typeof(Sealed), "Expected type FluentAssertions*Sealed to be static.")]
-        [InlineData(typeof(Abstract), "Expected type FluentAssertions*Abstract to be static.")]
+        [InlineData(typeof(ClassWithoutMembers), "Expected type *.ClassWithoutMembers to be static.")]
+        [InlineData(typeof(Sealed), "Expected type *.Sealed to be static.")]
+        [InlineData(typeof(Abstract), "Expected type *.Abstract to be static.")]
         public void When_type_is_not_static_it_fails(Type type, string exceptionMessage)
         {
             // Act
@@ -2234,17 +2159,17 @@ namespace FluentAssertions.Specs.Types
             var type = typeof(ClassWithoutMembers);
 
             // Act
-            Action act = () => type.Should().BeStatic("it's {0} important", "very");
+            Action act = () => type.Should().BeStatic("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*ClassWithoutMembers to be static because it's very important.");
+                .WithMessage("Expected type *.ClassWithoutMembers to be static *failure message*.");
         }
 
         [Theory]
-        [InlineData(typeof(IDummyInterface), "FluentAssertions*IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "FluentAssertions*Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "FluentAssertions*ExampleDelegate must be a class.")]
+        [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "*.Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
         public void When_type_is_not_valid_for_BeStatic_it_throws_exception(Type type, string exceptionMessage)
         {
             // Act
@@ -2295,7 +2220,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*Static not to be static.");
+                .WithMessage("Expected type *.Static not to be static.");
         }
 
         [Fact]
@@ -2305,17 +2230,17 @@ namespace FluentAssertions.Specs.Types
             var type = typeof(Static);
 
             // Act
-            Action act = () => type.Should().NotBeStatic("it's {0} important", "very");
+            Action act = () => type.Should().NotBeStatic("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*Static not to be static because it's very important.");
+                .WithMessage("Expected type *.Static not to be static *failure message*.");
         }
 
         [Theory]
-        [InlineData(typeof(IDummyInterface), "FluentAssertions*IDummyInterface must be a class.")]
-        [InlineData(typeof(Struct), "FluentAssertions*Struct must be a class.")]
-        [InlineData(typeof(ExampleDelegate), "FluentAssertions*ExampleDelegate must be a class.")]
+        [InlineData(typeof(IDummyInterface), "*.IDummyInterface must be a class.")]
+        [InlineData(typeof(Struct), "*.Struct must be a class.")]
+        [InlineData(typeof(ExampleDelegate), "*.ExampleDelegate must be a class.")]
         public void When_type_is_not_valid_for_NotBeStatic_it_throws_exception(Type type, string exceptionMessage)
         {
             // Act
@@ -2367,13 +2292,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().Implement(typeof(IDummyInterface), "because we want to test the error {0}", "message");
+                type.Should().Implement(typeof(IDummyInterface), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*ClassThatDoesNotImplementInterface to implement " +
-                             "interface FluentAssertions*IDummyInterface because we want to test the error message, " +
-                             "but it does not.");
+                .WithMessage("Expected type *.ClassThatDoesNotImplementInterface to implement interface *.IDummyInterface *failure message*, but it does not.");
         }
 
         [Fact]
@@ -2384,11 +2307,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().Implement(typeof(DateTime), "because we want to test the error {0}", "message");
+                type.Should().Implement(typeof(DateTime), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassThatDoesNotImplementInterface to implement interface *.DateTime *error message*, but *.DateTime is not an interface.");
+                .WithMessage("Expected type *.ClassThatDoesNotImplementInterface to implement interface *.DateTime *failure message*, but *.DateTime is not an interface.");
         }
 
         [Fact]
@@ -2450,12 +2373,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotImplement(typeof(IDummyInterface), "because we want to test the error {0}", "message");
+                type.Should().NotImplement(typeof(IDummyInterface), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*ClassThatImplementsInterface to not implement interface " +
-                             "FluentAssertions*IDummyInterface because we want to test the error message, but it does.");
+                .WithMessage("Expected type *.ClassThatImplementsInterface to not implement interface *.IDummyInterface *failure message*, but it does.");
         }
 
         [Fact]
@@ -2466,11 +2388,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotImplement(typeof(DateTime), "because we want to test the error {0}", "message");
+                type.Should().NotImplement(typeof(DateTime), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassThatDoesNotImplementInterface to not implement interface *.DateTime *error message*, but *.DateTime is not an interface.");
+                .WithMessage("Expected type *.ClassThatDoesNotImplementInterface to not implement interface *.DateTime *failure message*, but *.DateTime is not an interface.");
         }
 
         [Fact]
@@ -2536,13 +2458,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveProperty(typeof(string), "PublicProperty", "because we want to test the error {0}", "message");
+                type.Should().HaveProperty(typeof(string), "PublicProperty", "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected String FluentAssertions*ClassWithNoMembers.PublicProperty to exist because we want to " +
-                    "test the error message, but it does not.");
+                .WithMessage("Expected String *.ClassWithNoMembers.PublicProperty to exist *failure message*, but it does not.");
         }
 
         [Fact]
@@ -2553,12 +2473,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveProperty(typeof(int), "PrivateWriteProtectedReadProperty", "because we want to test the error {0}", "message");
+                type.Should().HaveProperty(typeof(int), "PrivateWriteProtectedReadProperty", "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected String FluentAssertions*ClassWithMembers.PrivateWriteProtectedReadProperty to be of type System.Int32 because we want to test the error message, but it is not.");
+                .WithMessage("Expected String *.ClassWithMembers.PrivateWriteProtectedReadProperty to be of type System.Int32 *failure message*, but it is not.");
         }
 
         [Fact]
@@ -2699,13 +2618,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveProperty("PrivateWriteProtectedReadProperty", "because we want to test the error {0}", "message");
+                type.Should().NotHaveProperty("PrivateWriteProtectedReadProperty", "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected String FluentAssertions*ClassWithMembers.PrivateWriteProtectedReadProperty to not exist because we want to " +
-                    "test the error message, but it does.");
+                .WithMessage("Expected String *.ClassWithMembers.PrivateWriteProtectedReadProperty to not exist *failure message*, but it does.");
         }
 
         [Fact]
@@ -2806,9 +2723,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to explicitly implement " +
-                    "FluentAssertions*IExplicitInterface.ImplicitStringProperty, but it does not.");
+                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to explicitly implement *.IExplicitInterface.ImplicitStringProperty, but it does not.");
         }
 
         [Fact]
@@ -2826,9 +2741,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to explicitly implement " +
-                    "FluentAssertions*IExplicitInterface.NonExistentProperty, but it does not.");
+                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to explicitly implement *.IExplicitInterface.NonExistentProperty, but it does not.");
         }
 
         [Fact]
@@ -2846,9 +2759,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type FluentAssertions*ClassExplicitlyImplementingInterface to implement interface " +
-                    "FluentAssertions*IDummyInterface, but it does not.");
+                .WithMessage("Expected type *.ClassExplicitlyImplementingInterface to implement interface *.IDummyInterface, but it does not.");
         }
 
         [Fact]
@@ -2994,9 +2905,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "FluentAssertions*IExplicitInterface.ExplicitStringProperty, but it does.");
+                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitStringProperty, but it does.");
         }
 
         [Fact]
@@ -3014,9 +2923,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "FluentAssertions*IExplicitInterface.ExplicitImplicitStringProperty, but it does.");
+                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitImplicitStringProperty, but it does.");
         }
 
         [Fact]
@@ -3068,8 +2975,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*ClassExplicitlyImplementingInterface to implement interface " +
-                             "FluentAssertions*IDummyInterface, but it does not.");
+                .WithMessage("Expected type *.ClassExplicitlyImplementingInterface to implement interface *.IDummyInterface, but it does not.");
         }
 
         [Fact]
@@ -3149,9 +3055,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "FluentAssertions*IExplicitInterface.ExplicitStringProperty, but it does.");
+                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitStringProperty, but it does.");
         }
 
         [Fact]
@@ -3252,9 +3156,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to explicitly implement " +
-                    "FluentAssertions*IExplicitInterface.ImplicitMethod, but it does not.");
+                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to explicitly implement *.IExplicitInterface.ImplicitMethod, but it does not.");
         }
 
         [Fact]
@@ -3272,9 +3174,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to explicitly implement " +
-                    "FluentAssertions*IExplicitInterface.NonExistentMethod, but it does not.");
+                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to explicitly implement *.IExplicitInterface.NonExistentMethod, but it does not.");
         }
 
         [Fact]
@@ -3292,9 +3192,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type FluentAssertions*ClassExplicitlyImplementingInterface to implement interface " +
-                    "FluentAssertions*IDummyInterface, but it does not.");
+                .WithMessage("Expected type *.ClassExplicitlyImplementingInterface to implement interface *.IDummyInterface, but it does not.");
         }
 
         [Fact]
@@ -3470,9 +3368,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "FluentAssertions*IExplicitInterface.ExplicitMethod, but it does.");
+                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitMethod, but it does.");
         }
 
         [Fact]
@@ -3490,9 +3386,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "FluentAssertions*IExplicitInterface.ExplicitImplicitMethod, but it does.");
+                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitImplicitMethod, but it does.");
         }
 
         [Fact]
@@ -3544,8 +3438,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*ClassExplicitlyImplementingInterface to implement interface " +
-                             "FluentAssertions*IDummyInterface, but it does not.");
+                .WithMessage("Expected type *.ClassExplicitlyImplementingInterface to implement interface *.IDummyInterface, but it does not.");
         }
 
         [Fact]
@@ -3640,9 +3533,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected FluentAssertions*ClassExplicitlyImplementingInterface to not explicitly implement " +
-                    "FluentAssertions*IExplicitInterface.ExplicitMethod, but it does.");
+                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitMethod, but it does.");
         }
 
         [Fact]
@@ -3735,13 +3626,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveIndexer(typeof(string), new[] { typeof(int), typeof(Type) }, "because we want to test the error {0}", "message");
+                type.Should().HaveIndexer(typeof(string), new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected String FluentAssertions*ClassWithNoMembers[System.Int32, System.Type] to exist because we want to test the error" +
-                    " message, but it does not.");
+                .WithMessage("Expected String *.ClassWithNoMembers[System.Int32, System.Type] to exist *failure message*, but it does not.");
         }
 
         [Fact]
@@ -3752,13 +3641,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveIndexer(typeof(string), new[] { typeof(int), typeof(Type) }, "because we want to test the error {0}", "message");
+                type.Should().HaveIndexer(typeof(string), new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected String FluentAssertions*ClassWithMembers[System.Int32, System.Type] to exist because we want to test the error" +
-                    " message, but it does not.");
+                .WithMessage("Expected String *.ClassWithMembers[System.Int32, System.Type] to exist *failure message*, but it does not.");
         }
 
         [Fact]
@@ -3832,13 +3719,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveIndexer(new[] { typeof(string) }, "because we want to test the error {0}", "message");
+                type.Should().NotHaveIndexer(new[] { typeof(string) }, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected indexer FluentAssertions*ClassWithMembers[System.String] to not exist because we want to " +
-                    "test the error message, but it does.");
+                .WithMessage("Expected indexer *.ClassWithMembers[System.String] to not exist *failure message*, but it does.");
         }
 
         [Fact]
@@ -3900,13 +3785,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveConstructor(new[] { typeof(int), typeof(Type) }, "because we want to test the error {0}", "message");
+                type.Should().HaveConstructor(new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected constructor FluentAssertions*ClassWithNoMembers(System.Int32, System.Type) to exist because " +
-                    "we want to test the error message, but it does not.");
+                .WithMessage("Expected constructor *.ClassWithNoMembers(System.Int32, System.Type) to exist *failure message*, but it does not.");
         }
 
         [Fact]
@@ -3969,7 +3852,7 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 type.Should()
-                    .HaveDefaultConstructor("because the compiler generates one even if not explicitly defined.")
+                    .HaveDefaultConstructor()
                     .Which.Should()
                         .HaveAccessModifier(CSharpAccessModifier.Public);
 
@@ -3985,7 +3868,7 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             type.Should()
-                    .HaveDefaultConstructor("because the compiler generates one even if not explicitly defined.")
+                    .HaveDefaultConstructor()
                     .Which.Should()
                         .HaveAccessModifier(CSharpAccessModifier.Public);
             Action act = () =>
@@ -4006,13 +3889,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveDefaultConstructor("because we want to test the error {0}", "message");
+                type.Should().HaveDefaultConstructor("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected constructor FluentAssertions*ClassWithCctorAndNonDefaultConstructor() to exist because we " +
-                    "want to test the error message, but it does not.");
+                .WithMessage("Expected constructor *.ClassWithCctorAndNonDefaultConstructor() to exist *failure message*, but it does not.");
         }
 
         [Fact]
@@ -4057,13 +3938,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveConstructor(new[] { typeof(string) }, "because we want to test the error {0}", "message");
+                type.Should().NotHaveConstructor(new[] { typeof(string) }, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected constructor*ClassWithMembers(System.String) not to exist because " +
-                    "we want to test the error message, but it does.");
+                .WithMessage("Expected constructor *.ClassWithMembers(System.String) not to exist *failure message*, but it does.");
         }
 
         [Fact]
@@ -4124,13 +4003,11 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 type.Should()
-                    .NotHaveDefaultConstructor("because we want to test the error {0}", "message");
+                    .NotHaveDefaultConstructor("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected constructor*ClassWithMembers() not to exist because " +
-                    "we want to test the error message, but it does.");
+                .WithMessage("Expected constructor *.ClassWithMembers() not to exist *failure message*, but it does.");
         }
 
         [Fact]
@@ -4140,14 +4017,12 @@ namespace FluentAssertions.Specs.Types
             var type = typeof(ClassWithCctor);
 
             // Act
-            Action act = () => type.Should()
-                .NotHaveDefaultConstructor("because we want to test the error {0}", "message");
+            Action act = () =>
+                type.Should().NotHaveDefaultConstructor("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected constructor*ClassWithCctor*() not to exist because we " +
-                    "want to test the error message, but it does.");
+                .WithMessage("Expected constructor *.ClassWithCctor*() not to exist *failure message*, but it does.");
         }
 
         [Fact]
@@ -4209,13 +4084,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveMethod("NonExistentMethod", new[] { typeof(int), typeof(Type) }, "because we want to test the error {0}", "message");
+                type.Should().HaveMethod("NonExistentMethod", new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method FluentAssertions*ClassWithNoMembers.NonExistentMethod(System.Int32, System.Type) to exist " +
-                    "because we want to test the error message, but it does not.");
+                .WithMessage("Expected method *.ClassWithNoMembers.NonExistentMethod(System.Int32, System.Type) to exist *failure message*, but it does not.");
         }
 
         [Fact]
@@ -4226,13 +4099,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveMethod("VoidMethod", new[] { typeof(int), typeof(Type) }, "because we want to test the error {0}", "message");
+                type.Should().HaveMethod("VoidMethod", new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method FluentAssertions*ClassWithMembers.VoidMethod(System.Int32, System.Type) to exist " +
-                    "because we want to test the error message, but it does not.");
+                .WithMessage("Expected method *.ClassWithMembers.VoidMethod(System.Int32, System.Type) to exist *failure message*, but it does not.");
         }
 
         [Fact]
@@ -4335,13 +4206,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveMethod("VoidMethod", new Type[] { }, "because we want to test the error {0}", "message");
+                type.Should().NotHaveMethod("VoidMethod", new Type[] { }, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected method Void FluentAssertions*ClassWithMembers.VoidMethod() to not exist because we want to " +
-                    "test the error message, but it does.");
+                .WithMessage("Expected method Void *.ClassWithMembers.VoidMethod() to not exist *failure message*, but it does.");
         }
 
         [Fact]
@@ -4432,12 +4301,11 @@ namespace FluentAssertions.Specs.Types
             Action act = () =>
                 type
                     .Should()
-                    .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the error {0}", "message");
+                    .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type IPublicInterface to be Internal because we want to test the error message, but it " +
-                             "is Public.");
+                .WithMessage("Expected type IPublicInterface to be Internal *failure message*, but it is Public.");
         }
 
         [Fact]
@@ -4462,13 +4330,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "because we want to test the" +
-                                                                                                " error {0}", "message");
+                type.Should().HaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type InternalClass to be ProtectedInternal because we want to test the error message, " +
-                             "but it is Internal.");
+                .WithMessage("Expected type InternalClass to be ProtectedInternal *failure message*, but it is Internal.");
         }
 
         [Fact]
@@ -4493,12 +4359,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the error {0}", "message");
+                type.Should().HaveAccessModifier(CSharpAccessModifier.Protected, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type PrivateClass to be Protected because we want to test the error message, but it " +
-                             "is Private.");
+                .WithMessage("Expected type PrivateClass to be Protected *failure message*, but it is Private.");
         }
 
         [Fact]
@@ -4554,12 +4419,11 @@ namespace FluentAssertions.Specs.Types
             Action act = () =>
                 type
                     .Should()
-                    .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the error {0}", "message");
+                    .HaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type IPublicInterface to be Internal because we want to test the error message, " +
-                             "but it is Public.");
+                .WithMessage("Expected type IPublicInterface to be Internal *failure message*, but it is Public.");
         }
 
         [Fact]
@@ -4584,13 +4448,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "because we want to test the" +
-                                                                                                " error {0}", "message");
+                type.Should().HaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type InternalClass to be ProtectedInternal because we want to test the error message, " +
-                             "but it is Internal.");
+                .WithMessage("Expected type InternalClass to be ProtectedInternal *failure message*, but it is Internal.");
         }
 
         [Fact]
@@ -4615,12 +4477,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.Private, "we want to test the error {0}", "message");
+                type.Should().HaveAccessModifier(CSharpAccessModifier.Private, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type IProtectedInternalInterface to be Private because we want to test the error " +
-                             "message, but it is ProtectedInternal.");
+                .WithMessage("Expected type IProtectedInternalInterface to be Private *failure message*, but it is ProtectedInternal.");
         }
 
         [Fact]
@@ -4681,12 +4542,11 @@ namespace FluentAssertions.Specs.Types
             Action act = () =>
                 type
                     .Should()
-                    .NotHaveAccessModifier(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
+                    .NotHaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type IPublicInterface not to be Public because we want to test the error message, but it " +
-                             "is.");
+                .WithMessage("Expected type IPublicInterface not to be Public *failure message*, but it is.");
         }
 
         [Fact]
@@ -4711,13 +4571,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal, "because we want to test the" +
-                                                                                                " error {0}", "message");
+                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type InternalClass not to be Internal because we want to test the error message, " +
-                             "but it is.");
+                .WithMessage("Expected type InternalClass not to be Internal *failure message*, but it is.");
         }
 
         [Fact]
@@ -4742,12 +4600,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Private, "we want to test the error {0}", "message");
+                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Private, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type PrivateClass not to be Private because we want to test the error message, but it " +
-                             "is.");
+                .WithMessage("Expected type PrivateClass not to be Private *failure message*, but it is.");
         }
 
         [Fact]
@@ -4803,12 +4660,11 @@ namespace FluentAssertions.Specs.Types
             Action act = () =>
                 type
                     .Should()
-                    .NotHaveAccessModifier(CSharpAccessModifier.Public, "we want to test the error {0}", "message");
+                    .NotHaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type IPublicInterface not to be Public because we want to test the error message, " +
-                             "but it is.");
+                .WithMessage("Expected type IPublicInterface not to be Public *failure message*, but it is.");
         }
 
         [Fact]
@@ -4833,13 +4689,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal, "because we want to test the" +
-                                                                                                " error {0}", "message");
+                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Internal, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type InternalClass not to be Internal because we want to test the error message, " +
-                             "but it is.");
+                .WithMessage("Expected type InternalClass not to be Internal *failure message*, but it is.");
         }
 
         [Fact]
@@ -4864,12 +4718,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "we want to test the error {0}", "message");
+                type.Should().NotHaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type IProtectedInternalInterface not to be ProtectedInternal because we want to test the error " +
-                             "message, but it is.");
+                .WithMessage("Expected type IProtectedInternalInterface not to be ProtectedInternal *failure message*, but it is.");
         }
 
         [Fact]
@@ -4935,13 +4788,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveExplicitConversionOperator(sourceType, targetType, "because we want to test the error {0}", "message");
+                type.Should().HaveExplicitConversionOperator(sourceType, targetType, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit System.String(FluentAssertions*TypeWithConversionOperators) to exist " +
-                    "because we want to test the error message, but it does not.");
+                .WithMessage("Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*, but it does not.");
         }
 
         [Fact]
@@ -4952,7 +4803,7 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveExplicitConversionOperator(typeof(TypeWithConversionOperators), typeof(string), "because we want to test the failure {0}", "message");
+                type.Should().HaveExplicitConversionOperator(typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -5018,13 +4869,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveExplicitConversionOperator<TypeWithConversionOperators, string>("because we want to test the error {0}", "message");
+                type.Should().HaveExplicitConversionOperator<TypeWithConversionOperators, string>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit System.String(FluentAssertions*TypeWithConversionOperators) to exist " +
-                    "because we want to test the error message, but it does not.");
+                .WithMessage("Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*, but it does not.");
         }
 
         [Fact]
@@ -5035,7 +4884,7 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveExplicitConversionOperator<TypeWithConversionOperators, string>("because we want to test the failure {0}", "message");
+                type.Should().HaveExplicitConversionOperator<TypeWithConversionOperators, string>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -5073,13 +4922,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveExplicitConversionOperator(sourceType, targetType, "because we want to test the error {0}", "message");
+                type.Should().NotHaveExplicitConversionOperator(sourceType, targetType, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit System.Byte(FluentAssertions*TypeWithConversionOperators) to not exist " +
-                    "because we want to test the error message, but it does.");
+                .WithMessage("Expected public static explicit System.Byte(*.TypeWithConversionOperators) to not exist *failure message*, but it does.");
         }
 
         [Fact]
@@ -5090,7 +4937,7 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveExplicitConversionOperator(typeof(TypeWithConversionOperators), typeof(string), "because we want to test the failure {0}", "message");
+                type.Should().NotHaveExplicitConversionOperator(typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -5154,13 +5001,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveExplicitConversionOperator<TypeWithConversionOperators, byte>("because we want to test the error {0}", "message");
+                type.Should().NotHaveExplicitConversionOperator<TypeWithConversionOperators, byte>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static explicit System.Byte(FluentAssertions*TypeWithConversionOperators) to not exist " +
-                    "because we want to test the error message, but it does.");
+                .WithMessage("Expected public static explicit System.Byte(*.TypeWithConversionOperators) to not exist *failure message*, but it does.");
         }
 
         #endregion
@@ -5196,13 +5041,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveImplicitConversionOperator(sourceType, targetType, "because we want to test the error {0}", "message");
+                type.Should().HaveImplicitConversionOperator(sourceType, targetType, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit System.String(FluentAssertions*TypeWithConversionOperators) to exist " +
-                    "because we want to test the error message, but it does not.");
+                .WithMessage("Expected public static implicit System.String(*.TypeWithConversionOperators) to exist *failure message*, but it does not.");
         }
 
         [Fact]
@@ -5213,7 +5056,7 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveImplicitConversionOperator(typeof(TypeWithConversionOperators), typeof(string), "because we want to test the failure {0}", "message");
+                type.Should().HaveImplicitConversionOperator(typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -5279,13 +5122,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveImplicitConversionOperator<TypeWithConversionOperators, string>("because we want to test the error {0}", "message");
+                type.Should().HaveImplicitConversionOperator<TypeWithConversionOperators, string>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit System.String(FluentAssertions*TypeWithConversionOperators) to exist " +
-                    "because we want to test the error message, but it does not.");
+                .WithMessage("Expected public static implicit System.String(*.TypeWithConversionOperators) to exist *failure message*, but it does not.");
         }
 
         [Fact]
@@ -5296,7 +5137,7 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveImplicitConversionOperator<TypeWithConversionOperators, string>("because we want to test the failure {0}", "message");
+                type.Should().HaveImplicitConversionOperator<TypeWithConversionOperators, string>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -5334,13 +5175,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator(sourceType, targetType, "because we want to test the error {0}", "message");
+                type.Should().NotHaveImplicitConversionOperator(sourceType, targetType, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit System.Int32(FluentAssertions*TypeWithConversionOperators) to not exist " +
-                    "because we want to test the error message, but it does.");
+                .WithMessage("Expected public static implicit System.Int32(*.TypeWithConversionOperators) to not exist *failure message*, but it does.");
         }
 
         [Fact]
@@ -5351,7 +5190,7 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator(typeof(TypeWithConversionOperators), typeof(string), "because we want to test the failure {0}", "message");
+                type.Should().NotHaveImplicitConversionOperator(typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -5415,13 +5254,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator<TypeWithConversionOperators, int>("because we want to test the error {0}", "message");
+                type.Should().NotHaveImplicitConversionOperator<TypeWithConversionOperators, int>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected public static implicit System.Int32(FluentAssertions*TypeWithConversionOperators) to not exist " +
-                    "because we want to test the error message, but it does.");
+                .WithMessage("Expected public static implicit System.Int32(*.TypeWithConversionOperators) to not exist *failure message*, but it does.");
         }
 
         [Fact]
@@ -5432,7 +5269,7 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator<TypeWithConversionOperators, string>("because we want to test the failure {0}", "message");
+                type.Should().NotHaveImplicitConversionOperator<TypeWithConversionOperators, string>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using DummyNamespace;
 using DummyNamespace.InnerDummyNamespace;
@@ -3215,7 +3214,7 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 type.Should()
-                    .HaveExplicitMethod(interfaceType, "ExplicitMethod", Enumerable.Empty<Type>());
+                    .HaveExplicitMethod(interfaceType, "ExplicitMethod", new Type[0]);
 
             // Assert
             act.Should().NotThrow();
@@ -3232,7 +3231,7 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 type.Should()
-                    .HaveExplicitMethod(interfaceType, "ExplicitImplicitMethod", Enumerable.Empty<Type>());
+                    .HaveExplicitMethod(interfaceType, "ExplicitImplicitMethod", new Type[0]);
 
             // Assert
             act.Should().NotThrow();
@@ -3249,7 +3248,7 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 type.Should()
-                    .HaveExplicitMethod(interfaceType, "ImplicitMethod", Enumerable.Empty<Type>());
+                    .HaveExplicitMethod(interfaceType, "ImplicitMethod", new Type[0]);
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -3269,7 +3268,7 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 type.Should()
-                    .HaveExplicitMethod(interfaceType, "NonExistentMethod", Enumerable.Empty<Type>());
+                    .HaveExplicitMethod(interfaceType, "NonExistentMethod", new Type[0]);
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -3289,7 +3288,7 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 type.Should()
-                    .HaveExplicitMethod(interfaceType, "NonExistentProperty", Enumerable.Empty<Type>());
+                    .HaveExplicitMethod(interfaceType, "NonExistentProperty", new Type[0]);
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -3386,7 +3385,7 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 type.Should()
-                    .HaveExplicitMethod<IExplicitInterface>("ExplicitMethod", Enumerable.Empty<Type>());
+                    .HaveExplicitMethod<IExplicitInterface>("ExplicitMethod", new Type[0]);
 
             // Assert
             act.Should().NotThrow();
@@ -3467,7 +3466,7 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 type.Should()
-                    .NotHaveExplicitMethod(interfaceType, "ExplicitMethod", Enumerable.Empty<Type>());
+                    .NotHaveExplicitMethod(interfaceType, "ExplicitMethod", new Type[0]);
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -3487,7 +3486,7 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 type.Should()
-                    .NotHaveExplicitMethod(interfaceType, "ExplicitImplicitMethod", Enumerable.Empty<Type>());
+                    .NotHaveExplicitMethod(interfaceType, "ExplicitImplicitMethod", new Type[0]);
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -3507,7 +3506,7 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 type.Should()
-                    .NotHaveExplicitMethod(interfaceType, "ImplicitMethod", Enumerable.Empty<Type>());
+                    .NotHaveExplicitMethod(interfaceType, "ImplicitMethod", new Type[0]);
 
             // Assert
             act.Should().NotThrow();
@@ -3524,7 +3523,7 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 type.Should()
-                    .NotHaveExplicitMethod(interfaceType, "NonExistentMethod", Enumerable.Empty<Type>());
+                    .NotHaveExplicitMethod(interfaceType, "NonExistentMethod", new Type[0]);
 
             // Assert
             act.Should().NotThrow();
@@ -3541,7 +3540,7 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 type.Should()
-                    .NotHaveExplicitMethod(interfaceType, "NonExistentMethod", Enumerable.Empty<Type>());
+                    .NotHaveExplicitMethod(interfaceType, "NonExistentMethod", new Type[0]);
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -3637,7 +3636,7 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 type.Should()
-                    .NotHaveExplicitMethod<IExplicitInterface>("ExplicitMethod", Enumerable.Empty<Type>());
+                    .NotHaveExplicitMethod<IExplicitInterface>("ExplicitMethod", new Type[0]);
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
@@ -259,7 +259,9 @@ namespace FluentAssertions.Specs.Types
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected someType *.DummyImplementingClass to be assignable to *.DateTime *failure message*, but it is not.");
+                .WithMessage(
+                    "Expected someType *.DummyImplementingClass to be assignable to *.DateTime *failure message*" +
+                    ", but it is not.");
         }
 
         [Fact]
@@ -331,7 +333,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected someType *.IDummyInterface to be assignable to *.IDummyInterface`1[T] *failure message*, but it is not.");
+                .WithMessage(
+                    "Expected someType *.IDummyInterface to be assignable to *.IDummyInterface`1[T] *failure message*" +
+                    ", but it is not.");
         }
 
         [Fact]
@@ -339,7 +343,8 @@ namespace FluentAssertions.Specs.Types
         {
             // Arrange
             Type someType = typeof(ClassWithAttribute);
-            Action act = () => someType.Should().BeAssignableTo(typeof(DummyBaseType<>), "we want to test the failure {0}", "message");
+            Action act = () =>
+                someType.Should().BeAssignableTo(typeof(DummyBaseType<>), "we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
@@ -376,33 +381,49 @@ namespace FluentAssertions.Specs.Types
         public void When_its_own_type_and_asserting_not_assignable_it_fails()
         {
             // Arrange
-            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo<DummyImplementingClass>("we want to test the failure {0}", "message");
+            var type = typeof(DummyImplementingClass);
 
-            // Act / Assert
+            // Act
+            Action act = () =>
+                type.Should().NotBeAssignableTo<DummyImplementingClass>("we want to test the failure {0}", "message");
+
+            // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected typeof(DummyImplementingClass) *.DummyImplementingClass to not be assignable to *.DummyImplementingClass *failure message*");
+                .WithMessage(
+                    "Expected type *.DummyImplementingClass to not be assignable to *.DummyImplementingClass *failure message*");
         }
 
         [Fact]
         public void When_its_base_type_and_asserting_not_assignable_it_fails()
         {
             // Arrange
-            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo<DummyBaseClass>("we want to test the failure {0}", "message");
+            var type = typeof(DummyImplementingClass);
 
-            // Act / Assert
+            // Act
+            Action act = () =>
+                type.Should().NotBeAssignableTo<DummyBaseClass>("we want to test the failure {0}", "message");
+
+            // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected typeof(DummyImplementingClass) *.DummyImplementingClass to not be assignable to *.DummyBaseClass *failure message*, but it is.");
+                .WithMessage(
+                    "Expected type *.DummyImplementingClass to not be assignable to *.DummyBaseClass *failure message*" +
+                    ", but it is.");
         }
 
         [Fact]
         public void When_implemented_interface_type_and_asserting_not_assignable_it_fails()
         {
             // Arrange
-            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo<IDisposable>("we want to test the failure {0}", "message");
+            var type = typeof(DummyImplementingClass);
 
-            // Act / Assert
+            // Act
+            Action act = () =>
+                type.Should().NotBeAssignableTo<IDisposable>("we want to test the failure {0}", "message");
+
+            // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected typeof(DummyImplementingClass) *.DummyImplementingClass to not be assignable to *.IDisposable *failure message*, but it is.");
+                .WithMessage(
+                    "Expected type *.DummyImplementingClass to not be assignable to *.IDisposable *failure message*, but it is.");
         }
 
         [Fact]
@@ -416,33 +437,50 @@ namespace FluentAssertions.Specs.Types
         public void When_its_own_type_instance_and_asserting_not_assignable_it_fails()
         {
             // Arrange
-            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(DummyImplementingClass), "we want to test the failure {0}", "message");
+            var type = typeof(DummyImplementingClass);
+
+            // Act
+            Action act = () =>
+                type.Should().NotBeAssignableTo(typeof(DummyImplementingClass), "we want to test the failure {0}", "message");
 
             // Act / Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected typeof(DummyImplementingClass) *.DummyImplementingClass to not be assignable to *.DummyImplementingClass *failure message*, but it is.");
+                .WithMessage(
+                    "Expected type *.DummyImplementingClass to not be assignable to *.DummyImplementingClass *failure message*" +
+                    ", but it is.");
         }
 
         [Fact]
         public void When_its_base_type_instance_and_asserting_not_assignable_it_fails()
         {
             // Arrange
-            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(DummyBaseClass), "we want to test the failure {0}", "message");
+            var type = typeof(DummyImplementingClass);
 
-            // Act / Assert
+            // Act
+            Action act = () =>
+                type.Should().NotBeAssignableTo(typeof(DummyBaseClass), "we want to test the failure {0}", "message");
+
+            // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected typeof(DummyImplementingClass) *.DummyImplementingClass to not be assignable to *.DummyBaseClass *failure message*, but it is.");
+                .WithMessage(
+                    "Expected type *.DummyImplementingClass to not be assignable to *.DummyBaseClass *failure message*" +
+                    ", but it is.");
         }
 
         [Fact]
         public void When_an_implemented_interface_type_instance_and_asserting_not_assignable_it_fails()
         {
             // Arrange
-            Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(IDisposable), "we want to test the failure {0}", "message");
+            var type = typeof(DummyImplementingClass);
 
-            // Act / Assert
+            // Act
+            Action act = () =>
+                type.Should().NotBeAssignableTo(typeof(IDisposable), "we want to test the failure {0}", "message");
+
+            // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected typeof(DummyImplementingClass) *.DummyImplementingClass to not be assignable to *.IDisposable *failure message*, but it is.");
+                .WithMessage(
+                    "Expected type *.DummyImplementingClass to not be assignable to *.IDisposable *failure message*, but it is.");
         }
 
         [Fact]
@@ -470,24 +508,34 @@ namespace FluentAssertions.Specs.Types
         public void When_implementation_of_open_generic_interface_and_asserting_not_assignable_it_fails()
         {
             // Arrange
-            Type someType = typeof(ClassWithGenericBaseType);
-            Action act = () => someType.Should().NotBeAssignableTo(typeof(IDummyInterface<>), "we want to test the failure {0}", "message");
+            Type type = typeof(ClassWithGenericBaseType);
 
-            // Act / Assert
+            // Act
+            Action act = () =>
+                type.Should().NotBeAssignableTo(typeof(IDummyInterface<>), "we want to test the failure {0}", "message");
+
+            // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected someType *.ClassWithGenericBaseType to not be assignable to *.IDummyInterface`1[T] *failure message*, but it is.");
+                .WithMessage(
+                    "Expected type *.ClassWithGenericBaseType to not be assignable to *.IDummyInterface`1[T] *failure message*" +
+                    ", but it is.");
         }
 
         [Fact]
         public void When_derived_from_open_generic_class_and_asserting_not_assignable_it_fails()
         {
             // Arrange
-            Type someType = typeof(ClassWithGenericBaseType);
-            Action act = () => someType.Should().NotBeAssignableTo(typeof(IDummyInterface<>), "we want to test the failure {0}", "message");
+            Type type = typeof(ClassWithGenericBaseType);
 
-            // Act / Assert
+            // Act
+            Action act = () =>
+                type.Should().NotBeAssignableTo(typeof(IDummyInterface<>), "we want to test the failure {0}", "message");
+
+            // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected someType *.ClassWithGenericBaseType to not be assignable to *.IDummyInterface`1[T] *failure message*, but it is.");
+                .WithMessage(
+                    "Expected type *.ClassWithGenericBaseType to not be assignable to *.IDummyInterface`1[T] *failure message*" +
+                    ", but it is.");
         }
 
         [Fact]
@@ -535,7 +583,8 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.DummyBaseClass to be derived from *.ClassWithMembers *failure message*, but it is not.");
+                .WithMessage(
+                    "Expected type *.DummyBaseClass to be derived from *.ClassWithMembers *failure message*, but it is not.");
         }
 
         [Fact]
@@ -550,7 +599,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassThatImplementsInterface to be derived from *.IDummyInterface *failure message*, but *.IDummyInterface is an interface.");
+                .WithMessage(
+                    "Expected type *.ClassThatImplementsInterface to be derived from *.IDummyInterface *failure message*" +
+                    ", but *.IDummyInterface is an interface.");
         }
 
         [Fact]
@@ -593,7 +644,8 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassWithMembers to be derived from *.DummyBaseType`* *failure message*, but it is not.");
+                .WithMessage(
+                    "Expected type *.ClassWithMembers to be derived from *.DummyBaseType`* *failure message*, but it is not.");
         }
 
         [Fact]
@@ -659,7 +711,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.DummyImplementingClass not to be derived from *.DummyBaseClass *failure message*, but it is.");
+                .WithMessage(
+                    "Expected type *.DummyImplementingClass not to be derived from *.DummyBaseClass *failure message*" +
+                    ", but it is.");
         }
 
         [Fact]
@@ -674,7 +728,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassThatImplementsInterface not to be derived from *.IDummyInterface *failure message*, but *.IDummyInterface is an interface.");
+                .WithMessage(
+                    "Expected type *.ClassThatImplementsInterface not to be derived from *.IDummyInterface *failure message*" +
+                    ", but *.IDummyInterface is an interface.");
         }
 
         [Fact]
@@ -717,7 +773,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.DummyBaseType`1[*.ClassWithGenericBaseType] not to be derived from *.DummyBaseType`1[T] *failure message*, but it is.");
+                .WithMessage(
+                    "Expected type *.DummyBaseType`1[*.ClassWithGenericBaseType] not to be derived from *.DummyBaseType`1[T] " +
+                    "*failure message*, but it is.");
         }
 
         [Fact]
@@ -798,7 +856,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassWithoutAttribute to be decorated with *.DummyClassAttribute *failure message*, but the attribute was not found.");
+                .WithMessage(
+                    "Expected type *.ClassWithoutAttribute to be decorated with *.DummyClassAttribute *failure message*" +
+                    ", but the attribute was not found.");
         }
 
         [Fact]
@@ -860,7 +920,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassWithAttribute to be decorated with *.DummyClassAttribute that matches ((a.Name == \"Unexpected\")*a.IsEnabled), but no matching attribute was found.");
+                .WithMessage(
+                    "Expected type *.ClassWithAttribute to be decorated with *.DummyClassAttribute that matches " +
+                    "((a.Name == \"Unexpected\")*a.IsEnabled), but no matching attribute was found.");
         }
 
         [Fact]
@@ -897,7 +959,10 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be decorated with *.DummyClassAttribute *failure message*, but the attribute was not found on the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
+                .WithMessage(
+                    "Expected all types to be decorated with *.DummyClassAttribute *failure message*" +
+                    ", but the attribute was not found on the following types:" +
+                    "*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
         }
 
         [Fact]
@@ -929,11 +994,15 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 types.Should()
-                    .BeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
+                    .BeDecoratedWith<DummyClassAttribute>(
+                        a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be decorated with *.DummyClassAttribute that matches ((a.Name == \"Expected\") * a.IsEnabled) *failure message*, but no matching attribute was found on the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
+                .WithMessage(
+                    "Expected all types to be decorated with *.DummyClassAttribute that matches " +
+                    "((a.Name == \"Expected\") * a.IsEnabled) *failure message*, but no matching attribute was found on " +
+                    "the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
         }
 
         #endregion
@@ -973,15 +1042,17 @@ namespace FluentAssertions.Specs.Types
         public void When_type_does_not_inherit_expected_attribute_it_fails()
         {
             // Arrange
-            Type typeWithoutAttribute = typeof(ClassWithoutAttribute);
+            Type type = typeof(ClassWithoutAttribute);
 
             // Act
             Action act = () =>
-                typeWithoutAttribute.Should().BeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
+                type.Should().BeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassWithoutAttribute to be decorated with or inherit *.DummyClassAttribute *failure message*, but the attribute was not found.");
+                .WithMessage(
+                    "Expected type *.ClassWithoutAttribute to be decorated with or inherit *.DummyClassAttribute " +
+                    "*failure message*, but the attribute was not found.");
         }
 
         [Fact]
@@ -1043,7 +1114,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassWithInheritedAttribute to be decorated with or inherit *.DummyClassAttribute that matches ((a.Name == \"Unexpected\")*a.IsEnabled), but no matching attribute was found.");
+                .WithMessage(
+                    "Expected type *.ClassWithInheritedAttribute to be decorated with or inherit *.DummyClassAttribute " +
+                    "that matches ((a.Name == \"Unexpected\")*a.IsEnabled), but no matching attribute was found.");
         }
 
         [Fact]
@@ -1080,7 +1153,10 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be decorated with or inherit *.DummyClassAttribute *failure message*, but the attribute was not found on the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
+                .WithMessage(
+                    "Expected all types to be decorated with or inherit *.DummyClassAttribute *failure message*" +
+                    ", but the attribute was not found on the following types:" +
+                    "*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
         }
 
         [Fact]
@@ -1113,11 +1189,15 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 types.Should()
-                    .BeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
+                    .BeDecoratedWithOrInherit<DummyClassAttribute>(
+                        a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be decorated with or inherit *.DummyClassAttribute that matches ((a.Name == \"Expected\")*a.IsEnabled) *failure message*, but no matching attribute was found on the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
+                .WithMessage(
+                    "Expected all types to be decorated with or inherit *.DummyClassAttribute that matches " +
+                    "((a.Name == \"Expected\")*a.IsEnabled) *failure message*, but no matching attribute was found " +
+                    "on the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
         }
 
         #endregion
@@ -1150,7 +1230,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassWithAttribute to not be decorated with *.DummyClassAttribute* *failure message*, but the attribute was found.");
+                .WithMessage(
+                    "Expected type *.ClassWithAttribute to not be decorated with *.DummyClassAttribute* *failure message*" +
+                    ", but the attribute was found.");
         }
 
         [Fact]
@@ -1196,7 +1278,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassWithAttribute to not be decorated with *.DummyClassAttribute that matches ((a.Name == \"Expected\") * a.IsEnabled), but a matching attribute was found.");
+                .WithMessage(
+                    "Expected type *.ClassWithAttribute to not be decorated with *.DummyClassAttribute that matches " +
+                    "((a.Name == \"Expected\") * a.IsEnabled), but a matching attribute was found.");
         }
 
         [Fact]
@@ -1233,7 +1317,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to not be decorated *.DummyClassAttribute *failure message*, but the attribute was found on the following types:*\"*.ClassWithAttribute\".");
+                .WithMessage(
+                    "Expected all types to not be decorated *.DummyClassAttribute *failure message*" +
+                    ", but the attribute was found on the following types:*\"*.ClassWithAttribute\".");
         }
 
         [Fact]
@@ -1264,11 +1350,15 @@ namespace FluentAssertions.Specs.Types
             // Act
             Action act = () =>
                 types.Should()
-                    .NotBeDecoratedWith<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
+                    .NotBeDecoratedWith<DummyClassAttribute>(
+                        a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to not be decorated with *.DummyClassAttribute that matches ((a.Name == \"Expected\") * a.IsEnabled) *failure message*, but a matching attribute was found on the following types:*\"*.ClassWithAttribute\".");
+                .WithMessage(
+                    "Expected all types to not be decorated with *.DummyClassAttribute that matches " +
+                    "((a.Name == \"Expected\") * a.IsEnabled) *failure message*, but a matching attribute was found " +
+                    "on the following types:*\"*.ClassWithAttribute\".");
         }
 
         #endregion
@@ -1297,11 +1387,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                typeWithAttribute.Should().NotBeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
+                typeWithAttribute.Should()
+                    .NotBeDecoratedWithOrInherit<DummyClassAttribute>("we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type*ClassWithInheritedAttribute to not be decorated with or inherit *.DummyClassAttribute* *failure message* attribute was found.");
+                .WithMessage(
+                    "Expected type *.ClassWithInheritedAttribute to not be decorated with or inherit *.DummyClassAttribute " +
+                    "*failure message* attribute was found.");
         }
 
         [Fact]
@@ -1347,7 +1440,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassWithInheritedAttribute to not be decorated with or inherit *.DummyClassAttribute that matches ((a.Name == \"Expected\") * a.IsEnabled), but a matching attribute was found.");
+                .WithMessage(
+                    "Expected type *.ClassWithInheritedAttribute to not be decorated with or inherit *.DummyClassAttribute " +
+                    "that matches ((a.Name == \"Expected\") * a.IsEnabled), but a matching attribute was found.");
         }
 
         [Fact]
@@ -1384,7 +1479,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to not be decorated with or inherit *.DummyClassAttribute *failure message*, but the attribute was found on the following types:*\"*.ClassWithInheritedAttribute\".");
+                .WithMessage(
+                    "Expected all types to not be decorated with or inherit *.DummyClassAttribute *failure message*" +
+                    ", but the attribute was found on the following types:*\"*.ClassWithInheritedAttribute\".");
         }
 
         [Fact]
@@ -1395,11 +1492,15 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () => types.Should()
-                .NotBeDecoratedWithOrInherit<DummyClassAttribute>(a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
+                .NotBeDecoratedWithOrInherit<DummyClassAttribute>(
+                    a => (a.Name == "Expected") && a.IsEnabled, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to not be decorated with or inherit *.DummyClassAttribute that matches ((a.Name == \"Expected\") * a.IsEnabled) *failure message*, but a matching attribute was found on the following types:*\"*.ClassWithInheritedAttribute\".");
+                .WithMessage(
+                    "Expected all types to not be decorated with or inherit *.DummyClassAttribute that matches " +
+                    "((a.Name == \"Expected\") * a.IsEnabled) *failure message*, but a matching attribute was found " +
+                    "on the following types:*\"*.ClassWithInheritedAttribute\".");
         }
 
         [Fact]
@@ -1465,7 +1566,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be in namespace \"DummyNamespace\" *failure message*, but the following types are in a different namespace:*\"*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
+                .WithMessage(
+                    "Expected all types to be in namespace \"DummyNamespace\" *failure message*, but the following types " +
+                    "are in a different namespace:*\"*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
         }
 
         [Fact]
@@ -1492,7 +1595,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be in namespace \"DummyNamespace\", but the following types are in a different namespace:*\"ClassInGlobalNamespace\".");
+                .WithMessage(
+                    "Expected all types to be in namespace \"DummyNamespace\", but the following types " +
+                    "are in a different namespace:*\"ClassInGlobalNamespace\".");
         }
 
         [Fact]
@@ -1511,7 +1616,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be in namespace <null>, but the following types are in a different namespace:*\"*.ClassInDummyNamespace*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
+                .WithMessage(
+                    "Expected all types to be in namespace <null>, but the following types are in a different namespace:" +
+                    "*\"*.ClassInDummyNamespace*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
         }
 
         #endregion
@@ -1562,7 +1669,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected no types to be in namespace \"DummyNamespace\" *failure message*, but the following types are in the namespace:*\"DummyNamespace.ClassInDummyNamespace\".");
+                .WithMessage(
+                    "Expected no types to be in namespace \"DummyNamespace\" *failure message*" +
+                    ", but the following types are in the namespace:*\"DummyNamespace.ClassInDummyNamespace\".");
         }
 
         #endregion
@@ -1652,7 +1761,8 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                    .WithMessage("Expected the namespaces of all types to start with \"DummyNamespace\" *failure message*, but the namespaces of the following types do not start with it:*\"*.ClassInDummyNamespaceTwo\".");
+                    .WithMessage("Expected the namespaces of all types to start with \"DummyNamespace\" *failure message*" +
+                    ", but the namespaces of the following types do not start with it:*\"*.ClassInDummyNamespaceTwo\".");
         }
 
         [Fact]
@@ -1671,7 +1781,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the namespaces of all types to start with \"DummyNamespace.InnerDummyNamespace\", but the namespaces of the following types do not start with it:*\"*.ClassInDummyNamespace\".");
+                .WithMessage(
+                    "Expected the namespaces of all types to start with \"DummyNamespace.InnerDummyNamespace\"" +
+                    ", but the namespaces of the following types do not start with it:*\"*.ClassInDummyNamespace\".");
         }
 
         #endregion
@@ -1709,7 +1821,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the namespaces of all types to not start with \"DummyNamespace\" *failure message*, but the namespaces of the following types start with it:*\"*.ClassInDummyNamespace\".");
+                .WithMessage(
+                    "Expected the namespaces of all types to not start with \"DummyNamespace\" *failure message*" +
+                    ", but the namespaces of the following types start with it:*\"*.ClassInDummyNamespace\".");
         }
 
         [Fact]
@@ -1724,7 +1838,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the namespaces of all types to not start with \"DummyNamespace.InnerDummyNamespace\", but the namespaces of the following types start with it:*\"*.ClassInInnerDummyNamespace\".");
+                .WithMessage(
+                    "Expected the namespaces of all types to not start with \"DummyNamespace.InnerDummyNamespace\"" +
+                    ", but the namespaces of the following types start with it:*\"*.ClassInInnerDummyNamespace\".");
         }
 
         [Fact]
@@ -1738,7 +1854,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the namespaces of all types to not start with \"DummyNamespace\", but the namespaces of the following types start with it:*\"*.ClassInInnerDummyNamespace\".");
+                .WithMessage(
+                    "Expected the namespaces of all types to not start with \"DummyNamespace\"" +
+                    ", but the namespaces of the following types start with it:*\"*.ClassInInnerDummyNamespace\".");
         }
 
         [Fact]
@@ -1752,7 +1870,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the namespaces of all types to not start with <null>, but the namespaces of the following types start with it:*\"ClassInGlobalNamespace\".");
+                .WithMessage(
+                    "Expected the namespaces of all types to not start with <null>" +
+                    ", but the namespaces of the following types start with it:*\"ClassInGlobalNamespace\".");
         }
 
         [Fact]
@@ -1771,7 +1891,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the namespaces of all types to not start with <null>, but the namespaces of the following types start with it:*\"*.ClassInDummyNamespace*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
+                .WithMessage(
+                    "Expected the namespaces of all types to not start with <null>, but the namespaces of the following types " +
+                    "start with it:*\"*.ClassInDummyNamespace*.ClassNotInDummyNamespace*.OtherClassNotInDummyNamespace\".");
         }
 
         [Fact]
@@ -1868,7 +1990,8 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected all types to be sealed *failure message*, but the following types are not:*\"*.Abstract\".");
+                .WithMessage(
+                    "Expected all types to be sealed *failure message*, but the following types are not:*\"*.Abstract\".");
         }
 
         [Fact]
@@ -2296,7 +2419,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassThatDoesNotImplementInterface to implement interface *.IDummyInterface *failure message*, but it does not.");
+                .WithMessage(
+                    "Expected type *.ClassThatDoesNotImplementInterface to implement interface *.IDummyInterface " +
+                    "*failure message*, but it does not.");
         }
 
         [Fact]
@@ -2311,7 +2436,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassThatDoesNotImplementInterface to implement interface *.DateTime *failure message*, but *.DateTime is not an interface.");
+                .WithMessage(
+                    "Expected type *.ClassThatDoesNotImplementInterface to implement interface *.DateTime *failure message*" +
+                    ", but *.DateTime is not an interface.");
         }
 
         [Fact]
@@ -2377,7 +2504,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassThatImplementsInterface to not implement interface *.IDummyInterface *failure message*, but it does.");
+                .WithMessage(
+                    "Expected type *.ClassThatImplementsInterface to not implement interface *.IDummyInterface " +
+                    "*failure message*, but it does.");
         }
 
         [Fact]
@@ -2392,7 +2521,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassThatDoesNotImplementInterface to not implement interface *.DateTime *failure message*, but *.DateTime is not an interface.");
+                .WithMessage(
+                    "Expected type *.ClassThatDoesNotImplementInterface to not implement interface *.DateTime *failure message*" +
+                    ", but *.DateTime is not an interface.");
         }
 
         [Fact]
@@ -2473,11 +2604,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveProperty(typeof(int), "PrivateWriteProtectedReadProperty", "we want to test the failure {0}", "message");
+                type.Should()
+                    .HaveProperty(typeof(int), "PrivateWriteProtectedReadProperty", "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected String *.ClassWithMembers.PrivateWriteProtectedReadProperty to be of type System.Int32 *failure message*, but it is not.");
+                .WithMessage(
+                    "Expected String *.ClassWithMembers.PrivateWriteProtectedReadProperty to be of type System.Int32 " +
+                    "*failure message*, but it is not.");
         }
 
         [Fact]
@@ -2622,7 +2756,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected String *.ClassWithMembers.PrivateWriteProtectedReadProperty to not exist *failure message*, but it does.");
+                .WithMessage(
+                    "Expected String *.ClassWithMembers.PrivateWriteProtectedReadProperty to not exist *failure message*" +
+                    ", but it does.");
         }
 
         [Fact]
@@ -2723,7 +2859,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to explicitly implement *.IExplicitInterface.ImplicitStringProperty, but it does not.");
+                .WithMessage(
+                    "Expected *.ClassExplicitlyImplementingInterface to explicitly implement " +
+                    "*.IExplicitInterface.ImplicitStringProperty, but it does not.");
         }
 
         [Fact]
@@ -2741,7 +2879,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to explicitly implement *.IExplicitInterface.NonExistentProperty, but it does not.");
+                .WithMessage(
+                    "Expected *.ClassExplicitlyImplementingInterface to explicitly implement " +
+                    "*.IExplicitInterface.NonExistentProperty, but it does not.");
         }
 
         [Fact]
@@ -2759,7 +2899,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassExplicitlyImplementingInterface to implement interface *.IDummyInterface, but it does not.");
+                .WithMessage(
+                    "Expected type *.ClassExplicitlyImplementingInterface to implement interface *.IDummyInterface" +
+                    ", but it does not.");
         }
 
         [Fact]
@@ -2770,11 +2912,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveExplicitProperty(typeof(IExplicitInterface), "ExplicitStringProperty", "we want to test the failure {0}", "message");
+                type.Should().HaveExplicitProperty(
+                    typeof(IExplicitInterface), "ExplicitStringProperty", "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*, but type is <null>.");
+                .WithMessage(
+                    "Expected type to explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*" +
+                    ", but type is <null>.");
         }
 
         [Fact]
@@ -2879,11 +3024,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveExplicitProperty<IExplicitInterface>("ExplicitStringProperty", "we want to test the failure {0}", "message");
+                type.Should().HaveExplicitProperty<IExplicitInterface>(
+                    "ExplicitStringProperty", "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*, but type is <null>.");
+                .WithMessage(
+                    "Expected type to explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*" +
+                    ", but type is <null>.");
         }
 
         #endregion
@@ -2905,7 +3053,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitStringProperty, but it does.");
+                .WithMessage(
+                    "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
+                    "*.IExplicitInterface.ExplicitStringProperty, but it does.");
         }
 
         [Fact]
@@ -2923,7 +3073,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitImplicitStringProperty, but it does.");
+                .WithMessage(
+                    "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
+                    "*.IExplicitInterface.ExplicitImplicitStringProperty, but it does.");
         }
 
         [Fact]
@@ -2975,7 +3127,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassExplicitlyImplementingInterface to implement interface *.IDummyInterface, but it does not.");
+                .WithMessage(
+                    "Expected type *.ClassExplicitlyImplementingInterface to implement interface *.IDummyInterface" +
+                    ", but it does not.");
         }
 
         [Fact]
@@ -2986,11 +3140,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveExplicitProperty(typeof(IExplicitInterface), "ExplicitStringProperty", "we want to test the failure {0}", "message");
+                type.Should().NotHaveExplicitProperty(
+                    typeof(IExplicitInterface), "ExplicitStringProperty", "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to not explicitly implement *IExplicitInterface.ExplicitStringProperty *failure message*, but type is <null>.");
+                .WithMessage(
+                    "Expected type to not explicitly implement *IExplicitInterface.ExplicitStringProperty *failure message*" +
+                    ", but type is <null>.");
         }
 
         [Fact]
@@ -3055,7 +3212,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitStringProperty, but it does.");
+                .WithMessage(
+                    "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
+                    "*.IExplicitInterface.ExplicitStringProperty, but it does.");
         }
 
         [Fact]
@@ -3066,11 +3225,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveExplicitProperty<IExplicitInterface>("ExplicitStringProperty", "we want to test the failure {0}", "message");
+                type.Should().NotHaveExplicitProperty<IExplicitInterface>(
+                    "ExplicitStringProperty", "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to not explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*, but type is <null>.");
+                .WithMessage(
+                    "Expected type to not explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*" +
+                    ", but type is <null>.");
         }
 
         [Fact]
@@ -3156,7 +3318,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to explicitly implement *.IExplicitInterface.ImplicitMethod(), but it does not.");
+                .WithMessage(
+                    "Expected *.ClassExplicitlyImplementingInterface to explicitly implement " +
+                    "*.IExplicitInterface.ImplicitMethod(), but it does not.");
         }
 
         [Fact]
@@ -3174,7 +3338,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to explicitly implement *.IExplicitInterface.NonExistentMethod(), but it does not.");
+                .WithMessage(
+                    "Expected *.ClassExplicitlyImplementingInterface to explicitly implement " +
+                    "*.IExplicitInterface.NonExistentMethod(), but it does not.");
         }
 
         [Fact]
@@ -3192,7 +3358,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassExplicitlyImplementingInterface to implement interface *.IDummyInterface, but it does not.");
+                .WithMessage(
+                    "Expected type *.ClassExplicitlyImplementingInterface to implement interface " +
+                    "*.IDummyInterface, but it does not.");
         }
 
         [Fact]
@@ -3203,11 +3371,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveExplicitMethod(typeof(IExplicitInterface), "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
+                type.Should().HaveExplicitMethod(
+                    typeof(IExplicitInterface), "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*, but type is <null>.");
+                .WithMessage(
+                    "Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*" +
+                    ", but type is <null>.");
         }
 
         [Fact]
@@ -3297,11 +3468,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveExplicitMethod<IExplicitInterface>("ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
+                type.Should().HaveExplicitMethod<IExplicitInterface>(
+                    "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*, but type is <null>.");
+                .WithMessage(
+                    "Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*" +
+                    ", but type is <null>.");
         }
 
         [Fact]
@@ -3368,7 +3542,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitMethod(), but it does.");
+                .WithMessage(
+                    "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
+                    "*.IExplicitInterface.ExplicitMethod(), but it does.");
         }
 
         [Fact]
@@ -3386,7 +3562,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitImplicitMethod(), but it does.");
+                .WithMessage(
+                    "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
+                    "*.IExplicitInterface.ExplicitImplicitMethod(), but it does.");
         }
 
         [Fact]
@@ -3438,7 +3616,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type *.ClassExplicitlyImplementingInterface to implement interface *.IDummyInterface, but it does not.");
+                .WithMessage(
+                    "Expected type *.ClassExplicitlyImplementingInterface to implement interface *.IDummyInterface" +
+                    ", but it does not.");
         }
 
         [Fact]
@@ -3449,11 +3629,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveExplicitMethod(typeof(IExplicitInterface), "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
+                type.Should().NotHaveExplicitMethod(
+                    typeof(IExplicitInterface), "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*, but type is <null>.");
+                .WithMessage(
+                    "Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*" +
+                    ", but type is <null>.");
         }
 
         [Fact]
@@ -3533,7 +3716,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitMethod(), but it does.");
+                .WithMessage(
+                    "Expected *.ClassExplicitlyImplementingInterface to not explicitly implement " +
+                    "*.IExplicitInterface.ExplicitMethod(), but it does.");
         }
 
         [Fact]
@@ -3544,11 +3729,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveExplicitMethod<IExplicitInterface>("ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
+                type.Should().NotHaveExplicitMethod<IExplicitInterface>(
+                    "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*, but type is <null>.");
+                .WithMessage(
+                    "Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*" +
+                    ", but type is <null>.");
         }
 
         [Fact]
@@ -3626,11 +3814,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveIndexer(typeof(string), new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+                type.Should().HaveIndexer(
+                    typeof(string), new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected String *.ClassWithNoMembers[System.Int32, System.Type] to exist *failure message*, but it does not.");
+                .WithMessage(
+                    "Expected String *.ClassWithNoMembers[System.Int32, System.Type] to exist *failure message*" +
+                    ", but it does not.");
         }
 
         [Fact]
@@ -3641,11 +3832,13 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveIndexer(typeof(string), new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+                type.Should().HaveIndexer(
+                    typeof(string), new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected String *.ClassWithMembers[System.Int32, System.Type] to exist *failure message*, but it does not.");
+                .WithMessage(
+                    "Expected String *.ClassWithMembers[System.Int32, System.Type] to exist *failure message*, but it does not.");
         }
 
         [Fact]
@@ -3789,7 +3982,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected constructor *.ClassWithNoMembers(System.Int32, System.Type) to exist *failure message*, but it does not.");
+                .WithMessage(
+                    "Expected constructor *.ClassWithNoMembers(System.Int32, System.Type) to exist *failure message*" +
+                    ", but it does not.");
         }
 
         [Fact]
@@ -3893,7 +4088,9 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected constructor *.ClassWithCctorAndNonDefaultConstructor() to exist *failure message*, but it does not.");
+                .WithMessage(
+                    "Expected constructor *.ClassWithCctorAndNonDefaultConstructor() to exist *failure message*" +
+                    ", but it does not.");
         }
 
         [Fact]
@@ -3942,7 +4139,8 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected constructor *.ClassWithMembers(System.String) not to exist *failure message*, but it does.");
+                .WithMessage(
+                    "Expected constructor *.ClassWithMembers(System.String) not to exist *failure message*, but it does.");
         }
 
         [Fact]
@@ -4084,11 +4282,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveMethod("NonExistentMethod", new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+                type.Should().HaveMethod(
+                        "NonExistentMethod", new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method *.ClassWithNoMembers.NonExistentMethod(System.Int32, System.Type) to exist *failure message*, but it does not.");
+                .WithMessage(
+                    "Expected method *.ClassWithNoMembers.NonExistentMethod(*.Int32, *.Type) to exist *failure message*" +
+                    ", but it does not.");
         }
 
         [Fact]
@@ -4099,11 +4300,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveMethod("VoidMethod", new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
+                type.Should().HaveMethod(
+                    "VoidMethod", new[] { typeof(int), typeof(Type) }, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected method *.ClassWithMembers.VoidMethod(System.Int32, System.Type) to exist *failure message*, but it does not.");
+                .WithMessage(
+                    "Expected method *.ClassWithMembers.VoidMethod(*.Int32, *.Type) to exist *failure message*" +
+                    ", but it does not.");
         }
 
         [Fact]
@@ -4330,7 +4534,8 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+                type.Should().HaveAccessModifier(
+                    CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -4448,7 +4653,8 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+                type.Should().HaveAccessModifier(
+                    CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -4481,7 +4687,8 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type IProtectedInternalInterface to be Private *failure message*, but it is ProtectedInternal.");
+                .WithMessage(
+                    "Expected type IProtectedInternalInterface to be Private *failure message*, but it is ProtectedInternal.");
         }
 
         [Fact]
@@ -4718,11 +4925,13 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveAccessModifier(CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
+                type.Should().NotHaveAccessModifier(
+                    CSharpAccessModifier.ProtectedInternal, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type IProtectedInternalInterface not to be ProtectedInternal *failure message*, but it is.");
+                .WithMessage(
+                    "Expected type IProtectedInternalInterface not to be ProtectedInternal *failure message*, but it is.");
         }
 
         [Fact]
@@ -4788,11 +4997,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveExplicitConversionOperator(sourceType, targetType, "we want to test the failure {0}", "message");
+                type.Should().HaveExplicitConversionOperator(
+                    sourceType, targetType, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*, but it does not.");
+                .WithMessage(
+                    "Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*" +
+                    ", but it does not.");
         }
 
         [Fact]
@@ -4803,11 +5015,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveExplicitConversionOperator(typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
+                type.Should().HaveExplicitConversionOperator(
+                    typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*, but type is <null>.");
+                .WithMessage(
+                    "Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*" +
+                    ", but type is <null>.");
         }
 
         [Fact]
@@ -4869,11 +5084,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveExplicitConversionOperator<TypeWithConversionOperators, string>("we want to test the failure {0}", "message");
+                type.Should().HaveExplicitConversionOperator<TypeWithConversionOperators, string>(
+                    "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*, but it does not.");
+                .WithMessage(
+                    "Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*" +
+                    ", but it does not.");
         }
 
         [Fact]
@@ -4884,11 +5102,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveExplicitConversionOperator<TypeWithConversionOperators, string>("we want to test the failure {0}", "message");
+                type.Should().HaveExplicitConversionOperator<TypeWithConversionOperators, string>(
+                    "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*, but type is <null>.");
+                .WithMessage(
+                    "Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*" +
+                    ", but type is <null>.");
         }
 
         #endregion
@@ -4922,11 +5143,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveExplicitConversionOperator(sourceType, targetType, "we want to test the failure {0}", "message");
+                type.Should().NotHaveExplicitConversionOperator(
+                    sourceType, targetType, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected public static explicit System.Byte(*.TypeWithConversionOperators) to not exist *failure message*, but it does.");
+                .WithMessage(
+                    "Expected public static explicit *.Byte(*.TypeWithConversionOperators) to not exist *failure message*" +
+                    ", but it does.");
         }
 
         [Fact]
@@ -4937,11 +5161,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveExplicitConversionOperator(typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
+                type.Should().NotHaveExplicitConversionOperator(
+                    typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected public static explicit System.String(*.TypeWithConversionOperators) to not exist *failure message*, but type is <null>.");
+                .WithMessage(
+                    "Expected public static explicit *.String(*.TypeWithConversionOperators) to not exist *failure message*" +
+                    ", but type is <null>.");
         }
 
         [Fact]
@@ -5001,11 +5228,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveExplicitConversionOperator<TypeWithConversionOperators, byte>("we want to test the failure {0}", "message");
+                type.Should().NotHaveExplicitConversionOperator<TypeWithConversionOperators, byte>(
+                    "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected public static explicit System.Byte(*.TypeWithConversionOperators) to not exist *failure message*, but it does.");
+                .WithMessage(
+                    "Expected public static explicit *.Byte(*.TypeWithConversionOperators) to not exist *failure message*" +
+                    ", but it does.");
         }
 
         #endregion
@@ -5041,11 +5271,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveImplicitConversionOperator(sourceType, targetType, "we want to test the failure {0}", "message");
+                type.Should().HaveImplicitConversionOperator(
+                    sourceType, targetType, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected public static implicit System.String(*.TypeWithConversionOperators) to exist *failure message*, but it does not.");
+                .WithMessage(
+                    "Expected public static implicit *.String(*.TypeWithConversionOperators) to exist *failure message*" +
+                    ", but it does not.");
         }
 
         [Fact]
@@ -5056,11 +5289,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveImplicitConversionOperator(typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
+                type.Should().HaveImplicitConversionOperator(
+                    typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected public static implicit System.String(*.TypeWithConversionOperators) to exist *failure message*, but type is <null>.");
+                .WithMessage(
+                    "Expected public static implicit *.String(*.TypeWithConversionOperators) to exist *failure message*" +
+                    ", but type is <null>.");
         }
 
         [Fact]
@@ -5122,11 +5358,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveImplicitConversionOperator<TypeWithConversionOperators, string>("we want to test the failure {0}", "message");
+                type.Should().HaveImplicitConversionOperator<TypeWithConversionOperators, string>(
+                    "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected public static implicit System.String(*.TypeWithConversionOperators) to exist *failure message*, but it does not.");
+                .WithMessage(
+                    "Expected public static implicit *.String(*.TypeWithConversionOperators) to exist *failure message*" +
+                    ", but it does not.");
         }
 
         [Fact]
@@ -5137,11 +5376,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().HaveImplicitConversionOperator<TypeWithConversionOperators, string>("we want to test the failure {0}", "message");
+                type.Should().HaveImplicitConversionOperator<TypeWithConversionOperators, string>(
+                    "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected public static implicit System.String(*.TypeWithConversionOperators) to exist *failure message*, but type is <null>.");
+                .WithMessage(
+                    "Expected public static implicit *.String(*.TypeWithConversionOperators) to exist *failure message*" +
+                    ", but type is <null>.");
         }
 
         #endregion
@@ -5175,11 +5417,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator(sourceType, targetType, "we want to test the failure {0}", "message");
+                type.Should().NotHaveImplicitConversionOperator(
+                    sourceType, targetType, "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected public static implicit System.Int32(*.TypeWithConversionOperators) to not exist *failure message*, but it does.");
+                .WithMessage(
+                    "Expected public static implicit *.Int32(*.TypeWithConversionOperators) to not exist *failure message*" +
+                    ", but it does.");
         }
 
         [Fact]
@@ -5190,11 +5435,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator(typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
+                type.Should().NotHaveImplicitConversionOperator(
+                    typeof(TypeWithConversionOperators), typeof(string), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected public static implicit System.String(*.TypeWithConversionOperators) to not exist *failure message*, but type is <null>.");
+                .WithMessage(
+                    "Expected public static implicit *.String(*.TypeWithConversionOperators) to not exist *failure message*" +
+                    ", but type is <null>.");
         }
 
         [Fact]
@@ -5254,11 +5502,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator<TypeWithConversionOperators, int>("we want to test the failure {0}", "message");
+                type.Should().NotHaveImplicitConversionOperator<TypeWithConversionOperators, int>(
+                    "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected public static implicit System.Int32(*.TypeWithConversionOperators) to not exist *failure message*, but it does.");
+                .WithMessage(
+                    "Expected public static implicit *.Int32(*.TypeWithConversionOperators) to not exist *failure message*" +
+                    ", but it does.");
         }
 
         [Fact]
@@ -5269,11 +5520,14 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotHaveImplicitConversionOperator<TypeWithConversionOperators, string>("we want to test the failure {0}", "message");
+                type.Should().NotHaveImplicitConversionOperator<TypeWithConversionOperators, string>(
+                    "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected public static implicit System.String(*.TypeWithConversionOperators) to not exist *failure message*, but type is <null>.");
+                .WithMessage(
+                    "Expected public static implicit *.String(*.TypeWithConversionOperators) to not exist *failure message*" +
+                    ", but type is <null>.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
@@ -3156,7 +3156,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to explicitly implement *.IExplicitInterface.ImplicitMethod, but it does not.");
+                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to explicitly implement *.IExplicitInterface.ImplicitMethod(), but it does not.");
         }
 
         [Fact]
@@ -3174,7 +3174,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to explicitly implement *.IExplicitInterface.NonExistentMethod, but it does not.");
+                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to explicitly implement *.IExplicitInterface.NonExistentMethod(), but it does not.");
         }
 
         [Fact]
@@ -3207,7 +3207,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod *failure message*, but type is <null>.");
+                .WithMessage("Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*, but type is <null>.");
         }
 
         [Fact]
@@ -3301,7 +3301,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod *failure message*, but type is <null>.");
+                .WithMessage("Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*, but type is <null>.");
         }
 
         [Fact]
@@ -3368,7 +3368,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitMethod, but it does.");
+                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitMethod(), but it does.");
         }
 
         [Fact]
@@ -3386,7 +3386,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitImplicitMethod, but it does.");
+                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitImplicitMethod(), but it does.");
         }
 
         [Fact]
@@ -3453,7 +3453,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod *failure message*, but type is <null>.");
+                .WithMessage("Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*, but type is <null>.");
         }
 
         [Fact]
@@ -3533,7 +3533,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitMethod, but it does.");
+                .WithMessage("Expected *.ClassExplicitlyImplementingInterface to not explicitly implement *.IExplicitInterface.ExplicitMethod(), but it does.");
         }
 
         [Fact]
@@ -3548,7 +3548,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod *failure message*, but type is <null>.");
+                .WithMessage("Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod() *failure message*, but type is <null>.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
@@ -419,6 +419,21 @@ namespace FluentAssertions.Specs.Types
             typeof(DummyBaseType<>).Should().BeAssignableTo(typeof(DummyBaseType<>));
         }
 
+        [Fact]
+        public void When_asserting_a_type_to_be_assignable_to_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(DummyBaseType<>);
+
+            // Act
+            Action act = () =>
+                type.Should().BeAssignableTo(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("type");
+        }
+
         #endregion
 
         #region NotBeAssignableTo
@@ -541,6 +556,21 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage($"*{typeof(ClassWithGenericBaseType)} to not be assignable to {typeof(IDummyInterface<>)}*failure message*");
         }
 
+        [Fact]
+        public void When_asserting_a_type_not_to_be_assignable_to_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(DummyBaseType<>);
+
+            // Act
+            Action act =
+                () => type.Should().NotBeAssignableTo(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("type");
+        }
+
         #endregion
 
         #region BeDerivedFrom
@@ -586,9 +616,8 @@ namespace FluentAssertions.Specs.Types
                 type.Should().BeDerivedFrom(typeof(IDummyInterface), "because we want to test the error {0}", "message");
 
             // Assert
-            act.Should().Throw<ArgumentException>()
-                .WithMessage("Must not be an interface Type.*")
-                .WithParameterName("baseType");
+            act.Should().Throw<XunitException>()
+                .WithMessage($"Expected type *.ClassThatImplementsInterface to be derived from *.IDummyInterface *error message*, but *.IDummyInterface is an interface.");
         }
 
         [Fact]
@@ -633,6 +662,21 @@ namespace FluentAssertions.Specs.Types
             act.Should().Throw<XunitException>()
                 .WithMessage($"Expected type {typeof(ClassWithMembers)} to be derived from " +
                              $"{typeof(DummyBaseType<>)} because we want to test the error message, but it is not.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_to_be_derived_from_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(DummyBaseType<>);
+
+            // Act
+            Action act =
+                () => type.Should().BeDerivedFrom(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("baseType");
         }
 
         #endregion
@@ -698,9 +742,8 @@ namespace FluentAssertions.Specs.Types
                 type.Should().NotBeDerivedFrom(typeof(IDummyInterface), "because we want to test the error {0}", "message");
 
             // Assert
-            act.Should().Throw<ArgumentException>()
-                .WithMessage("Must not be an interface Type.*")
-                .WithParameterName("baseType");
+            act.Should().Throw<XunitException>()
+                .WithMessage($"Expected type *.ClassThatImplementsInterface not to be derived from *.IDummyInterface *error message*, but *.IDummyInterface is an interface.");
         }
 
         [Fact]
@@ -745,6 +788,21 @@ namespace FluentAssertions.Specs.Types
             act.Should().Throw<XunitException>()
                 .WithMessage($"Expected type*{typeof(DummyBaseType<ClassWithGenericBaseType>)}*not to be derived from*" +
                              $"{typeof(DummyBaseType<>)}*because we want to test the error message*but it is.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_not_to_be_derived_from_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(DummyBaseType<>);
+
+            // Act
+            Action act =
+                () => type.Should().NotBeDerivedFrom(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("baseType");
         }
 
         #endregion
@@ -2014,6 +2072,21 @@ namespace FluentAssertions.Specs.Types
                              + ".");
         }
 
+        [Fact]
+        public void When_subject_is_null_be_sealed_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().BeSealed("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to be sealed *failure message*, but type is <null>.");
+        }
+
         #endregion
 
         #region NotBeSealed
@@ -2103,6 +2176,21 @@ namespace FluentAssertions.Specs.Types
                              + ".");
         }
 
+        [Fact]
+        public void When_subject_is_null_not_be_sealed_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().NotBeSealed("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type not to be sealed *failure message*, but type is <null>.");
+        }
+
         #endregion
 
         #region BeAbstract
@@ -2154,6 +2242,21 @@ namespace FluentAssertions.Specs.Types
             // Assert
             act.Should().Throw<InvalidOperationException>()
                 .WithMessage(exceptionMessage);
+        }
+
+        [Fact]
+        public void When_subject_is_null_be_abstract_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().BeAbstract("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to be abstract *failure message*, but type is <null>.");
         }
 
         #endregion
@@ -2212,6 +2315,21 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage(exceptionMessage);
         }
 
+        [Fact]
+        public void When_subject_is_null_not_be_abstract_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().NotBeAbstract("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type not to be abstract *failure message*, but type is <null>.");
+        }
+
         #endregion
 
         #region BeStatic
@@ -2263,6 +2381,21 @@ namespace FluentAssertions.Specs.Types
             // Assert
             act.Should().Throw<InvalidOperationException>()
                 .WithMessage(exceptionMessage);
+        }
+
+        [Fact]
+        public void When_subject_is_null_be_static_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().BeStatic("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to be static *failure message*, but type is <null>.");
         }
 
         #endregion
@@ -2321,6 +2454,21 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage(exceptionMessage);
         }
 
+        [Fact]
+        public void When_subject_is_null_not_be_static_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().NotBeStatic("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type not to be static *failure message*, but type is <null>.");
+        }
+
         #endregion
 
         #region Implement
@@ -2367,8 +2515,22 @@ namespace FluentAssertions.Specs.Types
                 type.Should().Implement(typeof(DateTime), "because we want to test the error {0}", "message");
 
             // Assert
-            act.Should().Throw<ArgumentException>()
-                .WithMessage("Must be an interface Type.*")
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type *.ClassThatDoesNotImplementInterface to implement interface *.DateTime *error message*, but *.DateTime is not an interface.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_to_implement_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(DummyBaseType<>);
+
+            // Act
+            Action act = () =>
+                type.Should().Implement(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
                 .WithParameterName("interfaceType");
         }
 
@@ -2435,8 +2597,22 @@ namespace FluentAssertions.Specs.Types
                 type.Should().NotImplement(typeof(DateTime), "because we want to test the error {0}", "message");
 
             // Assert
-            act.Should().Throw<ArgumentException>()
-                .WithMessage("Must be an interface Type.*")
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type *.ClassThatDoesNotImplementInterface to not implement interface *.DateTime *error message*, but *.DateTime is not an interface.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_not_to_implement_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassThatDoesNotImplementInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().NotImplement(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
                 .WithParameterName("interfaceType");
         }
 
@@ -2513,6 +2689,66 @@ namespace FluentAssertions.Specs.Types
                     "Expected String FluentAssertions*ClassWithMembers.PrivateWriteProtectedReadProperty to be of type System.Int32 because we want to test the error message, but it is not.");
         }
 
+        [Fact]
+        public void When_subject_is_null_have_property_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().HaveProperty(typeof(string), "PublicProperty", "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected String type.PublicProperty to exist *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_a_property_of_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveProperty(null, "PublicProperty");
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("propertyType");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_a_property_with_a_null_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveProperty(typeof(string), null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_a_property_with_an_empty_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveProperty(typeof(string), string.Empty);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
         #endregion
 
         #region HavePropertyOfT
@@ -2533,6 +2769,36 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_a_propertyOfT_with_a_null_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveProperty<string>(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_a_propertyOfT_with_an_empty_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveProperty<string>(string.Empty);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
         }
 
         #endregion
@@ -2568,6 +2834,51 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage(
                     "Expected String FluentAssertions*ClassWithMembers.PrivateWriteProtectedReadProperty to not exist because we want to " +
                     "test the error message, but it does.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_have_property_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveProperty("PublicProperty", "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type.PublicProperty to not exist *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_a_property_with_a_null_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveProperty(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_a_property_with_an_empty_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveProperty(string.Empty);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
         }
 
         #endregion
@@ -2668,6 +2979,66 @@ namespace FluentAssertions.Specs.Types
                     "FluentAssertions*IDummyInterface, but it does not.");
         }
 
+        [Fact]
+        public void When_subject_is_null_have_explicit_property_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitProperty(typeof(IExplicitInterface), "ExplicitStringProperty", "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicit_property_inherited_by_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitProperty(null, "ExplicitStringProperty");
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("interfaceType");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicit_property_with_a_null_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitProperty(typeof(IExplicitInterface), null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicit_property_with_an_empty_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitProperty(typeof(IExplicitInterface), string.Empty);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
         #endregion
 
         #region HaveExplicitPropertyOfT
@@ -2685,6 +3056,51 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicitlyOfT_property_with_a_null_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitProperty<IExplicitInterface>(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicitlyOfT_property_with_an_empty_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitProperty<IExplicitInterface>(string.Empty);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
+        [Fact]
+        public void When_subject_is_null_have_explicit_propertyOfT_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitProperty<IExplicitInterface>("ExplicitStringProperty", "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*, but type is <null>.");
         }
 
         #endregion
@@ -2784,6 +3200,66 @@ namespace FluentAssertions.Specs.Types
                              "FluentAssertions*IDummyInterface, but it does not.");
         }
 
+        [Fact]
+        public void When_subject_is_null_not_have_explicit_property_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitProperty(typeof(IExplicitInterface), "ExplicitStringProperty", "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to not explicitly implement *IExplicitInterface.ExplicitStringProperty *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicit_property_inherited_from_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitProperty(null, "ExplicitStringProperty");
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("interfaceType");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicit_property_with_a_null_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitProperty(typeof(IExplicitInterface), null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicit_property_with_an_empty_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitProperty(typeof(IExplicitInterface), string.Empty);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
         #endregion
 
         #region NotHaveExplicitPropertyOfT
@@ -2804,6 +3280,51 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage(
                     "Expected FluentAssertions*ClassExplicitlyImplementingInterface to not explicitly implement " +
                     "FluentAssertions*IExplicitInterface.ExplicitStringProperty, but it does.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_have_explicit_propertyOfT_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitProperty<IExplicitInterface>("ExplicitStringProperty", "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to not explicitly implement *.IExplicitInterface.ExplicitStringProperty *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicitlyOfT_property_with_a_null_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitProperty<IExplicitInterface>(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicitlyOfT_property_with_an_empty_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitProperty<IExplicitInterface>(string.Empty);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
         }
 
         #endregion
@@ -2904,6 +3425,81 @@ namespace FluentAssertions.Specs.Types
                     "FluentAssertions*IDummyInterface, but it does not.");
         }
 
+        [Fact]
+        public void When_subject_is_null_have_explicit_method_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitMethod(typeof(IExplicitInterface), "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicit_method_with_a_null_interface_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitMethod(null, "ExplicitMethod", new Type[0]);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("interfaceType");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicit_method_with_a_null_parameter_type_list_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitMethod(typeof(IExplicitInterface), "ExplicitMethod", null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("parameterTypes");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicit_method_with_a_null_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitMethod(typeof(IExplicitInterface), null, new Type[0]);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicit_method_with_an_empty_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitMethod(typeof(IExplicitInterface), string.Empty, new Type[0]);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
         #endregion
 
         #region HaveExplicitMethodOfT
@@ -2921,6 +3517,66 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_subject_is_null_have_explicit_methodOfT_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitMethod<IExplicitInterface>("ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to explicitly implement *.IExplicitInterface.ExplicitMethod *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicit_methodOfT_with_a_null_parameter_type_list_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitMethod<IExplicitInterface>("ExplicitMethod", null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("parameterTypes");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicit_methodOfT_with_a_null_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitMethod<IExplicitInterface>(null, new Type[0]);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicit_methodOfT_with_an_empty_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitMethod<IExplicitInterface>(string.Empty, new Type[0]);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
         }
 
         #endregion
@@ -3020,6 +3676,81 @@ namespace FluentAssertions.Specs.Types
                              "FluentAssertions*IDummyInterface, but it does not.");
         }
 
+        [Fact]
+        public void When_subject_is_null_not_have_explicit_method_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitMethod(typeof(IExplicitInterface), "ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicit_method_inherited_from_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitMethod(null, "ExplicitMethod", new Type[0]);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("interfaceType");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicit_method_with_a_null_parameter_type_list_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitMethod(typeof(IExplicitInterface), "ExplicitMethod", null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("parameterTypes");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicit_method_with_a_null_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitMethod(typeof(IExplicitInterface), null, new Type[0]);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicit_method_with_an_empty_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitMethod(typeof(IExplicitInterface), string.Empty, new Type[0]);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
         #endregion
 
         #region NotHaveExplicitMethodOfT
@@ -3040,6 +3771,66 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage(
                     "Expected FluentAssertions*ClassExplicitlyImplementingInterface to not explicitly implement " +
                     "FluentAssertions*IExplicitInterface.ExplicitMethod, but it does.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_have_explicit_methodOfT_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitMethod<IExplicitInterface>("ExplicitMethod", new Type[0], "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to not explicitly implement *.IExplicitInterface.ExplicitMethod *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicit_methodOfT_with_a_null_parameter_type_list_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitMethod<IExplicitInterface>("ExplicitMethod", null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("parameterTypes");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicit_methodOfT_with_a_null_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitMethod<IExplicitInterface>(null, new Type[0]);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicit_methodOfT_with_an_empty_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassExplicitlyImplementingInterface);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitMethod<IExplicitInterface>(string.Empty, new Type[0]);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
         }
 
         #endregion
@@ -3098,6 +3889,51 @@ namespace FluentAssertions.Specs.Types
                     " message, but it does not.");
         }
 
+        [Fact]
+        public void When_subject_is_null_have_indexer_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().HaveIndexer(typeof(string), new[] { typeof(string) }, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected String type[System.String] to exist *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_indexer_for_null_it_should_throw()
+        {
+            // Arrange
+            Type type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveIndexer(null, new[] { typeof(string) });
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("indexerType");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_indexer_with_a_null_parameter_type_list_it_should_throw()
+        {
+            // Arrange
+            Type type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveIndexer(typeof(string), null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("parameterTypes");
+        }
+
         #endregion
 
         #region NotHaveIndexer
@@ -3131,6 +3967,36 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage(
                     "Expected indexer FluentAssertions*ClassWithMembers[System.String] to not exist because we want to " +
                     "test the error message, but it does.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_have_indexer_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveIndexer(new[] { typeof(string) }, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected indexer type[System.String] to not exist *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_indexer_for_null_it_should_throw()
+        {
+            // Arrange
+            Type type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveIndexer(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("parameterTypes");
         }
 
         #endregion
@@ -3169,6 +4035,36 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage(
                     "Expected constructor FluentAssertions*ClassWithNoMembers(System.Int32, System.Type) to exist because " +
                     "we want to test the error message, but it does not.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_have_constructor_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().HaveConstructor(new[] { typeof(string) }, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected constructor type(System.String) to exist *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_a_constructor_of_null_it_should_throw()
+        {
+            // Arrange
+            Type type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveConstructor(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("parameterTypes");
         }
 
         #endregion
@@ -3247,6 +4143,21 @@ namespace FluentAssertions.Specs.Types
                     "want to test the error message, but it does not.");
         }
 
+        [Fact]
+        public void When_subject_is_null_have_default_constructor_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().HaveDefaultConstructor("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected constructor type() to exist *failure message*, but type is <null>.");
+        }
+
         #endregion
 
         #region NotHaveConstructor
@@ -3281,6 +4192,36 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage(
                     "Expected constructor*ClassWithMembers(System.String) not to exist because " +
                     "we want to test the error message, but it does.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_have_constructor_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveConstructor(new[] { typeof(string) }, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected constructor type(System.String) not to exist *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_a_constructor_of_null_it_should_throw()
+        {
+            // Arrange
+            Type type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveConstructor(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("parameterTypes");
         }
 
         #endregion
@@ -3351,6 +4292,21 @@ namespace FluentAssertions.Specs.Types
             act.Should().NotThrow();
         }
 
+        [Fact]
+        public void When_subject_is_null_not_have_default_constructor_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveDefaultConstructor("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected constructor type() not to exist *failure message*, but type is <null>.");
+        }
+
         #endregion
 
         #region HaveMethod
@@ -3407,6 +4363,66 @@ namespace FluentAssertions.Specs.Types
                     "because we want to test the error message, but it does not.");
         }
 
+        [Fact]
+        public void When_subject_is_null_have_method_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().HaveMethod("Name", new[] { typeof(string) }, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected method type.Name(System.String) to exist *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_a_method_with_a_null_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveMethod(null, new[] { typeof(string) });
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_a_method_with_an_empty_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveMethod(string.Empty, new[] { typeof(string) });
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_a_method_with_a_null_parameter_type_list_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveMethod("Name", null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("parameterTypes");
+        }
+
         #endregion
 
         #region NotHaveMethod
@@ -3454,6 +4470,66 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage(
                     "Expected method Void FluentAssertions*ClassWithMembers.VoidMethod() to not exist because we want to " +
                     "test the error message, but it does.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_have_method_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveMethod("Name", new[] { typeof(string) }, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected method type.Name(System.String) to not exist *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_a_method_with_a_null_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveMethod(null, new[] { typeof(string) });
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_a_method_with_an_empty_name_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveMethod(string.Empty, new[] { typeof(string) });
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_a_method_with_a_null_parameter_type_list_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(ClassWithMembers);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveMethod("Name", null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("parameterTypes");
         }
 
         #endregion
@@ -3675,6 +4751,36 @@ namespace FluentAssertions.Specs.Types
                              "message, but it is ProtectedInternal.");
         }
 
+        [Fact]
+        public void When_subject_is_null_have_access_modifier_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().HaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to be Public *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_access_modifier_with_an_invalid_enum_value_it_should_throw()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().HaveAccessModifier((CSharpAccessModifier)int.MaxValue);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentOutOfRangeException>()
+                .WithParameterName("accessModifier");
+        }
+
         #endregion
 
         #region NotHaveAccessModifier
@@ -3894,6 +5000,36 @@ namespace FluentAssertions.Specs.Types
                              "message, but it is.");
         }
 
+        [Fact]
+        public void When_subject_is_null_not_have_access_modifier_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type not to be Public *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_access_modifier_with_an_invalid_enum_value_it_should_throw()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveAccessModifier((CSharpAccessModifier)int.MaxValue);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentOutOfRangeException>()
+                .WithParameterName("accessModifier");
+        }
+
         #endregion
 
         #region HaveExplicitConversionOperator
@@ -3936,6 +5072,51 @@ namespace FluentAssertions.Specs.Types
                     "because we want to test the error message, but it does not.");
         }
 
+        [Fact]
+        public void When_subject_is_null_have_explicit_conversion_operator_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitConversionOperator(typeof(TypeWithConversionOperators), typeof(string), "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicit_conversion_operator_from_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(TypeWithConversionOperators);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitConversionOperator(null, typeof(string));
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("sourceType");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_explicit_conversion_operator_to_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(TypeWithConversionOperators);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitConversionOperator(typeof(TypeWithConversionOperators), null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("targetType");
+        }
+
         #endregion
 
         #region HaveExplicitConversionOperatorOfT
@@ -3972,6 +5153,21 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage(
                     "Expected public static explicit System.String(FluentAssertions*TypeWithConversionOperators) to exist " +
                     "because we want to test the error message, but it does not.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_have_explicit_conversion_operatorOfT_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().HaveExplicitConversionOperator<TypeWithConversionOperators, string>("because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected public static explicit System.String(*.TypeWithConversionOperators) to exist *failure message*, but type is <null>.");
         }
 
         #endregion
@@ -4012,6 +5208,51 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage(
                     "Expected public static explicit System.Byte(FluentAssertions*TypeWithConversionOperators) to not exist " +
                     "because we want to test the error message, but it does.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_have_explicit_conversion_operator_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitConversionOperator(typeof(TypeWithConversionOperators), typeof(string), "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected public static explicit System.String(*.TypeWithConversionOperators) to not exist *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicit_conversion_operator_from_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(TypeWithConversionOperators);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitConversionOperator(null, typeof(string));
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("sourceType");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_explicit_conversion_operator_to_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(TypeWithConversionOperators);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveExplicitConversionOperator(typeof(TypeWithConversionOperators), null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("targetType");
         }
 
         #endregion
@@ -4092,6 +5333,51 @@ namespace FluentAssertions.Specs.Types
                     "because we want to test the error message, but it does not.");
         }
 
+        [Fact]
+        public void When_subject_is_null_have_implicit_conversion_operator_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().HaveImplicitConversionOperator(typeof(TypeWithConversionOperators), typeof(string), "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected public static implicit System.String(*.TypeWithConversionOperators) to exist *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_implicit_conversion_operator_from_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(TypeWithConversionOperators);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveImplicitConversionOperator(null, typeof(string));
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("sourceType");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_has_an_implicit_conversion_operator_to_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(TypeWithConversionOperators);
+
+            // Act
+            Action act = () =>
+                type.Should().HaveImplicitConversionOperator(typeof(TypeWithConversionOperators), null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("targetType");
+        }
+
         #endregion
 
         #region HaveImplicitConversionOperatorOfT
@@ -4128,6 +5414,21 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage(
                     "Expected public static implicit System.String(FluentAssertions*TypeWithConversionOperators) to exist " +
                     "because we want to test the error message, but it does not.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_have_implicit_conversion_operatorOfT_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().HaveImplicitConversionOperator<TypeWithConversionOperators, string>("because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected public static implicit System.String(*.TypeWithConversionOperators) to exist *failure message*, but type is <null>.");
         }
 
         #endregion
@@ -4170,6 +5471,51 @@ namespace FluentAssertions.Specs.Types
                     "because we want to test the error message, but it does.");
         }
 
+        [Fact]
+        public void When_subject_is_null_not_have_implicit_conversion_operator_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveImplicitConversionOperator(typeof(TypeWithConversionOperators), typeof(string), "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected public static implicit System.String(*.TypeWithConversionOperators) to not exist *failure message*, but type is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_implicit_conversion_operator_from_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(TypeWithConversionOperators);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveImplicitConversionOperator(null, typeof(string));
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("sourceType");
+        }
+
+        [Fact]
+        public void When_asserting_a_type_does_not_have_an_implicit_conversion_operator_to_null_it_should_throw()
+        {
+            // Arrange
+            var type = typeof(TypeWithConversionOperators);
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveImplicitConversionOperator(typeof(TypeWithConversionOperators), null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("targetType");
+        }
+
         #endregion
 
         #region NotHaveImplicitConversionOperatorOfT
@@ -4204,6 +5550,21 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage(
                     "Expected public static implicit System.Int32(FluentAssertions*TypeWithConversionOperators) to not exist " +
                     "because we want to test the error message, but it does.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_have_implicit_conversion_operatorOfT_should_fail()
+        {
+            // Arrange
+            Type type = null;
+
+            // Act
+            Action act = () =>
+                type.Should().NotHaveImplicitConversionOperator<TypeWithConversionOperators, string>("because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected public static implicit System.String(*.TypeWithConversionOperators) to not exist *failure message*, but type is <null>.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.cs
@@ -43,27 +43,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().Be(differentType);
+                type.Should().Be(differentType, "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_type_is_equal_to_another_type_it_fails_with_a_useful_message()
-        {
-            // Arrange
-            Type type = typeof(ClassWithAttribute);
-            Type differentType = typeof(ClassWithoutAttribute);
-
-            // Act
-            Action act = () =>
-                type.Should().Be(differentType, "because we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected type to be FluentAssertions*ClassWithoutAttribute" +
-                    " because we want to test the error message, but found FluentAssertions*ClassWithAttribute.");
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to be *.ClassWithoutAttribute *failure message*, but found *.ClassWithAttribute.");
         }
 
         [Fact]
@@ -163,27 +147,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().Be<ClassWithoutAttribute>();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_type_is_equal_to_another_type_using_generics_it_fails_with_a_useful_message()
-        {
-            // Arrange
-            Type type = typeof(ClassWithAttribute);
-
-            // Act
-            Action act = () =>
-                type.Should().Be<ClassWithoutAttribute>("because we want to test the error {0}", "message");
+                type.Should().Be<ClassWithoutAttribute>("because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type to be FluentAssertions*ClassWithoutAttribute because we want to test " +
-                        "the error message, but found FluentAssertions*ClassWithAttribute.");
+                .WithMessage("Expected type to be *.ClassWithoutAttribute *failure message*, but found *.ClassWithAttribute.");
         }
 
         #endregion
@@ -214,10 +182,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotBe(sameType);
+                type.Should().NotBe(sameType, "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type not to be [*.ClassWithAttribute*] *failure message*, but it is.");
         }
 
         [Fact]
@@ -233,23 +202,6 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_type_is_not_equal_to_the_same_type_it_fails_with_a_useful_message()
-        {
-            // Arrange
-            Type type = typeof(ClassWithAttribute);
-            Type sameType = typeof(ClassWithAttribute);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBe(sameType, "because we want to test the error {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("Expected type not to be [FluentAssertions*ClassWithAttribute*]" +
-                             " because we want to test the error message, but it is.");
         }
 
         [Fact]
@@ -274,27 +226,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                type.Should().NotBe<ClassWithAttribute>();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_type_is_not_equal_to_the_same_type_using_generics_it_fails_with_a_useful_message()
-        {
-            // Arrange
-            Type type = typeof(ClassWithAttribute);
-
-            // Act
-            Action act = () =>
-                type.Should().NotBe<ClassWithAttribute>("because we want to test the error {0}", "message");
+                type.Should().NotBe<ClassWithAttribute>("because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage(
-                    "Expected type not to be [FluentAssertions*ClassWithAttribute*] because we want to test " +
-                    "the error message, but it is.");
+                .WithMessage("Expected type not to be [*.ClassWithAttribute*] *failure message*, but it is.");
         }
 
         #endregion
@@ -323,7 +259,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_an_unrelated_type_it_fails_with_a_useful_message()
+        public void When_an_unrelated_type_it_fails()
         {
             // Arrange
             Type someType = typeof(DummyImplementingClass);
@@ -356,15 +292,18 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_an_unrelated_type_instance_it_fails_with_a_useful_message()
+        public void When_an_unrelated_type_instance_it_fails()
         {
             // Arrange
             Type someType = typeof(DummyImplementingClass);
-            Action act = () => someType.Should().BeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
 
-            // Act / Assert
+            // Act
+            Action act = () =>
+                someType.Should().BeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
+
+            // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage($"*{typeof(DummyImplementingClass)} to be assignable to {typeof(DateTime)}*failure message*");
+                .WithMessage("*.DummyImplementingClass to be assignable to *.DateTime *failure message*");
         }
 
         [Fact]
@@ -389,19 +328,22 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_unrelated_to_open_generic_interface_it_fails_with_a_useful_message()
+        public void When_unrelated_to_open_generic_interface_it_fails()
         {
             // Arrange
             Type someType = typeof(IDummyInterface);
-            Action act = () => someType.Should().BeAssignableTo(typeof(IDummyInterface<>), "because we want to test the failure {0}", "message");
 
-            // Act / Assert
+            // Act
+            Action act = () =>
+                someType.Should().BeAssignableTo(typeof(IDummyInterface<>), "because we want to test the failure {0}", "message");
+
+            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage($"*{typeof(IDummyInterface)} to be assignable to {typeof(IDummyInterface<>)}*failure message*");
         }
 
         [Fact]
-        public void When_unrelated_to_open_generic_type_it_fails_with_a_useful_message()
+        public void When_unrelated_to_open_generic_type_it_fails()
         {
             // Arrange
             Type someType = typeof(ClassWithAttribute);
@@ -439,7 +381,7 @@ namespace FluentAssertions.Specs.Types
         #region NotBeAssignableTo
 
         [Fact]
-        public void When_its_own_type_and_asserting_not_assignable_it_fails_with_a_useful_message()
+        public void When_its_own_type_and_asserting_not_assignable_it_fails()
         {
             // Arrange
             Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo<DummyImplementingClass>("because we want to test the failure {0}", "message");
@@ -450,7 +392,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_its_base_type_and_asserting_not_assignable_it_fails_with_a_useful_message()
+        public void When_its_base_type_and_asserting_not_assignable_it_fails()
         {
             // Arrange
             Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo<DummyBaseClass>("because we want to test the failure {0}", "message");
@@ -461,7 +403,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_implemented_interface_type_and_asserting_not_assignable_it_fails_with_a_useful_message()
+        public void When_implemented_interface_type_and_asserting_not_assignable_it_fails()
         {
             // Arrange
             Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo<IDisposable>("because we want to test the failure {0}", "message");
@@ -479,7 +421,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_its_own_type_instance_and_asserting_not_assignable_it_fails_with_a_useful_message()
+        public void When_its_own_type_instance_and_asserting_not_assignable_it_fails()
         {
             // Arrange
             Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(DummyImplementingClass), "because we want to test the failure {0}", "message");
@@ -490,7 +432,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_its_base_type_instance_and_asserting_not_assignable_it_fails_with_a_useful_message()
+        public void When_its_base_type_instance_and_asserting_not_assignable_it_fails()
         {
             // Arrange
             Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(DummyBaseClass), "because we want to test the failure {0}", "message");
@@ -501,7 +443,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_an_implemented_interface_type_instance_and_asserting_not_assignable_it_fails_with_a_useful_message()
+        public void When_an_implemented_interface_type_instance_and_asserting_not_assignable_it_fails()
         {
             // Arrange
             Action act = () => typeof(DummyImplementingClass).Should().NotBeAssignableTo(typeof(IDisposable), "because we want to test the failure {0}", "message");
@@ -533,7 +475,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_implementation_of_open_generic_interface_and_asserting_not_assignable_it_fails_with_a_useful_message()
+        public void When_implementation_of_open_generic_interface_and_asserting_not_assignable_it_fails()
         {
             // Arrange
             Type someType = typeof(ClassWithGenericBaseType);
@@ -545,7 +487,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_derived_from_open_generic_class_and_asserting_not_assignable_it_fails_with_a_useful_message()
+        public void When_derived_from_open_generic_class_and_asserting_not_assignable_it_fails()
         {
             // Arrange
             Type someType = typeof(ClassWithGenericBaseType);
@@ -590,7 +532,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_is_derived_from_an_unrelated_class_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_is_derived_from_an_unrelated_class_it_fails()
         {
             // Arrange
             var type = typeof(DummyBaseClass);
@@ -606,7 +548,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_is_derived_from_an_interface_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_is_derived_from_an_interface_it_fails()
         {
             // Arrange
             var type = typeof(ClassThatImplementsInterface);
@@ -649,7 +591,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_is_derived_from_an_unrelated_open_generic_class_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_is_derived_from_an_unrelated_open_generic_class_it_fails()
         {
             // Arrange
             var type = typeof(ClassWithMembers);
@@ -716,7 +658,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_is_not_derived_from_its_base_class_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_is_not_derived_from_its_base_class_it_fails()
         {
             // Arrange
             var type = typeof(DummyImplementingClass);
@@ -732,7 +674,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_is_not_derived_from_an_interface_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_is_not_derived_from_an_interface_it_fails()
         {
             // Arrange
             var type = typeof(ClassThatImplementsInterface);
@@ -775,7 +717,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_is_not_derived_from_its_open_generic_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_is_not_derived_from_its_open_generic_it_fails()
         {
             // Arrange
             var type = typeof(DummyBaseType<ClassWithGenericBaseType>);
@@ -864,29 +806,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                typeWithoutAttribute.Should().BeDecoratedWith<DummyClassAttribute>();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_type_is_not_decorated_with_expected_attribute_it_fails_with_a_useful_message()
-        {
-            // Arrange
-            Type typeWithoutAttribute = typeof(ClassWithoutAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithoutAttribute.Should().BeDecoratedWith<DummyClassAttribute>(
-                    "because we want to test the error {0}",
-                    "message");
+                typeWithoutAttribute.Should().BeDecoratedWith<DummyClassAttribute>("because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*ClassWithoutAttribute to be decorated with " +
-                    "FluentAssertions*DummyClassAttribute because we want to test the error message, but the attribute " +
-                        "was not found.");
+                .WithMessage("Expected type *.ClassWithoutAttribute to be decorated with *.DummyClassAttribute *failure message*, but the attribute was not found.");
         }
 
         [Fact]
@@ -1074,29 +998,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                typeWithoutAttribute.Should().BeDecoratedWithOrInherit<DummyClassAttribute>();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_type_does_not_inherit_expected_attribute_it_fails_with_a_useful_message()
-        {
-            // Arrange
-            Type typeWithoutAttribute = typeof(ClassWithoutAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithoutAttribute.Should().BeDecoratedWithOrInherit<DummyClassAttribute>(
-                    "because we want to test the error {0}",
-                    "message");
+                typeWithoutAttribute.Should().BeDecoratedWithOrInherit<DummyClassAttribute>("because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type FluentAssertions*ClassWithoutAttribute to be decorated with or inherit " +
-                    "FluentAssertions*DummyClassAttribute because we want to test the error message, but the attribute " +
-                        "was not found.");
+                .WithMessage("Expected type *.ClassWithoutAttribute to be decorated with or inherit *.DummyClassAttribute *failure message*, but the attribute was not found.");
         }
 
         [Fact]
@@ -1270,28 +1176,12 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                typeWithAttribute.Should().NotBeDecoratedWith<DummyClassAttribute>();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_type_is_decorated_with_unexpected_attribute_it_fails_with_a_useful_message()
-        {
-            // Arrange
-            Type typeWithAttribute = typeof(ClassWithAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithAttribute.Should().NotBeDecoratedWith<DummyClassAttribute>(
-                    "because we want to test the error {0}",
-                    "message");
+                typeWithAttribute.Should().NotBeDecoratedWith<DummyClassAttribute>("because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected type*ClassWithAttribute to not be decorated with" +
-                    "*DummyClassAttribute*because we want to test the error message*attribute was found.");
+                    "*DummyClassAttribute* *failure message* attribute was found.");
         }
 
         [Fact]
@@ -1443,28 +1333,11 @@ namespace FluentAssertions.Specs.Types
 
             // Act
             Action act = () =>
-                typeWithAttribute.Should().NotBeDecoratedWithOrInherit<DummyClassAttribute>();
-
-            // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void When_type_inherits_unexpected_attribute_it_fails_with_a_useful_message()
-        {
-            // Arrange
-            Type typeWithAttribute = typeof(ClassWithInheritedAttribute);
-
-            // Act
-            Action act = () =>
-                typeWithAttribute.Should().NotBeDecoratedWithOrInherit<DummyClassAttribute>(
-                    "because we want to test the error {0}",
-                    "message");
+                typeWithAttribute.Should().NotBeDecoratedWithOrInherit<DummyClassAttribute>("because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected type*ClassWithInheritedAttribute to not be decorated with or inherit" +
-                    "*DummyClassAttribute*because we want to test the error message*attribute was found.");
+                .WithMessage("Expected type*ClassWithInheritedAttribute to not be decorated with or inherit *.DummyClassAttribute* *failure message* attribute was found.");
         }
 
         [Fact]
@@ -2488,7 +2361,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_does_not_implement_an_interface_which_it_does_then_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_implement_an_interface_which_it_does_then_it_fails()
         {
             // Arrange
             var type = typeof(ClassThatDoesNotImplementInterface);
@@ -2505,7 +2378,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_implements_a_NonInterface_type_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_implements_a_NonInterface_type_it_fails()
         {
             // Arrange
             var type = typeof(ClassThatDoesNotImplementInterface);
@@ -2571,7 +2444,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_implements_an_interface_which_it_does_not_then_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_implements_an_interface_which_it_does_not_then_it_fails()
         {
             // Arrange
             var type = typeof(ClassThatImplementsInterface);
@@ -2587,7 +2460,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_does_not_implement_a_NonInterface_type_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_implement_a_NonInterface_type_it_fails()
         {
             // Arrange
             var type = typeof(ClassThatDoesNotImplementInterface);
@@ -2657,7 +2530,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_has_a_property_which_it_does_not_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_has_a_property_which_it_does_not_it_fails()
         {
             // Arrange
             var type = typeof(ClassWithNoMembers);
@@ -2674,7 +2547,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_has_a_property_which_it_has_with_a_different_type_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_has_a_property_which_it_has_with_a_different_type_it_fails()
         {
             // Arrange
             var type = typeof(ClassWithMembers);
@@ -2820,7 +2693,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_does_not_have_a_property_which_it_does_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_have_a_property_which_it_does_it_fails()
         {
             // Arrange
             var type = typeof(ClassWithMembers);
@@ -2920,7 +2793,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_property_which_it_implements_implicitly_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_explicitly_implements_a_property_which_it_implements_implicitly_it_fails()
         {
             // Arrange
             var type = typeof(ClassExplicitlyImplementingInterface);
@@ -2940,7 +2813,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_property_which_it_does_not_implement_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_explicitly_implements_a_property_which_it_does_not_implement_it_fails()
         {
             // Arrange
             var type = typeof(ClassExplicitlyImplementingInterface);
@@ -2960,7 +2833,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_property_from_an_unimplemented_interface_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_explicitly_implements_a_property_from_an_unimplemented_interface_it_fails()
         {
             // Arrange
             var type = typeof(ClassExplicitlyImplementingInterface);
@@ -3108,7 +2981,7 @@ namespace FluentAssertions.Specs.Types
         #region NotHaveExplicitProperty
 
         [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implement_a_property_which_it_does_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_explicitly_implement_a_property_which_it_does_it_fails()
         {
             // Arrange
             var type = typeof(ClassExplicitlyImplementingInterface);
@@ -3128,7 +3001,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implement_a_property_which_it_implements_implicitly_and_explicitly_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_explicitly_implement_a_property_which_it_implements_implicitly_and_explicitly_it_fails()
         {
             // Arrange
             var type = typeof(ClassExplicitlyImplementingInterface);
@@ -3265,7 +3138,7 @@ namespace FluentAssertions.Specs.Types
         #region NotHaveExplicitPropertyOfT
 
         [Fact]
-        public void When_asserting_a_type_does_not_explicitlyOfT_implement_a_property_which_it_does_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_explicitlyOfT_implement_a_property_which_it_does_it_fails()
         {
             // Arrange
             var type = typeof(ClassExplicitlyImplementingInterface);
@@ -3366,7 +3239,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_method_which_it_implements_implicitly_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_explicitly_implements_a_method_which_it_implements_implicitly_it_fails()
         {
             // Arrange
             var type = typeof(ClassExplicitlyImplementingInterface);
@@ -3386,7 +3259,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_method_which_it_does_not_implement_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_explicitly_implements_a_method_which_it_does_not_implement_it_fails()
         {
             // Arrange
             var type = typeof(ClassExplicitlyImplementingInterface);
@@ -3406,7 +3279,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_explicitly_implements_a_method_from_an_unimplemented_interface_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_explicitly_implements_a_method_from_an_unimplemented_interface_it_fails()
         {
             // Arrange
             var type = typeof(ClassExplicitlyImplementingInterface);
@@ -3584,7 +3457,7 @@ namespace FluentAssertions.Specs.Types
         #region NotHaveExplicitMethod
 
         [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implement_a_method_which_it_does_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_explicitly_implement_a_method_which_it_does_it_fails()
         {
             // Arrange
             var type = typeof(ClassExplicitlyImplementingInterface);
@@ -3604,7 +3477,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implement_a_method_which_it_implements_implicitly_and_explicitly_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_explicitly_implement_a_method_which_it_implements_implicitly_and_explicitly_it_fails()
         {
             // Arrange
             var type = typeof(ClassExplicitlyImplementingInterface);
@@ -3756,7 +3629,7 @@ namespace FluentAssertions.Specs.Types
         #region NotHaveExplicitMethodOfT
 
         [Fact]
-        public void When_asserting_a_type_does_not_explicitly_implementOfT_a_method_which_it_does_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_explicitly_implementOfT_a_method_which_it_does_it_fails()
         {
             // Arrange
             var type = typeof(ClassExplicitlyImplementingInterface);
@@ -3856,7 +3729,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_has_an_indexer_which_it_does_not_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_has_an_indexer_which_it_does_not_it_fails()
         {
             // Arrange
             var type = typeof(ClassWithNoMembers);
@@ -3873,7 +3746,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_has_an_indexer_with_different_parameters_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_has_an_indexer_with_different_parameters_it_fails()
         {
             // Arrange
             var type = typeof(ClassWithMembers);
@@ -3953,7 +3826,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_does_not_have_an_indexer_which_it_does_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_have_an_indexer_which_it_does_it_fails()
         {
             // Arrange
             var type = typeof(ClassWithMembers);
@@ -4021,7 +3894,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_has_a_constructor_which_it_does_not_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_has_a_constructor_which_it_does_not_it_fails()
         {
             // Arrange
             var type = typeof(ClassWithNoMembers);
@@ -4178,7 +4051,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_does_not_have_a_constructor_which_it_does_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_have_a_constructor_which_it_does_it_fails()
         {
             // Arrange
             var type = typeof(ClassWithMembers);
@@ -4244,7 +4117,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_does_not_have_a_default_constructor_which_it_does_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_have_a_default_constructor_which_it_does_it_fails()
         {
             // Arrange
             var type = typeof(ClassWithMembers);
@@ -4262,7 +4135,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_does_not_have_a_default_constructor_which_it_does_and_a_cctor_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_have_a_default_constructor_which_it_does_and_a_cctor_it_fails()
         {
             // Arrange
             var type = typeof(ClassWithCctor);
@@ -4330,7 +4203,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_has_a_method_which_it_does_not_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_has_a_method_which_it_does_not_it_fails()
         {
             // Arrange
             var type = typeof(ClassWithNoMembers);
@@ -4347,7 +4220,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_has_a_method_with_different_parameter_types_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_has_a_method_with_different_parameter_types_it_fails()
         {
             // Arrange
             var type = typeof(ClassWithMembers);
@@ -4456,7 +4329,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_does_not_have_that_method_which_it_does_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_have_that_method_which_it_does_it_fails()
         {
             // Arrange
             var type = typeof(ClassWithMembers);
@@ -4551,7 +4424,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_public_member_is_internal_it_throws_with_a_useful_message()
+        public void When_asserting_a_public_member_is_internal_it_throws()
         {
             // Arrange
             Type type = typeof(IPublicInterface);
@@ -4583,7 +4456,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_an_internal_type_is_protected_internal_it_throws_with_a_useful_message()
+        public void When_asserting_an_internal_type_is_protected_internal_it_throws()
         {
             // Arrange
             Type type = typeof(InternalClass);
@@ -4614,7 +4487,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_nested_private_type_is_protected_it_throws_with_a_useful_message()
+        public void When_asserting_a_nested_private_type_is_protected_it_throws()
         {
             // Arrange
             Type type = typeof(Nested).GetNestedType("PrivateClass", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -4644,7 +4517,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_nested_protected_type_is_public_it_throws_with_a_useful_message()
+        public void When_asserting_a_nested_protected_type_is_public_it_throws()
         {
             // Arrange
             Type type = typeof(Nested).GetNestedType("ProtectedEnum", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -4673,7 +4546,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_nested_public_member_is_internal_it_throws_with_a_useful_message()
+        public void When_asserting_a_nested_public_member_is_internal_it_throws()
         {
             // Arrange
             Type type = typeof(Nested.IPublicInterface);
@@ -4705,7 +4578,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_nested_internal_type_is_protected_internal_it_throws_with_a_useful_message()
+        public void When_asserting_a_nested_internal_type_is_protected_internal_it_throws()
         {
             // Arrange
             Type type = typeof(Nested.InternalClass);
@@ -4736,7 +4609,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_nested_protected_internal_member_is_private_it_throws_with_a_useful_message()
+        public void When_asserting_a_nested_protected_internal_member_is_private_it_throws()
         {
             // Arrange
             Type type = typeof(Nested.IProtectedInternalInterface);
@@ -4800,7 +4673,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_public_member_is_not_public_it_throws_with_a_useful_message()
+        public void When_asserting_a_public_member_is_not_public_it_throws()
         {
             // Arrange
             Type type = typeof(IPublicInterface);
@@ -4832,7 +4705,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_an_internal_type_is_not_internal_it_throws_with_a_useful_message()
+        public void When_asserting_an_internal_type_is_not_internal_it_throws()
         {
             // Arrange
             Type type = typeof(InternalClass);
@@ -4863,7 +4736,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_nested_private_type_is_not_private_it_throws_with_a_useful_message()
+        public void When_asserting_a_nested_private_type_is_not_private_it_throws()
         {
             // Arrange
             Type type = typeof(Nested).GetNestedType("PrivateClass", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -4893,7 +4766,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_nested_protected_type_is_not_protected_it_throws_with_a_useful_message()
+        public void When_asserting_a_nested_protected_type_is_not_protected_it_throws()
         {
             // Arrange
             Type type = typeof(Nested).GetNestedType("ProtectedEnum", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -4922,7 +4795,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_nested_public_member_is_not_public_it_throws_with_a_useful_message()
+        public void When_asserting_a_nested_public_member_is_not_public_it_throws()
         {
             // Arrange
             Type type = typeof(Nested.IPublicInterface);
@@ -4954,7 +4827,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_nested_internal_type_is_not_internal_it_throws_with_a_useful_message()
+        public void When_asserting_a_nested_internal_type_is_not_internal_it_throws()
         {
             // Arrange
             Type type = typeof(Nested.InternalClass);
@@ -4985,7 +4858,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_nested_protected_internal_member_is_not_protected_internal_it_throws_with_a_useful_message()
+        public void When_asserting_a_nested_protected_internal_member_is_not_protected_internal_it_throws()
         {
             // Arrange
             Type type = typeof(Nested.IProtectedInternalInterface);
@@ -5139,7 +5012,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_has_an_explicit_conversion_operatorOfT_which_it_does_not_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_has_an_explicit_conversion_operatorOfT_which_it_does_not_it_fails()
         {
             // Arrange
             var type = typeof(TypeWithConversionOperators);
@@ -5192,7 +5065,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_conversion_operator_which_it_does_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_have_an_explicit_conversion_operator_which_it_does_it_fails()
         {
             // Arrange
             var type = typeof(TypeWithConversionOperators);
@@ -5275,7 +5148,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_does_not_have_an_explicit_conversion_operatorOfT_which_it_does_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_have_an_explicit_conversion_operatorOfT_which_it_does_it_fails()
         {
             // Arrange
             var type = typeof(TypeWithConversionOperators);
@@ -5315,7 +5188,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_has_an_implicit_conversion_operator_which_it_does_not_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_has_an_implicit_conversion_operator_which_it_does_not_it_fails()
         {
             // Arrange
             var type = typeof(TypeWithConversionOperators);
@@ -5400,7 +5273,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_has_an_implicit_conversion_operatorOfT_which_it_does_not_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_has_an_implicit_conversion_operatorOfT_which_it_does_not_it_fails()
         {
             // Arrange
             var type = typeof(TypeWithConversionOperators);
@@ -5453,7 +5326,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_does_not_have_an_implicit_conversion_operator_which_it_does_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_have_an_implicit_conversion_operator_which_it_does_it_fails()
         {
             // Arrange
             var type = typeof(TypeWithConversionOperators);
@@ -5536,7 +5409,7 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
-        public void When_asserting_a_type_does_not_have_an_implicit_conversion_operatorOfT_which_it_does_it_fails_with_a_useful_message()
+        public void When_asserting_a_type_does_not_have_an_implicit_conversion_operatorOfT_which_it_does_it_fails()
         {
             // Arrange
             var type = typeof(TypeWithConversionOperators);

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -27,6 +27,7 @@ sidebar:
 * Restrict what types `WhenTypeIs<T>` can use and how `Using<T>` handles non-nullable types, see the [Migration Guide](/upgradingtov6#using) for more details - [#1494](https://github.com/fluentassertions/fluentassertions/pull/1494).
 * `HaveElement` did not ignore the xml namespace - [#1541](https://github.com/fluentassertions/fluentassertions/pull/1541)
 * Better parameter checking of `TypeAssertions` - [#1550](https://github.com/fluentassertions/fluentassertions/pull/1550)
+* `[Not]HaveExplicitMethod` did not mention the parameters in the failure message - [#1550](https://github.com/fluentassertions/fluentassertions/pull/1550)
 
 **Breaking Changes**
 * Changed `becauseArgs` of `[Not]Reference(Assembly)` from `string[]` to `object[]` - [#1459](https://github.com/fluentassertions/fluentassertions/pull/1459)

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -26,6 +26,7 @@ sidebar:
 * Some dictionary failures did not honor the user-provided reason - [#1456](https://github.com/fluentassertions/fluentassertions/pull/1456)
 * Restrict what types `WhenTypeIs<T>` can use and how `Using<T>` handles non-nullable types, see the [Migration Guide](/upgradingtov6#using) for more details - [#1494](https://github.com/fluentassertions/fluentassertions/pull/1494).
 * `HaveElement` did not ignore the xml namespace - [#1541](https://github.com/fluentassertions/fluentassertions/pull/1541)
+* Better parameter checking of `TypeAssertions` - [#1550](https://github.com/fluentassertions/fluentassertions/pull/1550)
 
 **Breaking Changes**
 * Changed `becauseArgs` of `[Not]Reference(Assembly)` from `string[]` to `object[]` - [#1459](https://github.com/fluentassertions/fluentassertions/pull/1459)


### PR DESCRIPTION
Inspired by #1039

* Check for Subject to be null
* Check parameters types for null (or empty)
* Check enum parameters types for out-of-range values
* Add covering unit tests
* Add possible exceptions to XmlDoc
* Try to get more consistent function/test layout
* Try to get more consistent documentation
* ~~replace "to not exist" with "not to exist", [both are valid](https://www.learnersdictionary.com/qa/to-not-be-or-not-to-be) but this feels more fluent to me, but maybe it is just taste.~~
* Condense tests

Status:

* [x] [Not]BeAbstract
* [x] [Not]BeAssignableTo
* [x] [Not]BeDerivedFrom
* [x] [Not]BeSealed
* [x] [Not]BeStatic
* [x] [Not]HaveAccessModifier
* [x] [Not]HaveConstructor
* [x] [Not]HaveDefaultConstructor
* [x] [Not]HaveExplicitConversionOperator
* [x] [Not]HaveExplicitMethod
* [x] [Not]HaveExplicitProperty
* [x] [Not]HaveImplicitConversionOperator
* [x] [Not]HaveIndexer
* [x] [Not]HaveMethod
* [x] [Not]HaveProperty
* [x] [Not]Implement


## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).