### PR TITLE
Improve execution assertions

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
@@ -37,9 +37,14 @@ namespace FluentAssertions
         /// Invokes the specified action on a subject so that you can chain it
         /// with any of the assertions from <see cref="ActionAssertions"/>
         /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="subject"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
         [Pure]
         public static Action Invoking<T>(this T subject, Action<T> action)
         {
+            Guard.ThrowIfArgumentIsNull(subject, nameof(subject));
+            Guard.ThrowIfArgumentIsNull(action, nameof(action));
+
             return () => action(subject);
         }
 
@@ -47,9 +52,14 @@ namespace FluentAssertions
         /// Invokes the specified action on a subject so that you can chain it
         /// with any of the assertions from <see cref="FunctionAssertions{T}"/>
         /// </summary>
+        /// <exception cref="ArgumentNullException"><paramref name="subject"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
         [Pure]
         public static Func<TResult> Invoking<T, TResult>(this T subject, Func<T, TResult> action)
         {
+            Guard.ThrowIfArgumentIsNull(subject, nameof(subject));
+            Guard.ThrowIfArgumentIsNull(action, nameof(action));
+
             return () => action(subject);
         }
 

--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
@@ -101,9 +101,14 @@ namespace FluentAssertions
         /// <returns>
         /// Returns an object for asserting that the execution time matches certain conditions.
         /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="subject"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
         [MustUseReturnValue /* do not use Pure because this method executes the action before returning to the caller */]
         public static MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, Expression<Action<T>> action)
         {
+            Guard.ThrowIfArgumentIsNull(subject, nameof(subject));
+            Guard.ThrowIfArgumentIsNull(action, nameof(action));
+
             return new MemberExecutionTime<T>(subject, action);
         }
 
