### PR TITLE
Optionally include internal members in equivalency assertions

### DIFF
--- a/Src/FluentAssertions/Equivalency/CollectionMemberAssertionOptionsDecorator.cs
+++ b/Src/FluentAssertions/Equivalency/CollectionMemberAssertionOptionsDecorator.cs
@@ -57,9 +57,9 @@ namespace FluentAssertions.Equivalency
 
         public bool UseRuntimeTyping => inner.UseRuntimeTyping;
 
-        public bool IncludeProperties => inner.IncludeProperties;
+        public MemberVisibility IncludedProperties => inner.IncludedProperties;
 
-        public bool IncludeFields => inner.IncludeFields;
+        public MemberVisibility IncludedFields => inner.IncludedFields;
 
         public bool CompareRecordsByValue => inner.CompareRecordsByValue;
 

--- a/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/IEquivalencyAssertionOptions.cs
@@ -62,14 +62,14 @@ namespace FluentAssertions.Equivalency
         bool UseRuntimeTyping { get; }
 
         /// <summary>
-        /// Gets a value indicating whether properties should be considered.
+        /// Gets a value indicating whether and which properties should be considered.
         /// </summary>
-        bool IncludeProperties { get; }
+        MemberVisibility IncludedProperties { get; }
 
         /// <summary>
-        /// Gets a value indicating whether fields should be considered.
+        /// Gets a value indicating whether and which fields should be considered.
         /// </summary>
-        bool IncludeFields { get; }
+        MemberVisibility IncludedFields { get; }
 
         /// <summary>
         /// Gets a value indicating whether records should be compared by value instead of their members

