### PR TITLE
Make StringAssertions null-safe to being wrapped in an AssertionScope

### DIFF
--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -345,25 +345,31 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<TAssertions> MatchRegex(Regex regularExpression, string because = "", params object[] becauseArgs)
         {
-            Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");
+            Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression),
+                "Cannot match string against <null>. Provide a regex pattern or use the BeNull method.");
 
             var regexStr = regularExpression.ToString();
             if (regexStr.Length == 0)
             {
-                throw new ArgumentException("Cannot match string against an empty string. Provide a regex pattern or use the BeEmpty method.", nameof(regularExpression));
+                throw new ArgumentException(
+                    "Cannot match string against an empty string. Provide a regex pattern or use the BeEmpty method.",
+                    nameof(regularExpression));
             }
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .ForCondition(Subject is not null)
                 .UsingLineBreaks
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} to match regex {0}{reason}, but it was <null>.", regexStr);
 
-            Execute.Assertion
-                .ForCondition(regularExpression.IsMatch(Subject))
-                .BecauseOf(because, becauseArgs)
-                .UsingLineBreaks
-                .FailWith("Expected {context:string} to match regex {0}{reason}, but {1} does not match.", regexStr, Subject);
+            if (success)
+            {
+                Execute.Assertion
+                    .ForCondition(regularExpression.IsMatch(Subject))
+                    .BecauseOf(because, becauseArgs)
+                    .UsingLineBreaks
+                    .FailWith("Expected {context:string} to match regex {0}{reason}, but {1} does not match.", regexStr, Subject);
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -415,25 +421,31 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<TAssertions> NotMatchRegex(Regex regularExpression, string because = "", params object[] becauseArgs)
         {
-            Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression), "Cannot match string against <null>. Provide a regex pattern or use the NotBeNull method.");
+            Guard.ThrowIfArgumentIsNull(regularExpression, nameof(regularExpression),
+                "Cannot match string against <null>. Provide a regex pattern or use the NotBeNull method.");
 
             var regexStr = regularExpression.ToString();
             if (regexStr.Length == 0)
             {
-                throw new ArgumentException("Cannot match string against an empty regex pattern. Provide a regex pattern or use the NotBeEmpty method.", nameof(regularExpression));
+                throw new ArgumentException(
+                    "Cannot match string against an empty regex pattern. Provide a regex pattern or use the NotBeEmpty method.",
+                    nameof(regularExpression));
             }
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .ForCondition(Subject is not null)
                 .UsingLineBreaks
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:string} to not match regex {0}{reason}, but it was <null>.", regexStr);
 
-            Execute.Assertion
-                .ForCondition(!regularExpression.IsMatch(Subject))
-                .BecauseOf(because, becauseArgs)
-                .UsingLineBreaks
-                .FailWith("Did not expect {context:string} to match regex {0}{reason}, but {1} matches.", regexStr, Subject);
+            if (success)
+            {
+                Execute.Assertion
+                    .ForCondition(!regularExpression.IsMatch(Subject))
+                    .BecauseOf(because, becauseArgs)
+                    .UsingLineBreaks
+                    .FailWith("Did not expect {context:string} to match regex {0}{reason}, but {1} matches.", regexStr, Subject);
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -543,24 +555,26 @@ namespace FluentAssertions.Primitives
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare string end with <null>.");
 
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:string} {0} to end with {1}{reason}.", Subject, expected);
-            }
-
-            if (Subject.Length < expected.Length)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:string} to end with {0}{reason}, but {1} is too short.", expected, Subject);
-            }
-
-            Execute.Assertion
-                .ForCondition(Subject.EndsWith(expected, StringComparison.Ordinal))
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
                 .FailWith("Expected {context:string} {0} to end with {1}{reason}.", Subject, expected);
+
+            if (success)
+            {
+                success = Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.Length >= expected.Length)
+                    .FailWith("Expected {context:string} to end with {0}{reason}, but {1} is too short.", expected, Subject);
+
+                if (success)
+                {
+                    Execute.Assertion
+                        .ForCondition(Subject.EndsWith(expected, StringComparison.Ordinal))
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:string} {0} to end with {1}{reason}.", Subject, expected);
+                }
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -581,17 +595,18 @@ namespace FluentAssertions.Primitives
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare end of string with <null>.");
 
