### PR TITLE
Rename WhichValue to WhoseValue

### DIFF
--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -243,14 +243,14 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public WhichValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected,
+        public WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected,
             string because = "", params object[] becauseArgs)
         {
             AndConstraint<TAssertions> andConstraint = ContainKeys(new[] { expected }, because, becauseArgs);
 
             _ = TryGetValue(Subject, expected, out TValue value);
 
-            return new WhichValueConstraint<TCollection, TKey, TValue, TAssertions>(andConstraint.And, value);
+            return new WhoseValueConstraint<TCollection, TKey, TValue, TAssertions>(andConstraint.And, value);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Collections/WhoseValueConstraint.cs
+++ b/Src/FluentAssertions/Collections/WhoseValueConstraint.cs
@@ -2,22 +2,22 @@ using System.Collections.Generic;
 
 namespace FluentAssertions.Collections
 {
-    public class WhichValueConstraint<TCollection, TKey, TValue, TAssertions> : AndConstraint<TAssertions>
+    public class WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> : AndConstraint<TAssertions>
         where TCollection : IEnumerable<KeyValuePair<TKey, TValue>>
         where TAssertions : GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="WhichValueConstraint{TCollection, TKey, TValue, TAssertions}"/> class.
+        /// Initializes a new instance of the <see cref="WhoseValueConstraint{TCollection, TKey, TValue, TAssertions}"/> class.
         /// </summary>
-        public WhichValueConstraint(TAssertions parentConstraint, TValue value)
+        public WhoseValueConstraint(TAssertions parentConstraint, TValue value)
             : base(parentConstraint)
         {
-            WhichValue = value;
+            WhoseValue = value;
         }
 
         /// <summary>
         /// Gets the value of the object referred to by the key.
         /// </summary>
-        public TValue WhichValue { get; }
+        public TValue WhoseValue { get; }
     }
 }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -437,7 +437,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Collections.WhichValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(params TKey[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
@@ -501,12 +501,12 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
     }
-    public class WhichValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
+    public class WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
         where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
-        public WhichValueConstraint(TAssertions parentConstraint, TValue value) { }
-        public TValue WhichValue { get; }
+        public WhoseValueConstraint(TAssertions parentConstraint, TValue value) { }
+        public TValue WhoseValue { get; }
     }
 }
 namespace FluentAssertions.Common

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -437,7 +437,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Collections.WhichValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(params TKey[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
@@ -501,12 +501,12 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
     }
-    public class WhichValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
+    public class WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
         where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
-        public WhichValueConstraint(TAssertions parentConstraint, TValue value) { }
-        public TValue WhichValue { get; }
+        public WhoseValueConstraint(TAssertions parentConstraint, TValue value) { }
+        public TValue WhoseValue { get; }
     }
 }
 namespace FluentAssertions.Common

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -437,7 +437,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Collections.WhichValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(params TKey[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
@@ -501,12 +501,12 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
     }
-    public class WhichValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
+    public class WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
         where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
-        public WhichValueConstraint(TAssertions parentConstraint, TValue value) { }
-        public TValue WhichValue { get; }
+        public WhoseValueConstraint(TAssertions parentConstraint, TValue value) { }
+        public TValue WhoseValue { get; }
     }
 }
 namespace FluentAssertions.Common

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -430,7 +430,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Collections.WhichValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(params TKey[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
@@ -494,12 +494,12 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
     }
-    public class WhichValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
+    public class WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
         where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
-        public WhichValueConstraint(TAssertions parentConstraint, TValue value) { }
-        public TValue WhichValue { get; }
+        public WhoseValueConstraint(TAssertions parentConstraint, TValue value) { }
+        public TValue WhoseValue { get; }
     }
 }
 namespace FluentAssertions.Common

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -437,7 +437,7 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(System.Collections.Generic.KeyValuePair<TKey, TValue> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Contain(TKey key, TValue value, string because = "", params object[] becauseArgs) { }
-        public FluentAssertions.Collections.WhichValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.Collections.WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> ContainKey(TKey expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(params TKey[] expected) { }
         public FluentAssertions.AndConstraint<TAssertions> ContainKeys(System.Collections.Generic.IEnumerable<TKey> expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TValue> ContainValue(TValue expected, string because = "", params object[] becauseArgs) { }
@@ -501,12 +501,12 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Collections.SubsequentOrderingAssertions<T>> ThenBeInDescendingOrder<TSelector>(System.Linq.Expressions.Expression<System.Func<T, TSelector>> propertyExpression, System.Collections.Generic.IComparer<TSelector> comparer, string because = "", params object[] becauseArgs) { }
     }
-    public class WhichValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
+    public class WhoseValueConstraint<TCollection, TKey, TValue, TAssertions> : FluentAssertions.AndConstraint<TAssertions>
         where TCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>
         where TAssertions : FluentAssertions.Collections.GenericDictionaryAssertions<TCollection, TKey, TValue, TAssertions>
     {
-        public WhichValueConstraint(TAssertions parentConstraint, TValue value) { }
-        public TValue WhichValue { get; }
+        public WhoseValueConstraint(TAssertions parentConstraint, TValue value) { }
+        public TValue WhoseValue { get; }
     }
 }
 namespace FluentAssertions.Common

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
@@ -1335,7 +1335,7 @@ namespace FluentAssertions.Specs.Collections
             };
 
             // Act
-            Action act = () => dictionary.Should().ContainKey("Key").WhichValue.Should().Be(4);
+            Action act = () => dictionary.Should().ContainKey("Key").WhoseValue.Should().Be(4);
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("Expected*4*3*.");

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -37,6 +37,7 @@ sidebar:
 * Better parameter checking of `MethodInfoSelectorAssertions` - [#1569](https://github.com/fluentassertions/fluentassertions/pull/1569)
 
 **Breaking Changes**
+* Renamed `WhichValue` to `WhoseValue` - [#1581](https://github.com/fluentassertions/fluentassertions/pull/1581)
 * By default, records are now compared by their members. Can be overridden using `ComparingRecordsByValue` - [#1571](https://github.com/fluentassertions/fluentassertions/pull/1571)
 * Changed `becauseArgs` of `[Not]Reference(Assembly)` from `string[]` to `object[]` - [#1459](https://github.com/fluentassertions/fluentassertions/pull/1459)
 * Major overhaul on how enums are handled, see the [Migration Guide](/upgradingtov6#enums) for more details - [#1479](https://github.com/fluentassertions/fluentassertions/pull/1479).


### PR DESCRIPTION
I realize this has sort of been discussed in #577 and #1126, but without any real conclusion, which I think is unfortunate. However, in the case of WhichValue (on a dictionary), there can never be any ambiguity and "Which" will always be the wrong word. It could be argued that it should rather be something like "WhoseCorrespondingValue", since the Value does not belong to the Key, but that's a bit long.