### PR TITLE
Robust XML assertions

### DIFF
--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -19,6 +19,7 @@ namespace FluentAssertions.Formatting
 
         private static readonly List<IValueFormatter> DefaultFormatters = new()
         {
+            new XmlReaderValueFormatter(),
             new XmlNodeFormatter(),
             new AttributeBasedFormatter(),
             new AggregateExceptionValueFormatter(),

--- a/Src/FluentAssertions/Formatting/XmlReaderValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/XmlReaderValueFormatter.cs
@@ -1,0 +1,33 @@
+﻿using System.Xml;
+
+namespace FluentAssertions.Formatting
+{
+    public class XmlReaderValueFormatter : IValueFormatter
+    {
+        /// <summary>
+        /// Indicates whether the current <see cref="IValueFormatter"/> can handle the specified <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value for which to create a <see cref="string"/>.</param>
+        /// <returns>
+        /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+        /// </returns>
+        public bool CanHandle(object value)
+        {
+            return value is XmlReader;
+        }
+
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
+        {
+            var reader = (XmlReader)value;
+
+            if (reader.ReadState == ReadState.Initial)
+            {
+                reader.Read();
+            }
+
+            var result = "\"" + reader.ReadOuterXml() + "\"";
+
+            formattedGraph.AddFragment(result);
+        }
+    }
+}

--- a/Src/FluentAssertions/Xml/XAttributeAssertions.cs
+++ b/Src/FluentAssertions/Xml/XAttributeAssertions.cs
@@ -33,7 +33,7 @@ namespace FluentAssertions.Xml
         public AndConstraint<XAttributeAssertions> Be(XAttribute expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject.Name == expected.Name && Subject.Value == expected.Value)
+                .ForCondition(Subject?.Name == expected?.Name && Subject?.Value == expected?.Value)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context} to be {0}{reason}, but found {1}.", expected, Subject);
 
@@ -55,7 +55,7 @@ namespace FluentAssertions.Xml
         public AndConstraint<XAttributeAssertions> NotBe(XAttribute unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!(Subject.Name == unexpected.Name && Subject.Value == unexpected.Value))
+                .ForCondition(!(Subject?.Name == unexpected?.Name && Subject?.Value == unexpected?.Value))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context} to be {0}{reason}.", unexpected);
 
@@ -75,11 +75,19 @@ namespace FluentAssertions.Xml
         /// </param>
         public AndConstraint<XAttributeAssertions> HaveValue(string expected, string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
-                .ForCondition(Subject.Value == expected)
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context} \"{0}\" to have value {1}{reason}, but found {2}.",
-                    Subject.Name, expected, Subject.Value);
+                .ForCondition(Subject is not null)
+                .FailWith("Expected the attribute to have value {0}{reason}, but {context:member} is <null>.", expected);
+
+            if (success)
+            {
+                Execute.Assertion
+                    .ForCondition(Subject.Value == expected)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith("Expected {context} \"{0}\" to have value {1}{reason}, but found {2}.",
+                        Subject.Name, expected, Subject.Value);
+            }
 
             return new AndConstraint<XAttributeAssertions>(this);
         }

