### PR TITLE
Robust methodinfo assertions

### DIFF
--- a/Src/FluentAssertions/Types/MemberInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MemberInfoAssertions.cs
@@ -78,14 +78,26 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate, nameof(isMatchingAttributePredicate));
 
-            string failureMessage = $"Expected {Identifier} {SubjectDescription} to be decorated with {typeof(TAttribute)}{{reason}}, but that attribute was not found.";
-
-            IEnumerable<TAttribute> attributes = Subject.GetMatchingAttributes(isMatchingAttributePredicate);
-
-            Execute.Assertion
-                .ForCondition(attributes.Any())
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith(failureMessage);
+                .ForCondition(Subject is not null)
+                .FailWith(
+                    $"Expected {Identifier} to be decorated with {typeof(TAttribute)}{{reason}}" +
+                    $", but {{context:member}} is <null>.");
+
+            IEnumerable<TAttribute> attributes = new TAttribute[0];
+
+            if (success)
+            {
+                attributes = Subject.GetMatchingAttributes(isMatchingAttributePredicate);
+
+                Execute.Assertion
+                    .ForCondition(attributes.Any())
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        $"Expected {Identifier} {SubjectDescription} to be decorated with {typeof(TAttribute)}{{reason}}" +
+                        $", but that attribute was not found.");
+            }
 
             return new AndWhichConstraint<MemberInfoAssertions<TSubject, TAssertions>, TAttribute>(this, attributes);
         }
