### PR TITLE
Robust Assembly assertions

### DIFF
--- a/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using FluentAssertions.Common;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 
@@ -31,8 +32,11 @@ namespace FluentAssertions.Reflection
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="assembly"/> is <c>null</c>.</exception>
         public AndConstraint<AssemblyAssertions> NotReference(Assembly assembly, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(assembly, nameof(assembly));
+
             var assemblyName = assembly.GetName().Name;
 
             bool success = Execute.Assertion
@@ -67,8 +71,11 @@ namespace FluentAssertions.Reflection
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="assembly"/> is <c>null</c>.</exception>
         public AndConstraint<AssemblyAssertions> Reference(Assembly assembly, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNull(assembly, nameof(assembly));
+
             var assemblyName = assembly.GetName().Name;
 
             bool success = Execute.Assertion
@@ -103,8 +110,11 @@ namespace FluentAssertions.Reflection
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is <c>null</c> or empty.</exception>
         public AndWhichConstraint<AssemblyAssertions, Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNullOrEmpty(name, nameof(name));
+
             bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)

--- a/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
+++ b/Src/FluentAssertions/Specialized/AssemblyAssertions.cs
@@ -33,15 +33,25 @@ namespace FluentAssertions.Reflection
         /// </param>
         public AndConstraint<AssemblyAssertions> NotReference(Assembly assembly, string because = "", params object[] becauseArgs)
         {
-            var subjectName = Subject.GetName().Name;
             var assemblyName = assembly.GetName().Name;
 
-            IEnumerable<string> references = Subject.GetReferencedAssemblies().Select(x => x.Name);
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected assembly not to reference assembly {0}{reason}, but {context:assembly} is <null>.",
+                    assemblyName);
 
-            Execute.Assertion
-                   .BecauseOf(because, becauseArgs)
-                   .ForCondition(!references.Contains(assemblyName))
-                   .FailWith("Expected assembly {0} not to reference assembly {1}{reason}.", subjectName, assemblyName);
+            if (success)
+            {
+                var subjectName = Subject.GetName().Name;
+
+                IEnumerable<string> references = Subject.GetReferencedAssemblies().Select(x => x.Name);
+
+                Execute.Assertion
+                       .BecauseOf(because, becauseArgs)
+                       .ForCondition(!references.Contains(assemblyName))
+                       .FailWith("Expected assembly {0} not to reference assembly {1}{reason}.", subjectName, assemblyName);
+            }
 
             return new AndConstraint<AssemblyAssertions>(this);
         }
@@ -59,15 +69,24 @@ namespace FluentAssertions.Reflection
         /// </param>
         public AndConstraint<AssemblyAssertions> Reference(Assembly assembly, string because = "", params object[] becauseArgs)
         {
-            var subjectName = Subject.GetName().Name;
             var assemblyName = assembly.GetName().Name;
 
-            IEnumerable<string> references = Subject.GetReferencedAssemblies().Select(x => x.Name);
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected assembly to reference assembly {0}{reason}, but {context:assembly} is <null>.", assemblyName);
 
-            Execute.Assertion
-                   .BecauseOf(because, becauseArgs)
-                   .ForCondition(references.Contains(assemblyName))
-                   .FailWith("Expected assembly {0} to reference assembly {1}{reason}, but it does not.", subjectName, assemblyName);
+            if (success)
+            {
+                var subjectName = Subject.GetName().Name;
+
+                IEnumerable<string> references = Subject.GetReferencedAssemblies().Select(x => x.Name);
+
+                Execute.Assertion
+                       .BecauseOf(because, becauseArgs)
+                       .ForCondition(references.Contains(assemblyName))
+                       .FailWith("Expected assembly {0} to reference assembly {1}{reason}, but it does not.", subjectName, assemblyName);
+            }
 
             return new AndConstraint<AssemblyAssertions>(this);
         }
@@ -86,13 +105,24 @@ namespace FluentAssertions.Reflection
         /// </param>
         public AndWhichConstraint<AssemblyAssertions, Type> DefineType(string @namespace, string name, string because = "", params object[] becauseArgs)
         {
-            Type foundType = Subject.GetTypes().SingleOrDefault(t => t.Namespace == @namespace && t.Name == name);
-
-            Execute.Assertion
-                .ForCondition(foundType is not null)
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected assembly {0} to define type {1}.{2}{reason}, but it does not.",
-                    Subject.FullName, @namespace, name);
+                .ForCondition(Subject is not null)
+                .FailWith("Expected assembly to define type {0}.{1}{reason}, but {context:assembly} is <null>.",
+                    @namespace, name);
+
+            Type foundType = null;
+
+            if (success)
+            {
+                foundType = Subject.GetTypes().SingleOrDefault(t => t.Namespace == @namespace && t.Name == name);
+
+                Execute.Assertion
+                    .ForCondition(foundType is not null)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected assembly {0} to define type {1}.{2}{reason}, but it does not.",
+                        Subject.FullName, @namespace, name);
+            }
 
             return new AndWhichConstraint<AssemblyAssertions, Type>(this, foundType);
         }

