### PR TITLE
Fix build warning

### DIFF
--- a/Tests/Benchmarks/Benchmarks.csproj
+++ b/Tests/Benchmarks/Benchmarks.csproj
@@ -18,6 +18,6 @@
     <PackageReference Include="System.Collections" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data.DataSetExtensions" Condition="'$(TargetFramework)' == 'net472'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
During a build, the Benchmark project generates warnings about `System.Data.DataSetExtensions`.
Adding a condition should fix this warning.