### PR TITLE
Robust PropertyInfo assertions

### DIFF
--- a/Src/FluentAssertions/Types/MemberInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MemberInfoAssertions.cs
@@ -71,6 +71,7 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="isMatchingAttributePredicate"/> is <c>null</c>.</exception>
         public AndWhichConstraint<MemberInfoAssertions<TSubject, TAssertions>, TAttribute> BeDecoratedWith<TAttribute>(
             Expression<Func<TAttribute, bool>> isMatchingAttributePredicate,
             string because = "", params object[] becauseArgs)
@@ -116,6 +117,7 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="isMatchingAttributePredicate"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> NotBeDecoratedWith<TAttribute>(
             Expression<Func<TAttribute, bool>> isMatchingAttributePredicate,
             string because = "", params object[] becauseArgs)

--- a/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
@@ -117,8 +117,12 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="accessModifier"/>
+        /// is not a <see cref="CSharpAccessModifier"/> value.</exception>
         public AndConstraint<PropertyInfoAssertions> BeWritable(CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsOutOfRange(accessModifier, nameof(accessModifier));
+
             bool success = Execute.Assertion
               .BecauseOf(because, becauseArgs)
               .ForCondition(Subject is not null)
@@ -203,8 +207,12 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="accessModifier"/>
+        /// is not a <see cref="CSharpAccessModifier"/> value.</exception>
         public AndConstraint<PropertyInfoAssertions> BeReadable(CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsOutOfRange(accessModifier, nameof(accessModifier));
+
             bool success = Execute.Assertion
                .BecauseOf(because, becauseArgs)
                .ForCondition(Subject is not null)
@@ -262,9 +270,12 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="propertyType"/> is <c>null</c>.</exception>
         public AndConstraint<PropertyInfoAssertions> Return(Type propertyType,
             string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(propertyType, nameof(propertyType));
+
             bool success = Execute.Assertion
                .BecauseOf(because, becauseArgs)
                .ForCondition(Subject is not null)
@@ -308,8 +319,11 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="propertyType"/> is <c>null</c>.</exception>
         public AndConstraint<PropertyInfoAssertions> NotReturn(Type propertyType, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(propertyType, nameof(propertyType));
+
             bool success = Execute.Assertion
                .BecauseOf(because, becauseArgs)
                .ForCondition(Subject is not null)

--- a/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoAssertions.cs
@@ -31,14 +31,18 @@ namespace FluentAssertions.Types
         public AndConstraint<PropertyInfoAssertions> BeVirtual(
             string because = "", params object[] becauseArgs)
         {
-            string failureMessage = "Expected property " +
-                                    GetDescriptionFor(Subject) +
-                                    " to be virtual{reason}, but it is not.";
-
-            Execute.Assertion
-                .ForCondition(Subject.IsVirtual())
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith(failureMessage);
+                .ForCondition(Subject is not null)
+                .FailWith("Expected property to be virtual{reason}, but {context:property} is <null>.");
+
+            if (success)
+            {
+                Execute.Assertion
+                    .ForCondition(Subject.IsVirtual())
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith($"Expected property {GetDescriptionFor(Subject)} to be virtual{{reason}}, but it is not.");
+            }
 
             return new AndConstraint<PropertyInfoAssertions>(this);
         }
@@ -55,12 +59,18 @@ namespace FluentAssertions.Types
         /// </param>
         public AndConstraint<PropertyInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs)
         {
-            string failureMessage = "Expected property " + GetDescriptionFor(Subject) + " not to be virtual{reason}, but it is.";
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected property not to be virtual{reason}, but {context:property} is <null>.");
 
-            Execute.Assertion
+            if (success)
+            {
+                Execute.Assertion
                 .ForCondition(!Subject.IsVirtual())
                 .BecauseOf(because, becauseArgs)
-                .FailWith(failureMessage);
+                .FailWith($"Expected property {GetDescriptionFor(Subject)} not to be virtual{{reason}}, but it is.");
+            }
 
             return new AndConstraint<PropertyInfoAssertions>(this);
         }
@@ -78,12 +88,20 @@ namespace FluentAssertions.Types
         public AndConstraint<PropertyInfoAssertions> BeWritable(
             string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected property to have a setter{reason}, but {context:property} is <null>.");
+
+            if (success)
+            {
+                Execute.Assertion
                 .ForCondition(Subject.CanWrite)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected {context:property} {0} to have a setter{reason}.",
                     Subject);
+            }
 
             return new AndConstraint<PropertyInfoAssertions>(this);
         }
@@ -101,9 +119,17 @@ namespace FluentAssertions.Types
         /// </param>
         public AndConstraint<PropertyInfoAssertions> BeWritable(CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
         {
-            Subject.Should().BeWritable(because, becauseArgs);
+            bool success = Execute.Assertion
+              .BecauseOf(because, becauseArgs)
+              .ForCondition(Subject is not null)
+              .FailWith($"Expected {Identifier} to be {accessModifier}{{reason}}, but {{context:property}} is <null>.");
 
-            Subject.GetSetMethod(nonPublic: true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
+            if (success)
+            {
+                Subject.Should().BeWritable(because, becauseArgs);
+
+                Subject.GetSetMethod(nonPublic: true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
+            }
 
             return new AndConstraint<PropertyInfoAssertions>(this);
         }
@@ -121,12 +147,20 @@ namespace FluentAssertions.Types
         public AndConstraint<PropertyInfoAssertions> NotBeWritable(
             string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected property not to have a setter{reason}, but {context:property} is <null>.");
+
+            if (success)
+            {
+                Execute.Assertion
                 .ForCondition(!Subject.CanWrite)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected {context:property} {0} not to have a setter{reason}.",
                     Subject);
+            }
 
             return new AndConstraint<PropertyInfoAssertions>(this);
         }
@@ -143,9 +177,17 @@ namespace FluentAssertions.Types
         /// </param>
         public AndConstraint<PropertyInfoAssertions> BeReadable(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion.ForCondition(Subject.CanRead)
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected property to have a getter{reason}, but {context:property} is <null>.");
+
+            if (success)
+            {
+                Execute.Assertion.ForCondition(Subject.CanRead)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected property " + Subject.Name + " to have a getter{reason}, but it does not.");
+            }
 
             return new AndConstraint<PropertyInfoAssertions>(this);
         }
@@ -163,9 +205,17 @@ namespace FluentAssertions.Types
         /// </param>
         public AndConstraint<PropertyInfoAssertions> BeReadable(CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
         {
-            Subject.Should().BeReadable(because, becauseArgs);
+            bool success = Execute.Assertion
+               .BecauseOf(because, becauseArgs)
+               .ForCondition(Subject is not null)
+               .FailWith($"Expected {Identifier} to be {accessModifier}{{reason}}, but {{context:property}} is <null>.");
 
-            Subject.GetGetMethod(nonPublic: true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
+            if (success)
+            {
+                Subject.Should().BeReadable(because, becauseArgs);
+
+                Subject.GetGetMethod(nonPublic: true).Should().HaveAccessModifier(accessModifier, because, becauseArgs);
+            }
 
             return new AndConstraint<PropertyInfoAssertions>(this);
         }
@@ -183,12 +233,20 @@ namespace FluentAssertions.Types
         public AndConstraint<PropertyInfoAssertions> NotBeReadable(
             string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected property not to have a getter{reason}, but {context:property} is <null>.");
+
+            if (success)
+            {
+                Execute.Assertion
                 .ForCondition(!Subject.CanRead)
                 .BecauseOf(because, becauseArgs)
                 .FailWith(
                     "Expected {context:property} {0} not to have a getter{reason}.",
                     Subject);
+            }
 
             return new AndConstraint<PropertyInfoAssertions>(this);
         }
@@ -207,9 +265,18 @@ namespace FluentAssertions.Types
         public AndConstraint<PropertyInfoAssertions> Return(Type propertyType,
             string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion.ForCondition(Subject.PropertyType == propertyType)
+            bool success = Execute.Assertion
+               .BecauseOf(because, becauseArgs)
+               .ForCondition(Subject is not null)
+               .FailWith("Expected type of property to be {0}{reason}, but {context:property} is <null>.", propertyType);
+
+            if (success)
+            {
+                Execute.Assertion.ForCondition(Subject.PropertyType == propertyType)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected Type of property " + Subject.Name + " to be {0}{reason}, but it is {1}.", propertyType, Subject.PropertyType);
+                .FailWith("Expected Type of property " + Subject.Name + " to be {0}{reason}, but it is {1}.",
+                propertyType, Subject.PropertyType);
+            }
 
             return new AndConstraint<PropertyInfoAssertions>(this);
         }
@@ -243,10 +310,18 @@ namespace FluentAssertions.Types
         /// </param>
         public AndConstraint<PropertyInfoAssertions> NotReturn(Type propertyType, string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
+               .BecauseOf(because, becauseArgs)
+               .ForCondition(Subject is not null)
+               .FailWith("Expected type of property not to be {0}{reason}, but {context:property} is <null>.", propertyType);
+
+            if (success)
+            {
+                Execute.Assertion
                 .ForCondition(Subject.PropertyType != propertyType)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected Type of property " + Subject.Name + " not to be {0}{reason}, but it is.", propertyType);
+            }
 
             return new AndConstraint<PropertyInfoAssertions>(this);
         }

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using FluentAssertions.Common;
@@ -219,6 +219,21 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage("Expected property to be decorated with *.DummyPropertyAttribute *failure message*, but propertyInfo is <null>.");
         }
 
+        [Fact]
+        public void When_asserting_property_is_decorated_with_null_it_should_throw()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = typeof(ClassWithAllPropertiesDecoratedWithDummyAttribute).GetRuntimeProperty("PublicProperty");
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().BeDecoratedWith((Expression<Func<DummyPropertyAttribute, bool>>)null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("isMatchingAttributePredicate");
+        }
+
         #endregion
 
         #region NotBeDecoratedWithOfT
@@ -236,6 +251,21 @@ namespace FluentAssertions.Specs.Types
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected property to not be decorated with *.DummyPropertyAttribute *failure message*, but propertyInfo is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_property_is_not_decorated_with_null_it_should_throw()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().NotBeDecoratedWith((Expression<Func<DummyPropertyAttribute, bool>>)null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("isMatchingAttributePredicate");
         }
 
         #endregion
@@ -528,6 +558,21 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage("Expected property to be Public *failure message*, but propertyInfo is <null>.");
         }
 
+        [Fact]
+        public void When_asserting_is_readable_with_an_invalid_enum_value_it_should_throw()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().BeReadable((CSharpAccessModifier)int.MaxValue);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentOutOfRangeException>()
+                .WithParameterName("accessModifier");
+        }
+
         #endregion
 
         #region BeWritableAccessModifier
@@ -572,6 +617,21 @@ namespace FluentAssertions.Specs.Types
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected property to be Public *failure message*, but propertyInfo is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_is_writable_with_an_invalid_enum_value_it_should_throw()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().BeWritable((CSharpAccessModifier)int.MaxValue);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentOutOfRangeException>()
+                .WithParameterName("accessModifier");
         }
 
         #endregion
@@ -619,6 +679,21 @@ namespace FluentAssertions.Specs.Types
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected type of property to be *.Int32 *failure message*, but propertyInfo is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_property_type_is_null_it_should_throw()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().Return(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("propertyType");
         }
 
         #endregion
@@ -698,6 +773,21 @@ namespace FluentAssertions.Specs.Types
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected type of property not to be *.Int32 *failure message*, but propertyInfo is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_property_type_is_not_null_it_should_throw()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = typeof(ClassWithProperties).GetRuntimeProperty("StringProperty");
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().NotReturn(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("propertyType");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/PropertyInfoAssertionSpecs.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Linq.Expressions;
 using System.Reflection;
 using FluentAssertions.Common;
 using Xunit;
@@ -42,6 +43,21 @@ namespace FluentAssertions.Specs.Types
                        " but it is not.");
         }
 
+        [Fact]
+        public void When_subject_is_null_be_virtual_should_fail()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().BeVirtual("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected property to be virtual *failure message*, but propertyInfo is <null>.");
+        }
+
         #endregion
 
         #region NotBeVirtual