--- a/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
+++ b/Src/FluentAssertions/Equivalency/Matching/MustMatchByNameRule.cs
@@ -13,13 +13,13 @@ namespace FluentAssertions.Equivalency.Matching
         {
             IMember subjectMember = null;
 
-            if (config.IncludeProperties)
+            if (config.IncludedProperties != MemberVisibility.None)
             {
                 PropertyInfo propertyInfo = subject.GetType().FindProperty(expectedMember.Name, expectedMember.Type);
                 subjectMember = (propertyInfo is not null) && !propertyInfo.IsIndexer() ? new Property(propertyInfo, parent) : null;
             }
 
-            if ((subjectMember is null) && config.IncludeFields)
+            if ((subjectMember is null) && config.IncludedFields != MemberVisibility.None)
             {
                 FieldInfo fieldInfo = subject.GetType().FindField(expectedMember.Name, expectedMember.Type);
                 subjectMember = (fieldInfo is not null) ? new Field(fieldInfo, parent) : null;

--- a/Src/FluentAssertions/Equivalency/MemberSelectionContext.cs
+++ b/Src/FluentAssertions/Equivalency/MemberSelectionContext.cs
@@ -20,6 +20,16 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
+        /// Gets a value indicating whether and which properties should be considered.
+        /// </summary>
+        public MemberVisibility IncludedProperties => options.IncludedProperties;
+
+        /// <summary>
+        /// Gets a value indicating whether and which fields should be considered.
+        /// </summary>
+        public MemberVisibility IncludedFields => options.IncludedFields;
+
+        /// <summary>
         /// Gets either the compile-time or run-time type depending on the options provided by the caller.
         /// </summary>
         public Type Type

--- a/Src/FluentAssertions/Equivalency/MemberVisibility.cs
+++ b/Src/FluentAssertions/Equivalency/MemberVisibility.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+#pragma warning disable CA1714
+namespace FluentAssertions.Equivalency
+{
+    /// <summary>
+    /// Determines which members are included in the equivalency assertion
+    /// </summary>
+    [Flags]
+    public enum MemberVisibility
+    {
+        None = 0,
+        Internal = 1,
+        Public = 2
+    }
+}

--- a/Src/FluentAssertions/Equivalency/Selection/AllFieldsSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/AllFieldsSelectionRule.cs
@@ -7,7 +7,7 @@ namespace FluentAssertions.Equivalency.Selection
     /// <summary>
     /// Selection rule that adds all public fields of the expectation
     /// </summary>
-    internal class AllPublicFieldsSelectionRule : IMemberSelectionRule
+    internal class AllFieldsSelectionRule : IMemberSelectionRule
     {
         public bool IncludesMembers => false;
 
@@ -15,7 +15,7 @@ namespace FluentAssertions.Equivalency.Selection
             MemberSelectionContext context)
         {
             IEnumerable<IMember> selectedNonPrivateFields = context.Type
-                .GetNonPrivateFields()
+                .GetNonPrivateFields(context.IncludedFields)
                 .Select(info => new Field(info, currentNode));
 
             return selectedMembers.Union(selectedNonPrivateFields).ToList();

--- a/Src/FluentAssertions/Equivalency/Selection/AllPropertiesSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/AllPropertiesSelectionRule.cs
@@ -7,7 +7,7 @@ namespace FluentAssertions.Equivalency.Selection
     /// <summary>
     /// Selection rule that adds all public properties of the expectation.
     /// </summary>
-    internal class AllPublicPropertiesSelectionRule : IMemberSelectionRule
+    internal class AllPropertiesSelectionRule : IMemberSelectionRule
     {
         public bool IncludesMembers => false;
 
@@ -15,7 +15,7 @@ namespace FluentAssertions.Equivalency.Selection
             MemberSelectionContext context)
         {
             IEnumerable<IMember> selectedNonPrivateProperties = context.Type
-                .GetNonPrivateProperties()
+                .GetNonPrivateProperties(context.IncludedProperties)
                 .Select(info => new Property(info, currentNode));
 
             return selectedMembers.Union(selectedNonPrivateProperties).ToList();

--- a/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
@@ -21,7 +21,7 @@ namespace FluentAssertions.Equivalency.Selection
 
         protected override void AddOrRemoveMembersFrom(List<IMember> selectedMembers, INode parent, string parentPath, MemberSelectionContext context)
         {
-            foreach (MemberInfo memberInfo in context.Type.GetNonPrivateMembers())
+            foreach (MemberInfo memberInfo in context.Type.GetNonPrivateMembers(MemberVisibility.Public | MemberVisibility.Internal))
             {
                 var memberPath = new MemberPath(memberInfo.DeclaringType, parentPath.Combine(memberInfo.Name));
                 if (memberToInclude.IsSameAs(memberPath) || memberToInclude.IsParentOrChildOf(memberPath))

--- a/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPredicateSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPredicateSelectionRule.cs
@@ -28,7 +28,7 @@ namespace FluentAssertions.Equivalency.Selection
         {
             var members = new List<IMember>(selectedMembers);
 
-            foreach (MemberInfo memberInfo in currentNode.Type.GetNonPrivateMembers())
+            foreach (MemberInfo memberInfo in currentNode.Type.GetNonPrivateMembers(MemberVisibility.Public | MemberVisibility.Internal))
             {
                 IMember member = MemberFactory.Create(memberInfo, currentNode);
                 if (predicate(new MemberToMemberInfoAdapter(member)))

--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Common;
+using FluentAssertions.Equivalency;
 
 namespace FluentAssertions.Formatting
 {
@@ -58,7 +59,7 @@ namespace FluentAssertions.Formatting
         /// <remarks>The default is all non-private members.</remarks>
         protected virtual MemberInfo[] GetMembers(Type type)
         {
-            return type.GetNonPrivateMembers().ToArray();
+            return type.GetNonPrivateMembers(MemberVisibility.Public).ToArray();
         }
 
         private static bool HasDefaultToStringImplementation(object value)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -838,8 +838,8 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
-        bool IncludeFields { get; }
-        bool IncludeProperties { get; }
+        FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
+        FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberMatchingRule> MatchingRules { get; }
         FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
@@ -924,7 +924,16 @@ namespace FluentAssertions.Equivalency
     public class MemberSelectionContext
     {
         public MemberSelectionContext(System.Type compileTimeType, System.Type runtimeType, FluentAssertions.Equivalency.IEquivalencyAssertionOptions options) { }
+        public FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
+        public FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         public System.Type Type { get; }
+    }
+    [System.Flags]
+    public enum MemberVisibility
+    {
+        None = 0,
+        Internal = 1,
+        Public = 2,
     }
     public class Node : FluentAssertions.Equivalency.INode
     {
@@ -1007,6 +1016,8 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingAllDeclaredProperties() { }
         public TSelf IncludingAllRuntimeProperties() { }
         public TSelf IncludingFields() { }
+        public TSelf IncludingInternalFields() { }
+        public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -838,8 +838,8 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
-        bool IncludeFields { get; }
-        bool IncludeProperties { get; }
+        FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
+        FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberMatchingRule> MatchingRules { get; }
         FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
@@ -924,7 +924,16 @@ namespace FluentAssertions.Equivalency
     public class MemberSelectionContext
     {
         public MemberSelectionContext(System.Type compileTimeType, System.Type runtimeType, FluentAssertions.Equivalency.IEquivalencyAssertionOptions options) { }
+        public FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
+        public FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         public System.Type Type { get; }
+    }
+    [System.Flags]
+    public enum MemberVisibility
+    {
+        None = 0,
+        Internal = 1,
+        Public = 2,
     }
     public class Node : FluentAssertions.Equivalency.INode
     {
@@ -1007,6 +1016,8 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingAllDeclaredProperties() { }
         public TSelf IncludingAllRuntimeProperties() { }
         public TSelf IncludingFields() { }
+        public TSelf IncludingInternalFields() { }
+        public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -838,8 +838,8 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
-        bool IncludeFields { get; }
-        bool IncludeProperties { get; }
+        FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
+        FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberMatchingRule> MatchingRules { get; }
         FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
@@ -924,7 +924,16 @@ namespace FluentAssertions.Equivalency
     public class MemberSelectionContext
     {
         public MemberSelectionContext(System.Type compileTimeType, System.Type runtimeType, FluentAssertions.Equivalency.IEquivalencyAssertionOptions options) { }
+        public FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
+        public FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         public System.Type Type { get; }
+    }
+    [System.Flags]
+    public enum MemberVisibility
+    {
+        None = 0,
+        Internal = 1,
+        Public = 2,
     }
     public class Node : FluentAssertions.Equivalency.INode
     {
@@ -1007,6 +1016,8 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingAllDeclaredProperties() { }
         public TSelf IncludingAllRuntimeProperties() { }
         public TSelf IncludingFields() { }
+        public TSelf IncludingInternalFields() { }
+        public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -831,8 +831,8 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
-        bool IncludeFields { get; }
-        bool IncludeProperties { get; }
+        FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
+        FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberMatchingRule> MatchingRules { get; }
         FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
@@ -917,7 +917,16 @@ namespace FluentAssertions.Equivalency
     public class MemberSelectionContext
     {
         public MemberSelectionContext(System.Type compileTimeType, System.Type runtimeType, FluentAssertions.Equivalency.IEquivalencyAssertionOptions options) { }
+        public FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
+        public FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         public System.Type Type { get; }
+    }
+    [System.Flags]
+    public enum MemberVisibility
+    {
+        None = 0,
+        Internal = 1,
+        Public = 2,
     }
     public class Node : FluentAssertions.Equivalency.INode
     {
@@ -1000,6 +1009,8 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingAllDeclaredProperties() { }
         public TSelf IncludingAllRuntimeProperties() { }
         public TSelf IncludingFields() { }
+        public TSelf IncludingInternalFields() { }
+        public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -838,8 +838,8 @@ namespace FluentAssertions.Equivalency
         FluentAssertions.Equivalency.ConversionSelector ConversionSelector { get; }
         FluentAssertions.Equivalency.CyclicReferenceHandling CyclicReferenceHandling { get; }
         FluentAssertions.Equivalency.EnumEquivalencyHandling EnumEquivalencyHandling { get; }
-        bool IncludeFields { get; }
-        bool IncludeProperties { get; }
+        FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
+        FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         bool IsRecursive { get; }
         System.Collections.Generic.IEnumerable<FluentAssertions.Equivalency.IMemberMatchingRule> MatchingRules { get; }
         FluentAssertions.Equivalency.OrderingRuleCollection OrderingRules { get; }
@@ -924,7 +924,16 @@ namespace FluentAssertions.Equivalency
     public class MemberSelectionContext
     {
         public MemberSelectionContext(System.Type compileTimeType, System.Type runtimeType, FluentAssertions.Equivalency.IEquivalencyAssertionOptions options) { }
+        public FluentAssertions.Equivalency.MemberVisibility IncludedFields { get; }
+        public FluentAssertions.Equivalency.MemberVisibility IncludedProperties { get; }
         public System.Type Type { get; }
+    }
+    [System.Flags]
+    public enum MemberVisibility
+    {
+        None = 0,
+        Internal = 1,
+        Public = 2,
     }
     public class Node : FluentAssertions.Equivalency.INode
     {
@@ -1007,6 +1016,8 @@ namespace FluentAssertions.Equivalency
         public TSelf IncludingAllDeclaredProperties() { }
         public TSelf IncludingAllRuntimeProperties() { }
         public TSelf IncludingFields() { }
+        public TSelf IncludingInternalFields() { }
+        public TSelf IncludingInternalProperties() { }
         public TSelf IncludingNestedObjects() { }
         public TSelf IncludingProperties() { }
         public TSelf RespectingDeclaredTypes() { }

--- a/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
+++ b/Tests/Benchmarks/UsersOfGetClosedGenericInterfaces.cs
@@ -64,9 +64,9 @@ namespace Benchmarks
 
             public bool UseRuntimeTyping => false;
 
-            public bool IncludeProperties => throw new NotImplementedException();
+            public MemberVisibility IncludedProperties => throw new NotImplementedException();
 
-            public bool IncludeFields => throw new NotImplementedException();
+            public MemberVisibility IncludedFields => throw new NotImplementedException();
 
             public bool CompareRecordsByValue => throw new NotImplementedException();
 

--- a/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
@@ -1021,7 +1021,6 @@ namespace FluentAssertions.Specs.Equivalency
             // Arrange
             var dto = new CustomerDto
             {
-                Version = 2,
                 Age = 36,
                 Birthdate = new DateTime(1973, 9, 20),
                 Name = "John"
@@ -1030,7 +1029,6 @@ namespace FluentAssertions.Specs.Equivalency
             var customer = new Customer
             {
                 Id = 1,
-                Version = 2,
                 Age = 36,
                 Birthdate = new DateTime(1973, 9, 20),
                 Name = "John"
@@ -1181,6 +1179,118 @@ namespace FluentAssertions.Specs.Equivalency
         private class ClassThatHidesBaseClassProperty : ClassWithGuidProperty
         {
             public new string[] Property { get; set; }
+        }
+
+        [Fact]
+        public void When_a_property_is_internal_it_should_be_excluded_from_the_comparison()
+        {
+            // Arrange
+            var actual = new ClassWithInternalProperty
+            {
+                PublicProperty = "public",
+                InternalProperty = "internal",
+                ProtectedInternalProperty = "internal"
+            };
+
+            var expected = new ClassWithInternalProperty
+            {
+                PublicProperty = "public",
+                InternalProperty = "also internal",
+                ProtectedInternalProperty = "also internal"
+            };
+
+            // Act / Assert
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void When_a_property_is_internal_and_it_should_be_included_it_should_fail_the_assertion()
+        {
+            // Arrange
+            var actual = new ClassWithInternalProperty
+            {
+                PublicProperty = "public",
+                InternalProperty = "internal",
+                ProtectedInternalProperty = "internal"
+            };
+
+            var expected = new ClassWithInternalProperty
+            {
+                PublicProperty = "public",
+                InternalProperty = "also internal",
+                ProtectedInternalProperty = "also internal"
+            };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected, options => options.IncludingInternalProperties());
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("*InternalProperty*also internal*internal*ProtectedInternalProperty*");
+        }
+
+        private class ClassWithInternalProperty
+        {
+            public string PublicProperty { get; set; }
+
+            internal string InternalProperty { get; set; }
+
+            protected internal string ProtectedInternalProperty { get; set; }
+        }
+
+        [Fact]
+        public void When_a_field_is_internal_it_should_be_excluded_from_the_comparison()
+        {
+            // Arrange
+            var actual = new ClassWithInternalField
+            {
+                PublicField = "public",
+                InternalField = "internal",
+                ProtectedInternalField = "internal"
+            };
+
+            var expected = new ClassWithInternalField
+            {
+                PublicField = "public",
+                InternalField = "also internal",
+                ProtectedInternalField = "also internal"
+            };
+
+            // Act / Assert
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void When_a_field_is_internal_and_it_should_be_included_it_should_fail_the_assertion()
+        {
+            // Arrange
+            var actual = new ClassWithInternalField
+            {
+                PublicField = "public",
+                InternalField = "internal",
+                ProtectedInternalField = "internal"
+            };
+
+            var expected = new ClassWithInternalField
+            {
+                PublicField = "public",
+                InternalField = "also internal",
+                ProtectedInternalField = "also internal"
+            };
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expected, options => options.IncludingInternalFields());
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("*InternalField*also internal*internal*ProtectedInternalField*");
+        }
+
+        private class ClassWithInternalField
+        {
+            public string PublicField;
+
+            internal string InternalField;
+
+            protected internal string ProtectedInternalField;
         }
 
         [Fact]
@@ -4415,8 +4525,6 @@ namespace FluentAssertions.Specs.Equivalency
 
     public class CustomerDto
     {
-        public long Version { get; set; }
-
         public string Name { get; set; }
 
         public int Age { get; set; }

--- a/docs/_pages/objectgraphs.md
+++ b/docs/_pages/objectgraphs.md
@@ -144,13 +144,21 @@ Barring other configuration, Fluent Assertions will include all `public` propert
 This behavior can be changed:
 
 ```csharp
-// Include Fields
+// Include properties (which is the default)
+orderDto.Should().BeEquivalentTo(order, options => options
+    .IncludingProperties());
+
+// Include fields
 orderDto.Should().BeEquivalentTo(order, options => options
     .IncludingFields());
 
-// Include Properties
+// Include internal properties as well
 orderDto.Should().BeEquivalentTo(order, options => options
-    .IncludingProperties());
+    .IncludingInternalProperties());
+
+// And the internal fields
+orderDto.Should().BeEquivalentTo(order, options => options
+    .IncludingInternalFields());
 
 // Exclude Fields
 orderDto.Should().BeEquivalentTo(order, options => options
@@ -161,9 +169,7 @@ orderDto.Should().BeEquivalentTo(order, options => options
     .ExcludingProperties());
 ```
 
-This configuration affects the initial inclusion of members and happens before any `Exclude`s or other `IMemberSelectionRule`s.
-This configuration also affects matching.
-For example, that if properties are excluded, properties will not be inspected when looking for a match on the expected object.
+This configuration affects the initial inclusion of members and happens before any `Exclude`s or other `IMemberSelectionRule`s. This configuration also affects matching. For example, that if properties are excluded, properties will not be inspected when looking for a match on the expected object.
 
 ### Equivalency Comparison Behavior ###
 In addition to influencing the members that are including in the comparison, you can also override the actual assertion operation that is executed on a particular member.

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -44,6 +44,7 @@ sidebar:
 * Removed `[Not]Contain(IEnumerable<T>, params T[])` - [#1529](https://github.com/fluentassertions/fluentassertions/pull/1529).
 * Removed `BeEquivalentTo(params object[])` - [#1529](https://github.com/fluentassertions/fluentassertions/pull/1529).
 * Renamed `EquivalencyStepCollection` to `EquivalencyPlan` and `AssertionOptions.EquivalencyCollection` to `EquivalencyPlan` - [#1539](https://github.com/fluentassertions/fluentassertions/pull/1539).
+* `BeEquivalentTo` will no longer include `internal` properties and fields, unless `IncludingInternalProperties` or `IncludingInternalFields` is used - [#1575](https://github.com/fluentassertions/fluentassertions/pull/1575).
 
 **Breaking Changes (Extensibility)**
 * Pascal cased `CallerIdentifier.logger` - [#1458](https://github.com/fluentassertions/fluentassertions/pull/1458).


### PR DESCRIPTION
`BeEquivalentTo` will no longer include `internal` properties and fields, unless `IncludingInternalProperties` or `IncludingInternalFields` is used

Fixes #1205, #744

* [x] Release notes