### PR TITLE
Add Formatter for IDictionary

### DIFF
--- a/Src/FluentAssertions/Formatting/DictionaryValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DictionaryValueFormatter.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using FluentAssertions.Common;
+
+namespace FluentAssertions.Formatting
+{
+    public class DictionaryValueFormatter : IValueFormatter
+    {
+        /// <summary>
+        /// The number of items to include when formatting this object.
+        /// </summary>
+        /// <remarks>The default value is 32.</remarks>
+        protected virtual int MaxItems { get; } = 32;
+
+        /// <summary>
+        /// Indicates whether the current <see cref="IValueFormatter"/> can handle the specified <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The value for which to create a <see cref="string"/>.</param>
+        /// <returns>
+        /// <c>true</c> if the current <see cref="IValueFormatter"/> can handle the specified value; otherwise, <c>false</c>.
+        /// </returns>
+        public virtual bool CanHandle(object value)
+        {
+            return value is IDictionary;
+        }
+
+        public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
+        {
+            int startCount = formattedGraph.LineCount;
+            IEnumerable<KeyValuePair<object, object>> collection = AsEnumerable((IDictionary)value);
+
+            using var iterator = new Iterator<KeyValuePair<object, object>>(collection, MaxItems);
+            while (iterator.MoveNext())
+            {
+                if (iterator.IsFirst)
+                {
+                    formattedGraph.AddFragment("{");
+                }
+
+                if (!iterator.HasReachedMaxItems)
+                {
+                    var index = iterator.Index.ToString(CultureInfo.InvariantCulture);
+                    formattedGraph.AddFragment("[");
+                    formatChild(index + ".Key", iterator.Current.Key, formattedGraph);
+                    formattedGraph.AddFragment("] = ");
+                    formatChild(index + ".Value", iterator.Current.Value, formattedGraph);
+                }
+                else
+                {
+                    using IDisposable _ = formattedGraph.WithIndentation();
+                    string moreItemsMessage = $"…{collection.Count() - MaxItems} more…";
+                    AddLineOrFragment(formattedGraph, startCount, moreItemsMessage);
+                }
+
+                if (iterator.IsLast)
+                {
+                    AddLineOrFragment(formattedGraph, startCount, "}");
+                }
+                else
+                {
+                    formattedGraph.AddFragment(", ");
+                }
+            }
+
+            if (iterator.IsEmpty)
+            {
+                formattedGraph.AddFragment("{empty}");
+            }
+        }
+
+        private static void AddLineOrFragment(FormattedObjectGraph formattedGraph, int startCount, string fragment)
+        {
+            if (formattedGraph.LineCount > (startCount + 1))
+            {
+                formattedGraph.AddLine(fragment);
+            }
+            else
+            {
+                formattedGraph.AddFragment(fragment);
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<object, object>> AsEnumerable(IDictionary dictionary)
+        {
+            IDictionaryEnumerator iterator = dictionary.GetEnumerator();
+            using (iterator as IDisposable)
+            {
+                while (iterator.MoveNext())
+                {
+                    yield return new KeyValuePair<object, object>(iterator.Key, iterator.Value);
+                }
+            }
+        }
+    }
+}

--- a/Src/FluentAssertions/Formatting/Formatter.cs
+++ b/Src/FluentAssertions/Formatting/Formatter.cs
@@ -47,6 +47,7 @@ namespace FluentAssertions.Formatting
             new ExpressionValueFormatter(),
             new ExceptionValueFormatter(),
             new MultidimensionalArrayFormatter(),
+            new DictionaryValueFormatter(),
             new EnumerableValueFormatter(),
             new EnumValueFormatter(),
             new DefaultValueFormatter()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1367,6 +1367,13 @@ namespace FluentAssertions.Formatting
         protected virtual System.Reflection.MemberInfo[] GetMembers(System.Type type) { }
         protected virtual string TypeDisplayName(System.Type type) { }
     }
+    public class DictionaryValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DictionaryValueFormatter() { }
+        protected virtual int MaxItems { get; }
+        public virtual bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
     public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DoubleValueFormatter() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1367,6 +1367,13 @@ namespace FluentAssertions.Formatting
         protected virtual System.Reflection.MemberInfo[] GetMembers(System.Type type) { }
         protected virtual string TypeDisplayName(System.Type type) { }
     }
+    public class DictionaryValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DictionaryValueFormatter() { }
+        protected virtual int MaxItems { get; }
+        public virtual bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
     public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DoubleValueFormatter() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1367,6 +1367,13 @@ namespace FluentAssertions.Formatting
         protected virtual System.Reflection.MemberInfo[] GetMembers(System.Type type) { }
         protected virtual string TypeDisplayName(System.Type type) { }
     }
+    public class DictionaryValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DictionaryValueFormatter() { }
+        protected virtual int MaxItems { get; }
+        public virtual bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
     public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DoubleValueFormatter() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1320,6 +1320,13 @@ namespace FluentAssertions.Formatting
         protected virtual System.Reflection.MemberInfo[] GetMembers(System.Type type) { }
         protected virtual string TypeDisplayName(System.Type type) { }
     }