@@ -76,6 +92,21 @@ namespace FluentAssertions.Specs.Types
                    "Expected property *ClassWithAllPropertiesVirtual.PublicVirtualProperty" +
                        " not to be virtual because we want to test the error message," +
                        " but it is.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_be_virtual_should_fail()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().NotBeVirtual("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected property not to be virtual *failure message*, but propertyInfo is <null>.");
         }
 
         #endregion
@@ -173,6 +204,40 @@ namespace FluentAssertions.Specs.Types
             act.Should().NotThrow();
         }
 
+        [Fact]
+        public void When_subject_is_null_be_decorated_withOfT_should_fail()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().BeDecoratedWith<DummyPropertyAttribute>("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected property to be decorated with *.DummyPropertyAttribute *failure message*, but propertyInfo is <null>.");
+        }
+
+        #endregion
+
+        #region NotBeDecoratedWithOfT
+
+        [Fact]
+        public void When_subject_is_null_not_be_decorated_withOfT_should_fail()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().NotBeDecoratedWith<DummyPropertyAttribute>("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected property to not be decorated with *.DummyPropertyAttribute *failure message*, but propertyInfo is <null>.");
+        }
+
         #endregion
 
         #region BeWritable
@@ -218,6 +283,21 @@ namespace FluentAssertions.Specs.Types
             action.Should().NotThrow();
         }
 
