### PR TITLE
Use the same Subject nullable and non-nullable type

### DIFF
--- a/Src/FluentAssertions/Numeric/NullableNumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableNumericAssertions.cs
@@ -26,8 +26,6 @@ namespace FluentAssertions.Numeric
         {
         }
 
-        public new T? Subject => SubjectInternal;
-
         /// <summary>
         /// Asserts that a nullable numeric value is not <c>null</c>.
         /// </summary>

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -36,12 +36,10 @@ namespace FluentAssertions.Numeric
 
         private protected NumericAssertions(T? value)
         {
-            SubjectInternal = value;
+            Subject = value;
         }
 
-        public T Subject => SubjectInternal.Value;
-
-        private protected T? SubjectInternal { get; }
+        public T? Subject { get; }
 
         /// <summary>
         /// Asserts that the integral number value is exactly the same as the <paramref name="expected"/> value.
@@ -57,9 +55,9 @@ namespace FluentAssertions.Numeric
         public AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) == 0)
+                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) == 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be {0}{reason}, but found {1}.", expected, SubjectInternal);
+                .FailWith("Expected {context:value} to be {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -79,10 +77,10 @@ namespace FluentAssertions.Numeric
         {
             Execute.Assertion
                 .ForCondition(
-                    (!SubjectInternal.HasValue && !expected.HasValue)
-                    || (SubjectInternal.HasValue && expected.HasValue && SubjectInternal.Value.CompareTo(expected.Value) == 0))
+                    (!Subject.HasValue && !expected.HasValue)
+                    || (Subject.HasValue && expected.HasValue && Subject.Value.CompareTo(expected.Value) == 0))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be {0}{reason}, but found {1}.", expected, SubjectInternal);
+                .FailWith("Expected {context:value} to be {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -101,7 +99,7 @@ namespace FluentAssertions.Numeric
         public AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!SubjectInternal.HasValue || SubjectInternal.Value.CompareTo(unexpected) != 0)
+                .ForCondition(!Subject.HasValue || Subject.Value.CompareTo(unexpected) != 0)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:value} to be {0}{reason}.", unexpected);
 
@@ -123,8 +121,8 @@ namespace FluentAssertions.Numeric
         {
             Execute.Assertion
                 .ForCondition(
-                    (!SubjectInternal.HasValue == unexpected.HasValue)
-                    || (SubjectInternal.HasValue && unexpected.HasValue && SubjectInternal.Value.CompareTo(unexpected.Value) != 0))
+                    (!Subject.HasValue == unexpected.HasValue)
+                    || (Subject.HasValue && unexpected.HasValue && Subject.Value.CompareTo(unexpected.Value) != 0))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Did not expect {context:value} to be {0}{reason}.", unexpected);
 
@@ -144,9 +142,9 @@ namespace FluentAssertions.Numeric
         public AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(default(T)) > 0)
+                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(default(T)) > 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be positive{reason}, but found {0}.", SubjectInternal);
+                .FailWith("Expected {context:value} to be positive{reason}, but found {0}.", Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -164,9 +162,9 @@ namespace FluentAssertions.Numeric
         public AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(default(T)) < 0)
+                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(default(T)) < 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be negative{reason}, but found {0}.", SubjectInternal);
+                .FailWith("Expected {context:value} to be negative{reason}, but found {0}.", Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -185,9 +183,9 @@ namespace FluentAssertions.Numeric
         public AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) < 0)
