### PR TITLE
Add first-class support for C# 9.0 records

### DIFF
--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -580,6 +580,16 @@ namespace FluentAssertions.Common
             return hasCompilerGeneratedAttribute;
         }
 
+        public static bool IsRecord(this Type type)
+        {
+            return type.GetMethod("<Clone>$") is not null &&
+                type.GetTypeInfo()
+                    .DeclaredProperties
+                    .FirstOrDefault(p => p.Name == "EqualityContract")?
+                    .GetMethod?
+                    .GetCustomAttribute(typeof(CompilerGeneratedAttribute)) is not null;
+        }
+
         private static bool IsKeyValuePair(Type type)
         {
             return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>);

--- a/Src/FluentAssertions/Equivalency/CollectionMemberAssertionOptionsDecorator.cs
+++ b/Src/FluentAssertions/Equivalency/CollectionMemberAssertionOptionsDecorator.cs
@@ -61,6 +61,8 @@ namespace FluentAssertions.Equivalency
 
         public bool IncludeFields => inner.IncludeFields;
 
+        public bool CompareRecordsByValue => inner.CompareRecordsByValue;
+
         public EqualityStrategy GetEqualityStrategy(Type type)
         {
             return inner.GetEqualityStrategy(type);

--- a/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
@@ -72,6 +72,11 @@ namespace FluentAssertions.Equivalency
         bool IncludeFields { get; }
 
         /// <summary>
+        /// Gets a value indicating whether records should be compared by value instead of their members
+        /// </summary>
+        bool CompareRecordsByValue { get; }
+
+        /// <summary>
         /// Gets the currently configured tracer, or <c>null</c> if no tracing was configured.
         /// </summary>
         ITraceWriter TraceWriter { get; }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -834,6 +834,7 @@ namespace FluentAssertions.Equivalency
     public interface IEquivalencyAssertionOptions
     {
         bool AllowInfiniteRecursion { get; }
+        bool CompareRecordsByValue { get; }
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
@@ -981,6 +982,7 @@ namespace FluentAssertions.Equivalency
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
     {
         protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
+        public bool CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
@@ -993,6 +995,8 @@ namespace FluentAssertions.Equivalency
         public TSelf ComparingByValue<T>() { }
         public TSelf ComparingEnumsByName() { }
         public TSelf ComparingEnumsByValue() { }
+        public TSelf ComparingRecordsByMembers() { }
+        public TSelf ComparingRecordsByValue() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -834,6 +834,7 @@ namespace FluentAssertions.Equivalency
     public interface IEquivalencyAssertionOptions
     {
         bool AllowInfiniteRecursion { get; }
+        bool CompareRecordsByValue { get; }
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
@@ -981,6 +982,7 @@ namespace FluentAssertions.Equivalency
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
     {
         protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
+        public bool CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
@@ -993,6 +995,8 @@ namespace FluentAssertions.Equivalency
         public TSelf ComparingByValue<T>() { }
         public TSelf ComparingEnumsByName() { }
         public TSelf ComparingEnumsByValue() { }
+        public TSelf ComparingRecordsByMembers() { }
+        public TSelf ComparingRecordsByValue() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -834,6 +834,7 @@ namespace FluentAssertions.Equivalency
     public interface IEquivalencyAssertionOptions
     {
         bool AllowInfiniteRecursion { get; }
+        bool CompareRecordsByValue { get; }
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
@@ -981,6 +982,7 @@ namespace FluentAssertions.Equivalency
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
     {
         protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
+        public bool CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
@@ -993,6 +995,8 @@ namespace FluentAssertions.Equivalency
         public TSelf ComparingByValue<T>() { }
         public TSelf ComparingEnumsByName() { }
         public TSelf ComparingEnumsByValue() { }
+        public TSelf ComparingRecordsByMembers() { }
+        public TSelf ComparingRecordsByValue() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -827,6 +827,7 @@ namespace FluentAssertions.Equivalency
     public interface IEquivalencyAssertionOptions
     {
         bool AllowInfiniteRecursion { get; }
+        bool CompareRecordsByValue { get; }
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
@@ -974,6 +975,7 @@ namespace FluentAssertions.Equivalency
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
     {
         protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
+        public bool CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
@@ -986,6 +988,8 @@ namespace FluentAssertions.Equivalency
         public TSelf ComparingByValue<T>() { }
         public TSelf ComparingEnumsByName() { }
         public TSelf ComparingEnumsByValue() { }
+        public TSelf ComparingRecordsByMembers() { }
+        public TSelf ComparingRecordsByValue() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -834,6 +834,7 @@ namespace FluentAssertions.Equivalency
     public interface IEquivalencyAssertionOptions
     {
         bool AllowInfiniteRecursion { get; }
+        bool CompareRecordsByValue { get; }
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
@@ -981,6 +982,7 @@ namespace FluentAssertions.Equivalency
         where TSelf : FluentAssertions.Equivalency.SelfReferenceEquivalencyAssertionOptions<TSelf>
     {
         protected SelfReferenceEquivalencyAssertionOptions(FluentAssertions.Equivalency.IEquivalencyAssertionOptions defaults) { }
+        public bool CompareRecordsByValue { get; }
         public FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
         protected FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
@@ -993,6 +995,8 @@ namespace FluentAssertions.Equivalency
         public TSelf ComparingByValue<T>() { }
         public TSelf ComparingEnumsByName() { }
         public TSelf ComparingEnumsByValue() { }
+        public TSelf ComparingRecordsByMembers() { }
+        public TSelf ComparingRecordsByValue() { }
         public TSelf Excluding(System.Linq.Expressions.Expression<System.Func<FluentAssertions.Equivalency.IMemberInfo, bool>> predicate) { }
         public TSelf ExcludingFields() { }
         public TSelf ExcludingMissingMembers() { }

--- a/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
+++ b/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
@@ -68,6 +68,8 @@ namespace Benchmarks
 
             public bool IncludeFields => throw new NotImplementedException();
 
+            public bool CompareRecordsByValue => throw new NotImplementedException();
+
             public ITraceWriter TraceWriter => throw new NotImplementedException();
 
             public EqualityStrategy GetEqualityStrategy(Type type) => throw new NotImplementedException();

--- a/Tests/FluentAssertions.Specs/IsExternalInit.cs
+++ b/Tests/FluentAssertions.Specs/IsExternalInit.cs
@@ -1,0 +1,14 @@
+﻿// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+    using System.ComponentModel;
+
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    {
+    }
+}

--- a/docs/_pages/objectgraphs.md
+++ b/docs/_pages/objectgraphs.md
@@ -37,13 +37,21 @@ orderDto.Should().BeEquivalentTo(order, options =>
 
 ### Value Types ###
 
-To determine whether Fluent Assertions should recurs into an object's properties or fields, it needs to understand what types have value semantics and what types should be treated as reference types. The default behavior is to treat every type that overrides `Object.Equals` as an object that was designed to have value semantics. Unfortunately, anonymous types and tuples also override this method, but because we tend to use them quite often in equivalency comparison, we always compare them by their properties.
+To determine whether Fluent Assertions should recurs into an object's properties or fields, it needs to understand what types have value semantics and what types should be treated as reference types. The default behavior is to treat every type that overrides `Object.Equals` as an object that was designed to have value semantics. Anonymous types, records and tuples also override this method, but because the community proved us that they use them quite often in equivalency comparisons, we decided to always compare them by their members.
 
-You can easily override this by using the `ComparingByValue<T>` or `ComparingByMembers<T>` options for individual assertions:
+You can easily override this by using the `ComparingByValue<T>`, `ComparingByMembers<T>`, `ComparingRecordsByValue` and `ComparingRecordsByMembers` options for individual assertions:
 
 ```csharp
 subject.Should().BeEquivalentTo(expected,
    options => options.ComparingByValue<IPAddress>());
+```
+
+For records, this works like this:
+
+```csharp
+actual.Should().BeEquivalentTo(expected, options => options
+    .ComparingRecordsByValue()
+    .ComparingByMembers<MyRecord>());
 ```
 
 Or  do the same using the global options:

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -20,6 +20,7 @@ sidebar:
 * Added the possibility to set the maximum depth and other formatting settings either globally or per `AssertionScope` - [#1469](https://github.com/fluentassertions/fluentassertions/pull/1469).
 * Added `BeInAscendingOrder` and `BeInDescendingOrder` for collections taking a lambda expression - [#1526](https://github.com/fluentassertions/fluentassertions/pull/1526)
 * Added `[Not]BeWritable`, `[Not]BeSeekable`, `[Not]BeReadable`, `[Not]BeReadOnly`, `[Not]BeWriteOnly`, `[Not]HaveLength` , `[Not]HavePosition` for Stream and `[Not]HaveBufferSize` for BufferedStream - [#1543](https://github.com/fluentassertions/fluentassertions/pull/1543)
+* The equivalency failure message will include information on how tuples, anonymous types, records and other types are compared - [#1571](https://github.com/fluentassertions/fluentassertions/pull/1571)
 
 **Fixes**
 * Sometimes `BeEquivalentTo` reported an incorrect message when a dictionary was missing a key - [#1454](https://github.com/fluentassertions/fluentassertions/pull/1454)
@@ -35,6 +36,7 @@ sidebar:
 * Better parameter checking of `MethodInfoSelectorAssertions` - [#1569](https://github.com/fluentassertions/fluentassertions/pull/1569)
 
 **Breaking Changes**
+* By default, records are now compared by their members. Can be overridden using `ComparingRecordsByValue` - [#1571](https://github.com/fluentassertions/fluentassertions/pull/1571)
 * Changed `becauseArgs` of `[Not]Reference(Assembly)` from `string[]` to `object[]` - [#1459](https://github.com/fluentassertions/fluentassertions/pull/1459)
 * Major overhaul on how enums are handled, see the [Migration Guide](/upgradingtov6#enums) for more details - [#1479](https://github.com/fluentassertions/fluentassertions/pull/1479).
 * Removed support for non-generic collections, see the [Migration Guide](/upgradingtov6#collections) for more details - [#1529](https://github.com/fluentassertions/fluentassertions/pull/1529).


### PR DESCRIPTION
* By default, records are compared by their members
* This can be overridden by `ComparingRecordsByValue` or `ComparingByValue<T>`
* Also improved the reporting on how types with members are compared.

Fixes #1451