+        [Fact]
+        public void When_subject_is_null_be_writable_should_fail()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().BeWritable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected property to have a setter *failure message*, but propertyInfo is <null>.");
+        }
+
         #endregion
 
         #region BeReadable
@@ -261,6 +341,21 @@ namespace FluentAssertions.Specs.Types
             action
                 .Should().Throw<XunitException>()
                 .WithMessage("Expected property WriteOnlyProperty to have a getter because we want to test the error message, but it does not.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_be_readable_should_fail()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().BeReadable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected property to have a getter *failure message*, but propertyInfo is <null>.");
         }
 
         #endregion
@@ -310,6 +405,21 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage("Expected propertyInfo WriteOnlyProperty not to have a setter because we want to test the error message.");
         }
 
+        [Fact]
+        public void When_subject_is_null_not_be_writable_should_fail()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().NotBeWritable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected property not to have a setter *failure message*, but propertyInfo is <null>.");
+        }
+
         #endregion
 
         #region NotBeReadable
@@ -357,6 +467,21 @@ namespace FluentAssertions.Specs.Types
             action.Should().NotThrow();
         }
 
+        [Fact]
+        public void When_subject_is_null_not_be_readable_should_fail()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().NotBeReadable("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected property not to have a getter *failure message*, but propertyInfo is <null>.");
+        }
+
         #endregion
 
         #region BeReadableAccessModifier