-            if (Subject is null)
+            bool success = Execute.Assertion
+                .ForCondition(Subject is not null)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Expected {context:string} that does not end with {1}{reason}, but found {0}.", Subject, unexpected);
+
+            if (success)
             {
                 Execute.Assertion
+                    .ForCondition(!Subject.EndsWith(unexpected, StringComparison.Ordinal))
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:string} that does not end with {1}{reason}, but found {0}.", Subject, unexpected);
+                    .FailWith("Expected {context:string} {0} not to end with {1}{reason}.", Subject, unexpected);
             }
-
-            Execute.Assertion
-                .ForCondition(!Subject.EndsWith(unexpected, StringComparison.Ordinal))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:string} {0} not to end with {1}{reason}.", Subject, unexpected);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -612,24 +627,31 @@ namespace FluentAssertions.Primitives
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot compare string end equivalence with <null>.");
 
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:string} that ends with equivalent of {0}{reason}, but found {1}.", expected, Subject);
-            }
-
-            if (Subject.Length < expected.Length)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:string} to end with equivalent of {0}{reason}, but {1} is too short.", expected, Subject);
-            }
-
-            Execute.Assertion
-                .ForCondition(Subject.EndsWith(expected, StringComparison.OrdinalIgnoreCase))
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:string} that ends with equivalent of {0}{reason}, but found {1}.", expected, Subject);
+                .ForCondition(Subject is not null)
+                .FailWith(
+                    "Expected {context:string} that ends with equivalent of {0}{reason}, but found {1}.", expected, Subject);
+
+            if (success)
+            {
+                success = Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.Length >= expected.Length)
+                    .FailWith(
+                        "Expected {context:string} to end with equivalent of {0}{reason}, but {1} is too short.",
+                        expected, Subject);
+
+                if (success)
+                {
+                    Execute.Assertion
+                        .ForCondition(Subject.EndsWith(expected, StringComparison.OrdinalIgnoreCase))
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith(
+                            "Expected {context:string} that ends with equivalent of {0}{reason}, but found {1}.",
+                            expected, Subject);
+                }
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -650,17 +672,22 @@ namespace FluentAssertions.Primitives
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare end of string with <null>.");
 
-            if (Subject is null)
+            var success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith(
+                    "Expected {context:string} that does not end with equivalent of {0}{reason}, but found {1}.",
+                    unexpected, Subject);
+
+            if (success)
             {
                 Execute.Assertion
+                    .ForCondition(!Subject.EndsWith(unexpected, StringComparison.OrdinalIgnoreCase))
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:string} that does not end with equivalent of {0}{reason}, but found {1}.", unexpected, Subject);
+                    .FailWith(
+                        "Expected {context:string} that does not end with equivalent of {0}{reason}, but found {1}.",
+                        unexpected, Subject);
             }
-
-            Execute.Assertion
-                .ForCondition(!Subject.EndsWith(unexpected, StringComparison.OrdinalIgnoreCase))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:string} that does not end with equivalent of {0}{reason}, but found {1}.", unexpected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -1070,14 +1097,19 @@ namespace FluentAssertions.Primitives
         /// </param>
         public AndConstraint<TAssertions> HaveLength(int expected, string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
-                .FailWith("Expected {context:string} with length {0}{reason}, but found <null>", expected)
-                .Then
-                .ForCondition(Subject.Length == expected)
-                .FailWith("Expected {context:string} with length {0}{reason}, but found string {1} with length {2}.",
-                    expected, Subject, Subject.Length);
+                .FailWith("Expected {context:string} with length {0}{reason}, but found <null>.", expected);
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(Subject.Length == expected)
+                    .FailWith("Expected {context:string} with length {0}{reason}, but found string {1} with length {2}.",
+                        expected, Subject, Subject.Length);
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/StringAssertionSpecs.cs
@@ -769,11 +769,15 @@ namespace FluentAssertions.Specs.Primitives
             string subject = null;
 
             // Act
-            Action act = () => subject.Should().MatchRegex(new Regex(".*"), "because it should be a string");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                subject.Should().MatchRegex(new Regex(".*"), "because it should be a string");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
-             .WithMessage("Expected subject to match regex*\".*\" because it should be a string, but it was <null>.");
+                .WithMessage("Expected subject to match regex*\".*\" because it should be a string, but it was <null>.");
         }
 
         [Fact]
