### PR TITLE
Improve formatting excepting properties

### DIFF
--- a/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DefaultValueFormatter.cs
@@ -112,6 +112,7 @@ namespace FluentAssertions.Formatting
             }
             catch (Exception ex)
             {
+                ex = (ex as TargetInvocationException)?.InnerException ?? ex;
                 memberValue = $"[Member '{member.Name}' threw an exception: '{ex.Message}']";
             }
 

--- a/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/FormatterSpecs.cs
@@ -151,7 +151,7 @@ namespace FluentAssertions.Specs.Formatting
             string result = Formatter.ToString(subject);
 
             // Assert
-            result.Should().Contain("Member 'ThrowingProperty' threw an exception");
+            result.Should().Contain("Member 'ThrowingProperty' threw an exception: 'CustomMessage'");
         }
 
         [Fact]
@@ -912,7 +912,7 @@ namespace FluentAssertions.Specs.Formatting
 
     internal class ExceptionThrowingClass
     {
-        public string ThrowingProperty => throw new InvalidOperationException();
+        public string ThrowingProperty => throw new InvalidOperationException("CustomMessage");
     }
 
     internal class NullThrowingToStringImplementation


### PR DESCRIPTION
When a property is invoked via `PropertyInfo.GetValue` and the the property, the exception is wrapped in a `TargetInvocationException`. 
This PR unwraps such exceptions a single level, to get the actually thrown exception.