### PR TITLE
A succeeding condition should not be evaluated if the first one failed

### DIFF
--- a/Src/FluentAssertions/Execution/GivenSelector.cs
+++ b/Src/FluentAssertions/Execution/GivenSelector.cs
@@ -11,8 +11,9 @@ namespace FluentAssertions.Execution
     public class GivenSelector<T>
     {
         private readonly AssertionScope predecessor;
-        private readonly bool continueAsserting;
         private readonly T subject;
+
+        private bool continueAsserting;
 
         internal GivenSelector(Func<T> selector, AssertionScope predecessor, bool continueAsserting)
         {
@@ -129,8 +130,8 @@ namespace FluentAssertions.Execution
         {
             if (continueAsserting)
             {
-                bool success = predecessor.FailWith(message, args);
-                return new ContinuationOfGiven<T>(this, success);
+                continueAsserting = predecessor.FailWith(message, args);
+                return new ContinuationOfGiven<T>(this, continueAsserting);
             }
 
             return new ContinuationOfGiven<T>(this, succeeded: false);

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -746,6 +746,33 @@ namespace FluentAssertions.Specs.Execution
         }
 
         [Fact]
+        public void When_the_previous_assertion_failed_it_should_not_evaluate_the_succeeding_condition()
+        {
+            // Arrange
+            bool secondConditionEvaluated = false;
+            try
+            {
+                using var _ = new AssertionScope();
+
+                // Act
+                Execute.Assertion
+                    .Given(() => (string)null)
+                    .ForCondition(s => s is not null)
+                    .FailWith("but is was null")
+                    .Then
+                    .ForCondition(s => secondConditionEvaluated = true)
+                    .FailWith("it should be 42");
+            }
+            catch
+            {
+                // Ignore
+            }
+
+            // Assert
+            secondConditionEvaluated.Should().BeFalse("because the 2nd condition should not be invoked");
+        }
+
+        [Fact]
         public void When_the_previous_assertion_failed_it_should_not_execute_the_succeeding_failure()
         {
             // Arrange

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -37,6 +37,7 @@ sidebar:
 * Better parameter checking of `PropertyInfoSelectorAssertions` - [#1565](https://github.com/fluentassertions/fluentassertions/pull/1565)
 * Better parameter checking of `MethodInfoSelectorAssertions` - [#1569](https://github.com/fluentassertions/fluentassertions/pull/1569)
 * Better parameter checking of `XDocumentAssertions`, `XElementAssertions` and `XAttributeAssertions` - [#1564](https://github.com/fluentassertions/fluentassertions/pull/1564)
+* In a chained assertion API call, a second call to `ForCondition` should not even evaluate its lambda when the previous assertion failed - [#1587](https://github.com/fluentassertions/fluentassertions/pull/1587)
 
 **Breaking Changes**
 * By default, records are now compared by their members. Can be overridden using `ComparingRecordsByValue` - [#1571](https://github.com/fluentassertions/fluentassertions/pull/1571)


### PR DESCRIPTION
In a chained assertion API call, a second call to ForCondition should not even evaluate its lambda when the previous assertion failed.

Fixes #1568 