@@ -950,11 +954,15 @@ namespace FluentAssertions.Specs.Primitives
             string subject = null;
 
             // Act
-            Action act = () => subject.Should().NotMatchRegex(new Regex(".*"), "because it should not be a string");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                subject.Should().NotMatchRegex(new Regex(".*"), "because it should not be a string");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
-             .WithMessage("Expected subject to not match regex*\".*\" because it should not be a string, but it was <null>.");
+                .WithMessage("Expected subject to not match regex*\".*\" because it should not be a string, but it was <null>.");
         }
 
         [Fact]
@@ -1181,7 +1189,11 @@ namespace FluentAssertions.Specs.Primitives
         public void When_string_does_not_end_with_expected_phrase_it_should_throw()
         {
             // Act
-            Action act = () => "ABC".Should().EndWith("AB", "it should");
+            Action act = () =>
+            {
+                using var a = new AssertionScope();
+                "ABC".Should().EndWith("AB", "it should");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1225,9 +1237,15 @@ namespace FluentAssertions.Specs.Primitives
         [Fact]
         public void When_string_ending_is_compared_and_actual_value_is_null_then_it_should_throw()
         {
-            // Act
+            // Arrange
             string someString = null;
-            Action act = () => someString.Should().EndWith("ABC");
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                someString.Should().EndWith("ABC");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1300,9 +1318,15 @@ namespace FluentAssertions.Specs.Primitives
         [Fact]
         public void When_asserting_string_does_not_end_with_a_value_and_actual_value_is_null_it_should_throw()
         {
-            // Act
+            // Arrange
             string someString = null;
-            Action act = () => someString.Should().NotEndWith("ABC", "some {0}", "reason");
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                someString.Should().NotEndWith("ABC", "some {0}", "reason");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1547,9 +1571,15 @@ namespace FluentAssertions.Specs.Primitives
         [Fact]
         public void When_string_ending_is_compared_with_equivalent_and_actual_value_is_null_then_it_should_throw()
         {
-            // Act
+            // Arrange
             string someString = null;
-            Action act = () => someString.Should().EndWithEquivalentOf("abC");
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                someString.Should().EndWithEquivalentOf("abC");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1622,9 +1652,15 @@ namespace FluentAssertions.Specs.Primitives
         [Fact]
         public void When_asserting_string_does_not_end_with_equivalent_of_a_value_and_actual_value_is_null_it_should_throw()
         {
-            // Act
+            // Arrange
             string someString = null;
-            Action act = () => someString.Should().NotEndWithEquivalentOf("Abc", "some {0}", "reason");
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                someString.Should().NotEndWithEquivalentOf("Abc", "some {0}", "reason");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -3314,10 +3350,15 @@ namespace FluentAssertions.Specs.Primitives
             string actual = null;
 
             // Act
-            Action act = () => actual.Should().HaveLength(0);
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                actual.Should().HaveLength(0, "we want to test the failure {0}", "message");
+            };
 
             // Assert
-            act.Should().Throw<XunitException>();
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected actual with length 0 *failure message*, but found <null>.");
         }
 
         [Fact]
@@ -3327,24 +3368,15 @@ namespace FluentAssertions.Specs.Primitives
             string actual = "ABC";
 
             // Act
-            Action act = () => actual.Should().HaveLength(1);
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                actual.Should().HaveLength(1, "we want to test the failure {0}", "message");
+            };
 
             // Assert
-            act.Should().Throw<XunitException>();
-        }
-
-        [Fact]
-        public void Should_fail_with_descriptive_message_when_asserting_string_length_to_be_equal_to_different_value()
-        {
-            // Arrange
-            string actual = "ABC";
-
-            // Act
-            Action act = () => actual.Should().HaveLength(1, "because we want to test the failure {0}", "message");
-
-            // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected actual with length 1 because we want to test the failure message, but found string \"ABC\" with length 3.");
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected actual with length 1 *failure message*, but found string \"ABC\" with length 3.");
         }
 
         #endregion


### PR DESCRIPTION
Fixes NRE's in `StringAssertions` that were report in #1039