+    public class DictionaryValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DictionaryValueFormatter() { }
+        protected virtual int MaxItems { get; }
+        public virtual bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
     public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DoubleValueFormatter() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1367,6 +1367,13 @@ namespace FluentAssertions.Formatting
         protected virtual System.Reflection.MemberInfo[] GetMembers(System.Type type) { }
         protected virtual string TypeDisplayName(System.Type type) { }
     }
+    public class DictionaryValueFormatter : FluentAssertions.Formatting.IValueFormatter
+    {
+        public DictionaryValueFormatter() { }
+        protected virtual int MaxItems { get; }
+        public virtual bool CanHandle(object value) { }
+        public void Format(object value, FluentAssertions.Formatting.FormattedObjectGraph formattedGraph, FluentAssertions.Formatting.FormattingContext context, FluentAssertions.Formatting.FormatChild formatChild) { }
+    }
     public class DoubleValueFormatter : FluentAssertions.Formatting.IValueFormatter
     {
         public DoubleValueFormatter() { }

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
@@ -172,7 +172,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary {[1, One], [2, Two], [3, Three]} to contain 4 item(s) because we want to test the failure message, but found 3.");
+                .WithMessage("Expected dictionary {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"} to contain 4 item(s) because we want to test the failure message, but found 3.");
         }
 
         [Fact]
@@ -206,7 +206,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1, One], [2, Two], [3, Three]} to have a count (c >= 4) because a minimum of 4 is required, but count is 3.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\", [3] = \"Three\"} to have a count (c >= 4) because a minimum of 4 is required, but count is 3.");
         }
 
         [Fact]
@@ -858,7 +858,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected dictionary to be empty because we want to test the failure message, but found {[1, One]}.");
+                .WithMessage("Expected dictionary to be empty because we want to test the failure message, but found {[1] = \"One\"}.");
         }
 
         [Fact]
@@ -1004,7 +1004,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary1 to be equal to {[1, One], [22, Two]} because we want to test the failure message, but could not find keys {22}.");
+                "Expected dictionary1 to be equal to {[1] = \"One\", [22] = \"Two\"} because we want to test the failure message, but could not find keys {22}.");
         }
 
         [Fact]
@@ -1028,7 +1028,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary1 to be equal to {[1, One], [2, Two]} because we want to test the failure message, but found additional keys {3}.");
+                "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Two\"} because we want to test the failure message, but found additional keys {3}.");
         }
 
         [Fact]
@@ -1051,7 +1051,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary1 to be equal to {[1, One], [2, Three]} because we want to test the failure message, but {[1, One], [2, Two]} differs at key 2.");
+                "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Three\"} because we want to test the failure message, but {[1] = \"One\", [2] = \"Two\"} differs at key 2.");
         }
 
         [Fact]
@@ -1070,7 +1070,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary1 to be equal to {[1, One], [2, Two]} because we want to test the behaviour with a null subject, but found <null>.");
+                "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Two\"} because we want to test the behaviour with a null subject, but found <null>.");
         }
 
         [Fact]
@@ -1109,7 +1109,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary1 to be equal to {[1, One], [2, Two]}, but could not find keys {1, 2}.");
+                "Expected dictionary1 to be equal to {[1] = \"One\", [2] = \"Two\"}, but could not find keys {1, 2}.");
         }
 
         [Fact]
@@ -1170,7 +1170,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect dictionaries {[1, One], [2, Two]} and {[1, One], [2, Two]} to be equal.");
+                "Did not expect dictionaries {[1] = \"One\", [2] = \"Two\"} and {[1] = \"One\", [2] = \"Two\"} to be equal.");
         }
 
         [Fact]
@@ -1193,7 +1193,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect dictionaries {[1, One], [2, Two]} and {[1, One], [2, Two]} to be equal because we want to test the failure message.");
+                "Did not expect dictionaries {[1] = \"One\", [2] = \"Two\"} and {[1] = \"One\", [2] = \"Two\"} to be equal because we want to test the failure message.");
         }
 
         [Fact]
@@ -1322,7 +1322,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1, One], [2, Two]} to contain key 3 because we do.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key 3 because we do.");
         }
 
         [Fact]
@@ -1391,7 +1391,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1, One], [2, Two]} to contain key {2, 3} because we do, but could not find {3}.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key {2, 3} because we do, but could not find {3}.");
         }
 
         [Fact]
@@ -1461,7 +1461,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1, One], [2, Two]} not to contain key 1 because we don't like it, but found it anyhow.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} not to contain key 1 because we don't like it, but found it anyhow.");
         }
 
         [Fact]
@@ -1494,7 +1494,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1, One], [2, Two]} to not contain key {2, 3} because we do, but found {2}.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain key {2, 3} because we do, but found {2}.");
         }
 
         [Fact]
@@ -1512,7 +1512,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1, One], [2, Two]} to not contain key 2 because we do.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain key 2 because we do.");
         }
 
         [Fact]