--- a/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
@@ -10,6 +10,8 @@ namespace FluentAssertions.Specs.Specialized
 {
     public class AssemblyAssertionSpecs
     {
+        #region NotReference
+
         [Fact]
         public void When_an_assembly_is_not_referenced_and_should_not_reference_is_asserted_it_should_succeed()
         {
@@ -52,6 +54,26 @@ namespace FluentAssertions.Specs.Specialized
             // Assert
             act.Should().Throw<XunitException>();
         }
+
+        [Fact]
+        public void When_subject_is_null_not_reference_should_fail()
+        {
+            // Arrange
+            Assembly assemblyA = null;
+            Assembly assemblyB = FindAssembly.Containing<ClassB>();
+
+            // Act
+            Action act = () => assemblyA.Should().NotReference(assemblyB, "we want to to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected assembly not to reference assembly \"AssemblyB\" *failure message*, but assemblyA is <null>.");
+        }
+
+        #endregion
+
+        #region Reference
 
         [Fact]
         public void When_an_assembly_is_referenced_and_should_reference_is_asserted_it_should_succeed()
@@ -97,6 +119,26 @@ namespace FluentAssertions.Specs.Specialized
         }
 
         [Fact]
+        public void When_subject_is_null_reference_should_fail()
+        {
+            // Arrange
+            Assembly assemblyA = null;
+            Assembly assemblyB = FindAssembly.Containing<ClassB>();
+
+            // Act
+            Action act = () => assemblyA.Should().Reference(assemblyB, "we want to to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected assembly to reference assembly \"AssemblyB\" *failure message*, but assemblyA is <null>.");
+        }
+
+        #endregion
+
+        #region DefineType
+
+        [Fact]
         public void When_an_assembly_defines_a_type_and_Should_DefineType_is_asserted_it_should_succeed()
         {
             // Arrange
@@ -129,6 +171,28 @@ namespace FluentAssertions.Specs.Specialized
         }
 
         [Fact]
+        public void When_subject_is_null_define_type_should_fail()
+        {
+            // Arrange
+            Assembly thisAssembly = null;
+
+            // Act
+            Action act = () =>
+                thisAssembly.Should().DefineType(GetType().Namespace, "WellKnownClassWithAttribute",
+                    "we want to to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected assembly to define type *.\"WellKnownClassWithAttribute\" *failure message*" +
+                    ", but thisAssembly is <null>.");
+        }
+
+        #endregion
+
+        #region BeNull
+
+        [Fact]
         public void When_an_assembly_is_null_and_Should_BeNull_is_asserted_it_should_succeed()
         {
             // Arrange
@@ -141,6 +205,8 @@ namespace FluentAssertions.Specs.Specialized
             // Assert
             act.Should().NotThrow();
         }
+
+        #endregion
     }
 
     [DummyClass("name", true)]

--- a/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/AssemblyAssertionSpecs.cs
@@ -71,6 +71,20 @@ namespace FluentAssertions.Specs.Specialized
                     "Expected assembly not to reference assembly \"AssemblyB\" *failure message*, but assemblyA is <null>.");
         }
 
+        [Fact]
+        public void When_an_assembly_is_not_referencing_null_it_should_throw()
+        {
+            // Arrange
+            var assemblyA = FindAssembly.Containing<ClassA>();
+
+            // Act
+            Action act = () => assemblyA.Should().NotReference(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("assembly");
+        }
+
         #endregion
 
         #region Reference
@@ -134,6 +148,20 @@ namespace FluentAssertions.Specs.Specialized
                     "Expected assembly to reference assembly \"AssemblyB\" *failure message*, but assemblyA is <null>.");
         }
 
+        [Fact]
+        public void When_an_assembly_is_referencing_null_it_should_throw()
+        {
+            // Arrange
+            var assemblyA = FindAssembly.Containing<ClassA>();
+
+            // Act
+            Action act = () => assemblyA.Should().Reference(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("assembly");
+        }
+
         #endregion
 
         #region DefineType
@@ -186,6 +214,34 @@ namespace FluentAssertions.Specs.Specialized
                 .WithMessage(
                     "Expected assembly to define type *.\"WellKnownClassWithAttribute\" *failure message*" +
                     ", but thisAssembly is <null>.");
+        }
+
+        [Fact]
+        public void When_an_assembly_defining_a_type_with_a_null_name_it_should_throw()
+        {
+            // Arrange
+            var thisAssembly = GetType().Assembly;
+
+            // Act
+            Action act = () => thisAssembly.Should().DefineType(GetType().Namespace, null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
+        }
+
+        [Fact]
+        public void When_an_assembly_defining_a_type_with_an_empty_name_it_should_throw()
+        {
+            // Arrange
+            var thisAssembly = GetType().Assembly;
+
+            // Act
+            Action act = () => thisAssembly.Should().DefineType(GetType().Namespace, string.Empty);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("name");
         }
 
         #endregion

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -29,6 +29,7 @@ sidebar:
 * Better parameter checking of `TypeAssertions` - [#1550](https://github.com/fluentassertions/fluentassertions/pull/1550)
 * `[Not]HaveExplicitMethod` did not mention the parameters in the failure message - [#1550](https://github.com/fluentassertions/fluentassertions/pull/1550)
 * Better parameter checking of `MethodBaseAssertions` and `MethodInfoAssertions` - [#1559](https://github.com/fluentassertions/fluentassertions/pull/1559)
+* Better parameter checking of `AssemblyAssertions` - [#1561](https://github.com/fluentassertions/fluentassertions/pull/1561)
 
 **Breaking Changes**
 * Changed `becauseArgs` of `[Not]Reference(Assembly)` from `string[]` to `object[]` - [#1459](https://github.com/fluentassertions/fluentassertions/pull/1459)


### PR DESCRIPTION
More coverage of #1039

* Added failure message when Subject is null
* Added Guards against null parameters

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).