### PR TITLE
Harden DataSet types against a continuing AssertionScope

### DIFF
--- a/Src/FluentAssertions/Equivalency/DataColumnEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataColumnEquivalencyStep.cs
@@ -54,9 +54,9 @@ namespace FluentAssertions.Equivalency
             var dataTableConfig = context.Options as DataEquivalencyAssertionOptions<DataTable>;
             var dataColumnConfig = context.Options as DataEquivalencyAssertionOptions<DataColumn>;
 
-            if (((dataSetConfig is not null) && dataSetConfig.ShouldExcludeColumn(subject))
-                || ((dataTableConfig is not null) && dataTableConfig.ShouldExcludeColumn(subject))
-                || ((dataColumnConfig is not null) && dataColumnConfig.ShouldExcludeColumn(subject)))
+            if ((dataSetConfig?.ShouldExcludeColumn(subject) == true)
+                || (dataTableConfig?.ShouldExcludeColumn(subject) == true)
+                || (dataColumnConfig?.ShouldExcludeColumn(subject) == true))
             {
                 compareColumn = false;
             }

--- a/Src/FluentAssertions/Equivalency/DataRelationEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRelationEquivalencyStep.cs
@@ -158,12 +158,12 @@ namespace FluentAssertions.Equivalency
 
             // These column references are in different tables in different data sets that _should_ be equivalent
             // to one another.
-            AssertionScope.Current
+            bool success = AssertionScope.Current
                 .ForCondition(subjectColumns.Length == expectationColumns.Length)
                 .FailWith("Expected {context:DataRelation} to reference {0} column(s){reason}, but found {subjectColumns.Length}",
                     expectationColumns.Length, subjectColumns.Length);
 