@@ -111,14 +123,24 @@ namespace FluentAssertions.Types
         {
             Guard.ThrowIfArgumentIsNull(isMatchingAttributePredicate, nameof(isMatchingAttributePredicate));
 
-            string failureMessage = $"Expected {Identifier} {SubjectDescription} to not be decorated with {typeof(TAttribute)}{{reason}}, but that attribute was found.";
-
-            IEnumerable<TAttribute> attributes = Subject.GetMatchingAttributes(isMatchingAttributePredicate);
-
-            Execute.Assertion
-                .ForCondition(!attributes.Any())
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith(failureMessage);
+                .ForCondition(Subject is not null)
+                .FailWith(
+                    $"Expected {Identifier} to not be decorated with {typeof(TAttribute)}{{reason}}" +
+                    $", but {{context:member}} is <null>.");
+
+            if (success)
+            {
+                IEnumerable<TAttribute> attributes = Subject.GetMatchingAttributes(isMatchingAttributePredicate);
+
+                Execute.Assertion
+                    .ForCondition(!attributes.Any())
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        $"Expected {Identifier} {SubjectDescription} to not be decorated with {typeof(TAttribute)}{{reason}}" +
+                        $", but that attribute was found.");
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Types/MethodBaseAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodBaseAssertions.cs
@@ -35,12 +35,21 @@ namespace FluentAssertions.Types
         public AndConstraint<TAssertions> HaveAccessModifier(
             CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
         {
-            CSharpAccessModifier subjectAccessModifier = Subject.GetCSharpAccessModifier();
-
-            Execute.Assertion.ForCondition(accessModifier == subjectAccessModifier)
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected method " + Subject.Name + " to be " + accessModifier.ToString()
-                    + "{reason}, but it is " + subjectAccessModifier.ToString() + ".");
+                .ForCondition(Subject is not null)
+                .FailWith($"Expected method to be {accessModifier}{{reason}}, but {{context:member}} is <null>.");
+
+            if (success)
+            {
+                CSharpAccessModifier subjectAccessModifier = Subject.GetCSharpAccessModifier();
+
+                Execute.Assertion
+                    .ForCondition(accessModifier == subjectAccessModifier)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        $"Expected method {Subject.Name} to be {accessModifier}{{reason}}, but it is {subjectAccessModifier}.");
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -58,10 +67,20 @@ namespace FluentAssertions.Types
         /// </param>
         public AndConstraint<TAssertions> NotHaveAccessModifier(CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
-                .ForCondition(accessModifier != Subject.GetCSharpAccessModifier())
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected method " + Subject.Name + " not to be " + accessModifier.ToString() + "{reason}, but it is.");
+                .ForCondition(Subject is not null)
+                .FailWith($"Expected method not to be {accessModifier}{{reason}}, but {{context:member}} is <null>.");
+
+            if (success)
+            {
+                CSharpAccessModifier subjectAccessModifier = Subject.GetCSharpAccessModifier();
+
+                Execute.Assertion
+                    .ForCondition(accessModifier != subjectAccessModifier)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith($"Expected method {Subject.Name} not to be {accessModifier}{{reason}}, but it is.");
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Types/MethodBaseAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodBaseAssertions.cs
@@ -32,9 +32,13 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="accessModifier"/>
+        /// is not a <see cref="CSharpAccessModifier"/> value.</exception>
         public AndConstraint<TAssertions> HaveAccessModifier(
             CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsOutOfRange(accessModifier, nameof(accessModifier));
+
             bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
@@ -65,8 +69,12 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="accessModifier"/>
+        /// is not a <see cref="CSharpAccessModifier"/> value.</exception>
         public AndConstraint<TAssertions> NotHaveAccessModifier(CSharpAccessModifier accessModifier, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsOutOfRange(accessModifier, nameof(accessModifier));
+
             bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)

--- a/Src/FluentAssertions/Types/MethodInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoAssertions.cs
@@ -169,8 +169,11 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="returnType"/> is <c>null</c>.</exception>
         public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> Return(Type returnType, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(returnType, nameof(returnType));
+
             bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
@@ -243,8 +246,11 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="returnType"/> is <c>null</c>.</exception>
         public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> NotReturn(Type returnType, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(returnType, nameof(returnType));
+
             bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)

--- a/Src/FluentAssertions/Types/MethodInfoAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoAssertions.cs
@@ -27,17 +27,20 @@ namespace FluentAssertions.Types
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<MethodInfoAssertions> BeVirtual(
-            string because = "", params object[] becauseArgs)
+        public AndConstraint<MethodInfoAssertions> BeVirtual(string because = "", params object[] becauseArgs)
         {
-            string failureMessage = "Expected method " +
-                                    SubjectDescription +
-                                    " to be virtual{reason}, but it is not virtual.";
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected method to be virtual{reason}, but {context:member} is <null>.");
 
-            Execute.Assertion
+            if (success)
+            {
+                Execute.Assertion
                 .ForCondition(!Subject.IsNonVirtual())
                 .BecauseOf(because, becauseArgs)
-                .FailWith(failureMessage);
+                .FailWith("Expected method " + SubjectDescription + " to be virtual{reason}, but it is not virtual.");
+            }
 
             return new AndConstraint<MethodInfoAssertions>(this);
         }
@@ -54,12 +57,18 @@ namespace FluentAssertions.Types
         /// </param>
         public AndConstraint<MethodInfoAssertions> NotBeVirtual(string because = "", params object[] becauseArgs)
         {
-            string failureMessage = "Expected method " + SubjectDescription + " not to be virtual{reason}, but it is.";
-
-            Execute.Assertion
-                .ForCondition(Subject.IsNonVirtual())
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith(failureMessage);
+                .ForCondition(Subject is not null)
+                .FailWith("Expected method not to be virtual{reason}, but {context:member} is <null>.");
+
+            if (success)
+            {
+                Execute.Assertion
+                    .ForCondition(Subject.IsNonVirtual())
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected method " + SubjectDescription + " not to be virtual{reason}, but it is.");
+            }
 
             return new AndConstraint<MethodInfoAssertions>(this);
         }
@@ -76,14 +85,18 @@ namespace FluentAssertions.Types
         /// </param>
         public AndConstraint<MethodInfoAssertions> BeAsync(string because = "", params object[] becauseArgs)
         {
-            string failureMessage = "Expected method " +
-                        SubjectDescription +
-                        " to be async{reason}, but it is not.";
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected method to be async{reason}, but {context:member} is <null>.");
 
-            Execute.Assertion
+            if (success)
+            {
+                Execute.Assertion
                 .ForCondition(Subject.IsAsync())
                 .BecauseOf(because, becauseArgs)
-                .FailWith(failureMessage);
+                .FailWith("Expected method " + SubjectDescription + " to be async{reason}, but it is not.");
+            }
 
             return new AndConstraint<MethodInfoAssertions>(this);
         }
@@ -100,12 +113,18 @@ namespace FluentAssertions.Types
         /// </param>
         public AndConstraint<MethodInfoAssertions> NotBeAsync(string because = "", params object[] becauseArgs)
         {
-            string failureMessage = "Expected method " + SubjectDescription + " not to be async{reason}, but it is.";
-
-            Execute.Assertion
-                .ForCondition(!Subject.IsAsync())
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith(failureMessage);
+                .ForCondition(Subject is not null)
+                .FailWith("Expected method not to be async{reason}, but {context:member} is <null>.");
+
+            if (success)
+            {
+                Execute.Assertion
+                    .ForCondition(!Subject.IsAsync())
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected method " + SubjectDescription + " not to be async{reason}, but it is.");
+            }
 
             return new AndConstraint<MethodInfoAssertions>(this);
         }
@@ -122,10 +141,19 @@ namespace FluentAssertions.Types
         /// </param>
         public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> ReturnVoid(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion.ForCondition(typeof(void) == Subject.ReturnType)
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected the return type of method " + Subject.Name + " to be void{reason}, but it is {0}.",
-                    Subject.ReturnType.FullName);
+                .ForCondition(Subject is not null)
+                .FailWith("Expected the return type of method to be void{reason}, but {context:member} is <null>.");
+
+            if (success)
+            {
+                Execute.Assertion
+                    .ForCondition(typeof(void) == Subject.ReturnType)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected the return type of method " + Subject.Name + " to be void{reason}, but it is {0}.",
+                        Subject.ReturnType.FullName);
+            }
 
             return new AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>>(this);
         }
@@ -143,10 +171,19 @@ namespace FluentAssertions.Types
         /// </param>
         public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> Return(Type returnType, string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion.ForCondition(returnType == Subject.ReturnType)
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected the return type of method " + Subject.Name + " to be {0}{reason}, but it is {1}.",
-                    returnType, Subject.ReturnType.FullName);
+                .ForCondition(Subject is not null)
+                .FailWith("Expected the return type of method to be {0}{reason}, but {context:member} is <null>.", returnType);
+
+            if (success)
+            {
+                Execute.Assertion
+                    .ForCondition(returnType == Subject.ReturnType)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected the return type of method " + Subject.Name + " to be {0}{reason}, but it is {1}.",
+                        returnType, Subject.ReturnType.FullName);
+            }
 
             return new AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>>(this);
         }
@@ -179,10 +216,18 @@ namespace FluentAssertions.Types
         /// </param>
         public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> NotReturnVoid(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
-                .ForCondition(typeof(void) != Subject.ReturnType)
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected the return type of method " + Subject.Name + " not to be void{reason}, but it is.");
+                .ForCondition(Subject is not null)
+                .FailWith("Expected the return type of method not to be void{reason}, but {context:member} is <null>.");
+
+            if (success)
+            {
+                Execute.Assertion
+                    .ForCondition(typeof(void) != Subject.ReturnType)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected the return type of method " + Subject.Name + " not to be void{reason}, but it is.");
+            }
 
             return new AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>>(this);
         }
@@ -200,10 +245,20 @@ namespace FluentAssertions.Types
         /// </param>
         public AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>> NotReturn(Type returnType, string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith(
+                    "Expected the return type of method not to be {0}{reason}, but {context:member} is <null>.", returnType);
+
+            if (success)
+            {
+                Execute.Assertion
                 .ForCondition(returnType != Subject.ReturnType)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected the return type of method " + Subject.Name + " not to be {0}{reason}, but it is.", returnType);
+                .FailWith(
+                    "Expected the return type of method " + Subject.Name + " not to be {0}{reason}, but it is.", returnType);
+            }
 
             return new AndConstraint<MethodBaseAssertions<MethodInfo, MethodInfoAssertions>>(this);
         }

--- a/Tests/FluentAssertions.Specs/Types/MethodBaseAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodBaseAssertionSpecs.cs
@@ -72,6 +72,21 @@ namespace FluentAssertions.Specs.Types
                     "Expected the return type of method to be *.String *failure message*, but methodInfo is <null>.");
         }
 
