### PR TITLE
Guard MethodInfoSelector(Assertions) against null reference exceptions

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using FluentAssertions.Collections;
+using FluentAssertions.Common;
 using FluentAssertions.Data;
 #if !NETSTANDARD2_0
 using FluentAssertions.Events;
@@ -706,9 +707,12 @@ namespace FluentAssertions
         /// current <see cref="MethodInfoSelector"/>.
         /// </summary>
         /// <seealso cref="TypeAssertions"/>
+        /// <exception cref="ArgumentNullException"><paramref name="methodSelector"/> is <c>null</c>.</exception>
         [Pure]
         public static MethodInfoSelectorAssertions Should(this MethodInfoSelector methodSelector)
         {
+            Guard.ThrowIfArgumentIsNull(methodSelector, nameof(methodSelector));
+
             return new MethodInfoSelectorAssertions(methodSelector.ToArray());
         }
 

--- a/Src/FluentAssertions/TypeExtensions.cs
+++ b/Src/FluentAssertions/TypeExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using FluentAssertions.Common;
 using FluentAssertions.Types;
 
 namespace FluentAssertions
@@ -38,18 +39,22 @@ namespace FluentAssertions
         }
 
         /// <summary>
-        /// Returns a method selector for the current <see cref="System.Type"/>.
+        /// Returns a method selector for the current <see cref="Type"/>.
         /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
         public static MethodInfoSelector Methods(this Type type)
         {
             return new MethodInfoSelector(type);
         }
 
         /// <summary>
-        /// Returns a method selector for the current <see cref="System.Type"/>.
+        /// Returns a method selector for the current <see cref="Type"/>.
         /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="typeSelector"/> is <c>null</c>.</exception>
         public static MethodInfoSelector Methods(this TypeSelector typeSelector)
         {
+            Guard.ThrowIfArgumentIsNull(typeSelector, nameof(typeSelector));
+
             return new MethodInfoSelector(typeSelector.ToList());
         }
 

--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -18,6 +18,7 @@ namespace FluentAssertions.Types
         /// Initializes a new instance of the <see cref="MethodInfoSelector"/> class.
         /// </summary>
         /// <param name="type">The type from which to select methods.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
         public MethodInfoSelector(Type type)
             : this(new[] { type })
         {
@@ -27,8 +28,16 @@ namespace FluentAssertions.Types
         /// Initializes a new instance of the <see cref="MethodInfoSelector"/> class.
         /// </summary>
         /// <param name="types">The types from which to select methods.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="types"/> is <c>null</c>.</exception>
         public MethodInfoSelector(IEnumerable<Type> types)
         {
+            Guard.ThrowIfArgumentIsNull(types, nameof(types));
+
+            if (types.Any(t => t is null))
+            {
+                throw new ArgumentNullException(nameof(types), "Collection contains a null value");
+            }
+
             selectedMethods = types.SelectMany(t => t
                 .GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                 .Where(method => !HasSpecialName(method)));

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -19,8 +19,11 @@ namespace FluentAssertions.Types
         /// Initializes a new instance of the <see cref="MethodInfoSelectorAssertions"/> class.
         /// </summary>
         /// <param name="methods">The methods to assert.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="methods"/> is <c>null</c>.</exception>
         public MethodInfoSelectorAssertions(params MethodInfo[] methods)
         {
+            Guard.ThrowIfArgumentIsNull(methods, nameof(methods));
+
             SubjectMethods = methods;
         }
 
@@ -85,22 +88,12 @@ namespace FluentAssertions.Types
 
         private MethodInfo[] GetAllNonVirtualMethodsFromSelection()
         {
-            IEnumerable<MethodInfo> query =
-                from method in SubjectMethods
-                where method.IsNonVirtual()
-                select method;
-
-            return query.ToArray();
+            return SubjectMethods.Where(method => method.IsNonVirtual()).ToArray();
         }
 
         private MethodInfo[] GetAllVirtualMethodsFromSelection()
         {
-            IEnumerable<MethodInfo> query =
-                from method in SubjectMethods
-                where !method.IsNonVirtual()
-                select method;
-
-            return query.ToArray();
+            return SubjectMethods.Where(method => !method.IsNonVirtual()).ToArray();
         }
 
         /// <summary>
@@ -267,8 +260,9 @@ namespace FluentAssertions.Types
 
         private static string GetDescriptionsFor(IEnumerable<MethodInfo> methods)
         {
-            return string.Join(Environment.NewLine,
-                methods.Select(MethodInfoAssertions.GetDescriptionFor).ToArray());
+            IEnumerable<string> descriptions = methods.Select(MethodInfoAssertions.GetDescriptionFor).ToArray();
+
+            return string.Join(Environment.NewLine, descriptions);
         }
 
         /// <summary>

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorAssertionSpecs.cs
@@ -8,6 +8,8 @@ namespace FluentAssertions.Specs.Types
 {
     public class MethodInfoSelectorAssertionSpecs
     {
+        #region BeVirtual
+
         [Fact]
         public void When_asserting_methods_are_virtual_and_they_are_it_should_succeed()
         {
@@ -56,6 +58,10 @@ namespace FluentAssertions.Specs.Types
                              "Void FluentAssertions*ClassWithNonVirtualPublicMethods.ProtectedDoNothing");
         }
 
+        #endregion
+
+        #region NotBeVirtual
+
         [Fact]
         public void When_asserting_methods_are_not_virtual_and_they_are_not_it_should_succeed()
         {
@@ -103,6 +109,10 @@ namespace FluentAssertions.Specs.Types
                              "*ClassWithAllMethodsVirtual.InternalVirtualDoNothing" +
                              "*ClassWithAllMethodsVirtual.ProtectedVirtualDoNothing*");
         }
+
+        #endregion
+
+        #region BeDecoratedWith
 
         [Fact]
         public void When_injecting_a_null_predicate_into_BeDecoratedWith_it_should_throw()
@@ -169,6 +179,10 @@ namespace FluentAssertions.Specs.Types
                              "Void FluentAssertions*ClassWithMethodsThatAreNotDecoratedWithDummyAttribute.PrivateDoNothing");
         }
 