@@ -114,6 +119,7 @@ namespace FluentAssertions
         /// <returns>
         /// Returns an object for asserting that the execution time matches certain conditions.
         /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
         [MustUseReturnValue /* do not use Pure because this method executes the action before returning to the caller */]
         public static ExecutionTime ExecutionTime(this Action action)
         {
@@ -127,6 +133,7 @@ namespace FluentAssertions
         /// <returns>
         /// Returns an object for asserting that the execution time matches certain conditions.
         /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
         [MustUseReturnValue /* do not use Pure because this method executes the action before returning to the caller */]
         public static ExecutionTime ExecutionTime(this Func<Task> action)
         {

--- a/Src/FluentAssertions/Specialized/ExecutionTime.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTime.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Specialized
 {
@@ -10,6 +11,7 @@ namespace FluentAssertions.Specialized
         /// Initializes a new instance of the <see cref="ExecutionTime"/> class.
         /// </summary>
         /// <param name="action">The action of which the execution time must be asserted.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
         public ExecutionTime(Action action)
             : this(action, "the action")
         {
@@ -19,6 +21,7 @@ namespace FluentAssertions.Specialized
         /// Initializes a new instance of the <see cref="ExecutionTime"/> class.
         /// </summary>
         /// <param name="action">The action of which the execution time must be asserted.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
         public ExecutionTime(Func<Task> action)
             : this(action, "the action")
         {
@@ -29,8 +32,11 @@ namespace FluentAssertions.Specialized
         /// </summary>
         /// <param name="action">The action of which the execution time must be asserted.</param>
         /// <param name="actionDescription">The description of the action to be asserted.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
         protected ExecutionTime(Action action, string actionDescription)
         {
+            Guard.ThrowIfArgumentIsNull(action, nameof(action));
+
             ActionDescription = actionDescription;
             stopwatch = new Stopwatch();
             IsRunning = true;
@@ -66,8 +72,11 @@ namespace FluentAssertions.Specialized
         /// The original constructor shall stay in place in order to keep backward-compatibility
         /// and to avoid unnecessary wrapping action in <see cref="Task"/>.
         /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
         protected ExecutionTime(Func<Task> action, string actionDescription)
         {
+            Guard.ThrowIfArgumentIsNull(action, nameof(action));
+
             ActionDescription = actionDescription;
             stopwatch = new Stopwatch();
             IsRunning = true;

--- a/Src/FluentAssertions/Specialized/MemberExecutionTime.cs
+++ b/Src/FluentAssertions/Specialized/MemberExecutionTime.cs
@@ -10,6 +10,8 @@ namespace FluentAssertions.Specialized
         /// </summary>
         /// <param name="subject">The object that exposes the method or property.</param>
         /// <param name="action">A reference to the method or property to measure the execution time of.</param>
+        /// <exception cref="NullReferenceException"><paramref name="subject"/> is <c>null</c>.</exception>
+        /// <exception cref="NullReferenceException"><paramref name="action"/> is <c>null</c>.</exception>
         public MemberExecutionTime(T subject, Expression<Action<T>> action)
             : base(() => action.Compile()(subject), "(" + action.Body + ")")
         {

--- a/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/ExceptionAssertionSpecs.cs
@@ -779,6 +779,48 @@ namespace FluentAssertions.Specs.Exceptions
                 .WithMessage("*with parameter name \"someParameter\"*we want to test the failure message*\"someOtherParameter\"*");
         }
 
+        [Fact]
+        public void When_invoking_a_function_on_a_null_subject_it_should_throw()
+        {
+            // Arrange
+            Does someClass = null;
+
+            // Act
+            Action act = () => someClass.Invoking(d => d.ToString());
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("subject");
+        }
+
+        [Fact]
+        public void When_invoking_an_action_on_a_null_subject_it_should_throw()
+        {
+            // Arrange
+            Does someClass = null;
+
+            // Act
+            Action act = () => someClass.Invoking(d => d.Do());
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("subject");
+        }
+
+        [Fact]
+        public void When_invoking_null_it_should_throw()
+        {
+            // Arrange
+            Does someClass = Does.NotThrow();
+
+            // Act
+            Action act = () => someClass.Invoking(null).Should().NotThrow();
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("action");
+        }
+
         #endregion
 
         #region Not Throw

--- a/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions.Extensions;
@@ -479,6 +479,63 @@ namespace FluentAssertions.Specs.Specialized
             act.Should().Throw<ArgumentNullException>()
                 .WithParameterName("executionTime");
         }
+
+        [Fact]
+        public void When_asserting_on_null_action_it_should_throw()
+        {
+            // Arrange
+            Action someAction = null;
+
+            // Act
+            Action act = () => someAction.ExecutionTime().Should().BeLessThan(1.Days());
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("action");
+        }
+
+        [Fact]
+        public void When_asserting_on_null_func_it_should_throw()
+        {
+            // Arrange
+            Func<Task> someFunc = null;
+
+            // Act
+            Action act = () => someFunc.ExecutionTime().Should().BeLessThan(1.Days());
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("action");
+        }
+
+        [Fact]
+        public void When_asserting_execution_time_of_null_action_it_should_throw()
+        {
+            // Arrange
+            object subject = null;
+
+            // Act
+            Action act = () => subject.ExecutionTimeOf(s => s.ToString()).Should().BeLessThan(1.Days());
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("subject");
+        }
+
+        [Fact]
+        public void When_asserting_execution_time_of_null_it_should_throw()
+        {
+            // Arrange
+            var subject = new object();
+
+            // Act
+            Action act = () => subject.ExecutionTimeOf(null).Should().BeLessThan(1.Days());
+
+            // Assert
+            act.Should().ThrowExactly<ArgumentNullException>()
+                .WithParameterName("action");
+        }
+
         #endregion
 
         internal class SleepingClass


### PR DESCRIPTION
Discovered some additional NRE's when investigating #1039

* `Invoking`
* `ExecutionTime`
* `ExecutionTimeOf`

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).