+        [Fact]
+        public void When_asserting_method_return_type_is_null_it_should_throw()
+        {
+            // Arrange
+            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().Return(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("returnType");
+        }
+
         #endregion
 
         #region NotReturn
@@ -119,6 +134,21 @@ namespace FluentAssertions.Specs.Types
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected the return type of method not to be *.String *failure message*, but methodInfo is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_method_return_type_is_not_null_it_should_throw()
+        {
+            // Arrange
+            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("IntMethod");
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().NotReturn(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("returnType");
         }
 
         #endregion
@@ -512,6 +542,21 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage("Expected method to be Public *failure message*, but methodInfo is <null>.");
         }
 
+        [Fact]
+        public void When_asserting_method_has_access_modifier_with_an_invalid_enum_value_it_should_throw()
+        {
+            // Arrange
+            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateMethod");
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().HaveAccessModifier((CSharpAccessModifier)int.MaxValue);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentOutOfRangeException>()
+                .WithParameterName("accessModifier");
+        }
+
         #endregion
 
         #region NotHaveAccessModifier
@@ -713,6 +758,21 @@ namespace FluentAssertions.Specs.Types
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected method not to be Public *failure message*, but methodInfo is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_method_does_not_have_access_modifier_with_an_invalid_enum_value_it_should_throw()
+        {
+            // Arrange
+            MethodInfo methodInfo = typeof(TestClass).GetParameterlessMethod("PrivateMethod");
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().NotHaveAccessModifier((CSharpAccessModifier)int.MaxValue);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentOutOfRangeException>()
+                .WithParameterName("accessModifier");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Types/MethodBaseAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodBaseAssertionSpecs.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Reflection;
 using FluentAssertions.Common;
-using FluentAssertions.Specs.Common;
 using Xunit;
 using Xunit.Sdk;
 
@@ -57,6 +56,22 @@ namespace FluentAssertions.Specs.Types
                              "error message, but it is \"System.Void\".");
         }
 
