### PR TITLE
Replace xor with inequality operator

### DIFF
--- a/Src/FluentAssertions/Common/EnumerableExtensions.cs
+++ b/Src/FluentAssertions/Common/EnumerableExtensions.cs
@@ -40,7 +40,7 @@ namespace FluentAssertions.Common
                     return -1;
                 }
 
-                if (isFirstCompleted ^ isSecondCompleted)
+                if (isFirstCompleted != isSecondCompleted)
                 {
                     return index;
                 }

--- a/Src/FluentAssertions/Equivalency/StringEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/StringEqualityEquivalencyStep.cs
@@ -39,7 +39,7 @@ namespace FluentAssertions.Equivalency
             object expected = comparands.Expectation;
             object subject = comparands.Subject;
 
-            bool onlyOneNull = (expected is null) ^ (subject is null);
+            bool onlyOneNull = (expected is null) != (subject is null);
 
             if (onlyOneNull)
             {

--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -1097,7 +1097,7 @@ namespace FluentAssertions
                 throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
             }
 
-            if (parent.Subject is null ^ unexpectedValue is null)
+            if ((parent.Subject is null) != (unexpectedValue is null))
             {
                 return new AndConstraint<NullableNumericAssertions<float>>(parent);
             }
@@ -1222,7 +1222,7 @@ namespace FluentAssertions
                 throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
             }
 
-            if (parent.Subject is null ^ unexpectedValue is null)
+            if ((parent.Subject is null) != (unexpectedValue is null))
             {
                 return new AndConstraint<NullableNumericAssertions<double>>(parent);
             }
@@ -1347,7 +1347,7 @@ namespace FluentAssertions
                 throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
             }
 
-            if (parent.Subject is null ^ unexpectedValue is null)
+            if ((parent.Subject is null) != (unexpectedValue is null))
             {
                 return new AndConstraint<NullableNumericAssertions<decimal>>(parent);
             }

--- a/Src/FluentAssertions/Primitives/StringValidator.cs
+++ b/Src/FluentAssertions/Primitives/StringValidator.cs
@@ -52,7 +52,7 @@ namespace FluentAssertions.Primitives
 
         private bool ValidateAgainstNulls()
         {
-            if ((Expected is null) ^ (Subject is null))
+            if ((Expected is null) != (Subject is null))
             {
                 Assertion.FailWith(ExpectationDescription + "{0}{reason}, but found {1}.", Expected, Subject);
                 return false;


### PR DESCRIPTION
For Booleans both operators are equivalent ways of expressing
"one but not both".
According to review comments the latter way is more readable.