### PR TITLE
Make StreamAssertions null-safe to being wrapped in an AssertionScope

### DIFF
--- a/Src/FluentAssertions/Streams/BufferedStreamAssertions.cs
+++ b/Src/FluentAssertions/Streams/BufferedStreamAssertions.cs
@@ -41,16 +41,20 @@ namespace FluentAssertions.Streams
         /// </param>
         public AndConstraint<TAssertions> HaveBufferSize(int expected, string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected the buffer size of {context:stream} to be {0}{reason}, ", expected)
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> reference.")
-                .Then
-                .ForCondition(Subject.BufferSize == expected)
-                .FailWith("but it was {0}.", Subject.BufferSize)
-                .Then
-                .ClearExpectation();
+                .FailWith("Expected the buffer size of {context:stream} to be {0}{reason}, but found a <null> reference.",
+                    expected);
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.BufferSize == expected)
+                    .FailWith("Expected the buffer size of {context:stream} to be {0}{reason}, but it was {1}.",
+                        expected, Subject.BufferSize);
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -68,16 +72,20 @@ namespace FluentAssertions.Streams
         /// </param>
         public AndConstraint<TAssertions> NotHaveBufferSize(int unexpected, string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected the buffer size of {context:stream} not to be {0}{reason}, ", unexpected)
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> reference.")
-                .Then
-                .ForCondition(Subject.BufferSize != unexpected)
-                .FailWith("but it was {0}.", Subject.BufferSize)
-                .Then
-                .ClearExpectation();
+                .FailWith("Expected the buffer size of {context:stream} not to be {0}{reason}, but found a <null> reference.",
+                    unexpected);
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.BufferSize != unexpected)
+                    .FailWith("Expected the buffer size of {context:stream} not to be {0}{reason}, but it was.",
+                        unexpected);
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Streams/StreamAssertions.cs
+++ b/Src/FluentAssertions/Streams/StreamAssertions.cs
@@ -43,16 +43,18 @@ namespace FluentAssertions.Streams
         /// </param>
         public AndConstraint<TAssertions> BeWritable(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:stream} to be writable{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> reference.")
-                .Then
-                .ForCondition(Subject.CanWrite)
-                .FailWith("but it was not.")
-                .Then
-                .ClearExpectation();
+                .FailWith("Expected {context:stream} to be writable{reason}, but found a <null> reference.");
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.CanWrite)
+                    .FailWith("Expected {context:stream} to be writable{reason}, but it was not.");
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -69,16 +71,18 @@ namespace FluentAssertions.Streams
         /// </param>
         public AndConstraint<TAssertions> NotBeWritable(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:stream} not to be writable{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> reference.")
-                .Then
-                .ForCondition(!Subject.CanWrite)
-                .FailWith("but it was.")
-                .Then
-                .ClearExpectation();
+                .FailWith("Expected {context:stream} not to be writable{reason}, but found a <null> reference.");
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(!Subject.CanWrite)
+                    .FailWith("Expected {context:stream} not to be writable{reason}, but it was.");
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -95,16 +99,18 @@ namespace FluentAssertions.Streams
         /// </param>
         public AndConstraint<TAssertions> BeSeekable(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:stream} to be seekable{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> reference.")
-                .Then
-                .ForCondition(Subject.CanSeek)
-                .FailWith("but it was not.")
-                .Then
-                .ClearExpectation();
+                .FailWith("Expected {context:stream} to be seekable{reason}, but found a <null> reference.");
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.CanSeek)
+                    .FailWith("Expected {context:stream} to be seekable{reason}, but it was not.");
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -121,16 +127,18 @@ namespace FluentAssertions.Streams
         /// </param>
         public AndConstraint<TAssertions> NotBeSeekable(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:stream} not to be seekable{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> reference.")
-                .Then
-                .ForCondition(!Subject.CanSeek)
-                .FailWith("but it was.")
-                .Then
-                .ClearExpectation();
+                .FailWith("Expected {context:stream} not to be seekable{reason}, but found a <null> reference.");
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(!Subject.CanSeek)
+                    .FailWith("Expected {context:stream} not to be seekable{reason}, but it was.");
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -147,16 +155,18 @@ namespace FluentAssertions.Streams
         /// </param>
         public AndConstraint<TAssertions> BeReadable(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:stream} to be readable{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> reference.")
-                .Then
-                .ForCondition(Subject.CanRead)
-                .FailWith("but it was not.")
-                .Then
-                .ClearExpectation();
+                .FailWith("Expected {context:stream} to be readable{reason}, but found a <null> reference.");
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.CanRead)
+                    .FailWith("Expected {context:stream} to be readable{reason}, but it was not.");
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -173,16 +183,18 @@ namespace FluentAssertions.Streams
         /// </param>
         public AndConstraint<TAssertions> NotBeReadable(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:stream} not to be readable{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> reference.")
-                .Then
-                .ForCondition(!Subject.CanRead)
-                .FailWith("but it was.")
-                .Then
-                .ClearExpectation();
+                .FailWith("Expected {context:stream} not to be readable{reason}, but found a <null> reference.");
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(!Subject.CanRead)
+                    .FailWith("Expected {context:stream} not to be readable{reason}, but it was.");
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -200,19 +212,29 @@ namespace FluentAssertions.Streams
         /// </param>
         public AndConstraint<TAssertions> HavePosition(long expected, string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected the position of {context:stream} to be {0}{reason}, ", expected)
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> reference.")
-                .Then
-                .ForCondition(Subject.CanSeek)
-                .FailWith("but found a non-seekable stream.")
-                .Then
-                .ForCondition(Subject.Position == expected)
-                .FailWith("but it was {0}.", Subject.Position)
-                .Then
-                .ClearExpectation();
+                .FailWith("Expected the position of {context:stream} to be {0}{reason}, but found a <null> reference.",
+                    expected);
+
+            if (success)
+            {
+                success = Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.CanSeek)
+                    .FailWith("Expected the position of {context:stream} to be {0}{reason}, but found a non-seekable stream.",
+                        expected);
+            }
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.Position == expected)
+                    .FailWith("Expected the position of {context:stream} to be {0}{reason}, but it was {1}.",
+                        expected, Subject.Position);
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -230,19 +252,29 @@ namespace FluentAssertions.Streams
         /// </param>
         public AndConstraint<TAssertions> NotHavePosition(long unexpected, string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected the position of {context:stream} not to be {0}{reason}, ", unexpected)
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> reference.")
-                .Then
-                .ForCondition(Subject.CanSeek)
-                .FailWith("but found a non-seekable stream.")
-                .Then
-                .ForCondition(Subject.Position != unexpected)
-                .FailWith("but it was.")
-                .Then
-                .ClearExpectation();
+                .FailWith("Expected the position of {context:stream} not to be {0}{reason}, but found a <null> reference.",
+                    unexpected);
+
+            if (success)
+            {
+                success = Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.CanSeek)
+                    .FailWith("Expected the position of {context:stream} not to be {0}{reason}, but found a non-seekable stream.",
+                        unexpected);
+            }
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.Position != unexpected)
+                    .FailWith("Expected the position of {context:stream} not to be {0}{reason}, but it was.",
+                        unexpected);
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -260,19 +292,29 @@ namespace FluentAssertions.Streams
         /// </param>
         public AndConstraint<TAssertions> HaveLength(long expected, string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected the length of {context:stream} to be {0}{reason}, ", expected)
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> reference.")
-                .Then
-                .ForCondition(Subject.CanSeek)
-                .FailWith("but found a non-seekable stream.")
-                .Then
-                .ForCondition(Subject.Length == expected)
-                .FailWith("but it was {0}.", Subject.Length)
-                .Then
-                .ClearExpectation();
+                .FailWith("Expected the length of {context:stream} to be {0}{reason}, but found a <null> reference.",
+                    expected);
+
+            if (success)
+            {
+                success = Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.CanSeek)
+                    .FailWith("Expected the length of {context:stream} to be {0}{reason}, but found a non-seekable stream.",
+                        expected);
+            }
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.Length == expected)
+                    .FailWith("Expected the length of {context:stream} to be {0}{reason}, but it was {1}.",
+                        expected, Subject.Length);
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -290,19 +332,29 @@ namespace FluentAssertions.Streams
         /// </param>
         public AndConstraint<TAssertions> NotHaveLength(long unexpected, string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected the length of {context:stream} not to be {0}{reason}, ", unexpected)
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> reference.")
-                .Then
-                .ForCondition(Subject.CanSeek)
-                .FailWith("but found a non-seekable stream.")
-                .Then
-                .ForCondition(Subject.Length != unexpected)
-                .FailWith("but it was.")
-                .Then
-                .ClearExpectation();
+                .FailWith("Expected the length of {context:stream} not to be {0}{reason}, but found a <null> reference.",
+                    unexpected);
+
+            if (success)
+            {
+                success = Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.CanSeek)
+                    .FailWith("Expected the length of {context:stream} not to be {0}{reason}, but found a non-seekable stream.",
+                        unexpected);
+            }
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.Length != unexpected)
+                    .FailWith("Expected the length of {context:stream} not to be {0}{reason}, but it was.",
+                        unexpected);
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -319,16 +371,18 @@ namespace FluentAssertions.Streams
         /// </param>
         public AndConstraint<TAssertions> BeReadOnly(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:stream} to be read-only{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> reference.")
-                .Then
-                .ForCondition(!Subject.CanWrite && Subject.CanRead)
-                .FailWith("but it was writable or not readable.")
-                .Then
-                .ClearExpectation();
+                .FailWith("Expected {context:stream} to be read-only{reason}, but found a <null> reference.");
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(!Subject.CanWrite && Subject.CanRead)
+                    .FailWith("Expected {context:stream} to be read-only{reason}, but it was writable or not readable.");
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -345,16 +399,18 @@ namespace FluentAssertions.Streams
         /// </param>
         public AndConstraint<TAssertions> NotBeReadOnly(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:stream} not to be read-only{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> reference.")
-                .Then
-                .ForCondition(Subject.CanWrite || !Subject.CanRead)
-                .FailWith("but it was.")
-                .Then
-                .ClearExpectation();
+                .FailWith("Expected {context:stream} not to be read-only{reason}, but found a <null> reference.");
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.CanWrite || !Subject.CanRead)
+                    .FailWith("Expected {context:stream} not to be read-only{reason}, but it was.");
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -371,16 +427,18 @@ namespace FluentAssertions.Streams
         /// </param>
         public AndConstraint<TAssertions> BeWriteOnly(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:stream} to be write-only{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> reference.")
-                .Then
-                .ForCondition(Subject.CanWrite && !Subject.CanRead)
-                .FailWith("but it was readable or not writable.")
-                .Then
-                .ClearExpectation();
+                .FailWith("Expected {context:stream} to be write-only{reason}, but found a <null> reference.");
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.CanWrite && !Subject.CanRead)
+                    .FailWith("Expected {context:stream} to be write-only{reason}, but it was readable or not writable.");
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -397,16 +455,18 @@ namespace FluentAssertions.Streams
         /// </param>
         public AndConstraint<TAssertions> NotBeWriteOnly(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:stream} not to be write-only{reason}, ")
                 .ForCondition(Subject is not null)
-                .FailWith("but found a <null> reference.")
-                .Then
-                .ForCondition(!Subject.CanWrite || Subject.CanRead)
-                .FailWith("but it was.")
-                .Then
-                .ClearExpectation();
+                .FailWith("Expected {context:stream} not to be write-only{reason}, but found a <null> reference.");
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(!Subject.CanWrite || Subject.CanRead)
+                    .FailWith("Expected {context:stream} not to be write-only{reason}, but it was.");
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Streams/StreamAssertions.cs
+++ b/Src/FluentAssertions/Streams/StreamAssertions.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.IO;
 using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
@@ -220,20 +221,28 @@ namespace FluentAssertions.Streams
 
             if (success)
             {
-                success = Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .ForCondition(Subject.CanSeek)
-                    .FailWith("Expected the position of {context:stream} to be {0}{reason}, but found a non-seekable stream.",
-                        expected);
-            }
+                long position;
 
-            if (success)
-            {
+                try
+                {
+                    position = Subject.Position;
+                }
+                catch (Exception exception)
+                    when (exception is IOException or NotSupportedException or ObjectDisposedException)
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected the position of {context:stream} to be {0}{reason}, but it failed with:{1}{2}",
+                            expected, Environment.NewLine, exception.Message);
+
+                    return new AndConstraint<TAssertions>((TAssertions)this);
+                }
+
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .ForCondition(Subject.Position == expected)
+                    .ForCondition(position == expected)
                     .FailWith("Expected the position of {context:stream} to be {0}{reason}, but it was {1}.",
-                        expected, Subject.Position);
+                        expected, position);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -260,18 +269,26 @@ namespace FluentAssertions.Streams
 
             if (success)
             {
-                success = Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .ForCondition(Subject.CanSeek)
-                    .FailWith("Expected the position of {context:stream} not to be {0}{reason}, but found a non-seekable stream.",
-                        unexpected);
-            }
+                long position;
 