+        [Fact]
+        public void When_subject_is_null_return_should_fail()
+        {
+            // Arrange
+            MethodInfo methodInfo = null;
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().Return(typeof(string), "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected the return type of method to be *.String *failure message*, but methodInfo is <null>.");
+        }
+
         #endregion
 
         #region NotReturn
@@ -89,6 +104,21 @@ namespace FluentAssertions.Specs.Types
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected the return type of*IntMethod*not to be System.Int32*because we want to test the " +
                              "error message, but it is.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_return_should_fail()
+        {
+            // Arrange
+            MethodInfo methodInfo = null;
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().NotReturn(typeof(string), "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the return type of method not to be *.String *failure message*, but methodInfo is <null>.");
         }
 
         #endregion
@@ -125,6 +155,21 @@ namespace FluentAssertions.Specs.Types
                              "error message, but it is \"System.Int32\".");
         }
 
+        [Fact]
+        public void When_subject_is_null_returnOfT_should_fail()
+        {
+            // Arrange
+            MethodInfo methodInfo = null;
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().Return<string>("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the return type of method to be *.String *failure message*, but methodInfo is <null>.");
+        }
+
         #endregion
 
         #region NotReturnOfT
@@ -157,6 +202,21 @@ namespace FluentAssertions.Specs.Types
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected the return type of*IntMethod*not to be System.Int32*because we want to test the " +
                              "error message, but it is.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_returnOfT_should_fail()
+        {
+            // Arrange
+            MethodInfo methodInfo = null;
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().NotReturn<string>("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the return type of method not to be *.String *failure message*, but methodInfo is <null>.");
         }
 
         #endregion
@@ -193,6 +253,21 @@ namespace FluentAssertions.Specs.Types
                              "message, but it is \"System.Int32\".");
         }
 
+        [Fact]
+        public void When_subject_is_null_return_void_should_fail()
+        {
+            // Arrange
+            MethodInfo methodInfo = null;
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().ReturnVoid("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the return type of method to be void *failure message*, but methodInfo is <null>.");
+        }
+
         #endregion
 
         #region NotReturnVoid
@@ -224,6 +299,21 @@ namespace FluentAssertions.Specs.Types
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected the return type of*VoidMethod*not to be void*because we want to test the error message*");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_return_void_should_fail()
+        {
+            // Arrange
+            MethodInfo methodInfo = null;
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().NotReturnVoid("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the return type of method not to be void *failure message*, but methodInfo is <null>.");
         }
 
         #endregion
@@ -405,6 +495,21 @@ namespace FluentAssertions.Specs.Types
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected method ProtectedInternalMethod to be Private because we want to test the error message, but it is " +
                              "ProtectedInternal.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_have_access_modifier_should_fail()