-            if (subjectColumns.Length == expectationColumns.Length)
+            if (success)
             {
                 for (int i = 0; i < expectationColumns.Length; i++)
                 {

--- a/Src/FluentAssertions/Equivalency/DataRowCollectionEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRowCollectionEquivalencyStep.cs
@@ -33,25 +33,28 @@ namespace FluentAssertions.Equivalency
                 var subject = (DataRowCollection)comparands.Subject;
                 var expectation = (DataRowCollection)comparands.Expectation;
 
-                AssertionScope.Current
+                bool success = AssertionScope.Current
                     .ForCondition(subject.Count == expectation.Count)
                     .FailWith("Expected {context:DataRowCollection} to contain {0} row(s){reason}, but found {1}",
                         expectation.Count, subject.Count);
 
-                switch (rowMatchMode)
+                if (success)
                 {
-                    case RowMatchMode.Index:
-                        MatchRowsByIndexAndCompare(context, nestedValidator, subject, expectation);
-                        break;
+                    switch (rowMatchMode)
+                    {
+                        case RowMatchMode.Index:
+                            MatchRowsByIndexAndCompare(context, nestedValidator, subject, expectation);
+                            break;
 
-                    case RowMatchMode.PrimaryKey:
-                        MatchRowsByPrimaryKeyAndCompare(nestedValidator, context, subject, expectation);
-                        break;
+                        case RowMatchMode.PrimaryKey:
+                            MatchRowsByPrimaryKeyAndCompare(nestedValidator, context, subject, expectation);
+                            break;
 
-                    default:
-                        AssertionScope.Current.FailWith(
-                            "Unknown RowMatchMode {0} when trying to compare {context:DataRowCollection}", rowMatchMode);
-                        break;
+                        default:
+                            AssertionScope.Current.FailWith(
+                                "Unknown RowMatchMode {0} when trying to compare {context:DataRowCollection}", rowMatchMode);
+                            break;
+                    }
                 }
             }
 

--- a/Src/FluentAssertions/Equivalency/DataRowEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRowEquivalencyStep.cs
@@ -98,9 +98,9 @@ namespace FluentAssertions.Equivalency
                 .Select(col => col.ColumnName);
 
             bool ignoreUnmatchedColumns =
-                ((dataSetConfig is not null) && dataSetConfig.IgnoreUnmatchedColumns) ||
-                ((dataTableConfig is not null) && dataTableConfig.IgnoreUnmatchedColumns) ||
-                ((dataRowConfig is not null) && dataRowConfig.IgnoreUnmatchedColumns);
+                (dataSetConfig?.IgnoreUnmatchedColumns == true) ||
+                (dataTableConfig?.IgnoreUnmatchedColumns == true) ||
+                (dataRowConfig?.IgnoreUnmatchedColumns == true);
 
             DataRowVersion subjectVersion =
                 (subject.RowState == DataRowState.Deleted)
@@ -115,9 +115,9 @@ namespace FluentAssertions.Equivalency
             bool compareOriginalVersions =
                 (subject.RowState == DataRowState.Modified) && (expectation.RowState == DataRowState.Modified);
 
-            if (((dataSetConfig is not null) && dataSetConfig.ExcludeOriginalData)
-                || ((dataTableConfig is not null) && dataTableConfig.ExcludeOriginalData)
-                || ((dataRowConfig is not null) && dataRowConfig.ExcludeOriginalData))
+            if ((dataSetConfig?.ExcludeOriginalData == true)
+                || (dataTableConfig?.ExcludeOriginalData == true)
+                || (dataRowConfig?.ExcludeOriginalData == true))
             {
                 compareOriginalVersions = false;
             }
@@ -127,9 +127,9 @@ namespace FluentAssertions.Equivalency
                 DataColumn expectationColumn = expectation.Table.Columns[columnName];
                 DataColumn subjectColumn = subject.Table.Columns[columnName];
 
-                if (((dataSetConfig is not null) && dataSetConfig.ShouldExcludeColumn(subjectColumn))
-                    || ((dataTableConfig is not null) && dataTableConfig.ShouldExcludeColumn(subjectColumn))
-                    || ((dataRowConfig is not null) && dataRowConfig.ShouldExcludeColumn(subjectColumn)))
+                if ((dataSetConfig?.ShouldExcludeColumn(subjectColumn) == true)
+                    || (dataTableConfig?.ShouldExcludeColumn(subjectColumn) == true)
+                    || (dataRowConfig?.ShouldExcludeColumn(subjectColumn) == true))
                 {
                     continue;
                 }

--- a/Src/FluentAssertions/Equivalency/DataRowEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataRowEquivalencyStep.cs
@@ -127,9 +127,10 @@ namespace FluentAssertions.Equivalency
                 DataColumn expectationColumn = expectation.Table.Columns[columnName];
                 DataColumn subjectColumn = subject.Table.Columns[columnName];
 
-                if ((dataSetConfig?.ShouldExcludeColumn(subjectColumn) == true)
-                    || (dataTableConfig?.ShouldExcludeColumn(subjectColumn) == true)
-                    || (dataRowConfig?.ShouldExcludeColumn(subjectColumn) == true))
+                if (subjectColumn is not null
+                    && ((dataSetConfig?.ShouldExcludeColumn(subjectColumn) == true)
+                        || (dataTableConfig?.ShouldExcludeColumn(subjectColumn) == true)
+                        || (dataRowConfig?.ShouldExcludeColumn(subjectColumn) == true)))
                 {
                     continue;
                 }

--- a/Src/FluentAssertions/Equivalency/DataSetEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/DataSetEquivalencyStep.cs
@@ -188,7 +188,7 @@ namespace FluentAssertions.Equivalency
 
                 foreach (string tableName in expectationTableNames.Union(subjectTableNames))
                 {
-                    if ((dataConfig is not null) && dataConfig.ExcludeTableNames.Contains(tableName))
+                    if (dataConfig?.ExcludeTableNames.Contains(tableName) == true)
                     {
                         continue;
                     }


### PR DESCRIPTION
In 44efddb454397f15c50068ca5b5245b4542317db `ShouldExcludeColumn` threw an NRE when `subjectColumn` was null.
This is now null guarded to avoid checking whether a non-existing column should be excluded.
A few lines below `subjectColumn` and `expectationColumn` are compared and potential null values are taken into account.

In 03fffcd `DataRowCollectionEquivalencyStep.OnHandle` did check `subject.Count == expectation.Count` before invoking `MatchRowsByIndexAndCompare` which threw an `IndexOutOfRangeException`, but it didn't take into account being on a continuing `AssertionScope`.

I also added some more `AssertionScope` guards to the `DataSet` related classes in 03fffcd.

This fixes #1530 