--- a/Src/FluentAssertions/Xml/XDocumentAssertions.cs
+++ b/Src/FluentAssertions/Xml/XDocumentAssertions.cs
@@ -82,8 +82,8 @@ namespace FluentAssertions.Xml
         /// </param>
         public AndConstraint<XDocumentAssertions> BeEquivalentTo(XDocument expected, string because = "", params object[] becauseArgs)
         {
-            using (XmlReader subjectReader = Subject.CreateReader())
-            using (XmlReader otherReader = expected.CreateReader())
+            using (XmlReader subjectReader = Subject?.CreateReader())
+            using (XmlReader otherReader = expected?.CreateReader())
             {
                 var xmlReaderValidator = new XmlReaderValidator(subjectReader, otherReader, because, becauseArgs);
                 xmlReaderValidator.Validate(shouldBeEquivalent: true);
@@ -106,8 +106,8 @@ namespace FluentAssertions.Xml
         /// </param>
         public AndConstraint<XDocumentAssertions> NotBeEquivalentTo(XDocument unexpected, string because = "", params object[] becauseArgs)
         {
-            using (XmlReader subjectReader = Subject.CreateReader())
-            using (XmlReader otherReader = unexpected.CreateReader())
+            using (XmlReader subjectReader = Subject?.CreateReader())
+            using (XmlReader otherReader = unexpected?.CreateReader())
             {
                 var xmlReaderValidator = new XmlReaderValidator(subjectReader, otherReader, because, becauseArgs);
                 xmlReaderValidator.Validate(shouldBeEquivalent: false);

--- a/Src/FluentAssertions/Xml/XElementAssertions.cs
+++ b/Src/FluentAssertions/Xml/XElementAssertions.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Xml;
 using System.Xml.Linq;
 using FluentAssertions.Common;
@@ -63,7 +64,7 @@ namespace FluentAssertions.Xml
             Execute.Assertion
                 .ForCondition((Subject is null && unexpected is not null) || !XNode.DeepEquals(Subject, unexpected))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:subject} not to be {0}{reason}.", unexpected);
+                .FailWith("Did not expect {context:subject} to be {0}{reason}.", unexpected);
 
             return new AndConstraint<XElementAssertions>(this);
         }
@@ -84,8 +85,8 @@ namespace FluentAssertions.Xml
         public AndConstraint<XElementAssertions> BeEquivalentTo(XElement expected, string because = "",
             params object[] becauseArgs)
         {
-            using (XmlReader subjectReader = Subject.CreateReader())
-            using (XmlReader expectedReader = expected.CreateReader())
+            using (XmlReader subjectReader = Subject?.CreateReader())
+            using (XmlReader expectedReader = expected?.CreateReader())
             {
                 var xmlReaderValidator = new XmlReaderValidator(subjectReader, expectedReader, because, becauseArgs);
                 xmlReaderValidator.Validate(shouldBeEquivalent: true);
@@ -110,8 +111,8 @@ namespace FluentAssertions.Xml
         public AndConstraint<XElementAssertions> NotBeEquivalentTo(XElement unexpected, string because = "",
             params object[] becauseArgs)
         {
-            using (XmlReader subjectReader = Subject.CreateReader())
-            using (XmlReader otherReader = unexpected.CreateReader())
+            using (XmlReader subjectReader = Subject?.CreateReader())
+            using (XmlReader otherReader = unexpected?.CreateReader())
             {
                 var xmlReaderValidator = new XmlReaderValidator(subjectReader, otherReader, because, becauseArgs);
                 xmlReaderValidator.Validate(shouldBeEquivalent: false);
@@ -133,12 +134,20 @@ namespace FluentAssertions.Xml
         /// </param>
         public AndConstraint<XElementAssertions> HaveValue(string expected, string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
-                .ForCondition(Subject.Value == expected)
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith(
-                    "Expected {context:subject} '{0}' to have value {1}{reason}, but found {2}.",
-                    Subject.Name, expected, Subject.Value);
+                .ForCondition(Subject is not null)
+                .FailWith("Expected the element to have value {0}{reason}, but {context:member} is <null>.", expected);
+
+            if (success)
+            {
+                Execute.Assertion
+                    .ForCondition(Subject.Value == expected)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected {context:subject} '{0}' to have value {1}{reason}, but found {2}.",
+                        Subject.Name, expected, Subject.Value);
+            }
 
             return new AndConstraint<XElementAssertions>(this);
         }
@@ -156,9 +165,12 @@ namespace FluentAssertions.Xml
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="expectedName"/> is <c>null</c> or empty.</exception>
         public AndConstraint<XElementAssertions> HaveAttribute(string expectedName, string expectedValue, string because = "",
             params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNullOrEmpty(expectedName, nameof(expectedName));
+
             return HaveAttribute(XNamespace.None + expectedName, expectedValue, because, becauseArgs);
         }
 
@@ -175,26 +187,40 @@ namespace FluentAssertions.Xml
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="expectedName"/> is <c>null</c>.</exception>
         public AndConstraint<XElementAssertions> HaveAttribute(XName expectedName, string expectedValue, string because = "",
             params object[] becauseArgs)
         {
-            XAttribute attribute = Subject.Attribute(expectedName);
+            Guard.ThrowIfArgumentIsNull(expectedName, nameof(expectedName));
+
             string expectedText = expectedName.ToString();
 
-            Execute.Assertion
-                .ForCondition(attribute is not null)
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
                 .FailWith(
-                    "Expected {context:subject} to have attribute {0} with value {1}{reason},"
-                    + " but found no such attribute in {2}",
-                    expectedText, expectedValue, Subject);
+                    "Expected attribute {0} in element to have value {1}{reason}, but {context:member} is <null>.",
+                    expectedText, expectedValue);
 
-            Execute.Assertion
-                .ForCondition(attribute.Value == expectedValue)
-                .BecauseOf(because, becauseArgs)
-                .FailWith(
-                    "Expected attribute {0} in {context:subject} to have value {1}{reason}, but found {2}.",
-                    expectedText, expectedValue, attribute.Value);
+            if (success)
+            {
+                XAttribute attribute = Subject.Attribute(expectedName);
+
+                Execute.Assertion
+                    .ForCondition(attribute is not null)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected {context:subject} to have attribute {0} with value {1}{reason},"
+                        + " but found no such attribute in {2}",
+                        expectedText, expectedValue, Subject);
+
+                Execute.Assertion
+                    .ForCondition(attribute.Value == expectedValue)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected attribute {0} in {context:subject} to have value {1}{reason}, but found {2}.",
+                        expectedText, expectedValue, attribute.Value);
+            }
 
             return new AndConstraint<XElementAssertions>(this);
         }
@@ -211,9 +237,12 @@ namespace FluentAssertions.Xml
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <c>null</c> or empty.</exception>
         public AndWhichConstraint<XElementAssertions, XElement> HaveElement(string expected, string because = "",
             params object[] becauseArgs)
         {
+            Guard.ThrowIfArgumentIsNullOrEmpty(expected, nameof(expected));
+
             return HaveElement(XNamespace.None + expected, because, becauseArgs);
         }
 
@@ -229,16 +258,32 @@ namespace FluentAssertions.Xml
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <c>null</c>.</exception>
         public AndWhichConstraint<XElementAssertions, XElement> HaveElement(XName expected, string because = "",
             params object[] becauseArgs)
         {
-            XElement xElement = Subject.Element(expected);
-            Execute.Assertion
-                .ForCondition(xElement is not null)
+            Guard.ThrowIfArgumentIsNull(expected, nameof(expected));
+
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
                 .FailWith(
-                    "Expected {context:subject} to have child element {0}{reason}, but no such child element was found.",
+                    "Expected the element to have child element {0}{reason}, but {context:member} is <null>.",
                     expected.ToString().EscapePlaceholders());
+
+            XElement xElement = null;
+
+            if (success)
+            {
+                xElement = Subject.Element(expected);
+
+                Execute.Assertion
+                    .ForCondition(xElement is not null)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected {context:subject} to have child element {0}{reason}, but no such child element was found.",
+                        expected.ToString().EscapePlaceholders());
+            }
 
             return new AndWhichConstraint<XElementAssertions, XElement>(this, xElement);
         }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1559,6 +1559,12 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
+    public class XmlReaderValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XmlReaderValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
 }
 namespace FluentAssertions.Numeric
 {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1559,6 +1559,12 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
+    public class XmlReaderValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XmlReaderValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
 }
 namespace FluentAssertions.Numeric
 {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1559,6 +1559,12 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
+    public class XmlReaderValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XmlReaderValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
 }
 namespace FluentAssertions.Numeric
 {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1512,6 +1512,12 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
+    public class XmlReaderValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XmlReaderValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
 }
 namespace FluentAssertions.Numeric
 {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1559,6 +1559,12 @@ namespace FluentAssertions.Formatting
         public bool CanHandle(object value) { }
         public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
     }