+        {
+            // Arrange
+            MethodInfo methodInfo = null;
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().HaveAccessModifier(CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected method to be Public *failure message*, but methodInfo is <null>.");
         }
 
         #endregion
@@ -592,6 +697,22 @@ namespace FluentAssertions.Specs.Types
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected method ProtectedInternalMethod not to be ProtectedInternal*because we want to test the error message*");
+        }
+
+        [Fact]
+        public void When_subject_is_not_null_have_access_modifier_should_fail()
+        {
+            // Arrange
+            MethodInfo methodInfo = null;
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().NotHaveAccessModifier(
+                    CSharpAccessModifier.Public, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected method not to be Public *failure message*, but methodInfo is <null>.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoAssertionSpecs.cs
@@ -43,6 +43,21 @@ namespace FluentAssertions.Specs.Types
                     " but it is not virtual.");
         }
 
+        [Fact]
+        public void When_subject_is_null_be_virtual_should_fail()
+        {
+            // Arrange
+            MethodInfo methodInfo = null;
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().BeVirtual("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected method to be virtual *failure message*, but methodInfo is <null>.");
+        }
+
         #endregion
 
         #region NotBeVirtual
@@ -76,6 +91,21 @@ namespace FluentAssertions.Specs.Types
                 .WithMessage("Expected method *ClassWithAllMethodsVirtual.PublicVirtualDoNothing" +
                     " not to be virtual because we want to test the error message," +
                     " but it is.");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_be_virtual_should_fail()
+        {
+            // Arrange
+            MethodInfo methodInfo = null;
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().NotBeVirtual("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected method not to be virtual *failure message*, but methodInfo is <null>.");
         }
 
         #endregion
@@ -318,6 +348,22 @@ namespace FluentAssertions.Specs.Types
             act.Should().Throw<XunitException>();
         }
 
+        [Fact]
+        public void When_subject_is_null_be_decorated_withOfT_should_fail()
+        {
+            // Arrange
+            MethodInfo methodInfo = null;
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().BeDecoratedWith<DummyMethodAttribute>("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected method to be decorated with *.DummyMethodAttribute *failure message*, but methodInfo is <null>.");
+        }
+
         #endregion
 
         #region NotBeDecoratedWithOfT
@@ -445,6 +491,23 @@ namespace FluentAssertions.Specs.Types
                         " but that attribute was found.");
         }
 
+        [Fact]
+        public void When_subject_is_null_not_be_decorated_withOfT_should_fail()
+        {
+            // Arrange
+            MethodInfo methodInfo = null;
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().NotBeDecoratedWith<DummyMethodAttribute>("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected method to not be decorated with *.DummyMethodAttribute *failure message*" +
+                    ", but methodInfo is <null>.");
+        }
+
         #endregion
 
         #region BeAsync
@@ -480,6 +543,21 @@ namespace FluentAssertions.Specs.Types
                     " but it is not.");
         }
 
+        [Fact]
+        public void When_subject_is_null_be_async_should_fail()
+        {
+            // Arrange
+            MethodInfo methodInfo = null;
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().BeAsync("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected method to be async *failure message*, but methodInfo is <null>.");
+        }
+
         #endregion
 
         #region NotBeAsync
@@ -512,6 +590,21 @@ namespace FluentAssertions.Specs.Types
             act.Should().Throw<XunitException>()
                 .WithMessage("*ClassWithAllMethodsAsync.PublicAsyncDoNothing*" +
                     "not to be async*because we want to test the error message*");
+        }
+
+        [Fact]
+        public void When_subject_is_null_not_be_async_should_fail()
+        {
+            // Arrange
+            MethodInfo methodInfo = null;
+
+            // Act
+            Action act = () =>
+                methodInfo.Should().NotBeAsync("we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected method not to be async *failure message*, but methodInfo is <null>.");
         }
 
         #endregion

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -28,6 +28,7 @@ sidebar:
 * `HaveElement` did not ignore the xml namespace - [#1541](https://github.com/fluentassertions/fluentassertions/pull/1541)
 * Better parameter checking of `TypeAssertions` - [#1550](https://github.com/fluentassertions/fluentassertions/pull/1550)
 * `[Not]HaveExplicitMethod` did not mention the parameters in the failure message - [#1550](https://github.com/fluentassertions/fluentassertions/pull/1550)
+* Better parameter checking of `MethodBaseAssertions` and `MethodInfoAssertions` - [#1559](https://github.com/fluentassertions/fluentassertions/pull/1559)
 
 **Breaking Changes**
 * Changed `becauseArgs` of `[Not]Reference(Assembly)` from `string[]` to `object[]` - [#1459](https://github.com/fluentassertions/fluentassertions/pull/1459)


### PR DESCRIPTION
More coverage of #1039

* Added failure message when Subject is null
* Added Guards against null parameters

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).