@@ -1680,7 +1680,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1, One], [2, Two]} to contain value \"Three\" because we do.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain value \"Three\" because we do.");
         }
 
         [Fact]
@@ -1698,7 +1698,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1, One], [2, Two]} to contain value {\"Two\", \"Three\"} because we do, but could not find {\"Three\"}.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain value {\"Two\", \"Three\"} because we do, but could not find {\"Three\"}.");
         }
 
         [Fact]
@@ -1751,7 +1751,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1, One], [2, Two]} not to contain value \"One\" because we don't like it, but found it anyhow.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} not to contain value \"One\" because we don't like it, but found it anyhow.");
         }
 
         [Fact]
@@ -1801,7 +1801,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1, One], [2, Two]} to not contain value \"Two\" because we do.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain value \"Two\" because we do.");
         }
 
         [Fact]
@@ -1819,7 +1819,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1, One], [2, Two]} to not contain value {\"Two\", \"Three\"} because we do, but found {\"Two\"}.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to not contain value {\"Two\", \"Three\"} because we do, but found {\"Two\"}.");
         }
 
         [Fact]
@@ -2065,7 +2065,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1, One], [2, Two]} to contain key 3 because we do.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key 3 because we do.");
         }
 
         [Fact]
@@ -2090,7 +2090,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dictionary {[1, One], [2, Two]} to contain key(s) {1, 3, 4} because we do, but could not find keys {3, 4}.");
+                "Expected dictionary {[1] = \"One\", [2] = \"Two\"} to contain key(s) {1, 3, 4} because we do, but could not find keys {3, 4}.");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
@@ -601,6 +601,58 @@ namespace FluentAssertions.Specs.Formatting
             result.Should().Match("*TaskCompletionSource*Task*System.Int32*Status=WaitingForActivation*");
         }
 
+        private class MyKey
+        {
+            public int KeyProp { get; set; }
+        }
+
+        private class MyValue
+        {
+            public int ValueProp { get; set; }
+        }
+
+        [Fact]
+        public void When_formatting_a_dictionary_it_should_format_keys_and_values()
+        {
+            // Arrange
+            var subject = new Dictionary<MyKey, MyValue>
+            {
+                [new() { KeyProp = 13 }] = new() { ValueProp = 37 }
+            };
+
+            // Act
+            string result = Formatter.ToString(subject);
+
+            // Assert
+            result.Should().Match("*{*[*MyKey*KeyProp = 13*] = *MyValue*ValueProp = 37*}*");
+        }
+
+        [Fact]
+        public void When_formatting_an_empty_dictionary_it_should_be_clear_from_the_message()
+        {
+            // Arrange
+            var subject = new Dictionary<int, int>();
+
+            // Act
+            string result = Formatter.ToString(subject);
+
+            // Assert
+            result.Should().Match("{empty}");
+        }
+
+        [Fact]
+        public void When_formatting_a_large_dictionary_it_should_limit_the_number_of_formatted_entries()
+        {
+            // Arrange
+            var subject = Enumerable.Range(0, 50).ToDictionary(e => e, e => e);
+
+            // Act
+            string result = Formatter.ToString(subject);
+
+            // Assert
+            result.Should().Match("*…18 more…*");
+        }
+
         public class BaseStuff
         {
             public int StuffId { get; set; }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -22,6 +22,7 @@ sidebar:
 * Added `[Not]BeWritable`, `[Not]BeSeekable`, `[Not]BeReadable`, `[Not]BeReadOnly`, `[Not]BeWriteOnly`, `[Not]HaveLength` , `[Not]HavePosition` for Stream and `[Not]HaveBufferSize` for BufferedStream - [#1543](https://github.com/fluentassertions/fluentassertions/pull/1543)
 * Added native support for `XDocument`, `XElement` and `XAttribute` properties and fields to `BeEquivalentTo` - [#1572](https://github.com/fluentassertions/fluentassertions/pull/1572) 
 * The equivalency failure message will include information on how tuples, anonymous types, records and other types are compared - [#1571](https://github.com/fluentassertions/fluentassertions/pull/1571)
+* Improved formatting a dictionary when key or value is a complex type - [#1577](https://github.com/fluentassertions/fluentassertions/pull/1577).
 
 **Fixes**
 * Sometimes `BeEquivalentTo` reported an incorrect message when a dictionary was missing a key - [#1454](https://github.com/fluentassertions/fluentassertions/pull/1454)


### PR DESCRIPTION
Copied and adjusted the `EnumerableValueFormatter` to handle instances of `IDictionary`.

With the addition of `DictionaryValueFormatter` the output of the included `When_formatting_a_dictionary_it_should_format_keys_and_values` changes from
```
{[FluentAssertions.Specs.Formatting.FormatterSpecs+MyKey, FluentAssertions.Specs.Formatting.FormatterSpecs+MyValue]}
```
to
```
{[
    FluentAssertions.Specs.Formatting.FormatterSpecs+MyKey
    {
        KeyProp = 13
    }] = 
    FluentAssertions.Specs.Formatting.FormatterSpecs+MyValue
    {
        ValueProp = 37
    }
}
```

Part of fixing #1527 