### PR TITLE
Improve wildcard documentation

### DIFF
--- a/Src/FluentAssertions/Primitives/StringAssertions.cs
+++ b/Src/FluentAssertions/Primitives/StringAssertions.cs
@@ -172,10 +172,11 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Asserts that a string matches a wildcard pattern.
+        /// Asserts that a string matches the <paramref name="wildcardPattern"/>.
         /// </summary>
         /// <param name="wildcardPattern">
-        /// The wildcard pattern with which the subject is matched, where * and ? have special meanings.
+        /// The pattern to match against the subject. This parameter can contain a combination of literal text and wildcard
+        /// (* and ?) characters, but it doesn't support regular expressions.
         /// </param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -184,6 +185,27 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <remarks>
+        /// <paramref name="wildcardPattern"/> can be a combination of literal and wildcard characters,
+        /// but it doesn't support regular expressions. The following wildcard specifiers are permitted in
+        /// <paramref name="wildcardPattern"/>.
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Wildcard character</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>* (asterisk)</term>
+        /// <description>Zero or more characters in that position.</description>
+        /// </item>
+        /// <item>
+        /// <term>? (question mark)</term>
+        /// <description>Exactly one character in that position.</description>
+        /// </item>
+        /// </list>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="wildcardPattern"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="wildcardPattern"/> is empty.</exception>
         public AndConstraint<TAssertions> Match(string wildcardPattern, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern), "Cannot match string against <null>. Provide a wildcard pattern or use the BeNull method.");
@@ -200,10 +222,11 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Asserts that a string does not match a wildcard pattern.
+        /// Asserts that a string does not match the <paramref name="wildcardPattern"/>.
         /// </summary>
         /// <param name="wildcardPattern">
-        /// The wildcard pattern with which the subject is matched, where * and ? have special meanings.
+        /// The pattern to match against the subject. This parameter can contain a combination literal text and wildcard of
+        /// (* and ?) characters, but it doesn't support regular expressions.
         /// </param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -212,6 +235,27 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <remarks>
