### PR TITLE
Robust TypeSelector Assertions

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -673,11 +673,14 @@ namespace FluentAssertions
 
         /// <summary>
         /// Returns a <see cref="TypeAssertions"/> object that can be used to assert the
-        /// current <see cref="System.Type"/>.
+        /// current <see cref="Type"/>.
         /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="typeSelector"/> is <c>null</c>.</exception>
         [Pure]
         public static TypeSelectorAssertions Should(this TypeSelector typeSelector)
         {
+            Guard.ThrowIfArgumentIsNull(typeSelector, nameof(typeSelector));
+
             return new TypeSelectorAssertions(typeSelector.ToArray());
         }
 

--- a/Src/FluentAssertions/Common/Guard.cs
+++ b/Src/FluentAssertions/Common/Guard.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace FluentAssertions.Common
 {
@@ -36,7 +38,7 @@ namespace FluentAssertions.Common
             }
         }
 
-        public static void ThrowIfArgumentIsOutOfRange<T>([ValidatedNotNull] T value, string paramName)
+        public static void ThrowIfArgumentIsOutOfRange<T>(T value, string paramName)
             where T : Enum
         {
             if (!Enum.IsDefined(typeof(T), value))
@@ -45,12 +47,28 @@ namespace FluentAssertions.Common
             }
         }
 
-        public static void ThrowIfArgumentIsOutOfRange<T>([ValidatedNotNull] T value, string paramName, string message)
+        public static void ThrowIfArgumentIsOutOfRange<T>(T value, string paramName, string message)
             where T : Enum
         {
             if (!Enum.IsDefined(typeof(T), value))
             {
                 throw new ArgumentOutOfRangeException(paramName, message);
+            }
+        }
+
+        public static void ThrowIfArgumentContainsNull<T>(IEnumerable<T> values, string paramName)
+        {
+            if (values.Any(t => t is null))
+            {
+                throw new ArgumentNullException(paramName, "Collection contains a null value");
+            }
+        }
+
+        public static void ThrowIfArgumentContainsNull<T>(IEnumerable<T> values, string paramName, string message)
+        {
+            if (values.Any(t => t is null))
+            {
+                throw new ArgumentNullException(paramName, message);
             }
         }
 

--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -32,11 +32,7 @@ namespace FluentAssertions.Types
         public MethodInfoSelector(IEnumerable<Type> types)
         {
             Guard.ThrowIfArgumentIsNull(types, nameof(types));
-
-            if (types.Any(t => t is null))
-            {
-                throw new ArgumentNullException(nameof(types), "Collection contains a null value");
-            }
+            Guard.ThrowIfArgumentContainsNull(types, nameof(types));
 
             selectedMethods = types.SelectMany(t => t
                 .GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)

--- a/Src/FluentAssertions/Types/PropertyInfoSelector.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelector.cs
@@ -32,11 +32,7 @@ namespace FluentAssertions.Types
         public PropertyInfoSelector(IEnumerable<Type> types)
         {
             Guard.ThrowIfArgumentIsNull(types, nameof(types));
-
-            if (types.Any(t => t is null))
-            {
-                throw new ArgumentNullException(nameof(types), "Collection contains a null value");
-            }
+            Guard.ThrowIfArgumentContainsNull(types, nameof(types));
 
             selectedProperties = types.SelectMany(t => t
                 .GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -21,6 +21,9 @@ namespace FluentAssertions.Types
 
         public TypeSelector(IEnumerable<Type> types)
         {
+            Guard.ThrowIfArgumentIsNull(types, nameof(types));
+            Guard.ThrowIfArgumentContainsNull(types, nameof(types));
+
             this.types = types.ToList();
         }
 
@@ -55,10 +58,10 @@ namespace FluentAssertions.Types
         /// </summary>
         public TypeSelector ThatImplement<TInterface>()
         {
-            types = types.Where(t =>
-                        typeof(TInterface).IsAssignableFrom(t)
-                        && (t != typeof(TInterface)))
-                    .ToList();
+            types = types
+                .Where(t => typeof(TInterface).IsAssignableFrom(t) && (t != typeof(TInterface)))
+                .ToList();
+
             return this;
         }
 
@@ -67,10 +70,10 @@ namespace FluentAssertions.Types
         /// </summary>
         public TypeSelector ThatDoNotImplement<TInterface>()
         {
-            types = types.Where(t =>
-                        !typeof(TInterface).IsAssignableFrom(t)
-                        && (t != typeof(TInterface)))
-                    .ToList();
+            types = types
+                .Where(t => !typeof(TInterface).IsAssignableFrom(t) && (t != typeof(TInterface)))
+                .ToList();
+
             return this;
         }
 
@@ -81,7 +84,6 @@ namespace FluentAssertions.Types
             where TAttribute : Attribute
         {
             types = types
-
                 .Where(t => t.IsDecoratedWith<TAttribute>())
                 .ToList();
 
@@ -95,7 +97,6 @@ namespace FluentAssertions.Types
             where TAttribute : Attribute
         {
             types = types
-
                 .Where(t => t.IsDecoratedWithOrInherit<TAttribute>())
                 .ToList();
 
@@ -109,7 +110,6 @@ namespace FluentAssertions.Types
             where TAttribute : Attribute
         {
             types = types
-
                 .Where(t => !t.IsDecoratedWith<TAttribute>())
                 .ToList();
 
@@ -123,7 +123,6 @@ namespace FluentAssertions.Types
             where TAttribute : Attribute
         {
             types = types
-
                 .Where(t => !t.IsDecoratedWithOrInherit<TAttribute>())
                 .ToList();
 

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -20,6 +20,9 @@ namespace FluentAssertions.Types
         /// </summary>
         public TypeSelectorAssertions(params Type[] types)
         {
+            Guard.ThrowIfArgumentIsNull(types, nameof(types));
+            Guard.ThrowIfArgumentContainsNull(types, nameof(types));
+
             Subject = types;
         }
 

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorSpecs.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 using FluentAssertions.Types;
-
 using Internal.Main.Test;
 using Internal.NotOnlyClasses.Test;
 using Internal.Other.Test;
@@ -18,6 +17,48 @@ namespace FluentAssertions.Specs.Types
 {
     public class TypeSelectorSpecs
     {
+        [Fact]
+        public void When_type_selector_is_created_with_a_null_type_it_should_throw()
+        {
+            // Arrange
+            TypeSelector propertyInfoSelector;
+
+            // Act
+            Action act = () => propertyInfoSelector = new TypeSelector((Type)null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("types");
+        }
+
+        [Fact]
+        public void When_type_selector_is_created_with_a_null_type_list_it_should_throw()
+        {
+            // Arrange
+            TypeSelector propertyInfoSelector;
+
+            // Act
+            Action act = () => propertyInfoSelector = new TypeSelector((Type[])null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("types");
+        }
+
+        [Fact]
+        public void When_type_selector_is_null_then_should_should_throw()
+        {
+            // Arrange
+            TypeSelector propertyInfoSelector = null;
+
+            // Act
+            Action act = () => propertyInfoSelector.Should();
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("typeSelector");
+        }
+
         [Fact]
         public void When_selecting_types_that_derive_from_a_specific_class_it_should_return_the_correct_types()
         {


### PR DESCRIPTION
More coverage of #1039

* Added failure message when Subject is null

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).