+        #endregion
+
+        #region NotBeDecoratedWith
+
         [Fact]
         public void When_injecting_a_null_predicate_into_NotBeDecoratedWith_it_should_throw()
         {
@@ -233,6 +247,10 @@ namespace FluentAssertions.Specs.Types
                              "*ClassWithAllMethodsDecoratedWithDummyAttribute.PrivateDoNothing");
         }
 
+        #endregion
+
+        #region Be
+
         [Fact]
         public void When_all_methods_have_specified_accessor_it_should_succeed()
         {
@@ -286,6 +304,10 @@ namespace FluentAssertions.Specs.Types
                              "Void FluentAssertions*ClassWithNonPublicMethods.DoNothingWithAnotherParameter");
         }
 
+        #endregion
+
+        #region NotBe
+
         [Fact]
         public void When_all_methods_does_not_have_specified_accessor_it_should_succeed()
         {
@@ -334,5 +356,7 @@ namespace FluentAssertions.Specs.Types
                              ", but the following methods are:*" +
                              "Void FluentAssertions*ClassWithPublicMethods.PublicDoNothing*");
         }
+
+        #endregion
     }
 }

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-
+using FluentAssertions.Types;
 using Internal.Main.Test;
 using Xunit;
 
@@ -9,6 +9,48 @@ namespace FluentAssertions.Specs.Types
 {
     public class MethodInfoSelectorSpecs
     {
+        [Fact]
+        public void When_method_info_selector_is_created_with_a_null_type_it_should_throw()
+        {
+            // Arrange
+            MethodInfoSelector methodInfoSelector;
+
+            // Act
+            Action act = () => methodInfoSelector = new MethodInfoSelector((Type)null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("types");
+        }
+
+        [Fact]
+        public void When_method_info_selector_is_created_with_a_null_type_list_it_should_throw()
+        {
+            // Arrange
+            MethodInfoSelector methodInfoSelector;
+
+            // Act
+            Action act = () => methodInfoSelector = new MethodInfoSelector((Type[])null);
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("types");
+        }
+
+        [Fact]
+        public void When_method_info_selector_is_null_then_should_should_throw()
+        {
+            // Arrange
+            MethodInfoSelector methodInfoSelector = null;
+
+            // Act
+            Action act = () => methodInfoSelector.Should();
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("methodSelector");
+        }
+
         [Fact]
         public void When_selecting_methods_from_types_in_an_assembly_it_should_return_the_applicable_methods()
         {

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -31,6 +31,7 @@ sidebar:
 * Better parameter checking of `PropertyInfoAssertions` - [#1558](https://github.com/fluentassertions/fluentassertions/pull/1558)
 * Better parameter checking of `MethodBaseAssertions` and `MethodInfoAssertions` - [#1559](https://github.com/fluentassertions/fluentassertions/pull/1559)
 * Better parameter checking of `AssemblyAssertions` - [#1561](https://github.com/fluentassertions/fluentassertions/pull/1561)
+* Better parameter checking of `MethodInfoSelectorAssertions` - [#1569](https://github.com/fluentassertions/fluentassertions/pull/1569)
 
 **Breaking Changes**
 * Changed `becauseArgs` of `[Not]Reference(Assembly)` from `string[]` to `object[]` - [#1459](https://github.com/fluentassertions/fluentassertions/pull/1459)


### PR DESCRIPTION
More coverage of #1039

Follows the changes made in #1565

* Added failure message when Subject is null
* Added Guards against null parameters

Will need a rebase after #1565 is merged.

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