@@ -386,6 +511,21 @@ namespace FluentAssertions.Specs.Types
             // Assert
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected method get_WritePrivateReadProperty to be Public because we want to test the error message, but it is Private.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_be_readable_with_accessmodifier_should_fail()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().BeReadable(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected property to be Public *failure message*, but propertyInfo is <null>.");
         }
 
         #endregion
@@ -419,6 +559,21 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage("Expected method set_ReadPrivateWriteProperty to be Public because we want to test the error message, but it is Private.");
         }
 
+        [Fact]
+        public void When_subject_is_null_be_writable_with_accessmodifier_should_fail()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().BeWritable(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected property to be Public *failure message*, but propertyInfo is <null>.");
+        }
+
         #endregion
 
         #region Return
@@ -449,6 +604,21 @@ namespace FluentAssertions.Specs.Types
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected Type of property StringProperty to be System.Int32 because we want to test the error " +
                              "message, but it is System.String.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_return_should_fail()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().Return(typeof(int), "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type of property to be *.Int32 *failure message*, but propertyInfo is <null>.");
         }
 
         #endregion
@@ -513,6 +683,21 @@ namespace FluentAssertions.Specs.Types
             action.Should().Throw<XunitException>()
                 .WithMessage("Expected Type of property StringProperty not to be*String*because we want to test the error " +
                              "message, but it is.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_return_should_fail()
+        {
+            // Arrange
+            PropertyInfo propertyInfo = null;
+
+            // Act
+            Action act = () =>
+                propertyInfo.Should().NotReturn(typeof(int), "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type of property not to be *.Int32 *failure message*, but propertyInfo is <null>.");
         }
 
         #endregion

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -28,6 +28,7 @@ sidebar:
 * `HaveElement` did not ignore the xml namespace - [#1541](https://github.com/fluentassertions/fluentassertions/pull/1541)
 * Better parameter checking of `TypeAssertions` - [#1550](https://github.com/fluentassertions/fluentassertions/pull/1550)
 * `[Not]HaveExplicitMethod` did not mention the parameters in the failure message - [#1550](https://github.com/fluentassertions/fluentassertions/pull/1550)
+* Better parameter checking of `PropertyInfoAssertions` - [#1558](https://github.com/fluentassertions/fluentassertions/pull/1558)
 * Better parameter checking of `MethodBaseAssertions` and `MethodInfoAssertions` - [#1559](https://github.com/fluentassertions/fluentassertions/pull/1559)
 
 **Breaking Changes**


### PR DESCRIPTION
More coverage of #1039

* Added failure message when `Subject` is null
* Added `Guards` against `null` parameters

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).