-            if (success)
-            {
+                try
+                {
+                    position = Subject.Position;
+                }
+                catch (Exception exception)
+                    when (exception is IOException or NotSupportedException or ObjectDisposedException)
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected the position of {context:stream} not to be {0}{reason}, but it failed with:{1}{2}",
+                            unexpected, Environment.NewLine, exception.Message);
+
+                    return new AndConstraint<TAssertions>((TAssertions)this);
+                }
+
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .ForCondition(Subject.Position != unexpected)
+                    .ForCondition(position != unexpected)
                     .FailWith("Expected the position of {context:stream} not to be {0}{reason}, but it was.",
                         unexpected);
             }
@@ -300,20 +317,28 @@ namespace FluentAssertions.Streams
 
             if (success)
             {
-                success = Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .ForCondition(Subject.CanSeek)
-                    .FailWith("Expected the length of {context:stream} to be {0}{reason}, but found a non-seekable stream.",
-                        expected);
-            }
+                long length;
 
-            if (success)
-            {
+                try
+                {
+                    length = Subject.Length;
+                }
+                catch (Exception exception)
+                    when (exception is IOException or NotSupportedException or ObjectDisposedException)
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected the length of {context:stream} to be {0}{reason}, but it failed with:{1}{2}",
+                            expected, Environment.NewLine, exception.Message);
+
+                    return new AndConstraint<TAssertions>((TAssertions)this);
+                }
+
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .ForCondition(Subject.Length == expected)
+                    .ForCondition(length == expected)
                     .FailWith("Expected the length of {context:stream} to be {0}{reason}, but it was {1}.",
-                        expected, Subject.Length);
+                        expected, length);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -340,18 +365,26 @@ namespace FluentAssertions.Streams
 
             if (success)
             {
-                success = Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .ForCondition(Subject.CanSeek)
-                    .FailWith("Expected the length of {context:stream} not to be {0}{reason}, but found a non-seekable stream.",
-                        unexpected);
-            }
+                long length;
 