+        /// <paramref name="wildcardPattern"/> can be a combination of literal and wildcard characters,
+        /// but it doesn't support regular expressions. The following wildcard specifiers are permitted in
+        /// <paramref name="wildcardPattern"/>.
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Wildcard character</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>* (asterisk)</term>
+        /// <description>Zero or more characters in that position.</description>
+        /// </item>
+        /// <item>
+        /// <term>? (question mark)</term>
+        /// <description>Exactly one character in that position.</description>
+        /// </item>
+        /// </list>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="wildcardPattern"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="wildcardPattern"/> is empty.</exception>
         public AndConstraint<TAssertions> NotMatch(string wildcardPattern, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(wildcardPattern, nameof(wildcardPattern), "Cannot match string against <null>. Provide a wildcard pattern or use the NotBeNull method.");
@@ -230,10 +274,11 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Asserts that a string matches a wildcard pattern.
+        /// Asserts that a string matches the <paramref name="wildcardPattern"/>.
         /// </summary>
         /// <param name="wildcardPattern">
-        /// The wildcard pattern with which the subject is matched, where * and ? have special meanings.
+        /// The pattern to match against the subject. This parameter can contain a combination of literal text and wildcard
+        /// (* and ?) characters, but it doesn't support regular expressions.
         /// </param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -242,6 +287,27 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <remarks>
+        /// <paramref name="wildcardPattern"/> can be a combination of literal and wildcard characters,
+        /// but it doesn't support regular expressions. The following wildcard specifiers are permitted in
+        /// <paramref name="wildcardPattern"/>.
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Wildcard character</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>* (asterisk)</term>
+        /// <description>Zero or more characters in that position.</description>
+        /// </item>
+        /// <item>
+        /// <term>? (question mark)</term>
+        /// <description>Exactly one character in that position.</description>
+        /// </item>
+        /// </list>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="wildcardPattern"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="wildcardPattern"/> is empty.</exception>
         public AndConstraint<TAssertions> MatchEquivalentOf(string wildcardPattern, string because = "",
             params object[] becauseArgs)
         {
@@ -264,10 +330,11 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Asserts that a string does not match a wildcard pattern.
+        /// Asserts that a string does not match the <paramref name="wildcardPattern"/>.
         /// </summary>
         /// <param name="wildcardPattern">
-        /// The wildcard pattern with which the subject is matched, where * and ? have special meanings.
+        /// The pattern to match against the subject. This parameter can contain a combination of literal text and wildcard
+        /// (* and ?) characters, but it doesn't support regular expressions.
         /// </param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -276,6 +343,27 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <remarks>
+        /// <paramref name="wildcardPattern"/> can be a combination of literal and wildcard characters,
+        /// but it doesn't support regular expressions. The following wildcard specifiers are permitted in
+        /// <paramref name="wildcardPattern"/>.
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Wildcard character</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>* (asterisk)</term>
+        /// <description>Zero or more characters in that position.</description>
+        /// </item>
+        /// <item>
+        /// <term>? (question mark)</term>
+        /// <description>Exactly one character in that position.</description>
+        /// </item>
+        /// </list>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="wildcardPattern"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="wildcardPattern"/> is empty.</exception>
         public AndConstraint<TAssertions> NotMatchEquivalentOf(string wildcardPattern, string because = "",
             params object[] becauseArgs)
         {

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -50,7 +50,8 @@ namespace FluentAssertions.Specialized
         /// Asserts that the thrown exception has a message that matches <paramref name="expectedWildcardPattern" />.
         /// </summary>
         /// <param name="expectedWildcardPattern">
-        /// The wildcard pattern with which the exception message is matched, where * and ? have special meanings.
+        /// The pattern to match against the exception message. This parameter can contain a combination of literal text and
+        /// wildcard (* and ?) characters, but it doesn't support regular expressions.
         /// </param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -59,6 +60,25 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
+        /// <remarks>
+        /// <paramref name="expectedWildcardPattern"/> can be a combination of literal and wildcard characters,
+        /// but it doesn't support regular expressions. The following wildcard specifiers are permitted in
+        /// <paramref name="expectedWildcardPattern"/>.
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Wildcard character</term>
+        /// <description>Description</description>
+        /// </listheader>
+        /// <item>
+        /// <term>* (asterisk)</term>
+        /// <description>Zero or more characters in that position.</description>
+        /// </item>
+        /// <item>
+        /// <term>? (question mark)</term>
+        /// <description>Exactly one character in that position.</description>
+        /// </item>
+        /// </list>
+        /// </remarks>
         public virtual ExceptionAssertions<TException> WithMessage(string expectedWildcardPattern, string because = "",
             params object[] becauseArgs)
         {

--- a/docs/_pages/exceptions.md
+++ b/docs/_pages/exceptions.md
@@ -43,6 +43,15 @@ act.Should().Throw<ArgumentNullException>().Where(e => e.Message.StartsWith("did
 
 However, we discovered that testing the exception message for a substring is so common, that we changed the default behavior of `WithMessage` to support wildcard expressions and match in a case-insensitive way.
 
+The pattern can be a combination of literal and wildcard characters, but it doesn't support regular expressions.
+
+The following wildcard specifiers are permitted in the pattern:
+
+| Wilcard specifier | Matches                                   |
+| ----------------- | ----------------------------------------- |
+| * (asterisk)      | Zero or more characters in that position. |
+| ? (question mark) | Exactly one character in that position.   |
+
 ```csharp
 Action act = () => subject.Foo(null);
 act

--- a/docs/_pages/strings.md
+++ b/docs/_pages/strings.md
@@ -68,7 +68,17 @@ theString.Should().EndWithEquivalentOf("a string");
 theString.Should().NotEndWithEquivalentOf("a string");
 ```
 
-We even support wildcards.
+For the `Match`, `NotMatch`, `MatchEquivalentOf`, and `NotMatchEquivalentOf` methods we support wildcards.
+
+The pattern can be a combination of literal and wildcard characters, but it doesn't support regular expressions.
+
+The following wildcard specifiers are permitted in the pattern:
+
+| Wilcard specifier | Matches                                   |
+| ----------------- | ----------------------------------------- |
+| * (asterisk)      | Zero or more characters in that position. |
+| ? (question mark) | Exactly one character in that position.   |
+
 For instance, if you would like to assert that some email address is correct, use this:
 
 ```csharp


### PR DESCRIPTION
Improves the documentation of wildcards for `[Not]Match`, `[Not]MatchEquivalentOf` and `WithMessage`.

Also fixes #1570

## IMPORTANT 

* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).