+                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) < 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be less than {0}{reason}, but found {1}.", expected, SubjectInternal);
+                .FailWith("Expected {context:value} to be less than {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -207,9 +205,9 @@ namespace FluentAssertions.Numeric
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) <= 0)
+                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) <= 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be less or equal to {0}{reason}, but found {1}.", expected, SubjectInternal);
+                .FailWith("Expected {context:value} to be less or equal to {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -229,9 +227,9 @@ namespace FluentAssertions.Numeric
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) > 0)
+                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) > 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be greater than {0}{reason}, but found {1}.", expected, SubjectInternal);
+                .FailWith("Expected {context:value} to be greater than {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -251,9 +249,9 @@ namespace FluentAssertions.Numeric
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(SubjectInternal.HasValue && SubjectInternal.Value.CompareTo(expected) >= 0)
+                .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) >= 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be greater or equal to {0}{reason}, but found {1}.", expected, SubjectInternal);
+                .FailWith("Expected {context:value} to be greater or equal to {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -281,10 +279,10 @@ namespace FluentAssertions.Numeric
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(SubjectInternal.HasValue && (SubjectInternal.Value.CompareTo(minimumValue) >= 0) && (SubjectInternal.Value.CompareTo(maximumValue) <= 0))
+                .ForCondition(Subject.HasValue && (Subject.Value.CompareTo(minimumValue) >= 0) && (Subject.Value.CompareTo(maximumValue) <= 0))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to be between {0} and {1}{reason}, but found {2}.",
-                    minimumValue, maximumValue, SubjectInternal);
+                    minimumValue, maximumValue, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -312,10 +310,10 @@ namespace FluentAssertions.Numeric
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(SubjectInternal.HasValue && !((SubjectInternal.Value.CompareTo(minimumValue) >= 0) && (SubjectInternal.Value.CompareTo(maximumValue) <= 0)))
+                .ForCondition(Subject.HasValue && !((Subject.Value.CompareTo(minimumValue) >= 0) && (Subject.Value.CompareTo(maximumValue) <= 0)))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to not be between {0} and {1}{reason}, but found {2}.",
-                    minimumValue, maximumValue, SubjectInternal);
+                    minimumValue, maximumValue, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -348,9 +346,9 @@ namespace FluentAssertions.Numeric
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(SubjectInternal.HasValue && validValues.Contains((T)SubjectInternal))
+                .ForCondition(Subject.HasValue && validValues.Contains((T)Subject))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be one of {0}{reason}, but found {1}.", validValues, SubjectInternal);
+                .FailWith("Expected {context:value} to be one of {0}{reason}, but found {1}.", validValues, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -372,7 +370,7 @@ namespace FluentAssertions.Numeric
         {
             Guard.ThrowIfArgumentIsNull(expectedType, nameof(expectedType));
 
-            Type subjectType = SubjectInternal?.GetType();
+            Type subjectType = Subject?.GetType();
             if (expectedType.IsGenericTypeDefinition && subjectType?.IsGenericType == true)
             {
                 (subjectType?.GetGenericTypeDefinition()).Should().Be(expectedType, because, becauseArgs);
@@ -403,11 +401,11 @@ namespace FluentAssertions.Numeric
             Guard.ThrowIfArgumentIsNull(unexpectedType, nameof(unexpectedType));
 
             Execute.Assertion
-                .ForCondition(SubjectInternal.HasValue)
+                .ForCondition(Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected type not to be " + unexpectedType + "{reason}, but found <null>.");
 
-            SubjectInternal.GetType().Should().NotBe(unexpectedType, because, becauseArgs);
+            Subject.GetType().Should().NotBe(unexpectedType, because, becauseArgs);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -432,9 +430,9 @@ namespace FluentAssertions.Numeric
             Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
 
             Execute.Assertion
-                .ForCondition(predicate.Compile()((T)SubjectInternal))
+                .ForCondition(predicate.Compile()((T)Subject))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to match {0}{reason}, but found {1}.", predicate.Body, SubjectInternal);
+                .FailWith("Expected {context:value} to match {0}{reason}, but found {1}.", predicate.Body, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/NumericAssertionsExtensions.cs
+++ b/Src/FluentAssertions/NumericAssertionsExtensions.cs
@@ -32,7 +32,7 @@ namespace FluentAssertions
             sbyte nearbyValue, byte delta, string because = "",
             params object[] becauseArgs)
         {
-            sbyte actualValue = parent.Subject;
+            sbyte actualValue = parent.Subject.Value;
             sbyte minValue = (sbyte)(nearbyValue - delta);
             if (minValue > nearbyValue)
             {
@@ -71,7 +71,7 @@ namespace FluentAssertions
             byte nearbyValue, byte delta, string because = "",
             params object[] becauseArgs)
         {
-            byte actualValue = parent.Subject;
+            byte actualValue = parent.Subject.Value;
             byte minValue = (byte)(nearbyValue - delta);
             if (minValue > nearbyValue)
             {
@@ -110,7 +110,7 @@ namespace FluentAssertions
             short nearbyValue, ushort delta, string because = "",
             params object[] becauseArgs)
         {
-            short actualValue = parent.Subject;
+            short actualValue = parent.Subject.Value;
             short minValue = (short)(nearbyValue - delta);
             if (minValue > nearbyValue)
             {
@@ -149,7 +149,7 @@ namespace FluentAssertions
             ushort nearbyValue, ushort delta, string because = "",
             params object[] becauseArgs)
         {
-            ushort actualValue = parent.Subject;
+            ushort actualValue = parent.Subject.Value;
             ushort minValue = (ushort)(nearbyValue - delta);
             if (minValue > nearbyValue)
             {
@@ -188,7 +188,7 @@ namespace FluentAssertions
             int nearbyValue, uint delta, string because = "",
             params object[] becauseArgs)
         {
-            int actualValue = parent.Subject;
+            int actualValue = parent.Subject.Value;
             int minValue = (int)(nearbyValue - delta);
             if (minValue > nearbyValue)
             {
@@ -227,7 +227,7 @@ namespace FluentAssertions
             uint nearbyValue, uint delta, string because = "",
             params object[] becauseArgs)
         {
-            uint actualValue = parent.Subject;
+            uint actualValue = parent.Subject.Value;
             uint minValue = nearbyValue - delta;
             if (minValue > nearbyValue)
             {
@@ -266,7 +266,7 @@ namespace FluentAssertions
             long nearbyValue, ulong delta, string because = "",
             params object[] becauseArgs)
         {
-            long actualValue = parent.Subject;
+            long actualValue = parent.Subject.Value;
             long minValue = GetMinValue(nearbyValue, delta);
             long maxValue = GetMaxValue(nearbyValue, delta);
 
@@ -296,7 +296,7 @@ namespace FluentAssertions
             ulong nearbyValue, ulong delta, string because = "",
             params object[] becauseArgs)
         {
-            ulong actualValue = parent.Subject;
+            ulong actualValue = parent.Subject.Value;
             ulong minValue = nearbyValue - delta;
             if (minValue > nearbyValue)
             {
@@ -350,7 +350,7 @@ namespace FluentAssertions
             sbyte distantValue, byte delta, string because = "",
             params object[] becauseArgs)
         {
-            sbyte actualValue = parent.Subject;
+            sbyte actualValue = parent.Subject.Value;
             sbyte minValue = (sbyte)(distantValue - delta);
             if (minValue > distantValue)
             {
@@ -389,7 +389,7 @@ namespace FluentAssertions
             byte distantValue, byte delta, string because = "",
             params object[] becauseArgs)
         {
-            byte actualValue = parent.Subject;
+            byte actualValue = parent.Subject.Value;
             byte minValue = (byte)(distantValue - delta);
             if (minValue > distantValue)
             {
@@ -428,7 +428,7 @@ namespace FluentAssertions
             short distantValue, ushort delta, string because = "",
             params object[] becauseArgs)
         {
-            short actualValue = parent.Subject;
+            short actualValue = parent.Subject.Value;
             short minValue = (short)(distantValue - delta);
             if (minValue > distantValue)
             {
@@ -467,7 +467,7 @@ namespace FluentAssertions
             ushort distantValue, ushort delta, string because = "",
             params object[] becauseArgs)
         {
-            ushort actualValue = parent.Subject;
+            ushort actualValue = parent.Subject.Value;
             ushort minValue = (ushort)(distantValue - delta);
             if (minValue > distantValue)
             {
@@ -506,7 +506,7 @@ namespace FluentAssertions
             int distantValue, uint delta, string because = "",
             params object[] becauseArgs)
         {
-            int actualValue = parent.Subject;
+            int actualValue = parent.Subject.Value;
             int minValue = (int)(distantValue - delta);
             if (minValue > distantValue)
             {
@@ -545,7 +545,7 @@ namespace FluentAssertions
             uint distantValue, uint delta, string because = "",
             params object[] becauseArgs)
         {
-            uint actualValue = parent.Subject;
+            uint actualValue = parent.Subject.Value;
             uint minValue = distantValue - delta;
             if (minValue > distantValue)
             {
@@ -584,7 +584,7 @@ namespace FluentAssertions
             long distantValue, ulong delta, string because = "",
             params object[] becauseArgs)
         {
-            long actualValue = parent.Subject;
+            long actualValue = parent.Subject.Value;
             long minValue = GetMinValue(distantValue, delta);
             long maxValue = GetMaxValue(distantValue, delta);
 
@@ -614,7 +614,7 @@ namespace FluentAssertions
             ulong distantValue, ulong delta, string because = "",
             params object[] becauseArgs)
         {
-            ulong actualValue = parent.Subject;
+            ulong actualValue = parent.Subject.Value;
             ulong minValue = distantValue - delta;
             if (minValue > distantValue)
             {
@@ -679,7 +679,7 @@ namespace FluentAssertions
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
-            var nonNullableAssertions = new NumericAssertions<float>((float)parent.Subject);
+            var nonNullableAssertions = new NumericAssertions<float>(parent.Subject.Value);
             nonNullableAssertions.BeApproximately(expectedValue, precision, because, becauseArgs);
 
             return new AndConstraint<NullableNumericAssertions<float>>(parent);
@@ -759,15 +759,15 @@ namespace FluentAssertions
 
             if (float.IsPositiveInfinity(expectedValue))
             {
-                FailIfDifferenceOutsidePrecision(float.IsPositiveInfinity(parent.Subject), parent, expectedValue, precision, float.NaN, because, becauseArgs);
+                FailIfDifferenceOutsidePrecision(float.IsPositiveInfinity(parent.Subject.Value), parent, expectedValue, precision, float.NaN, because, becauseArgs);
             }
             else if (float.IsNegativeInfinity(expectedValue))
             {
-                FailIfDifferenceOutsidePrecision(float.IsNegativeInfinity(parent.Subject), parent, expectedValue, precision, float.NaN, because, becauseArgs);
+                FailIfDifferenceOutsidePrecision(float.IsNegativeInfinity(parent.Subject.Value), parent, expectedValue, precision, float.NaN, because, becauseArgs);
             }
             else
             {
-                float actualDifference = Math.Abs(expectedValue - parent.Subject);
+                float actualDifference = Math.Abs(expectedValue - parent.Subject.Value);
 
                 FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference, because, becauseArgs);
             }
@@ -806,7 +806,7 @@ namespace FluentAssertions
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
-            var nonNullableAssertions = new NumericAssertions<double>((double)parent.Subject);
+            var nonNullableAssertions = new NumericAssertions<double>(parent.Subject.Value);
             BeApproximately(nonNullableAssertions, expectedValue, precision, because, becauseArgs);
 
             return new AndConstraint<NullableNumericAssertions<double>>(parent);
@@ -886,15 +886,15 @@ namespace FluentAssertions
 
             if (double.IsPositiveInfinity(expectedValue))
             {
-                FailIfDifferenceOutsidePrecision(double.IsPositiveInfinity(parent.Subject), parent, expectedValue, precision, double.NaN, because, becauseArgs);
+                FailIfDifferenceOutsidePrecision(double.IsPositiveInfinity(parent.Subject.Value), parent, expectedValue, precision, double.NaN, because, becauseArgs);
             }
             else if (double.IsNegativeInfinity(expectedValue))
             {
-                FailIfDifferenceOutsidePrecision(double.IsNegativeInfinity(parent.Subject), parent, expectedValue, precision, double.NaN, because, becauseArgs);
+                FailIfDifferenceOutsidePrecision(double.IsNegativeInfinity(parent.Subject.Value), parent, expectedValue, precision, double.NaN, because, becauseArgs);
             }
             else
             {
-                double actualDifference = Math.Abs(expectedValue - parent.Subject);
+                double actualDifference = Math.Abs(expectedValue - parent.Subject.Value);
 
                 FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference, because, becauseArgs);
             }
@@ -933,7 +933,7 @@ namespace FluentAssertions
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:value} to approximate {0} +/- {1}{reason}, but it was <null>.", expectedValue, precision);
 
-            var nonNullableAssertions = new NumericAssertions<decimal>((decimal)parent.Subject);
+            var nonNullableAssertions = new NumericAssertions<decimal>(parent.Subject.Value);
             BeApproximately(nonNullableAssertions, expectedValue, precision, because, becauseArgs);
 
             return new AndConstraint<NullableNumericAssertions<decimal>>(parent);
@@ -1011,7 +1011,7 @@ namespace FluentAssertions
                 throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
             }
 
-            decimal actualDifference = Math.Abs(expectedValue - parent.Subject);
+            decimal actualDifference = Math.Abs(expectedValue - parent.Subject.Value);
 
             FailIfDifferenceOutsidePrecision(actualDifference <= precision, parent, expectedValue, precision, actualDifference, because, becauseArgs);
 
@@ -1063,7 +1063,7 @@ namespace FluentAssertions
 
             if (parent.Subject is not null)
             {
-                var nonNullableAssertions = new NumericAssertions<float>((float)parent.Subject);
+                var nonNullableAssertions = new NumericAssertions<float>(parent.Subject.Value);
                 nonNullableAssertions.NotBeApproximately(unexpectedValue, precision, because, becauseArgs);
             }
 
@@ -1144,15 +1144,15 @@ namespace FluentAssertions
 
             if (float.IsPositiveInfinity(unexpectedValue))
             {
-                FailIfDifferenceWithinPrecision(parent, !float.IsPositiveInfinity(parent.Subject), unexpectedValue, precision, float.NaN, because, becauseArgs);
+                FailIfDifferenceWithinPrecision(parent, !float.IsPositiveInfinity(parent.Subject.Value), unexpectedValue, precision, float.NaN, because, becauseArgs);
             }
             else if (float.IsNegativeInfinity(unexpectedValue))
             {
-                FailIfDifferenceWithinPrecision(parent, !float.IsNegativeInfinity(parent.Subject), unexpectedValue, precision, float.NaN, because, becauseArgs);
+                FailIfDifferenceWithinPrecision(parent, !float.IsNegativeInfinity(parent.Subject.Value), unexpectedValue, precision, float.NaN, because, becauseArgs);
             }
             else
             {
-                float actualDifference = Math.Abs(unexpectedValue - parent.Subject);
+                float actualDifference = Math.Abs(unexpectedValue - parent.Subject.Value);
 
                 FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference, because, becauseArgs);
             }
@@ -1188,7 +1188,7 @@ namespace FluentAssertions
 
             if (parent.Subject is not null)
             {
-                var nonNullableAssertions = new NumericAssertions<double>((double)parent.Subject);
+                var nonNullableAssertions = new NumericAssertions<double>(parent.Subject.Value);
                 nonNullableAssertions.NotBeApproximately(unexpectedValue, precision, because, becauseArgs);
             }
 
@@ -1269,15 +1269,15 @@ namespace FluentAssertions
 
             if (double.IsPositiveInfinity(unexpectedValue))
             {
-                FailIfDifferenceWithinPrecision(parent, !double.IsPositiveInfinity(parent.Subject), unexpectedValue, precision, double.NaN, because, becauseArgs);
+                FailIfDifferenceWithinPrecision(parent, !double.IsPositiveInfinity(parent.Subject.Value), unexpectedValue, precision, double.NaN, because, becauseArgs);
             }
             else if (double.IsNegativeInfinity(unexpectedValue))
             {
-                FailIfDifferenceWithinPrecision(parent, !double.IsNegativeInfinity(parent.Subject), unexpectedValue, precision, double.NaN, because, becauseArgs);
+                FailIfDifferenceWithinPrecision(parent, !double.IsNegativeInfinity(parent.Subject.Value), unexpectedValue, precision, double.NaN, because, becauseArgs);
             }
             else
             {
-                double actualDifference = Math.Abs(unexpectedValue - parent.Subject);
+                double actualDifference = Math.Abs(unexpectedValue - parent.Subject.Value);
 
                 FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference, because, becauseArgs);
             }
@@ -1313,7 +1313,7 @@ namespace FluentAssertions
 
             if (parent.Subject is not null)
             {
-                var nonNullableAssertions = new NumericAssertions<decimal>((decimal)parent.Subject);
+                var nonNullableAssertions = new NumericAssertions<decimal>(parent.Subject.Value);
                 NotBeApproximately(nonNullableAssertions, unexpectedValue, precision, because, becauseArgs);
             }
 
@@ -1392,7 +1392,7 @@ namespace FluentAssertions
                 throw new ArgumentOutOfRangeException(nameof(precision), $"The value of {nameof(precision)} must be non-negative.");
             }
 
-            decimal actualDifference = Math.Abs(unexpectedValue - parent.Subject);
+            decimal actualDifference = Math.Abs(unexpectedValue - parent.Subject.Value);
 
             FailIfDifferenceWithinPrecision(parent, actualDifference > precision, unexpectedValue, precision, actualDifference, because, becauseArgs);
 

--- a/Src/FluentAssertions/Primitives/EnumAssertions.cs
+++ b/Src/FluentAssertions/Primitives/EnumAssertions.cs
@@ -30,12 +30,10 @@ namespace FluentAssertions.Primitives
 
         private protected EnumAssertions(TEnum? value)
         {
-            SubjectInternal = value;
+            Subject = value;
         }
 
-        public TEnum Subject => SubjectInternal.Value;
-
-        private protected TEnum? SubjectInternal { get; }
+        public TEnum? Subject { get; }
 
         /// <summary>
         /// Asserts that the current <typeparamref name="TEnum"/> is exactly equal to the <paramref name="expected"/> value.
@@ -51,10 +49,10 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> Be(TEnum expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(SubjectInternal?.Equals(expected) == true)
+                .ForCondition(Subject?.Equals(expected) == true)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected the enum to be {0}{reason}, but found {1}.",
-                    expected, SubjectInternal);
+                    expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -73,10 +71,10 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> Be(TEnum? expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Nullable.Equals(SubjectInternal, expected))
+                .ForCondition(Nullable.Equals(Subject, expected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected the enum to be {0}{reason}, but found {1}.",
-                    expected, SubjectInternal);
+                    expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -96,7 +94,7 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(SubjectInternal?.Equals(unexpected) != true)
+                .ForCondition(Subject?.Equals(unexpected) != true)
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected the enum not to be {0}{reason}, but it is.", unexpected);
 
@@ -118,7 +116,7 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!Nullable.Equals(SubjectInternal, unexpected))
+                .ForCondition(!Nullable.Equals(Subject, unexpected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected the enum not to be {0}{reason}, but it is.", unexpected);
 
@@ -139,10 +137,10 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> HaveValue(decimal expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(SubjectInternal.HasValue && (GetValue(SubjectInternal.Value) == expected))
+                .ForCondition(Subject.HasValue && (GetValue(Subject.Value) == expected))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected the enum to have value {0}{reason}, but found {1}.",
-                    expected, SubjectInternal);
+                    expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -161,10 +159,10 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotHaveValue(decimal unexpected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!(SubjectInternal.HasValue && (GetValue(SubjectInternal.Value) == unexpected)))
+                .ForCondition(!(Subject.HasValue && (GetValue(Subject.Value) == unexpected)))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected the enum to not have value {0}{reason}, but found {1}.",
-                    unexpected, SubjectInternal);
+                    unexpected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -184,10 +182,10 @@ namespace FluentAssertions.Primitives
             where T : struct, Enum
         {
             Execute.Assertion
-                .ForCondition(SubjectInternal.HasValue && (GetValue(SubjectInternal.Value) == GetValue(expected)))
+                .ForCondition(Subject.HasValue && (GetValue(Subject.Value) == GetValue(expected)))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected the enum to have same value as {0}{reason}, but found {1}.",
-                    expected, SubjectInternal);
+                    expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -207,10 +205,10 @@ namespace FluentAssertions.Primitives
             where T : struct, Enum
         {
             Execute.Assertion
-                .ForCondition(!(SubjectInternal.HasValue && (GetValue(SubjectInternal.Value) == GetValue(unexpected))))
+                .ForCondition(!(Subject.HasValue && (GetValue(Subject.Value) == GetValue(unexpected))))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected the enum to not have same value as {0}{reason}, but found {1}.",
-                    unexpected, SubjectInternal);
+                    unexpected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -230,10 +228,10 @@ namespace FluentAssertions.Primitives
             where T : struct, Enum
         {
             Execute.Assertion
-                .ForCondition(SubjectInternal.HasValue && (GetName(SubjectInternal.Value) == GetName(expected)))
+                .ForCondition(Subject.HasValue && (GetName(Subject.Value) == GetName(expected)))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected the enum to have same name as {0}{reason}, but found {1}.",
-                    expected, SubjectInternal);
+                    expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -253,10 +251,10 @@ namespace FluentAssertions.Primitives
             where T : struct, Enum
         {
             Execute.Assertion
-                .ForCondition(!(SubjectInternal.HasValue && (GetName(SubjectInternal.Value) == GetName(unexpected))))
+                .ForCondition(!(Subject.HasValue && (GetName(Subject.Value) == GetName(unexpected))))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected the enum to not have same name as {0}{reason}, but found {1}.",
-                    unexpected, SubjectInternal);
+                    unexpected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -277,8 +275,8 @@ namespace FluentAssertions.Primitives
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(SubjectInternal?.HasFlag(expectedFlag) == true)
-                .FailWith("Expected the enum to have flag {0}{reason}, but found {1}.", expectedFlag, SubjectInternal);
+                .ForCondition(Subject?.HasFlag(expectedFlag) == true)
+                .FailWith("Expected the enum to have flag {0}{reason}, but found {1}.", expectedFlag, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -299,7 +297,7 @@ namespace FluentAssertions.Primitives
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .ForCondition(SubjectInternal?.HasFlag(unexpectedFlag) != true)
+                .ForCondition(Subject?.HasFlag(unexpectedFlag) != true)
                 .FailWith("Expected the enum to not have flag {0}{reason}.", unexpectedFlag);
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/FluentAssertions/Primitives/NullableEnumAssertions.cs
+++ b/Src/FluentAssertions/Primitives/NullableEnumAssertions.cs
@@ -27,8 +27,6 @@ namespace FluentAssertions.Primitives
         {
         }
 
-        public new TEnum? Subject => SubjectInternal;
-
         /// <summary>
         /// Asserts that a nullable <typeparamref name="TEnum"/> value is not <c>null</c>.
         /// </summary>
@@ -42,11 +40,11 @@ namespace FluentAssertions.Primitives
         public AndWhichConstraint<TAssertions, TEnum> HaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(SubjectInternal.HasValue)
+                .ForCondition(Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:nullable date and time} to have a value{reason}, but found {0}.", SubjectInternal);
+                .FailWith("Expected {context:nullable date and time} to have a value{reason}, but found {0}.", Subject);
 
-            return new AndWhichConstraint<TAssertions, TEnum>((TAssertions)this, SubjectInternal.GetValueOrDefault());
+            return new AndWhichConstraint<TAssertions, TEnum>((TAssertions)this, Subject.GetValueOrDefault());
         }
 
         /// <summary>
@@ -77,9 +75,9 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> NotHaveValue(string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(!SubjectInternal.HasValue)
+                .ForCondition(!Subject.HasValue)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {context:nullable date and time} to have a value{reason}, but found {0}.", SubjectInternal);
+                .FailWith("Did not expect {context:nullable date and time} to have a value{reason}, but found {0}.", Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1621,7 +1621,6 @@ namespace FluentAssertions.Numeric
         where TAssertions : FluentAssertions.Numeric.NullableNumericAssertions<T, TAssertions>
     {
         public NullableNumericAssertions(T? value) { }
-        public T? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
@@ -1638,7 +1637,7 @@ namespace FluentAssertions.Numeric
         where TAssertions : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
     {
         public NumericAssertions(T value) { }
-        public T Subject { get; }
+        public T? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
@@ -1795,7 +1794,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
     {
         public EnumAssertions(TEnum subject) { }
-        public TEnum Subject { get; }
+        public TEnum? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveFlag(TEnum expectedFlag, string because = "", params object[] becauseArgs) { }
@@ -1880,7 +1879,6 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableEnumAssertions<TEnum, TAssertions>
     {
         public NullableEnumAssertions(TEnum? subject) { }
-        public TEnum? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> NotBeNull(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1621,7 +1621,6 @@ namespace FluentAssertions.Numeric
         where TAssertions : FluentAssertions.Numeric.NullableNumericAssertions<T, TAssertions>
     {
         public NullableNumericAssertions(T? value) { }
-        public T? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
@@ -1638,7 +1637,7 @@ namespace FluentAssertions.Numeric
         where TAssertions : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
     {
         public NumericAssertions(T value) { }
-        public T Subject { get; }
+        public T? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
@@ -1795,7 +1794,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
     {
         public EnumAssertions(TEnum subject) { }
-        public TEnum Subject { get; }
+        public TEnum? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveFlag(TEnum expectedFlag, string because = "", params object[] becauseArgs) { }
@@ -1880,7 +1879,6 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableEnumAssertions<TEnum, TAssertions>
     {
         public NullableEnumAssertions(TEnum? subject) { }
-        public TEnum? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> NotBeNull(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1621,7 +1621,6 @@ namespace FluentAssertions.Numeric
         where TAssertions : FluentAssertions.Numeric.NullableNumericAssertions<T, TAssertions>
     {
         public NullableNumericAssertions(T? value) { }
-        public T? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
@@ -1638,7 +1637,7 @@ namespace FluentAssertions.Numeric
         where TAssertions : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
     {
         public NumericAssertions(T value) { }
-        public T Subject { get; }
+        public T? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
@@ -1795,7 +1794,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
     {
         public EnumAssertions(TEnum subject) { }
-        public TEnum Subject { get; }
+        public TEnum? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveFlag(TEnum expectedFlag, string because = "", params object[] becauseArgs) { }
@@ -1880,7 +1879,6 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableEnumAssertions<TEnum, TAssertions>
     {
         public NullableEnumAssertions(TEnum? subject) { }
-        public TEnum? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> NotBeNull(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1574,7 +1574,6 @@ namespace FluentAssertions.Numeric
         where TAssertions : FluentAssertions.Numeric.NullableNumericAssertions<T, TAssertions>
     {
         public NullableNumericAssertions(T? value) { }
-        public T? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
@@ -1591,7 +1590,7 @@ namespace FluentAssertions.Numeric
         where TAssertions : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
     {
         public NumericAssertions(T value) { }
-        public T Subject { get; }
+        public T? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
@@ -1748,7 +1747,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
     {
         public EnumAssertions(TEnum subject) { }
-        public TEnum Subject { get; }
+        public TEnum? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveFlag(TEnum expectedFlag, string because = "", params object[] becauseArgs) { }
@@ -1833,7 +1832,6 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableEnumAssertions<TEnum, TAssertions>
     {
         public NullableEnumAssertions(TEnum? subject) { }
-        public TEnum? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> NotBeNull(string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1621,7 +1621,6 @@ namespace FluentAssertions.Numeric
         where TAssertions : FluentAssertions.Numeric.NullableNumericAssertions<T, TAssertions>
     {
         public NullableNumericAssertions(T? value) { }
-        public T? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Match(System.Linq.Expressions.Expression<System.Func<T?, bool>> predicate, string because = "", params object[] becauseArgs) { }
@@ -1638,7 +1637,7 @@ namespace FluentAssertions.Numeric
         where TAssertions : FluentAssertions.Numeric.NumericAssertions<T, TAssertions>
     {
         public NumericAssertions(T value) { }
-        public T Subject { get; }
+        public T? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
@@ -1795,7 +1794,7 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.EnumAssertions<TEnum, TAssertions>
     {
         public EnumAssertions(TEnum subject) { }
-        public TEnum Subject { get; }
+        public TEnum? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> Be(TEnum? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveFlag(TEnum expectedFlag, string because = "", params object[] becauseArgs) { }
@@ -1880,7 +1879,6 @@ namespace FluentAssertions.Primitives
         where TAssertions : FluentAssertions.Primitives.NullableEnumAssertions<TEnum, TAssertions>
     {
         public NullableEnumAssertions(TEnum? subject) { }
-        public TEnum? Subject { get; }
         public FluentAssertions.AndConstraint<TAssertions> BeNull(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> HaveValue(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, TEnum> NotBeNull(string because = "", params object[] becauseArgs) { }


### PR DESCRIPTION
In #1266 I changed `NullableNumericAssertions` to have a property `T? Subject` and its base class `NumericAssertions` to have a `T Subject`.
What I (presumably) didn't consider back then was extensibility.
Maybe I was fooled by `NumericAssertionsExtensions` which casted `Subject` (which used to be of type `IComparable`) to the primitive numeric type. 

If I create an extension method on `NumericAssertions` and call it on an instance of the derived `NullableNumericAssertions` it could throw an unexpected exception, if it tried to get an `int` from a `null`.

Exemplified in code
```cs
((int?)null).Should().Do();

public static void Do<T, TAssertions>(this NumericAssertions<T, TAssertions> assertions)
    where T : struct, IComparable<T>
    where TAssertions : NumericAssertions<T, TAssertions>
{
    T value = assertions.Subject; // <-- throws exception
}
```