### PR TITLE
Analyzer suppressions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -147,7 +147,7 @@ dotnet_diagnostic.RS0030.severity = error
 dotnet_diagnostic.IDE0004.severity = error
 
 # IDE0005: Remove unnecessary usings/imports
-dotnet_diagnostic.IDE0005.severity = error
+dotnet_diagnostic.IDE0005.severity = suggestion
 
 # IDE0051: Remove unused private members (no reads or writes)
 dotnet_diagnostic.IDE0051.severity = error
@@ -261,3 +261,7 @@ dotnet_diagnostic.AV2202.severity = none
 dotnet_diagnostic.AV2305.severity = none
 # AV2407: Region should be removed
 dotnet_diagnostic.AV2407.severity = none
+
+# ReSharper/Rider
+# Convert lambda expression to method group
+resharper_convert_closure_to_method_group_highlighting=none

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -168,19 +168,19 @@ namespace FluentAssertions.Equivalency
         {
             EqualityStrategy strategy;
 
-            if (!type.IsPrimitive && referenceTypes.Any(type.IsSameOrInherits))
+            if (!type.IsPrimitive && referenceTypes.Any(t => type.IsSameOrInherits(t)))
             {
                 strategy = EqualityStrategy.ForceMembers;
             }
-            else if (valueTypes.Any(type.IsSameOrInherits))
+            else if (valueTypes.Any(t => type.IsSameOrInherits(t)))
             {
                 strategy = EqualityStrategy.ForceEquals;
             }
-            else if (!type.IsPrimitive && referenceTypes.Any(type.IsAssignableToOpenGeneric))
+            else if (!type.IsPrimitive && referenceTypes.Any(t => type.IsAssignableToOpenGeneric(t)))
             {
                 strategy = EqualityStrategy.ForceMembers;
             }
-            else if (valueTypes.Any(type.IsAssignableToOpenGeneric))
+            else if (valueTypes.Any(t => type.IsAssignableToOpenGeneric(t)))
             {
                 strategy = EqualityStrategy.ForceEquals;
             }
@@ -590,7 +590,7 @@ namespace FluentAssertions.Equivalency
                 throw new InvalidOperationException($"Cannot compare a primitive type such as {type.Name} by its members");
             }
 