+    public class XmlReaderValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public XmlReaderValueFormatter() { }
+        public bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
 }
 namespace FluentAssertions.Numeric
 {

--- a/Tests/FluentAssertions.Specs/Xml/XAttributeAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XAttributeAssertionSpecs.cs
@@ -41,6 +41,45 @@ namespace FluentAssertions.Specs.Xml
         }
 
         [Fact]
+        public void When_both_subject_and_expected_are_null_it_succeeds()
+        {
+            XAttribute theAttribute = null;
+
+            // Act
+            Action act = () => theAttribute.Should().Be(null);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_the_expected_attribute_is_null_then_it_fails()
+        {
+            XAttribute theAttribute = null;
+
+            // Act
+            Action act = () =>
+                theAttribute.Should().Be(new XAttribute("name", "value"), "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected theAttribute to be name=\"value\" *failure message*, but found <null>.");
+        }
+
+        [Fact]
+        public void When_the_attribute_is_expected_to_equal_null_it_fails()
+        {
+            XAttribute theAttribute = new XAttribute("name", "value");
+
+            // Act
+            Action act = () => theAttribute.Should().Be(null, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected theAttribute to be <null> *failure message*, but found name=\"value\".");
+        }
+
+        [Fact]
         public void When_asserting_an_xml_attribute_is_not_equal_to_a_different_xml_attribute_it_should_succeed()
         {
             // Arrange
@@ -85,6 +124,46 @@ namespace FluentAssertions.Specs.Xml
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 $"Did not expect theAttribute to be {sameAttribute} because we want to test the failure message.");
+        }
+
+        [Fact]
+        public void When_a_null_attribute_is_not_supposed_to_be_an_attribute_it_succeeds()
+        {
+            // Arrange
+            XAttribute theAttribute = null;
+
+            // Act
+            Action act = () => theAttribute.Should().NotBe(new XAttribute("name", "value"));
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_an_attribute_is_not_supposed_to_be_null_it_succeeds()
+        {
+            // Arrange
+            XAttribute theAttribute = new XAttribute("name", "value");
+
+            // Act
+            Action act = () => theAttribute.Should().NotBe(null);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_a_null_attribute_is_not_supposed_to_be_null_it_fails()
+        {
+            // Arrange
+            XAttribute theAttribute = null;
+
+            // Act
+            Action act = () => theAttribute.Should().NotBe(null, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not expect theAttribute to be <null> *failure message*.");
         }
 
         #endregion
@@ -225,6 +304,20 @@ namespace FluentAssertions.Specs.Xml
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected theAttribute \"age\" to have value \"16\" because we want to test the failure message, but found \"36\".");
+        }
+
+        [Fact]
+        public void When_an_attribute_is_null_then_have_value_should_fail()
+        {
+            XAttribute theAttribute = null;
+
+            // Act
+            Action act = () =>
+                theAttribute.Should().HaveValue("value", "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the attribute to have value \"value\" *failure message*, but theAttribute is <null>.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
@@ -43,34 +43,44 @@ namespace FluentAssertions.Specs.Xml
         }
 
         [Fact]
-        public void When_asserting_a_null_xml_document_is_equal_to_another_xml_document_it_should_fail()
+        public void When_the_expected_element_is_null_it_fails()
         {
             // Arrange
             XDocument theDocument = null;
-            var otherXDocument = new XDocument();
 
             // Act
-            Action act = () =>
-                theDocument.Should().Be(otherXDocument);
+            Action act = () => theDocument.Should().Be(new XDocument(), "we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected theDocument to be [XML document without root element], but found <null>.");
+                "Expected theDocument to be [XML document without root element] *failure message*, but found <null>.");
         }
 
         [Fact]
-        public void When_a_null_xml_document_is_equal_to_a_null_xml_document_it_should_succeed()
+        public void When_both_subject_and_expected_documents_are_null_it_succeeds()
         {
             // Arrange
-            XDocument document = null;
-            XDocument otherXDocument = null;
+            XDocument theDocument = null;
 
             // Act
-            Action act = () =>
-                document.Should().Be(otherXDocument);
+            Action act = () => theDocument.Should().Be(null);
 
             // Assert
             act.Should().NotThrow<XunitException>();
+        }
+
+        [Fact]
+        public void When_a_document_is_expected_to_equal_null_it_fails()
+        {
+            // Arrange
+            XDocument theDocument = new XDocument();
+
+            // Act
+            Action act = () => theDocument.Should().Be(null, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected theDocument to be <null> *failure message*, but found [XML document without root element].");
         }
 
         [Fact]
@@ -121,33 +131,43 @@ namespace FluentAssertions.Specs.Xml
         }
 
         [Fact]
-        public void When_asserting_a_null_xml_document_is_not_equal_to_some_xml_document_it_should_succeed()
-        {
-            // Arrange
-            XDocument document = null;
-            var someXDocument = new XDocument();
-
-            // Act
-            Action act = () =>
-                document.Should().NotBe(someXDocument);
-
-            // Assert
-            act.Should().NotThrow<XunitException>();
-        }
-
-        [Fact]
-        public void When_asserting_a_null_xml_document_is_not_equal_to_a_null_xml_document_it_should_fail()
+        public void When_a_null_document_is_not_supposed_to_be_a_document_it_succeeds()
         {
             // Arrange
             XDocument theDocument = null;
-            XDocument someXDocument = null;
 
             // Act
-            Action act = () =>
-                theDocument.Should().NotBe(someXDocument);
+            Action act = () => theDocument.Should().NotBe(new XDocument());
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage("Did not expect theDocument to be <null>.");
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_a_document_is_not_supposed_to_be_null_it_succeeds()
+        {
+            // Arrange
+            XDocument theDocument = new XDocument();
+
+            // Act
+            Action act = () => theDocument.Should().NotBe(null);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_a_null_document_is_not_supposed_to_be_equal_to_null_it_fails()
+        {
+            // Arrange
+            XDocument theDocument = null;
+
+            // Act
+            Action act = () => theDocument.Should().NotBe(null, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not expect theDocument to be <null> *failure message*.");
         }
 
         [Fact]
@@ -295,6 +315,51 @@ namespace FluentAssertions.Specs.Xml
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected Element \"child2\" in theDocument at \"/parent\" because we want to test the failure message,"
                 + " but found EndElement \"parent\".");
+        }
+
+        [Fact]
+        public void When_a_document_is_null_then_be_equivalent_to_null_succeeds()
+        {
+            XDocument theDocument = null;
+
+            // Act
+            Action act = () => theDocument.Should().BeEquivalentTo(null);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_a_document_is_null_then_be_equivalent_to_a_document_fails()
+        {
+            XDocument theDocument = null;
+
+            // Act
+            Action act = () =>
+                theDocument.Should().BeEquivalentTo(
+                    XDocument.Parse("<parent><child /></parent>"), "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected theDocument to be equivalent to <null> *failure message*" +
+                    ", but found \"<parent><child /></parent>\".");
+        }
+
+        [Fact]
+        public void When_a_document_is_equivalent_to_null_it_fails()
+        {
+            XDocument theDocument = XDocument.Parse("<parent><child /></parent>");
+
+            // Act
+            Action act = () =>
+                theDocument.Should().BeEquivalentTo(null, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected theDocument to be equivalent to \"<parent><child /></parent>\" *failure message*" +
+                    ", but found <null>.");
         }
 
         [Fact]
@@ -607,6 +672,43 @@ namespace FluentAssertions.Specs.Xml
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("*\"/root/xml1[3]/xml2[2]\"*");
+        }
+
+        [Fact]
+        public void When_a_null_document_is_unexpected_equivalent_to_null_it_fails()
+        {
+            XDocument theDocument = null;
+
+            // Act
+            Action act = () => theDocument.Should().NotBeEquivalentTo(null, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not expect theDocument to be equivalent *failure message*, but it is.");
+        }
+
+        [Fact]
+        public void When_a_null_document_is_not_equivalent_to_a_document_it_succeeds()
+        {
+            XDocument theDocument = null;
+
+            // Act
+            Action act = () => theDocument.Should().NotBeEquivalentTo(XDocument.Parse("<parent><child /></parent>"));
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_a_document_is_not_equivalent_to_null_it_succeeds()
+        {
+            XDocument theDocument = XDocument.Parse("<parent><child /></parent>");
+
+            // Act
+            Action act = () => theDocument.Should().NotBeEquivalentTo(null);
+
+            // Assert
+            act.Should().NotThrow();
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XElementAssertionSpecs.cs
@@ -62,18 +62,45 @@ namespace FluentAssertions.Specs.Xml
         }
 
         [Fact]
-        public void When_asserting_the_equality_of_an_xml_element_but_is_null_it_should_throw_appropriately()
+        public void When_the_expected_element_is_null_it_fails()
         {
             // Arrange
             XElement theElement = null;
-            var expected = new XElement("other");
 
             // Act
-            Action act = () => theElement.Should().Be(expected);
+            Action act = () =>
+                theElement.Should().Be(new XElement("other"), "we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement to be*other*, but found <null>.");
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected theElement to be <other /> *failure message*, but found <null>.");
+        }
+
+        [Fact]
+        public void When_element_is_expected_to_equal_null_it_fails()
+        {
+            // Arrange
+            XElement theElement = new XElement("element");
+
+            // Act
+            Action act = () => theElement.Should().Be(null, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected theElement to be <null> *failure message*, but found <element />.");
+        }
+
+        [Fact]
+        public void When_both_subject_and_expected_are_null_it_succeeds()
+        {
+            // Arrange
+            XElement theElement = null;
+
+            // Act
+            Action act = () => theElement.Should().Be(null);
+
+            // Assert
+            act.Should().NotThrow();
         }
 
         [Fact]
@@ -120,41 +147,51 @@ namespace FluentAssertions.Specs.Xml
 
             // Act
             Action act = () =>
-                theElement.Should().NotBe(sameElement);
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement not to be <element />.");
-        }
-
-        [Fact]
-        public void When_asserting_an_xml_element_is_not_equal_to_the_same_xml_element_it_should_fail_with_descriptive_message()
-        {
-            // Arrange
-            var theElement = new XElement("element");
-            var sameElement = theElement;
-
-            // Act
-            Action act = () =>
                 theElement.Should().NotBe(sameElement, "because we want to test the failure {0}", "message");
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected theElement not to be <element /> because we want to test the failure message.");
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not expect theElement to be <element /> because we want to test the failure message.");
         }
 
         [Fact]
-        public void When_asserting_the_inequality_of_an_xml_element_but_it_is_null_it_should_succeed()
+        public void When_an_element_is_not_supposed_to_be_null_it_succeeds()
         {
             // Arrange
-            XElement actual = null;
-            var expected = new XElement("other");
+            XElement theElement = new XElement("element");
 
             // Act
-            Action act = () => actual.Should().NotBe(expected);
+            Action act = () => theElement.Should().NotBe(null);
 
             // Assert
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_a_null_element_is_not_supposed_to_be_an_element_it_succeeds()
+        {
+            // Arrange
+            XElement theElement = null;
+
+            // Act
+            Action act = () => theElement.Should().NotBe(new XElement("other"));
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_a_null_element_is_not_supposed_to_be_null_it_fails()
+        {
+            // Arrange
+            XElement theElement = null;
+
+            // Act
+            Action act = () => theElement.Should().NotBe(null, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not expect theElement to be <null> *failure message*.");
         }
 
         #endregion
@@ -390,6 +427,46 @@ namespace FluentAssertions.Specs.Xml
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected content \"text\" in theElement at \"/parent/child\" because we want to test the failure message, but found EndElement \"parent\".");
+        }
+
+        [Fact]
+        public void When_an_element_is_null_then_be_equivalent_to_null_succeeds()
+        {
+            XElement theElement = null;
+
+            // Act
+            Action act = () => theElement.Should().BeEquivalentTo(null);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_an_element_is_null_then_be_equivalent_to_an_element_fails()
+        {
+            XElement theElement = null;
+
+            // Act
+            Action act = () =>
+                theElement.Should().BeEquivalentTo(new XElement("element"), "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected theElement to be equivalent to <null> *failure message*, but found \"<element />\".");
+        }
+
+        [Fact]
+        public void When_an_element_is_equivalent_to_null_it_fails()
+        {
+            XElement theElement = new XElement("element");
+
+            // Act
+            Action act = () =>
+                theElement.Should().BeEquivalentTo(null, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected theElement to be equivalent to \"<element />\" *failure message*, but found <null>.");
         }
 
         [Fact]
@@ -644,6 +721,43 @@ namespace FluentAssertions.Specs.Xml
             act.Should().NotThrow();
         }
 
+        [Fact]
+        public void When_a_null_element_is_unexpected_equivalent_to_null_it_fails()
+        {
+            XElement theElement = null;
+
+            // Act
+            Action act = () => theElement.Should().NotBeEquivalentTo(null, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not expect theElement to be equivalent *failure message*, but it is.");
+        }
+
+        [Fact]
+        public void When_a_null_element_is_not_equivalent_to_an_element_it_succeeds()
+        {
+            XElement theElement = null;
+
+            // Act
+            Action act = () => theElement.Should().NotBeEquivalentTo(new XElement("element"));
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_an_element_is_not_equivalent_to_null_it_succeeds()
+        {
+            XElement theElement = new XElement("element");
+
+            // Act
+            Action act = () => theElement.Should().NotBeEquivalentTo(null);
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
         #endregion
 
         #region HaveValue
@@ -690,6 +804,20 @@ namespace FluentAssertions.Specs.Xml
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected theElement 'user' to have value \"stamac\" because we want to test the failure message, but found \"grega\".");
+        }
+
+        [Fact]
+        public void When_xml_element_is_null_then_have_value_should_fail()
+        {
+            XElement theElement = null;
+
+            // Act
+            Action act = () =>
+                theElement.Should().HaveValue("value", "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected the element to have value \"value\" *failure message*, but theElement is <null>.");
         }
 
         #endregion
@@ -852,6 +980,80 @@ namespace FluentAssertions.Specs.Xml
                 + " because we want to test the failure message, but found \"martin\".");
         }
 
+        [Fact]
+        public void When_xml_element_is_null_then_have_attribute_should_fail()
+        {
+            XElement theElement = null;
+
+            // Act
+            Action act = () =>
+                theElement.Should().HaveAttribute("name", "value", "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected attribute \"name\" in element to have value \"value\" *failure message*" +
+                    ", but theElement is <null>.");
+        }
+
+        [Fact]
+        public void When_xml_element_is_null_then_have_attribute_with_XName_should_fail()
+        {
+            XElement theElement = null;
+
+            // Act
+            Action act = () =>
+                theElement.Should().HaveAttribute((XName)"name", "value", "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected attribute \"name\" in element to have value \"value\" *failure message*" +
+                    ", but theElement is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_element_has_an_attribute_with_a_null_name_it_should_throw()
+        {
+            XElement theElement = new XElement("element");
+
+            // Act
+            Action act = () =>
+                theElement.Should().HaveAttribute(null, "value");
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("expectedName");
+        }
+
+        [Fact]
+        public void When_asserting_element_has_an_attribute_with_a_null_XName_it_should_throw()
+        {
+            XElement theElement = new XElement("element");
+
+            // Act
+            Action act = () =>
+                theElement.Should().HaveAttribute((XName)null, "value");
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("expectedName");
+        }
+
+        [Fact]
+        public void When_asserting_element_has_an_attribute_with_an_empty_name_it_should_throw()
+        {
+            XElement theElement = new XElement("element");
+
+            // Act
+            Action act = () =>
+                theElement.Should().HaveAttribute(string.Empty, "value");
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("expectedName");
+        }
+
         #endregion
 
         #region HaveElement
@@ -981,6 +1183,48 @@ namespace FluentAssertions.Specs.Xml
             matchedElement.Should().BeOfType<XElement>()
                 .And.HaveAttribute("attr", "1");
             matchedElement.Name.Should().Be(XName.Get("child"));
+        }
+
+        [Fact]
+        public void When_asserting_element_has_a_child_element_with_a_null_name_it_should_throw()
+        {
+            XElement theElement = new XElement("element");
+
+            // Act
+            Action act = () =>
+                theElement.Should().HaveElement(null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("expected");
+        }
+
+        [Fact]
+        public void When_asserting_element_has_a_child_element_with_a_null_XName_it_should_throw()
+        {
+            XElement theElement = new XElement("element");
+
+            // Act
+            Action act = () =>
+                theElement.Should().HaveElement((XName)null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("expected");
+        }
+
+        [Fact]
+        public void When_asserting_element_has_a_child_element_with_an_empty_name_it_should_throw()
+        {
+            XElement theElement = new XElement("element");
+
+            // Act
+            Action act = () =>
+                theElement.Should().HaveElement(string.Empty);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("expected");
         }
 
         #endregion

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -35,6 +35,7 @@ sidebar:
 * Better parameter checking of `AssemblyAssertions` - [#1561](https://github.com/fluentassertions/fluentassertions/pull/1561)
 * Better parameter checking of `PropertyInfoSelectorAssertions` - [#1565](https://github.com/fluentassertions/fluentassertions/pull/1565)
 * Better parameter checking of `MethodInfoSelectorAssertions` - [#1569](https://github.com/fluentassertions/fluentassertions/pull/1569)
+* Better parameter checking of `XDocumentAssertions`, `XElementAssertions` and `XAttributeAssertions` - [#1564](https://github.com/fluentassertions/fluentassertions/pull/1564)
 
 **Breaking Changes**
 * By default, records are now compared by their members. Can be overridden using `ComparingRecordsByValue` - [#1571](https://github.com/fluentassertions/fluentassertions/pull/1571)


### PR DESCRIPTION
More coverage of #1039

* Added failure message when Subject is null
* Added Guards against null parameters

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