-            if (success)
-            {
+                try
+                {
+                    length = Subject.Length;
+                }
+                catch (Exception exception)
+                    when (exception is IOException or NotSupportedException or ObjectDisposedException)
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected the length of {context:stream} not to be {0}{reason}, but it failed with:{1}{2}",
+                            unexpected, Environment.NewLine, exception.Message);
+
+                    return new AndConstraint<TAssertions>((TAssertions)this);
+                }
+
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .ForCondition(Subject.Length != unexpected)
+                    .ForCondition(length != unexpected)
                     .FailWith("Expected the length of {context:stream} not to be {0}{reason}, but it was.",
                         unexpected);
             }

--- a/Tests/FluentAssertions.Specs/Streams/BufferedStreamAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Streams/BufferedStreamAssertionSpecs.cs
@@ -1,6 +1,7 @@
 ﻿#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1
 using System;
 using System.IO;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 #endif
@@ -49,7 +50,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().HaveBufferSize(10, "we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -82,7 +86,7 @@ namespace FluentAssertions.Specs.Streams
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected the buffer size of stream not to be 10 *failure message*, but it was 10.");
+                .WithMessage("Expected the buffer size of stream not to be 10 *failure message*, but it was.");
         }
 
         [Fact]
@@ -93,7 +97,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().NotHaveBufferSize(10, "we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()

--- a/Tests/FluentAssertions.Specs/Streams/StreamAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Streams/StreamAssertionSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -46,7 +47,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().BeWritable("we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -90,7 +94,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().NotBeWritable("we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -138,7 +145,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().BeSeekable("we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -182,7 +192,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().NotBeSeekable("we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -230,7 +243,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().BeReadable("we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -274,7 +290,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().NotBeReadable("we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -322,7 +341,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().HavePosition(10, "we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -337,7 +359,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().HavePosition(10, "we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -381,7 +406,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().NotHavePosition(10, "we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -396,7 +424,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().NotHavePosition(10, "we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -444,7 +475,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().HaveLength(10, "we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -459,7 +493,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().HaveLength(10, "we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -503,7 +540,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().NotHaveLength(10, "we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -518,7 +558,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().NotHaveLength(10, "we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -581,7 +624,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().BeReadOnly("we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -639,7 +685,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().NotBeReadOnly("we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -702,7 +751,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().BeWriteOnly("we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -760,7 +812,10 @@ namespace FluentAssertions.Specs.Streams
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 stream.Should().NotBeWriteOnly("we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -772,6 +827,8 @@ namespace FluentAssertions.Specs.Streams
 
     internal class TestStream : Stream
     {
+        private long position;
+
         public bool Readable { private get; set; }
 
         public bool Seekable { private get; set; }
@@ -786,9 +843,24 @@ namespace FluentAssertions.Specs.Streams
 
         public override bool CanWrite => Writable;
 
-        public override long Length => WithLength;
+        public override long Length
+        {
+            get
+            {
+                EnsureCanSeek();
+                return WithLength;
+            }
+        }
 
-        public override long Position { get; set; }
+        public override long Position
+        {
+            get
+            {
+                EnsureCanSeek();
+                return position;
+            }
+            set => position = value;
+        }
 
         public override void Flush() => throw new NotImplementedException();
 
@@ -799,5 +871,13 @@ namespace FluentAssertions.Specs.Streams
         public override void SetLength(long value) => throw new NotImplementedException();
 
         public override void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
+
+        private void EnsureCanSeek()
+        {
+            if (!CanSeek)
+            {
+                throw new NotSupportedException("Stream does not support seeking.");
+            }
+        }
     }
 }


### PR DESCRIPTION
When an assertion on a stream was wrapped in an `AssertionScope` we would continue executing after a null check failed and get an NRE.

We could consider always augmenting our null tests with an enclosing `AssertionScope` to verify the null-safeness.
That's why I hijacked the original null tests for stream assertions.

cc: @eNeRGy164 