-            if (valueTypes.Any(type.IsSameOrInherits))
+            if (valueTypes.Any(t => type.IsSameOrInherits(t)))
             {
                 throw new InvalidOperationException(
                     $"Can't compare {type.Name} by its members if it already setup to be compared by value");
@@ -614,7 +614,7 @@ namespace FluentAssertions.Equivalency
         {
             Guard.ThrowIfArgumentIsNull(type, nameof(type));
 
-            if (referenceTypes.Any(type.IsSameOrInherits))
+            if (referenceTypes.Any(t => type.IsSameOrInherits(t)))
             {
                 throw new InvalidOperationException(
                     $"Can't compare {type.Name} by value if it already setup to be compared by its members");

--- a/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelectorAssertions.cs
@@ -260,7 +260,7 @@ namespace FluentAssertions.Types
 
         private static string GetDescriptionsFor(IEnumerable<MethodInfo> methods)
         {
-            IEnumerable<string> descriptions = methods.Select(MethodInfoAssertions.GetDescriptionFor).ToArray();
+            IEnumerable<string> descriptions = methods.Select(method => MethodInfoAssertions.GetDescriptionFor(method));
 
             return string.Join(Environment.NewLine, descriptions);
         }

--- a/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/PropertyInfoSelectorAssertions.cs
@@ -213,7 +213,7 @@ namespace FluentAssertions.Types
 
         private static string GetDescriptionsFor(IEnumerable<PropertyInfo> properties)
         {
-            IEnumerable<string> descriptions = properties.Select(PropertyInfoAssertions.GetDescriptionFor);
+            IEnumerable<string> descriptions = properties.Select(property => PropertyInfoAssertions.GetDescriptionFor(property));
 
             return string.Join(Environment.NewLine, descriptions);
         }

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -464,7 +464,7 @@ namespace FluentAssertions.Types
 
         private static string GetDescriptionsFor(IEnumerable<Type> types)
         {
-            string[] descriptions = types.Select(GetDescriptionFor).ToArray();
+            IEnumerable<string> descriptions = types.Select(type => GetDescriptionFor(type));
             return string.Join(Environment.NewLine, descriptions);
         }
 

--- a/Tests/FluentAssertions.Specs/.editorconfig
+++ b/Tests/FluentAssertions.Specs/.editorconfig
@@ -134,3 +134,6 @@ dotnet_diagnostic.SA1615.severity = none
 
 # SA1005: Single line comments should begin with single space
 dotnet_diagnostic.SA1005.severity = suggestion
+
+# ReSharper/Rider
+resharper_expression_is_always_null_highlighting=none

--- a/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
@@ -3933,7 +3933,6 @@ namespace FluentAssertions.Specs.Equivalency
             object expectedEnum = EnumULong.UInt64Max;
 
             // Act
-            // ReSharper disable once ExpressionIsAlwaysNull
             Action act = () => subject.Should().BeEquivalentTo(expectedEnum, x => x.ComparingEnumsByName(), "comparing enums should throw");
 
             // Assert
@@ -3949,7 +3948,6 @@ namespace FluentAssertions.Specs.Equivalency
             object expected = null;
 
             // Act
-            // ReSharper disable once ExpressionIsAlwaysNull
             Action act = () => subjectEnum.Should().BeEquivalentTo(expected, x => x.ComparingEnumsByName(), "comparing enums should throw");
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -11,7 +11,6 @@ using Xunit.Sdk;
 
 namespace FluentAssertions.Specs.Exceptions
 {
-    [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
     public class AsyncFunctionExceptionAssertionSpecs
     {
         [Fact]

--- a/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
@@ -216,7 +216,6 @@ namespace FluentAssertions.Specs.Numeric
             int? nullableValue = null;
 
             // Act
-            // ReSharper disable once ExpressionIsAlwaysNull
             Action act = () => value.Should().Be(nullableValue);
 
             // Assert
@@ -1075,7 +1074,6 @@ namespace FluentAssertions.Specs.Numeric
             float? value = null;
 
             // Act
-            // ReSharper disable once ExpressionIsAlwaysNull
             Action act = () => value.Should().Be(3.5F);
 
             // Assert
@@ -1222,7 +1220,6 @@ namespace FluentAssertions.Specs.Numeric
             float? value = null;
 
             // Act
-            // ReSharper disable once ExpressionIsAlwaysNull
             Action act = () => value.Should().BeApproximately(3.14F, 0.001F);
 
             // Assert
@@ -1369,7 +1366,6 @@ namespace FluentAssertions.Specs.Numeric
             float? value = null;
 
             // Act
-            // ReSharper disable once ExpressionIsAlwaysNull
             Action act = () => value.Should().NotBeApproximately(3.14F, 0.001F);
 
             // Assert
@@ -1430,7 +1426,6 @@ namespace FluentAssertions.Specs.Numeric
             double? value = null;
 
             // Act
-            // ReSharper disable once ExpressionIsAlwaysNull
             Action act = () => value.Should().Be(3.5);
 
             // Assert
@@ -1671,7 +1666,6 @@ namespace FluentAssertions.Specs.Numeric
             double? value = null;
 
             // Act
-            // ReSharper disable once ExpressionIsAlwaysNull
             Action act = () => value.Should().NotBeApproximately(3.14, 0.001);
 
             // Assert
@@ -1756,7 +1750,6 @@ namespace FluentAssertions.Specs.Numeric
             decimal someValue = 3.5m;
 
             // Act
-            // ReSharper disable once ExpressionIsAlwaysNull
             Action act = () => value.Should().Be(someValue);
 
             // Assert
@@ -1894,7 +1887,6 @@ namespace FluentAssertions.Specs.Numeric
             decimal? value = null;
 
             // Act
-            // ReSharper disable once ExpressionIsAlwaysNull
             Action act = () => value.Should().NotBeApproximately(3.5m, 0.001m);
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskCompletionSourceAssertionSpecs.cs
@@ -108,7 +108,6 @@ namespace FluentAssertions.Specs.Specialized
         }
 
         [Fact]
-        [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
         public async Task When_TCS_is_null_it_should_fail()
         {
             // Arrange
@@ -154,7 +153,6 @@ namespace FluentAssertions.Specs.Specialized
         }
 
         [Fact]
-        [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
         public async Task When_TCS_is_null_and_we_validate_to_not_complete_it_should_fail()
         {
             // Arrange

--- a/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/TaskOfTAssertionSpecs.cs
@@ -11,7 +11,6 @@ using Xunit.Sdk;
 
 namespace FluentAssertions.Specs.Specialized
 {
-    [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
     public class TaskOfTAssertionSpecs
     {
         #region CompleteWithinAsync

--- a/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Xml/XDocumentAssertionSpecs.cs
@@ -43,7 +43,6 @@ namespace FluentAssertions.Specs.Xml
         }
 
         [Fact]
-        [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
         public void When_asserting_a_null_xml_document_is_equal_to_another_xml_document_it_should_fail()
         {
             // Arrange
@@ -60,7 +59,6 @@ namespace FluentAssertions.Specs.Xml
         }
 
         [Fact]
-        [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
         public void When_a_null_xml_document_is_equal_to_a_null_xml_document_it_should_succeed()
         {
             // Arrange
@@ -123,7 +121,6 @@ namespace FluentAssertions.Specs.Xml
         }
 
         [Fact]
-        [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
         public void When_asserting_a_null_xml_document_is_not_equal_to_some_xml_document_it_should_succeed()
         {
             // Arrange
@@ -139,7 +136,6 @@ namespace FluentAssertions.Specs.Xml
         }
 
         [Fact]
-        [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
         public void When_asserting_a_null_xml_document_is_not_equal_to_a_null_xml_document_it_should_fail()
         {
             // Arrange
@@ -618,7 +614,6 @@ namespace FluentAssertions.Specs.Xml
         #region BeNull / NotBeNull
 
         [Fact]
-        [SuppressMessage("ReSharper", "ExpressionIsAlwaysNull")]
         public void When_asserting_a_null_xml_document_is_null_it_should_succeed()
         {
             // Arrange


### PR DESCRIPTION
These changes try to align IDE experiences of Rider and VS to avoid changes being added/deleted over and over in order to satisfy one of the IDEs.

ReSharper is (naturally) vague in when method groups are beneficial over lambda expressions.
Roslyn caches construction of lambdas of static functions, see
[SharpLab.io](https://sharplab.io/#v2:EYLgtghglgdgPgAQEwEYCwAoTCDMACZPAOQHsYBhCAYwAsBTAE0wG9M928AHAJygDcIAFzrtYgvAHE6ggBRi8UAJR4AvAD4FeANR4UAbkxsOPfkJHyAqgGc6AGQhhgDCDIQBWADxiANApiCNHkYoKjNldS5uYNDhGQAWJEUDLAwOAnx5ezBnGXCNazsHJxcRCKlZOkUko3Ya9L9xAFlpGhIGCW4SAFdOXNV8myzimXLqjABfQwxcAiQ8SlpGFjqTAWECFAA2BslpOX8FPM0dfSm01bMdgqGc9y9/XzFAqIYQsP7I6LN4xOS6mcyDhyR2uRRypQ05RklTGaX+GQOzUErXanR6fQioMcOVGyXGQA==)

I've benchmarked the difference between using a lambda and method group for static functions.

```cs
[MemoryDiagnoser]
[SimpleJob(RuntimeMoniker.Net50)]
public class MethodGroupConversion
{
    [MethodImpl(MethodImplOptions.NoInlining)]
    private static int Get(int i) => i + 1;

    private int UseLambda(Func<int, int> predicate) => predicate(42);

    [Benchmark(Baseline = true)]
    public int Lambda() => UseLambda(e => Get(e));

    [Benchmark]
    public int MethodGroup() => UseLambda(Get);
}
```

```
BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19043.985 (21H1/May2021Update)
Intel Core i7-10750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK=5.0.300-preview.21180.15
  [Host]   : .NET 5.0.6 (5.0.621.22011), X64 RyuJIT
  .NET 5.0 : .NET 5.0.6 (5.0.621.22011), X64 RyuJIT

Job=.NET 5.0  Runtime=.NET 5.0

|      Method |     Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |---------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
|      Lambda | 1.721 ns | 0.0379 ns | 0.0355 ns |  1.00 |    0.00 |      - |     - |     - |         - |
| MethodGroup | 7.762 ns | 0.1221 ns | 0.1020 ns |  4.52 |    0.09 | 0.0102 |     - |     - |      64 B |
```