### PR TITLE
Guard more assertions against null subject variables.

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -100,6 +100,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="expectedType"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> AllBeAssignableTo(Type expectedType, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expectedType, nameof(expectedType));
@@ -243,6 +244,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="expectedType"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> AllBeOfType(Type expectedType, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expectedType, nameof(expectedType));
@@ -408,6 +410,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
         public AndConstraint<SubsequentOrderingAssertions<T>> BeInAscendingOrder(
             IComparer<T> comparer, string because = "", params object[] becauseArgs)
         {
@@ -434,6 +437,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
         public AndConstraint<SubsequentOrderingAssertions<T>> BeInAscendingOrder<TSelector>(
             Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] becauseArgs)
         {
@@ -521,6 +525,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
         public AndConstraint<SubsequentOrderingAssertions<T>> BeInDescendingOrder(
             IComparer<T> comparer, string because = "", params object[] becauseArgs)
         {
@@ -547,6 +552,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
         public AndConstraint<SubsequentOrderingAssertions<T>> BeInDescendingOrder<TSelector>(
             Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] becauseArgs)
         {
@@ -628,6 +634,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="expectedSuperset"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> BeSubsetOf(IEnumerable<T> expectedSuperset, string because = "",
             params object[] becauseArgs)
         {
@@ -694,6 +701,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <c>null</c>.</exception>
         public AndWhichConstraint<TAssertions, T> Contain(Expression<Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
@@ -732,6 +740,8 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="expected"/> is empty.</exception>
         public AndConstraint<TAssertions> Contain(IEnumerable<T> expected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot verify containment against a <null> collection");
@@ -817,6 +827,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="config"/> is <c>null</c>.</exception>
         public AndWhichConstraint<TAssertions, T> ContainEquivalentOf<TExpectation>(TExpectation expectation, Func<EquivalencyAssertionOptions<TExpectation>,
                 EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs)
         {
@@ -893,6 +904,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> ContainInOrder(IEnumerable<T> expected, string because = "",
             params object[] becauseArgs)
         {
@@ -1024,6 +1036,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <c>null</c>.</exception>
         public AndWhichConstraint<TAssertions, T> ContainSingle(Expression<Func<T, bool>> predicate,
             string because = "", params object[] becauseArgs)
         {
@@ -1233,6 +1246,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="countPredicate"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> HaveCount(Expression<Func<int, bool>> countPredicate, string because = "",
             params object[] becauseArgs)
         {
@@ -1505,6 +1519,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="otherCollection"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> HaveSameCount<TExpectation>(IEnumerable<TExpectation> otherCollection, string because = "",
             params object[] becauseArgs)
         {
@@ -1537,6 +1552,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="otherCollection"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> IntersectWith(IEnumerable<T> otherCollection, string because = "",
             params object[] becauseArgs)
         {
@@ -1714,6 +1730,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> NotBeInAscendingOrder(
             IComparer<T> comparer, string because = "", params object[] becauseArgs)
         {
@@ -1740,6 +1757,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> NotBeInAscendingOrder<TSelector>(
             Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] becauseArgs)
         {
@@ -1826,6 +1844,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> NotBeInDescendingOrder(
             IComparer<T> comparer, string because = "", params object[] becauseArgs)
         {
@@ -1852,6 +1871,7 @@ namespace FluentAssertions.Collections
         /// <remarks>
         /// Empty and single element collections are considered to be ordered both in ascending and descending order at the same time.
         /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> NotBeInDescendingOrder<TSelector>(
             Expression<Func<T, TSelector>> propertyExpression, IComparer<TSelector> comparer, string because = "", params object[] becauseArgs)
         {
@@ -2004,6 +2024,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> NotContain(Expression<Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
@@ -2040,6 +2061,8 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="unexpected"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="unexpected"/> is empty.</exception>
         public AndConstraint<TAssertions> NotContain(IEnumerable<T> unexpected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot verify non-containment against a <null> collection");
@@ -2126,6 +2149,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="config"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> NotContainEquivalentOf<TExpectation>(TExpectation unexpected, Func<EquivalencyAssertionOptions<TExpectation>,
             EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs)
         {
@@ -2205,6 +2229,7 @@ namespace FluentAssertions.Collections
         /// Elements are compared using their <see cref="object.Equals(object)" /> implementation.
         /// </remarks>
         /// <param name="unexpected">A <see cref="Array"/> with the unexpected elements.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="unexpected"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> NotContainInOrder(params T[] unexpected)
         {
             return NotContainInOrder(unexpected, string.Empty);
@@ -2224,6 +2249,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="unexpected"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> NotContainInOrder(IEnumerable<T> unexpected, string because = "",
             params object[] becauseArgs)
         {
@@ -2292,6 +2318,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> NotContainNulls<TKey>(Expression<Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
             where TKey : class
         {
@@ -2377,6 +2404,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="unexpected"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> NotEqual(IEnumerable<T> unexpected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare collection with <null>.");
@@ -2440,6 +2468,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="otherCollection"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> NotHaveSameCount<TExpectation>(IEnumerable<TExpectation> otherCollection, string because = "",
             params object[] becauseArgs)
         {
@@ -2478,6 +2507,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="otherCollection"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> NotIntersectWith(IEnumerable<T> otherCollection, string because = "",
             params object[] becauseArgs)
         {
@@ -2516,6 +2546,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> OnlyContain(
             Expression<Func<T, bool>> predicate, string because = "", params object[] becauseArgs)
         {
@@ -2554,6 +2585,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> OnlyHaveUniqueItems<TKey>(Expression<Func<T, TKey>> predicate, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
@@ -2650,6 +2682,8 @@ namespace FluentAssertions.Collections
         /// The element inspectors, which inspect each element in turn. The
         /// total number of element inspectors must exactly match the number of elements in the collection.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="elementInspectors"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="elementInspectors"/> is empty.</exception>
         public AndConstraint<TAssertions> SatisfyRespectively(params Action<T>[] elementInspectors)
         {
             return SatisfyRespectively(elementInspectors, string.Empty);
@@ -2670,6 +2704,8 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="expected"/> is empty.</exception>
         public AndConstraint<TAssertions> SatisfyRespectively(IEnumerable<Action<T>> expected, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot verify against a <null> collection of inspectors");
@@ -2734,6 +2770,8 @@ namespace FluentAssertions.Collections
         /// The predicates that the elements of the collection must match.
         /// The total number of predicates must exactly match the number of elements in the collection.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="predicates"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="predicates"/> is empty.</exception>
         public AndConstraint<TAssertions> Satisfy(params Expression<Func<T, bool>>[] predicates)
         {
             return Satisfy(predicates, because: string.Empty);
@@ -2755,6 +2793,8 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="predicates"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="predicates"/> is empty.</exception>
         public AndConstraint<TAssertions> Satisfy(IEnumerable<Expression<Func<T, bool>>> predicates, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(predicates, nameof(predicates), "Cannot verify against a <null> collection of predicates");
@@ -2826,6 +2866,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="expectation"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> StartWith(IEnumerable<T> expectation, string because = "", params object[] becauseArgs)
         {
             return StartWith(expectation, (a, b) => EqualityComparer<T>.Default.Equals(a, b), because, becauseArgs);
@@ -2848,6 +2889,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="expectation"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> StartWith<TExpectation>(
             IEnumerable<TExpectation> expectation, Func<T, TExpectation, bool> equalityComparison, string because = "", params object[] becauseArgs)
         {

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -63,18 +63,30 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndWhichConstraint<TAssertions, IEnumerable<TExpectation>> AllBeAssignableTo<TExpectation>(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected type to be {0}{reason}, ", typeof(TExpectation).FullName)
-                .ForCondition(Subject.All(x => x is not null))
-                .FailWith("but found a null element.")
-                .Then
-                .ForCondition(Subject.All(x => typeof(TExpectation).IsAssignableFrom(GetType(x))))
-                .FailWith("but found {0}.", () => $"[{string.Join(", ", Subject.Select(x => GetType(x).FullName))}]")
-                .Then
-                .ClearExpectation();
+                .ForCondition(Subject is not null)
+                .FailWith("Expected type to be {0}{reason}, but found {context:the collection} is <null>.", typeof(TExpectation).FullName);
 
-            return new AndWhichConstraint<TAssertions, IEnumerable<TExpectation>>((TAssertions)this, Subject.OfType<TExpectation>());
+            IEnumerable<TExpectation> matches = new TExpectation[0];
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .WithExpectation("Expected type to be {0}{reason}, ", typeof(TExpectation).FullName)
+                    .ForCondition(Subject.All(x => x is not null))
+                    .FailWith("but found a null element.")
+                    .Then
+                    .ForCondition(Subject.All(x => typeof(TExpectation).IsAssignableFrom(GetType(x))))
+                    .FailWith("but found {0}.", () => $"[{string.Join(", ", Subject.Select(x => GetType(x).FullName))}]")
+                    .Then
+                    .ClearExpectation();
+
+                matches = Subject.OfType<TExpectation>();
+            }
+
+            return new AndWhichConstraint<TAssertions, IEnumerable<TExpectation>>((TAssertions)this, matches);
         }
 
         /// <summary>
@@ -95,11 +107,15 @@ namespace FluentAssertions.Collections
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected type to be {0}{reason}, ", expectedType.FullName)
-                .ForCondition(Subject.All(x => x is not null))
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith("but found {context:collection} is <null>.")
+                .Then
+                .ForCondition(subject => subject.All(x => x is not null))
                 .FailWith("but found a null element.")
                 .Then
-                .ForCondition(Subject.All(x => expectedType.IsAssignableFrom(GetType(x))))
-                .FailWith("but found {0}.", () => $"[{string.Join(", ", Subject.Select(x => GetType(x).FullName))}]")
+                .ForCondition(subject => subject.All(x => expectedType.IsAssignableFrom(GetType(x))))
+                .FailWith("but found {0}.", subject => $"[{string.Join(", ", subject.Select(x => GetType(x).FullName))}]")
                 .Then
                 .ClearExpectation();
 
@@ -190,18 +206,30 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndWhichConstraint<TAssertions, IEnumerable<TExpectation>> AllBeOfType<TExpectation>(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected type to be {0}{reason}, ", typeof(TExpectation).FullName)
-                .ForCondition(Subject.All(x => x is not null))
-                .FailWith("but found a null element.")
-                .Then
-                .ForCondition(Subject.All(x => typeof(TExpectation) == GetType(x)))
-                .FailWith("but found {0}.", () => $"[{string.Join(", ", Subject.Select(x => GetType(x).FullName))}]")
-                .Then
-                .ClearExpectation();
+                .ForCondition(Subject is not null)
+                .FailWith("Expected type to be {0}{reason}, but found {context:collection} is <null>.", typeof(TExpectation).FullName);
 
-            return new AndWhichConstraint<TAssertions, IEnumerable<TExpectation>>((TAssertions)this, Subject.OfType<TExpectation>());
+            IEnumerable<TExpectation> matches = new TExpectation[0];
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .WithExpectation("Expected type to be {0}{reason}, ", typeof(TExpectation).FullName)
+                    .ForCondition(Subject.All(x => x is not null))
+                    .FailWith("but found a null element.")
+                    .Then
+                    .ForCondition(Subject.All(x => typeof(TExpectation) == GetType(x)))
+                    .FailWith("but found {0}.", () => $"[{string.Join(", ", Subject.Select(x => GetType(x).FullName))}]")
+                    .Then
+                    .ClearExpectation();
+
+                matches = Subject.OfType<TExpectation>();
+            }
+
+            return new AndWhichConstraint<TAssertions, IEnumerable<TExpectation>>((TAssertions)this, matches);
         }
 
         /// <summary>
@@ -222,11 +250,15 @@ namespace FluentAssertions.Collections
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected type to be {0}{reason}, ", expectedType.FullName)
-                .ForCondition(Subject.All(x => x is not null))
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith("but found {context:collection} is <null>.")
+                .Then
+                .ForCondition(subject => subject.All(x => x is not null))
                 .FailWith("but found a null element.")
                 .Then
-                .ForCondition(Subject.All(x => expectedType == GetType(x)))
-                .FailWith("but found {0}.", () => $"but found [{string.Join(", ", Subject.Select(x => GetType(x).FullName))}].")
+                .ForCondition(subject => subject.All(x => expectedType == GetType(x)))
+                .FailWith("but found {0}.", subject => $"but found [{string.Join(", ", subject.Select(x => GetType(x).FullName))}].")
                 .Then
                 .ClearExpectation();
 
@@ -248,10 +280,11 @@ namespace FluentAssertions.Collections
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:collection} to be empty{reason}, ")
-                .ForCondition(Subject is not null)
-                .FailWith("but found {0}.", Subject)
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith("but found <null>.")
                 .Then
-                .ForCondition(!Subject.Any())
+                .ForCondition(subject => !subject.Any())
                 .FailWith("but found {0}.", Subject)
                 .Then
                 .ClearExpectation();
@@ -600,24 +633,18 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(expectedSuperset, nameof(expectedSuperset), "Cannot verify a subset against a <null> collection.");
 
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to be a subset of {0}{reason}, but found {1}.", expectedSuperset,
-                        Subject);
-            }
-
-            IEnumerable<T> excessItems = Subject.Except(expectedSuperset);
-
-            if (excessItems.Any())
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith(
-                        "Expected {context:collection} to be a subset of {0}{reason}, but items {1} are not part of the superset.",
-                        expectedSuperset, excessItems);
-            }
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:collection} to be a subset of {0}{reason}, ", expectedSuperset)
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith("but found <null>.")
+                .Then
+                .Given(subject => subject.Except(expectedSuperset))
+                .ForCondition(excessItems => !excessItems.Any())
+                .FailWith("but items {0} are not part of the superset.", excessItems => excessItems)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -635,24 +662,25 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndWhichConstraint<TAssertions, T> Contain(T expected, string because = "", params object[] becauseArgs)
         {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to contain {0}{reason}, but found {1}.", expected, Subject);
-            }
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} to contain {0}{reason}, but found <null>.", expected);
 
-            var collection = Subject.ConvertOrCastToCollection();
-            if (!collection.Contains(expected))
+            IEnumerable<T> matches = new T[0];
+
+            if (success)
             {
+                ICollection<T> collection = Subject.ConvertOrCastToCollection();
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
+                    .ForCondition(collection.Contains(expected))
                     .FailWith("Expected {context:collection} {0} to contain {1}{reason}.", collection, expected);
+
+                matches = collection.Where(item => EqualityComparer<T>.Default.Equals(item, expected));
             }
 
-            return new AndWhichConstraint<TAssertions, T>((TAssertions)this,
-                collection.Where(
-                    item => EqualityComparer<T>.Default.Equals(item, expected)));
+            return new AndWhichConstraint<TAssertions, T>((TAssertions)this, matches);
         }
 
         /// <summary>
@@ -670,21 +698,26 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
 
-            if (Subject is null)
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} to contain {0}{reason}, but found <null>.", predicate.Body);
+
+            IEnumerable<T> matches = new T[0];
+
+            if (success)
             {
+                Func<T, bool> func = predicate.Compile();
+
                 Execute.Assertion
+                    .ForCondition(Subject.Any(func))
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to contain {0}{reason}, but found {1}.", predicate.Body, Subject);
+                    .FailWith("Expected {context:collection} {0} to have an item matching {1}{reason}.", Subject, predicate.Body);
+
+                matches = Subject.Where(func);
             }
 
-            Func<T, bool> func = predicate.Compile();
-
-            Execute.Assertion
-                .ForCondition(Subject.Any(func))
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:collection} {0} to have an item matching {1}{reason}.", Subject, predicate.Body);
-
-            return new AndWhichConstraint<TAssertions, T>((TAssertions)this, Subject.Where(func));
+            return new AndWhichConstraint<TAssertions, T>((TAssertions)this, matches);
         }
 
         /// <summary>
@@ -706,33 +739,32 @@ namespace FluentAssertions.Collections
             ICollection<T> expectedObjects = expected.ConvertOrCastToCollection();
             if (!expectedObjects.Any())
             {
-                throw new ArgumentException("Cannot verify containment against an empty collection",
-                    nameof(expected));
+                throw new ArgumentException("Cannot verify containment against an empty collection", nameof(expected));
             }
 
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to contain {0}{reason}, but found <null>.", expected);
-            }
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} to contain {0}{reason}, but found <null>.", expected);
 
-            IEnumerable<T> missingItems = expectedObjects.Except(Subject);
-            if (missingItems.Any())
+            if (success)
             {
-                if (expectedObjects.Count > 1)
+                IEnumerable<T> missingItems = expectedObjects.Except(Subject);
+                if (missingItems.Any())
                 {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} {0} to contain {1}{reason}, but could not find {2}.", Subject,
-                            expected, missingItems);
-                }
-                else
-                {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} {0} to contain {1}{reason}.", Subject,
-                            expected.First());
+                    if (expectedObjects.Count > 1)
+                    {
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith("Expected {context:collection} {0} to contain {1}{reason}, but could not find {2}.",
+                                Subject, expected, missingItems);
+                    }
+                    else
+                    {
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith("Expected {context:collection} {0} to contain {1}{reason}.", Subject, expected.First());
+                    }
                 }
             }
 
@@ -790,47 +822,48 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(config, nameof(config));
 
-            if (Subject is null)
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} to contain equivalent of {0}{reason}, but found <null>.", expectation);
+
+            if (success)
             {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to contain equivalent of {0}{reason}, but found <null>.", expectation);
-            }
+                EquivalencyAssertionOptions<TExpectation> options = config(AssertionOptions.CloneDefaults<TExpectation>());
 
-            EquivalencyAssertionOptions<TExpectation> options = config(AssertionOptions.CloneDefaults<TExpectation>());
-
-            using (var scope = new AssertionScope())
-            {
-                scope.AddReportable("configuration", options.ToString());
-
-                foreach (T actualItem in Subject)
+                using (var scope = new AssertionScope())
                 {
-                    var context = new EquivalencyValidationContext(Node.From<TExpectation>(() => CallerIdentifier.DetermineCallerIdentity()), options)
+                    scope.AddReportable("configuration", options.ToString());
+
+                    foreach (T actualItem in Subject)
                     {
-                        Reason = new Reason(because, becauseArgs),
-                        TraceWriter = options.TraceWriter
-                    };
+                        var context = new EquivalencyValidationContext(Node.From<TExpectation>(() => CallerIdentifier.DetermineCallerIdentity()), options)
+                        {
+                            Reason = new Reason(because, becauseArgs),
+                            TraceWriter = options.TraceWriter
+                        };
 
-                    var comparands = new Comparands
-                    {
-                        Subject = actualItem,
-                        Expectation = expectation,
-                        CompileTimeType = typeof(TExpectation),
-                    };
+                        var comparands = new Comparands
+                        {
+                            Subject = actualItem,
+                            Expectation = expectation,
+                            CompileTimeType = typeof(TExpectation),
+                        };
 
-                    new EquivalencyValidator().AssertEquality(comparands, context);
+                        new EquivalencyValidator().AssertEquality(comparands, context);
 
-                    string[] failures = scope.Discard();
+                        string[] failures = scope.Discard();
 
-                    if (!failures.Any())
-                    {
-                        return new AndWhichConstraint<TAssertions, T>((TAssertions)this, actualItem);
+                        if (!failures.Any())
+                        {
+                            return new AndWhichConstraint<TAssertions, T>((TAssertions)this, actualItem);
+                        }
                     }
-                }
 
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} {0} to contain equivalent of {1}{reason}.", Subject, expectation);
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:collection} {0} to contain equivalent of {1}{reason}.", Subject, expectation);
+                }
             }
 
             return new AndWhichConstraint<TAssertions, T>((TAssertions)this, default(T));
@@ -865,32 +898,34 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(expected, nameof(expected), "Cannot verify ordered containment against a <null> collection.");
 
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to contain {0} in order{reason}, but found <null>.", expected);
-            }
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} to contain {0} in order{reason}, but found <null>.", expected);
 
-            IList<T> expectedItems = expected.ConvertOrCastToList();
-            IList<T> actualItems = Subject.ConvertOrCastToList();
-
-            Func<T, T, bool> areSameOrEqual = ObjectExtensions.GetComparer<T>();
-            for (int index = 0; index < expectedItems.Count; index++)
+            if (success)
             {
-                T expectedItem = expectedItems[index];
-                actualItems = actualItems.SkipWhile(actualItem => !areSameOrEqual(actualItem, expectedItem)).ToArray();
-                if (actualItems.Any())
+                IList<T> expectedItems = expected.ConvertOrCastToList();
+                IList<T> actualItems = Subject.ConvertOrCastToList();
+
+                Func<T, T, bool> areSameOrEqual = ObjectExtensions.GetComparer<T>();
+                for (int index = 0; index < expectedItems.Count; index++)
                 {
-                    actualItems = actualItems.Skip(1).ToArray();
-                }
-                else
-                {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith(
-                            "Expected {context:collection} {0} to contain items {1} in order{reason}, but {2} (index {3}) did not appear (in the right order).",
-                            Subject, expected, expectedItem, index);
+                    T expectedItem = expectedItems[index];
+                    actualItems = actualItems.SkipWhile(actualItem => !areSameOrEqual(actualItem, expectedItem)).ToArray();
+                    if (actualItems.Any())
+                    {
+                        actualItems = actualItems.Skip(1).ToArray();
+                    }
+                    else
+                    {
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith(
+                                "Expected {context:collection} {0} to contain items {1} in order{reason}" +
+                                ", but {2} (index {3}) did not appear (in the right order).",
+                                Subject, expected, expectedItem, index);
+                    }
                 }
             }
 
@@ -909,27 +944,28 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> ContainItemsAssignableTo<TExpectation>(string because = "", params object[] becauseArgs)
         {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to contain element assignable to type {0}{reason}, but found <null>.",
-                        typeof(TExpectation));
-            }
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} to contain element assignable to type {0}{reason}, but found <null>.",
+                    typeof(TExpectation));
 
-            int index = 0;
-            foreach (T item in Subject)
+            if (success)
             {
-                if (item is not TExpectation)
+                int index = 0;
+                foreach (T item in Subject)
                 {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith(
-                            "Expected {context:collection} to contain only items of type {0}{reason}, but item {1} at index {2} is of type {3}.",
-                            typeof(TExpectation), item, index, item.GetType());
-                }
+                    if (item is not TExpectation)
+                    {
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith(
+                                "Expected {context:collection} to contain only items of type {0}{reason}" +
+                                ", but item {1} at index {2} is of type {3}.", typeof(TExpectation), item, index, item.GetType());
+                    }
 
-                ++index;
+                    ++index;
+                }
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -947,26 +983,34 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndWhichConstraint<TAssertions, T> ContainSingle(string because = "", params object[] becauseArgs)
         {
-            if (Subject is null)
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} to contain a single item{reason}, but found <null>.");
+
+            T match = default;
+
+            if (success)
             {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to contain a single item{reason}, but found <null>.");
+                switch (Subject.Count())
+                {
+                    case 0: // Fail, Collection is empty
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith("Expected {context:collection} to contain a single item{reason}, but the collection is empty.");
+                        break;
+                    case 1: // Success Condition
+                        match = Subject.SingleOrDefault();
+                        break;
+                    default: // Fail, Collection contains more than a single item
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith("Expected {context:collection} to contain a single item{reason}, but found {0}.", Subject);
+                        break;
+                }
             }
 
-            switch (Subject.Count())
-            {
-                case 0: // Fail, Collection is empty
-                    Execute.Assertion.BecauseOf(because, becauseArgs).FailWith("Expected {context:collection} to contain a single item{reason}, but the collection is empty.");
-                    break;
-                case 1: // Success Condition
-                    break;
-                default: // Fail, Collection contains more than a single item
-                    Execute.Assertion.BecauseOf(because, becauseArgs).FailWith("Expected {context:collection} to contain a single item{reason}, but found {0}.", Subject);
-                    break;
-            }
-
-            return new AndWhichConstraint<TAssertions, T>((TAssertions)this, Subject.SingleOrDefault());
+            return new AndWhichConstraint<TAssertions, T>((TAssertions)this, match);
         }
 
         /// <summary>
@@ -988,39 +1032,41 @@ namespace FluentAssertions.Collections
             string expectationPrefix =
                 "Expected {context:collection} to contain a single item matching {0}{reason}, ";
 
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith(expectationPrefix + "but found {1}.", predicate.Body, Subject);
-            }
-
-            ICollection<T> actualItems = Subject.ConvertOrCastToCollection();
-            Execute.Assertion
-                .ForCondition(actualItems.Any())
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith(expectationPrefix + "but the collection is empty.", predicate.Body);
+                .ForCondition(Subject is not null)
+                .FailWith(expectationPrefix + "but found <null>.", predicate.Body);
 
-            T[] matchingElements = actualItems.Where(predicate.Compile()).ToArray();
-            int count = matchingElements.Length;
-            if (count == 0)
+            T[] matches = new T[0];
+
+            if (success)
             {
+                ICollection<T> actualItems = Subject.ConvertOrCastToCollection();
                 Execute.Assertion
+                    .ForCondition(actualItems.Any())
                     .BecauseOf(because, becauseArgs)
-                    .FailWith(expectationPrefix + "but no such item was found.", predicate.Body);
-            }
-            else if (count > 1)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith(expectationPrefix + "but " + count.ToString(CultureInfo.InvariantCulture) + " such items were found.", predicate.Body);
-            }
-            else
-            {
-                // Exactly 1 item was expected
+                    .FailWith(expectationPrefix + "but the collection is empty.", predicate.Body);
+
+                matches = actualItems.Where(predicate.Compile()).ToArray();
+                int count = matches.Length;
+                switch (count)
+                {
+                    case 0:
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith(expectationPrefix + "but no such item was found.", predicate.Body);
+                        break;
+                    case > 1:
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith(expectationPrefix + "but " + count.ToString(CultureInfo.InvariantCulture) + " such items were found.", predicate.Body);
+                        break;
+                    default:
+                        break;
+                }
             }
 
-            return new AndWhichConstraint<TAssertions, T>((TAssertions)this, matchingElements);
+            return new AndWhichConstraint<TAssertions, T>((TAssertions)this, matches);
         }
 
         /// <summary>
@@ -1156,19 +1202,22 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> HaveCount(int expected, string because = "", params object[] becauseArgs)
         {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to contain {0} item(s){reason}, but found <null>.", expected);
-            }
-
-            int actualCount = Subject.Count();
-
-            Execute.Assertion
-                .ForCondition(actualCount == expected)
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:collection} {0} to contain {1} item(s){reason}, but found {2}.", Subject, expected, actualCount);
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} to contain {0} item(s){reason}, but found <null>.", expected);
+
+            if (success)
+            {
+                int actualCount = Subject.Count();
+
+                Execute.Assertion
+                    .ForCondition(actualCount == expected)
+                    .BecauseOf(because, becauseArgs)
+                    .FailWith(
+                        "Expected {context:collection} {0} to contain {1} item(s){reason}, but found {2}.",
+                        Subject, expected, actualCount);
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -1189,23 +1238,24 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(countPredicate, nameof(countPredicate), "Cannot compare collection count against a <null> predicate.");
 
-            if (Subject is null)
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} to contain {0} items{reason}, but found <null>.", countPredicate.Body);
+
+            if (success)
             {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to contain {0} items{reason}, but found {1}.", countPredicate.Body, Subject);
-            }
+                Func<int, bool> compiledPredicate = countPredicate.Compile();
 
-            Func<int, bool> compiledPredicate = countPredicate.Compile();
+                int actualCount = Subject.Count();
 
-            int actualCount = Subject.Count();
-
-            if (!compiledPredicate(actualCount))
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} {0} to have a count {1}{reason}, but count is {2}.",
-                        Subject, countPredicate.Body, actualCount);
+                if (!compiledPredicate(actualCount))
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:collection} {0} to have a count {1}{reason}, but count is {2}.",
+                            Subject, countPredicate.Body, actualCount);
+                }
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -1224,19 +1274,18 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs)
         {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to contain at least {0} item(s){reason}, but found <null>.", expected);
-            }
-
-            int actualCount = Subject.Count();
-
             Execute.Assertion
-                .ForCondition(actualCount >= expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:collection} to contain at least {0} item(s){reason}, but found {1}.", expected, actualCount);
+                .WithExpectation("Expected {context:collection} to contain at least {0} item(s){reason}, ", expected)
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith("but found <null>.")
+                .Then
+                .Given(subject => subject.Count())
+                .ForCondition(actualCount => actualCount >= expected)
+                .FailWith("but found {0}.", actualCount => actualCount)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -1254,19 +1303,18 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs)
         {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to contain more than {0} item(s){reason}, but found <null>.", expected);
-            }
-
-            int actualCount = Subject.Count();
-
             Execute.Assertion
-                .ForCondition(actualCount > expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:collection} to contain more than {0} item(s){reason}, but found {1}.", expected, actualCount);
+                .WithExpectation("Expected {context:collection} to contain more than {0} item(s){reason}, ", expected)
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith("but found <null>.")
+                .Then
+                .Given(subject => subject.Count())
+                .ForCondition(actualCount => actualCount > expected)
+                .FailWith("but found {0}.", actualCount => actualCount)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -1284,19 +1332,18 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs)
         {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to contain at most {0} item(s){reason}, but found <null>.", expected);
-            }
-
-            int actualCount = Subject.Count();
-
             Execute.Assertion
-                .ForCondition(actualCount <= expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:collection} to contain at most {0} item(s){reason}, but found {1}.", expected, actualCount);
+                .WithExpectation("Expected {context:collection} to contain at most {0} item(s){reason}, ", expected)
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith("but found <null>.")
+                .Then
+                .Given(subject => subject.Count())
+                .ForCondition(actualCount => actualCount <= expected)
+                .FailWith("but found {0}.", actualCount => actualCount)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -1314,19 +1361,18 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs)
         {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to contain fewer than {0} item(s){reason}, but found <null>.", expected);
-            }
-
-            int actualCount = Subject.Count();
-
             Execute.Assertion
-                .ForCondition(actualCount < expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:collection} to contain fewer than {0} item(s){reason}, but found {1}.", expected, actualCount);
+                .WithExpectation("Expected {context:collection} to contain fewer than {0} item(s){reason}, ", expected)
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith("but found <null>.")
+                .Then
+                .Given(subject => subject.Count())
+                .ForCondition(actualCount => actualCount < expected)
+                .FailWith("but found {0}.", actualCount => actualCount)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -1347,28 +1393,30 @@ namespace FluentAssertions.Collections
         public AndWhichConstraint<TAssertions, T> HaveElementAt(int index, T element, string because = "",
             params object[] becauseArgs)
         {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to have element at index {0}{reason}, but found {1}.", index, Subject);
-            }
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} to have element at index {0}{reason}, but found <null>.", index);
 
             T actual = default;
-            if (index < Subject.Count())
-            {
-                actual = Subject.ElementAt(index);
 
-                Execute.Assertion
-                    .ForCondition(ObjectExtensions.GetComparer<T>()(actual, element))
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {0} at index {1}{reason}, but found {2}.", element, index, actual);
-            }
-            else
+            if (success)
             {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {0} at index {1}{reason}, but found no element.", element, index);
+                if (index < Subject.Count())
+                {
+                    actual = Subject.ElementAt(index);
+
+                    Execute.Assertion
+                        .ForCondition(ObjectExtensions.GetComparer<T>()(actual, element))
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {0} at index {1}{reason}, but found {2}.", element, index, actual);
+                }
+                else
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {0} at index {1}{reason}, but found no element.", element, index);
+                }
             }
 
             return new AndWhichConstraint<TAssertions, T>((TAssertions)this, actual);
@@ -1391,13 +1439,17 @@ namespace FluentAssertions.Collections
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:collection} to have {0} precede {1}{reason}, ", expectation, successor)
-                .ForCondition(Subject.Any())
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith("but the collection is <null>.")
+                .Then
+                .ForCondition(subject => subject.Any())
                 .FailWith("but the collection is empty.")
                 .Then
-                .ForCondition(HasPredecessor(successor, Subject))
+                .ForCondition(subject => HasPredecessor(successor, subject))
                 .FailWith("but found nothing.")
                 .Then
-                .Given(() => PredecessorOf(successor, Subject))
+                .Given(subject => PredecessorOf(successor, subject))
                 .ForCondition(predecessor => ObjectExtensions.GetComparer<T>()(predecessor, expectation))
                 .FailWith("but found {0}.", predecessor => predecessor)
                 .Then
@@ -1423,13 +1475,17 @@ namespace FluentAssertions.Collections
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:collection} to have {0} succeed {1}{reason}, ", expectation, predecessor)
-                .ForCondition(Subject.Any())
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith("but the collection is <null>.")
+                .Then
+                .ForCondition(subject => subject.Any())
                 .FailWith("but the collection is empty.")
                 .Then
-                .ForCondition(HasSuccessor(predecessor, Subject))
+                .ForCondition(subject => HasSuccessor(predecessor, subject))
                 .FailWith("but found nothing.")
                 .Then
-                .Given(() => SuccessorOf(predecessor, Subject))
+                .Given(subject => SuccessorOf(predecessor, subject))
                 .ForCondition(successor => ObjectExtensions.GetComparer<T>()(successor, expectation))
                 .FailWith("but found {0}.", successor => successor)
                 .Then
@@ -1454,22 +1510,18 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot verify count against a <null> collection.");
 
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to have the same count as {0}{reason}, but found {1}.",
-                        otherCollection,
-                        Subject);
-            }
-
-            int actualCount = Subject.Count();
-            int expectedCount = otherCollection.Count();
-
             Execute.Assertion
-                .ForCondition(actualCount == expectedCount)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:collection} to have {0} item(s){reason}, but found {1}.", expectedCount, actualCount);
+                .WithExpectation("Expected {context:collection} to have ")
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith("the same count as {0}{reason}, but found <null>.", otherCollection)
+                .Then
+                .Given(subject => (actual: subject.Count(), expected: otherCollection.Count()))
+                .ForCondition(count => count.actual == count.expected)
+                .FailWith("{0} item(s){reason}, but found {1}.", count => count.expected, count => count.actual)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -1490,20 +1542,18 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot verify intersection against a <null> collection.");
 
-            if (Subject is null)
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} to intersect with {0}{reason}, but found <null>.", otherCollection);
+
+            if (success)
             {
+                IEnumerable<T> sharedItems = Subject.Intersect(otherCollection);
+
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to intersect with {0}{reason}, but found {1}.", otherCollection,
-                        Subject);
-            }
-
-            IEnumerable<T> sharedItems = Subject.Intersect(otherCollection);
-
-            if (!sharedItems.Any())
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(sharedItems.Any())
                     .FailWith(
                         "Expected {context:collection} to intersect with {0}{reason}, but {1} does not contain any shared items.",
                         otherCollection, Subject);
@@ -1524,17 +1574,17 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs)
         {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} not to be empty{reason}, but found {0}.", Subject);
-            }
-
             Execute.Assertion
-                .ForCondition(Subject.Any())
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:collection} not to be empty{reason}.");
+                .WithExpectation("Expected {context:collection} not to be empty{reason}")
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith(", but found <null>.")
+                .Then
+                .ForCondition(subject => subject.Any())
+                .FailWith(".")
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -1878,27 +1928,30 @@ namespace FluentAssertions.Collections
         public AndConstraint<TAssertions> NotBeSubsetOf(IEnumerable<T> unexpectedSuperset, string because = "",
             params object[] becauseArgs)
         {
-            Execute.Assertion
-                .ForCondition(Subject is not null)
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
                 .FailWith("Cannot assert a <null> collection against a subset.");
 
-            if (ReferenceEquals(Subject, unexpectedSuperset))
+            if (success)
             {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Did not expect {context:collection} {0} to be a subset of {1}{reason}, but they both reference the same object.",
-                        Subject,
-                        unexpectedSuperset);
-            }
+                if (ReferenceEquals(Subject, unexpectedSuperset))
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Did not expect {context:collection} {0} to be a subset of {1}{reason}, but they both reference the same object.",
+                            Subject,
+                            unexpectedSuperset);
+                }
 
-            ICollection<T> actualItems = Subject.ConvertOrCastToCollection();
+                ICollection<T> actualItems = Subject.ConvertOrCastToCollection();
 
-            if (actualItems.Intersect(unexpectedSuperset).Count() == actualItems.Count)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Did not expect {context:collection} {0} to be a subset of {1}{reason}.", actualItems, unexpectedSuperset);
+                if (actualItems.Intersect(unexpectedSuperset).Count() == actualItems.Count)
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Did not expect {context:collection} {0} to be a subset of {1}{reason}.", actualItems, unexpectedSuperset);
+                }
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -1917,24 +1970,27 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndWhichConstraint<TAssertions, T> NotContain(T unexpected, string because = "", params object[] becauseArgs)
         {
-            if (Subject is null)
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} to not contain {0}{reason}, but found <null>.", unexpected);
+
+            IEnumerable<T> matched = new T[0];
+
+            if (success)
             {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to not contain {0}{reason}, but found <null>.", unexpected);
+                ICollection<T> collection = Subject.ConvertOrCastToCollection();
+                if (collection.Contains(unexpected))
+                {
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .FailWith("Expected {context:collection} {0} to not contain {1}{reason}.", collection, unexpected);
+                }
+
+                matched = collection.Where(item => !EqualityComparer<T>.Default.Equals(item, unexpected));
             }
 
-            var collection = Subject.ConvertOrCastToCollection();
-            if (collection.Contains(unexpected))
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} {0} to not contain {1}{reason}.", collection, unexpected);
-            }
-
-            return new AndWhichConstraint<TAssertions, T>((TAssertions)this,
-                collection.Where(
-                    item => !EqualityComparer<T>.Default.Equals(item, unexpected)));
+            return new AndWhichConstraint<TAssertions, T>((TAssertions)this, matched);
         }
 
         /// <summary>
@@ -1952,20 +2008,19 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
 
-            if (Subject is null)
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} not to contain {0}{reason}, but found <null>.", predicate.Body);
+
+            if (success)
             {
+                Func<T, bool> compiledPredicate = predicate.Compile();
+                IEnumerable<T> unexpectedItems = Subject.Where(item => compiledPredicate(item));
+
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} not to contain {0}{reason}, but found {1}.", predicate.Body, Subject);
-            }
-
-            Func<T, bool> compiledPredicate = predicate.Compile();
-            IEnumerable<T> unexpectedItems = Subject.Where(item => compiledPredicate(item));
-
-            if (unexpectedItems.Any())
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(!unexpectedItems.Any())
                     .FailWith("Expected {context:collection} {0} to not have any items matching {1}{reason}, but found {2}.",
                         Subject, predicate.Body, unexpectedItems);
             }
@@ -1992,33 +2047,33 @@ namespace FluentAssertions.Collections
             ICollection<T> unexpectedObjects = unexpected.ConvertOrCastToCollection();
             if (!unexpectedObjects.Any())
             {
-                throw new ArgumentException("Cannot verify non-containment against an empty collection",
-                    nameof(unexpected));
+                throw new ArgumentException("Cannot verify non-containment against an empty collection", nameof(unexpected));
             }
 
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to not contain {0}{reason}, but found <null>.", unexpected);
-            }
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} to not contain {0}{reason}, but found <null>.", unexpected);
 
-            IEnumerable<T> foundItems = unexpectedObjects.Intersect(Subject);
-            if (foundItems.Any())
+            if (success)
             {
-                if (unexpectedObjects.Count > 1)
+                IEnumerable<T> foundItems = unexpectedObjects.Intersect(Subject);
+                if (foundItems.Any())
                 {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} {0} to not contain {1}{reason}, but found {2}.", Subject,
-                            unexpected, foundItems);
-                }
-                else
-                {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} {0} to not contain element {1}{reason}.", Subject,
-                            unexpectedObjects.First());
+                    if (unexpectedObjects.Count > 1)
+                    {
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith("Expected {context:collection} {0} to not contain {1}{reason}, but found {2}.", Subject,
+                                unexpected, foundItems);
+                    }
+                    else
+                    {
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith("Expected {context:collection} {0} to not contain element {1}{reason}.", Subject,
+                                unexpectedObjects.First());
+                    }
                 }
             }
 
@@ -2076,63 +2131,66 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(config, nameof(config));
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
                 .FailWith("Expected {context:collection} not to contain equivalent of {0}{reason}, but collection is <null>.", unexpected);
 
-            EquivalencyAssertionOptions<TExpectation> options = config(AssertionOptions.CloneDefaults<TExpectation>());
-
-            var foundIndices = new List<int>();
-            using (var scope = new AssertionScope())
+            if (success)
             {
-                int index = 0;
-                foreach (T actualItem in Subject)
+                EquivalencyAssertionOptions<TExpectation> options = config(AssertionOptions.CloneDefaults<TExpectation>());
+
+                var foundIndices = new List<int>();
+                using (var scope = new AssertionScope())
                 {
-                    var context = new EquivalencyValidationContext(Node.From<TExpectation>(() => CallerIdentifier.DetermineCallerIdentity()), options)
+                    int index = 0;
+                    foreach (T actualItem in Subject)
                     {
-                        Reason = new Reason(because, becauseArgs),
-                        TraceWriter = options.TraceWriter
-                    };
+                        var context = new EquivalencyValidationContext(Node.From<TExpectation>(() => CallerIdentifier.DetermineCallerIdentity()), options)
+                        {
+                            Reason = new Reason(because, becauseArgs),
+                            TraceWriter = options.TraceWriter
+                        };
 
-                    var comparands = new Comparands
-                    {
-                        Subject = actualItem,
-                        Expectation = unexpected,
-                        CompileTimeType = typeof(TExpectation),
-                    };
+                        var comparands = new Comparands
+                        {
+                            Subject = actualItem,
+                            Expectation = unexpected,
+                            CompileTimeType = typeof(TExpectation),
+                        };
 
-                    new EquivalencyValidator().AssertEquality(comparands, context);
+                        new EquivalencyValidator().AssertEquality(comparands, context);
 
-                    string[] failures = scope.Discard();
+                        string[] failures = scope.Discard();
 
-                    if (!failures.Any())
-                    {
-                        foundIndices.Add(index);
+                        if (!failures.Any())
+                        {
+                            foundIndices.Add(index);
+                        }
+
+                        index++;
                     }
-
-                    index++;
                 }
-            }
 
-            if (foundIndices.Count > 0)
-            {
-                using (new AssertionScope())
+                if (foundIndices.Count > 0)
                 {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .WithExpectation("Expected {context:collection} {0} not to contain equivalent of {1}{reason}, ", Subject, unexpected)
-                        .AddReportable("configuration", options.ToString());
+                    using (new AssertionScope())
+                    {
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .WithExpectation("Expected {context:collection} {0} not to contain equivalent of {1}{reason}, ", Subject, unexpected)
+                            .AddReportable("configuration", options.ToString());
 
-                    if (foundIndices.Count == 1)
-                    {
-                        Execute.Assertion
-                            .FailWith("but found one at index {0}.", foundIndices[0]);
-                    }
-                    else
-                    {
-                        Execute.Assertion
-                            .FailWith("but found several at indices {0}.", foundIndices);
+                        if (foundIndices.Count == 1)
+                        {
+                            Execute.Assertion
+                                .FailWith("but found one at index {0}.", foundIndices[0]);
+                        }
+                        else
+                        {
+                            Execute.Assertion
+                                .FailWith("but found several at indices {0}.", foundIndices);
+                        }
                     }
                 }
             }
@@ -2239,26 +2297,24 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
 
-            if (Subject is null)
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} not to contain <null>s{reason}, but collection is <null>.");
+
+            if (success)
             {
+                Func<T, TKey> compiledPredicate = predicate.Compile();
+
+                T[] values = Subject
+                    .Where(e => compiledPredicate(e) is null)
+                    .ToArray();
+
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} not to contain <null>s{reason}, but collection is <null>.");
-            }
-
-            Func<T, TKey> compiledPredicate = predicate.Compile();
-
-            T[] values = Subject
-                .Where(e => compiledPredicate(e) is null)
-                .ToArray();
-
-            if (values.Length > 0)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(values.Length == 0)
                     .FailWith("Expected {context:collection} not to contain <null>s on {0}{reason}, but found {1}.",
-                        predicate.Body,
-                        values);
+                        predicate.Body, values);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -2276,32 +2332,33 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> NotContainNulls(string because = "", params object[] becauseArgs)
         {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} not to contain <null>s{reason}, but collection is <null>.");
-            }
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} not to contain <null>s{reason}, but collection is <null>.");
 
-            int[] indices = Subject
-                .Select((item, index) => (Item: item, Index: index))
-                .Where(e => e.Item is null)
-                .Select(e => e.Index)
-                .ToArray();
-
-            if (indices.Length > 0)
+            if (success)
             {
-                if (indices.Length > 1)
+                int[] indices = Subject
+                    .Select((item, index) => (Item: item, Index: index))
+                    .Where(e => e.Item is null)
+                    .Select(e => e.Index)
+                    .ToArray();
+
+                if (indices.Length > 0)
                 {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} not to contain <null>s{reason}, but found several at indices {0}.", indices);
-                }
-                else
-                {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} not to contain <null>s{reason}, but found one at index {0}.", indices[0]);
+                    if (indices.Length > 1)
+                    {
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith("Expected {context:collection} not to contain <null>s{reason}, but found several at indices {0}.", indices);
+                    }
+                    else
+                    {
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith("Expected {context:collection} not to contain <null>s{reason}, but found one at index {0}.", indices[0]);
+                    }
                 }
             }
 
@@ -2322,30 +2379,23 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> NotEqual(IEnumerable<T> unexpected, string because = "", params object[] becauseArgs)
         {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected collections not to be equal{reason}, but found <null>.");
-            }
-
             Guard.ThrowIfArgumentIsNull(unexpected, nameof(unexpected), "Cannot compare collection with <null>.");
 
-            if (ReferenceEquals(Subject, unexpected))
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected collections not to be equal{reason}, but they both reference the same object.");
-            }
-
-            ICollection<T> actualItems = Subject.ConvertOrCastToCollection();
-
-            if (actualItems.SequenceEqual(unexpected))
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Did not expect collections {0} and {1} to be equal{reason}.", unexpected, actualItems);
-            }
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected collections not to be equal{reason}, ")
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith("but found <null>.")
+                .Then
+                .ForCondition(subject => !ReferenceEquals(subject, unexpected))
+                .FailWith("but they both reference the same object.")
+                .Then
+                .ClearExpectation()
+                .Then
+                .Given(subject => subject.ConvertOrCastToCollection())
+                .ForCondition(actualItems => !actualItems.SequenceEqual(unexpected))
+                .FailWith("Did not expect collections {0} and {1} to be equal{reason}.", actualItems => unexpected, actualItems => actualItems);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -2363,19 +2413,18 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> NotHaveCount(int unexpected, string because = "", params object[] becauseArgs)
         {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to not contain {0} item(s){reason}, but found <null>.", unexpected);
-            }
-
-            int actualCount = Subject.Count();
-
             Execute.Assertion
-                .ForCondition(actualCount != unexpected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:collection} to not contain {0} item(s){reason}, but found {1}.", unexpected, actualCount);
+                .WithExpectation("Expected {context:collection} to not contain {0} item(s){reason}, ", unexpected)
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith("but found <null>.")
+                .Then
+                .Given(subject => subject.Count())
+                .ForCondition(actualCount => actualCount != unexpected)
+                .FailWith("but found {0}.", actualCount => actualCount)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -2396,31 +2445,24 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot verify count against a <null> collection.");
 
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to not have the same count as {0}{reason}, but found {1}.",
-                        otherCollection,
-                        Subject);
-            }
-
-            if (ReferenceEquals(Subject, otherCollection))
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} {0} to not have the same count as {1}{reason}, but they both reference the same object.",
-                        Subject,
-                        otherCollection);
-            }
-
-            int actualCount = Subject.Count();
-            int expectedCount = otherCollection.Count();
-
             Execute.Assertion
-                .ForCondition(actualCount != expectedCount)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:collection} to not have {0} item(s){reason}, but found {1}.", expectedCount, actualCount);
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith(
+                    "Expected {context:collection} to not have the same count as {0}{reason}, but found <null>.",
+                    otherCollection)
+                .Then
+                .ForCondition(subject => !ReferenceEquals(subject, otherCollection))
+                .FailWith(
+                    "Expected {context:collection} {0} to not have the same count as {1}{reason}, but they both reference the same object.",
+                    subject => subject, subject => otherCollection)
+                .Then
+                .Given(subject => (actual: subject.Count(), expected: otherCollection.Count()))
+                .ForCondition(count => count.actual != count.expected)
+                .FailWith(
+                    "Expected {context:collection} to not have {0} item(s){reason}, but found {1}.",
+                    count => count.expected, count => count.actual);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -2441,33 +2483,24 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(otherCollection, nameof(otherCollection), "Cannot verify intersection against a <null> collection.");
 
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Did not expect {context:collection} to intersect with {0}{reason}, but found {1}.", otherCollection,
-                        Subject);
-            }
-
-            if (ReferenceEquals(Subject, otherCollection))
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Did not expect {context:collection} {0} to intersect with {1}{reason}, but they both reference the same object.",
-                        Subject,
-                        otherCollection);
-            }
-
-            IEnumerable<T> sharedItems = Subject.Intersect(otherCollection);
-
-            if (sharedItems.Any())
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith(
-                        "Did not expect {context:collection} to intersect with {0}{reason}, but found the following shared items {1}.",
-                        otherCollection, sharedItems);
-            }
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith(
+                    "Did not expect {context:collection} to intersect with {0}{reason}, but found <null>.",
+                    otherCollection)
+                .Then
+                .ForCondition(subject => !ReferenceEquals(subject, otherCollection))
+                .FailWith(
+                    "Did not expect {context:collection} {0} to intersect with {1}{reason}, but they both reference the same object.",
+                    subject => subject, subject => otherCollection)
+                .Then
+                .Given(subject => subject.Intersect(otherCollection))
+                .ForCondition(sharedItems => !sharedItems.Any())
+                .FailWith(
+                    "Did not expect {context:collection} to intersect with {0}{reason}, but found the following shared items {1}.",
+                    sharedItems => otherCollection, sharedItems => sharedItems);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -2490,21 +2523,22 @@ namespace FluentAssertions.Collections
 
             Func<T, bool> compiledPredicate = predicate.Compile();
 
-            var collection = Subject.ConvertOrCastToCollection();
             Execute.Assertion
-                .ForCondition(collection.Any())
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:collection} to contain only items matching {0}{reason}, but the collection is empty.",
-                    predicate.Body);
-
-            IEnumerable<T> mismatchingItems = collection.Where(item => !compiledPredicate(item));
-            if (mismatchingItems.Any())
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to contain only items matching {0}{reason}, but {1} do(es) not match.",
-                        predicate.Body, mismatchingItems);
-            }
+                .WithExpectation("Expected {context:collection} to contain only items matching {0}{reason}, ", predicate.Body)
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith("but the collection is <null>.")
+                .Then
+                .Given(subject => subject.ConvertOrCastToCollection())
+                .ForCondition(collection => collection.Any())
+                .FailWith("but the collection is empty.")
+                .Then
+                .Given(collection => collection.Where(item => !compiledPredicate(item)))
+                .ForCondition(mismatchingItems => !mismatchingItems.Any())
+                .FailWith("but {0} do(es) not match.", mismatchingItems => mismatchingItems)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -2524,37 +2558,38 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(predicate, nameof(predicate));
 
-            if (Subject is null)
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} to only have unique items{reason}, but found <null>.");
+
+            if (success)
             {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to only have unique items{reason}, but found {0}.", Subject);
-            }
+                Func<T, TKey> compiledPredicate = predicate.Compile();
 
-            Func<T, TKey> compiledPredicate = predicate.Compile();
+                IGrouping<TKey, T>[] groupWithMultipleItems = Subject
+                    .GroupBy(compiledPredicate)
+                    .Where(g => g.Count() > 1)
+                    .ToArray();
 
-            IGrouping<TKey, T>[] groupWithMultipleItems = Subject
-                .GroupBy(compiledPredicate)
-                .Where(g => g.Count() > 1)
-                .ToArray();
-
-            if (groupWithMultipleItems.Length > 0)
-            {
-                if (groupWithMultipleItems.Length > 1)
+                if (groupWithMultipleItems.Length > 0)
                 {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} to only have unique items on {0}{reason}, but items {1} are not unique.",
-                            predicate.Body,
-                            groupWithMultipleItems.SelectMany(g => g));
-                }
-                else
-                {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} to only have unique items on {0}{reason}, but item {1} is not unique.",
-                            predicate.Body,
-                            groupWithMultipleItems[0].First());
+                    if (groupWithMultipleItems.Length > 1)
+                    {
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith("Expected {context:collection} to only have unique items on {0}{reason}, but items {1} are not unique.",
+                                predicate.Body,
+                                groupWithMultipleItems.SelectMany(g => g));
+                    }
+                    else
+                    {
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith("Expected {context:collection} to only have unique items on {0}{reason}, but item {1} is not unique.",
+                                predicate.Body,
+                                groupWithMultipleItems[0].First());
+                    }
                 }
             }
 
@@ -2573,33 +2608,34 @@ namespace FluentAssertions.Collections
         /// </param>
         public AndConstraint<TAssertions> OnlyHaveUniqueItems(string because = "", params object[] becauseArgs)
         {
-            if (Subject is null)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to only have unique items{reason}, but found {0}.", Subject);
-            }
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith("Expected {context:collection} to only have unique items{reason}, but found <null>.");
 
-            IEnumerable<T> groupWithMultipleItems = Subject
-                .GroupBy(o => o)
-                .Where(g => g.Count() > 1)
-                .Select(g => g.Key);
-
-            if (groupWithMultipleItems.Any())
+            if (success)
             {
-                if (groupWithMultipleItems.Count() > 1)
+                IEnumerable<T> groupWithMultipleItems = Subject
+                    .GroupBy(o => o)
+                    .Where(g => g.Count() > 1)
+                    .Select(g => g.Key);
+
+                if (groupWithMultipleItems.Any())
                 {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} to only have unique items{reason}, but items {0} are not unique.",
-                            groupWithMultipleItems);
-                }
-                else
-                {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} to only have unique items{reason}, but item {0} is not unique.",
-                            groupWithMultipleItems.First());
+                    if (groupWithMultipleItems.Count() > 1)
+                    {
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith("Expected {context:collection} to only have unique items{reason}, but items {0} are not unique.",
+                                groupWithMultipleItems);
+                    }
+                    else
+                    {
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith("Expected {context:collection} to only have unique items{reason}, but item {0} is not unique.",
+                                groupWithMultipleItems.First());
+                    }
                 }
             }
 
@@ -2644,43 +2680,45 @@ namespace FluentAssertions.Collections
                 throw new ArgumentException("Cannot verify against an empty collection of inspectors", nameof(expected));
             }
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .WithExpectation("Expected {context:collection} to satisfy all inspectors{reason}, ")
-                .ForCondition(Subject is not null)
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
                 .FailWith("but collection is <null>.")
                 .Then
-                .ForCondition(Subject.Any())
+                .ForCondition(subject => subject.Any())
                 .FailWith("but collection is empty.")
                 .Then
-                .ClearExpectation();
+                .ClearExpectation()
+                .Then
+                .Given(subject => (elements: subject.Count(), inspectors: elementInspectors.Count))
+                .ForCondition(count => count.elements == count.inspectors)
+                .FailWith(
+                    "Expected {context:collection} to contain exactly {0} items{reason}, but it contains {1} items",
+                    count => count.inspectors, count => count.elements);
 
-            int elementsCount = Subject.Count();
-            int inspectorsCount = elementInspectors.Count;
-            Execute.Assertion
-                .BecauseOf(because, becauseArgs)
-                .ForCondition(elementsCount == inspectorsCount)
-                .FailWith("Expected {context:collection} to contain exactly {0} items{reason}, but it contains {1} items",
-                    inspectorsCount, elementsCount);
-
-            string[] failuresFromInspectors;
-
-            using (CallerIdentifier.OverrideStackSearchUsingCurrentScope())
+            if (success)
             {
-                failuresFromInspectors = CollectFailuresFromInspectors(elementInspectors);
-            }
+                string[] failuresFromInspectors;
 
-            if (failuresFromInspectors.Any())
-            {
-                string failureMessage = Environment.NewLine
-                    + string.Join(Environment.NewLine, failuresFromInspectors.Select(x => x.IndentLines()));
+                using (CallerIdentifier.OverrideStackSearchUsingCurrentScope())
+                {
+                    failuresFromInspectors = CollectFailuresFromInspectors(elementInspectors);
+                }
 
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .WithExpectation("Expected {context:collection} to satisfy all inspectors{reason}, but some inspectors are not satisfied:")
-                    .FailWithPreFormatted(failureMessage)
-                    .Then
-                    .ClearExpectation();
+                if (failuresFromInspectors.Any())
+                {
+                    string failureMessage = Environment.NewLine
+                        + string.Join(Environment.NewLine, failuresFromInspectors.Select(x => x.IndentLines()));
+
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .WithExpectation("Expected {context:collection} to satisfy all inspectors{reason}, but some inspectors are not satisfied:")
+                        .FailWithPreFormatted(failureMessage)
+                        .Then
+                        .ClearExpectation();
+                }
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -2721,50 +2759,54 @@ namespace FluentAssertions.Collections
         {
             Guard.ThrowIfArgumentIsNull(predicates, nameof(predicates), "Cannot verify against a <null> collection of predicates");
 
-            var predicatesList = predicates.ConvertOrCastToList();
+            IList<Expression<Func<T, bool>>> predicatesList = predicates.ConvertOrCastToList();
             if (predicatesList.Count == 0)
             {
                 throw new ArgumentException("Cannot verify against an empty collection of predicates", nameof(predicates));
             }
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:collection} to satisfy all predicates{reason}, ")
-                .ForCondition(Subject is not null)
-                .FailWith("but collection is <null>.")
+                .Given(() => Subject)
+                .ForCondition(subject => subject is not null)
+                .FailWith("Expected {context:collection} to satisfy all predicates{reason}, but collection is <null>.")
                 .Then
-                .ForCondition(Subject.Any())
-                .FailWith("but collection is empty.")
-                .Then
-                .ClearExpectation();
+                .ForCondition(subject => subject.Any())
+                .FailWith("Expected {context:collection} to satisfy all predicates{reason}, but collection is empty.");
 
-            var maximumMatchingSolution = new MaximumMatchingProblem<T>(predicatesList, Subject).Solve();
-
-            if (maximumMatchingSolution.UnmatchedPredicatesExist || maximumMatchingSolution.UnmatchedElementsExist)
+            if (success)
             {
-                string message = string.Empty;
-                var doubleNewLine = Environment.NewLine + Environment.NewLine;
+                MaximumMatchingSolution<T> maximumMatchingSolution = new MaximumMatchingProblem<T>(predicatesList, Subject).Solve();
 
-                var unmatchedPredicates = maximumMatchingSolution.GetUnmatchedPredicates();
-                if (unmatchedPredicates.Any())
+                if (maximumMatchingSolution.UnmatchedPredicatesExist || maximumMatchingSolution.UnmatchedElementsExist)
                 {
-                    message += doubleNewLine + "The following predicates did not have matching elements:";
-                    message += doubleNewLine + string.Join(Environment.NewLine, unmatchedPredicates.Select(predicate => Formatter.ToString(predicate.Expression)));
+                    string message = string.Empty;
+                    var doubleNewLine = Environment.NewLine + Environment.NewLine;
+
+                    List<MaximumMatching.Predicate<T>> unmatchedPredicates = maximumMatchingSolution.GetUnmatchedPredicates();
+                    if (unmatchedPredicates.Any())
+                    {
+                        message += doubleNewLine + "The following predicates did not have matching elements:";
+                        message += doubleNewLine +
+                            string.Join(Environment.NewLine,
+                                unmatchedPredicates.Select(predicate => Formatter.ToString(predicate.Expression)));
+                    }
+
+                    List<Element<T>> unmatchedElements = maximumMatchingSolution.GetUnmatchedElements();
+                    if (unmatchedElements.Any())
+                    {
+                        message += doubleNewLine + "The following elements did not match any predicate:";
+
+                        IEnumerable<string> elementDescriptions = unmatchedElements
+                            .Select(element => $"Index: {element.Index}, Element: {Formatter.ToString(element.Value)}");
+                        message += doubleNewLine + string.Join(doubleNewLine, elementDescriptions);
+                    }
+
+                    Execute.Assertion
+                        .BecauseOf(because, becauseArgs)
+                        .WithExpectation("Expected {context:collection} to satisfy all predicates{reason}, but:")
+                        .FailWithPreFormatted(message);
                 }
-
-                var unmatchedElements = maximumMatchingSolution.GetUnmatchedElements();
-                if (unmatchedElements.Any())
-                {
-                    message += doubleNewLine + "The following elements did not match any predicate:";
-
-                    var elementDescriptions = unmatchedElements.Select(element => $"Index: {element.Index}, Element: {Formatter.ToString(element.Value)}");
-                    message += doubleNewLine + string.Join(doubleNewLine, elementDescriptions);
-                }
-
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .WithExpectation("Expected {context:collection} to satisfy all predicates{reason}, but:")
-                    .FailWithPreFormatted(message);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -3097,39 +3139,41 @@ namespace FluentAssertions.Collections
 
             string sortOrder = (expectedOrder == SortOrder.Ascending) ? "ascending" : "descending";
 
-            if (Subject is null)
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith($"Expected {{context:collection}} to be in {sortOrder} order{{reason}}, but found <null>.");
+
+            IOrderedEnumerable<T> ordering = new List<T>(0).OrderBy(x => x);
+
+            if (success)
             {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to be in " + sortOrder + " order{reason}, but found <null>.");
-            }
+                IList<T> actualItems = Subject.ConvertOrCastToList();
 
-            IList<T> actualItems = Subject.ConvertOrCastToList();
+                ordering = (expectedOrder == SortOrder.Ascending)
+                    ? actualItems.OrderBy(item => item, comparer)
+                    : actualItems.OrderByDescending(item => item, comparer);
 
-            IOrderedEnumerable<T> ordering = (expectedOrder == SortOrder.Ascending)
-                ? actualItems.OrderBy(item => item, comparer)
-                : actualItems.OrderByDescending(item => item, comparer);
+                T[] orderedItems = ordering.ToArray();
+                Func<T, T, bool> areSameOrEqual = ObjectExtensions.GetComparer<T>();
 
-            T[] orderedItems = ordering.ToArray();
-            Func<T, T, bool> areSameOrEqual = ObjectExtensions.GetComparer<T>();
-
-            for (int index = 0; index < orderedItems.Length; index++)
-            {
-                if (!areSameOrEqual(actualItems[index], orderedItems[index]))
+                for (int index = 0; index < orderedItems.Length; index++)
                 {
-                    Execute.Assertion
-                        .BecauseOf(because, becauseArgs)
-                        .FailWith("Expected {context:collection} to be in " + sortOrder +
-                                  " order{reason}, but found {0} where item at index {1} is in wrong order.",
-                            actualItems, index);
+                    if (!areSameOrEqual(actualItems[index], orderedItems[index]))
+                    {
+                        Execute.Assertion
+                            .BecauseOf(because, becauseArgs)
+                            .FailWith("Expected {context:collection} to be in " + sortOrder +
+                                      " order{reason}, but found {0} where item at index {1} is in wrong order.",
+                                actualItems, index);
 
-                    return new AndConstraint<SubsequentOrderingAssertions<T>>(
-                        new SubsequentOrderingAssertions<T>(Subject, Enumerable.Empty<T>().OrderBy(x => x)));
+                        return new AndConstraint<SubsequentOrderingAssertions<T>>(
+                            new SubsequentOrderingAssertions<T>(Subject, Enumerable.Empty<T>().OrderBy(x => x)));
+                    }
                 }
             }
 
-            return new AndConstraint<SubsequentOrderingAssertions<T>>(
-                new SubsequentOrderingAssertions<T>(Subject, ordering));
+            return new AndConstraint<SubsequentOrderingAssertions<T>>(new SubsequentOrderingAssertions<T>(Subject, ordering));
         }
 
         /// <summary>
@@ -3142,29 +3186,27 @@ namespace FluentAssertions.Collections
 
             string sortOrder = (order == SortOrder.Ascending) ? "ascending" : "descending";
 
-            if (Subject is null)
+            bool success = Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(Subject is not null)
+                .FailWith($"Did not expect {{context:collection}} to be in {sortOrder} order{{reason}}, but found <null>.");
+
+            if (success)
             {
+                IList<T> actualItems = Subject.ConvertOrCastToList();
+
+                T[] orderedItems = (order == SortOrder.Ascending)
+                    ? actualItems.OrderBy(item => item, comparer).ToArray()
+                    : actualItems.OrderByDescending(item => item, comparer).ToArray();
+
+                Func<T, T, bool> areSameOrEqual = ObjectExtensions.GetComparer<T>();
+                bool itemsAreUnordered = actualItems
+                    .Where((actualItem, index) => !areSameOrEqual(actualItem, orderedItems[index]))
+                    .Any();
+
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith(
-                        "Did not expect {context:collection} to be in " + sortOrder + " order{reason}, but found <null>.");
-            }
-
-            IList<T> actualItems = Subject.ConvertOrCastToList();
-
-            T[] orderedItems = (order == SortOrder.Ascending)
-                ? actualItems.OrderBy(item => item, comparer).ToArray()
-                : actualItems.OrderByDescending(item => item, comparer).ToArray();
-
-            Func<T, T, bool> areSameOrEqual = ObjectExtensions.GetComparer<T>();
-            bool itemsAreUnordered = actualItems
-                .Where((actualItem, index) => !areSameOrEqual(actualItem, orderedItems[index]))
-                .Any();
-
-            if (!itemsAreUnordered)
-            {
-                Execute.Assertion
-                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(itemsAreUnordered)
                     .FailWith(
                         "Did not expect {context:collection} to be in " + sortOrder + " order{reason}, but found {0}.",
                         actualItems);

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -241,15 +241,24 @@ namespace FluentAssertions.Collections
                 throw new ArgumentException("Cannot match strings in collection against an empty string. Provide a wildcard pattern or use the Contain method.", nameof(wildcardPattern));
             }
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
-                .FailWith("Expected {context:collection} to contain a match of {0}{reason}, but found <null>.", wildcardPattern)
-                .Then
-                .ForCondition(ContainsMatch(wildcardPattern))
-                .FailWith("Expected {context:collection} {0} to contain a match of {1}{reason}.", Subject, wildcardPattern);
+                .FailWith("Expected {context:collection} to contain a match of {0}{reason}, but found <null>.", wildcardPattern);
 
-            return new AndWhichConstraint<TAssertions, string>((TAssertions)this, AllThatMatch(wildcardPattern));
+            IEnumerable<string> matched = new List<string>(0);
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(ContainsMatch(wildcardPattern))
+                    .FailWith("Expected {context:collection} {0} to contain a match of {1}{reason}.", Subject, wildcardPattern);
+
+                matched = AllThatMatch(wildcardPattern);
+            }
+
+            return new AndWhichConstraint<TAssertions, string>((TAssertions)this, matched);
         }
 
         private bool ContainsMatch(string wildcardPattern)
@@ -317,13 +326,18 @@ namespace FluentAssertions.Collections
                 throw new ArgumentException("Cannot match strings in collection against an empty string. Provide a wildcard pattern or use the NotContain method.", nameof(wildcardPattern));
             }
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .BecauseOf(because, becauseArgs)
                 .ForCondition(Subject is not null)
-                .FailWith("Did not expect {context:collection} to contain a match of {0}{reason}, but found <null>.", wildcardPattern)
-                .Then
-                .ForCondition(NotContainsMatch(wildcardPattern))
-                .FailWith("Did not expect {context:collection} {0} to contain a match of {1}{reason}.", Subject, wildcardPattern);
+                .FailWith("Did not expect {context:collection} to contain a match of {0}{reason}, but found <null>.", wildcardPattern);
+
+            if (success)
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .ForCondition(NotContainsMatch(wildcardPattern))
+                    .FailWith("Did not expect {context:collection} {0} to contain a match of {1}{reason}.", Subject, wildcardPattern);
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics;
 using System.Linq.Expressions;
-
 using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
@@ -135,10 +134,10 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Asserts that the object is of the specified type <paramref name="expectedType"/>.
+        /// Asserts that the object is of the <paramref name="expectedType"/>.
         /// </summary>
         /// <param name="expectedType">
-        /// The type that the subject is supposed to be of.
+        /// The type that the subject is supposed to be.
         /// </param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -147,24 +146,28 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="expectedType"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> BeOfType(Type expectedType, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(expectedType, nameof(expectedType));
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .WithDefaultIdentifier("type")
                 .FailWith("Expected {context} to be {0}{reason}, but found <null>.", expectedType);
 
-            Type subjectType = Subject.GetType();
-            if (expectedType.IsGenericTypeDefinition && subjectType.IsGenericType)
+            if (success)
             {
-                subjectType.GetGenericTypeDefinition().Should().Be(expectedType, because, becauseArgs);
-            }
-            else
-            {
-                subjectType.Should().Be(expectedType, because, becauseArgs);
+                Type subjectType = Subject.GetType();
+                if (expectedType.IsGenericTypeDefinition && subjectType.IsGenericType)
+                {
+                    subjectType.GetGenericTypeDefinition().Should().Be(expectedType, because, becauseArgs);
+                }
+                else
+                {
+                    subjectType.Should().Be(expectedType, because, becauseArgs);
+                }
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -173,7 +176,7 @@ namespace FluentAssertions.Primitives
         /// <summary>
         /// Asserts that the object is not of the specified type <typeparamref name="T"/>.
         /// </summary>
-        /// <typeparam name="T">The type that the subject is not supposed to be of.</typeparam>
+        /// <typeparam name="T">The type that the subject is not supposed to be.</typeparam>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -189,10 +192,10 @@ namespace FluentAssertions.Primitives
         }
 
         /// <summary>
-        /// Asserts that the object is not of the specified type <paramref name="unexpectedType"/>.
+        /// Asserts that the object is not the <paramref name="unexpectedType"/>.
         /// </summary>
         /// <param name="unexpectedType">
-        /// The type that the subject is not supposed to be of.
+        /// The type that the subject is not supposed to be.
         /// </param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
@@ -201,24 +204,28 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="unexpectedType"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> NotBeOfType(Type unexpectedType, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(unexpectedType, nameof(unexpectedType));
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .WithDefaultIdentifier("type")
                 .FailWith("Expected {context} not to be {0}{reason}, but found <null>.", unexpectedType);
 
-            Type subjectType = Subject.GetType();
-            if (unexpectedType.IsGenericTypeDefinition && subjectType.IsGenericType)
+            if (success)
             {
-                subjectType.GetGenericTypeDefinition().Should().NotBe(unexpectedType, because, becauseArgs);
-            }
-            else
-            {
-                subjectType.Should().NotBe(unexpectedType, because, becauseArgs);
+                Type subjectType = Subject.GetType();
+                if (unexpectedType.IsGenericTypeDefinition && subjectType.IsGenericType)
+                {
+                    subjectType.GetGenericTypeDefinition().Should().NotBe(unexpectedType, because, becauseArgs);
+                }
+                else
+                {
+                    subjectType.Should().NotBe(unexpectedType, because, becauseArgs);
+                }
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -227,7 +234,7 @@ namespace FluentAssertions.Primitives
         /// <summary>
         /// Asserts that the object is assignable to a variable of type <typeparamref name="T"/>.
         /// </summary>
-        /// <typeparam name="T">The type to which the object should be assignable.</typeparam>
+        /// <typeparam name="T">The type to which the object should be assignable to.</typeparam>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -238,13 +245,20 @@ namespace FluentAssertions.Primitives
         /// <returns>An <see cref="AndWhichConstraint{TAssertions, T}"/> which can be used to chain assertions.</returns>
         public AndWhichConstraint<TAssertions, T> BeAssignableTo<T>(string because = "", params object[] becauseArgs)
         {
-            Execute.Assertion
-                .ForCondition(Subject is T)
+            bool success = Execute.Assertion
+                .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
-                .WithDefaultIdentifier(Identifier)
-                .FailWith("Expected {context} to be assignable to {0}{reason}, but {1} is not.",
-                    typeof(T),
-                    Subject.GetType());
+                .WithDefaultIdentifier("type")
+                .FailWith("Expected {context} to be assignable to {0}{reason}, but found <null>.", typeof(T));
+
+            if (success)
+            {
+                Execute.Assertion
+                    .ForCondition(Subject is T)
+                    .BecauseOf(because, becauseArgs)
+                    .WithDefaultIdentifier(Identifier)
+                    .FailWith("Expected {context} to be assignable to {0}{reason}, but {1} is not.", typeof(T), Subject.GetType());
+            }
 
             T typedSubject = (Subject is T type)
                 ? type
@@ -256,7 +270,7 @@ namespace FluentAssertions.Primitives
         /// <summary>
         /// Asserts that the object is assignable to a variable of given <paramref name="type"/>.
         /// </summary>
-        /// <param name="type">The type to which the object should be assignable.</param>
+        /// <param name="type">The type to which the object should be assignable to.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -265,33 +279,31 @@ namespace FluentAssertions.Primitives
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
         /// <returns>An <see cref="AndConstraint{TAssertions}"/> which can be used to chain assertions.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> BeAssignableTo(Type type, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(type, nameof(type));
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .WithDefaultIdentifier("type")
                 .FailWith("Expected {context} to be assignable to {0}{reason}, but found <null>.", type);
 
-            bool isAssignable;
-            if (type.IsGenericTypeDefinition)
+            if (success)
             {
-                isAssignable = Subject.GetType().IsAssignableToOpenGeneric(type);
-            }
-            else
-            {
-                isAssignable = type.IsAssignableFrom(Subject.GetType());
-            }
+                bool isAssignable = type.IsGenericTypeDefinition
+                    ? Subject.GetType().IsAssignableToOpenGeneric(type)
+                    : type.IsAssignableFrom(Subject.GetType());
 
-            Execute.Assertion
-                .ForCondition(isAssignable)
-                .BecauseOf(because, becauseArgs)
-                .WithDefaultIdentifier(Identifier)
-                .FailWith("Expected {context} to be assignable to {0}{reason}, but {1} is not.",
-                    type,
-                    Subject.GetType());
+                Execute.Assertion
+                    .ForCondition(isAssignable)
+                    .BecauseOf(because, becauseArgs)
+                    .WithDefaultIdentifier(Identifier)
+                    .FailWith("Expected {context} to be assignable to {0}{reason}, but {1} is not.",
+                        type,
+                        Subject.GetType());
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -299,7 +311,7 @@ namespace FluentAssertions.Primitives
         /// <summary>
         /// Asserts that the object is not assignable to a variable of type <typeparamref name="T"/>.
         /// </summary>
-        /// <typeparam name="T">The type to which the object should not be assignable.</typeparam>
+        /// <typeparam name="T">The type to which the object should not be assignable to.</typeparam>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -316,7 +328,7 @@ namespace FluentAssertions.Primitives
         /// <summary>
         /// Asserts that the object is not assignable to a variable of given <paramref name="type"/>.
         /// </summary>
-        /// <param name="type">The type to which the object should not be assignable.</param>
+        /// <param name="type">The type to which the object should not be assignable to.</param>
         /// <param name="because">
         /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -325,33 +337,29 @@ namespace FluentAssertions.Primitives
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
         /// <returns>An <see cref="AndConstraint{TAssertions}"/> which can be used to chain assertions.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> NotBeAssignableTo(Type type, string because = "", params object[] becauseArgs)
         {
             Guard.ThrowIfArgumentIsNull(type, nameof(type));
 
-            Execute.Assertion
+            bool success = Execute.Assertion
                 .ForCondition(Subject is not null)
                 .BecauseOf(because, becauseArgs)
                 .WithDefaultIdentifier("type")
                 .FailWith("Expected {context} to not be assignable to {0}{reason}, but found <null>.", type);
 
-            bool isAssignable;
-            if (type.IsGenericTypeDefinition)
+            if (success)
             {
-                isAssignable = Subject.GetType().IsAssignableToOpenGeneric(type);
-            }
-            else
-            {
-                isAssignable = type.IsAssignableFrom(Subject.GetType());
-            }
+                bool isAssignable = type.IsGenericTypeDefinition
+                    ? Subject.GetType().IsAssignableToOpenGeneric(type)
+                    : type.IsAssignableFrom(Subject.GetType());
 
-            Execute.Assertion
-                .ForCondition(!isAssignable)
-                .BecauseOf(because, becauseArgs)
-                .WithDefaultIdentifier(Identifier)
-                .FailWith("Expected {context} to not be assignable to {0}{reason}, but {1} is.",
-                    type,
-                    Subject.GetType());
+                Execute.Assertion
+                    .ForCondition(!isAssignable)
+                    .BecauseOf(because, becauseArgs)
+                    .WithDefaultIdentifier(Identifier)
+                    .FailWith("Expected {context} to not be assignable to {0}{reason}, but {1} is.", type, Subject.GetType());
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -387,6 +395,7 @@ namespace FluentAssertions.Primitives
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
         /// <returns>An <see cref="AndConstraint{T}" /> which can be used to chain assertions.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <c>null</c>.</exception>
         public AndConstraint<TAssertions> Match<T>(Expression<Func<T, bool>> predicate,
             string because = "",
             params object[] becauseArgs)

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -148,7 +148,11 @@ namespace FluentAssertions.Specs.Collections
             int[] collection = null;
 
             // Act
-            Action act = () => collection.Should().HaveCount(1, "we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().HaveCount(1, "we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -162,8 +166,11 @@ namespace FluentAssertions.Specs.Collections
             int[] collection = null;
 
             // Act
-            Action act =
-                () => collection.Should().HaveCount(c => c < 3, "we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().HaveCount(c => c < 3, "we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -541,7 +548,11 @@ namespace FluentAssertions.Specs.Collections
             int[] collection = null;
 
             // Act
-            Action act = () => collection.Should().NotHaveCount(1, "we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotHaveCount(1, "we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("*not contain*1*we want to test the behaviour with a null subject*found <null>*");
@@ -595,7 +606,11 @@ namespace FluentAssertions.Specs.Collections
             int[] collection = null;
 
             // Act
-            Action act = () => collection.Should().HaveCountGreaterThan(1, "we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().HaveCountGreaterThan(1, "we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("*more than*1*we want to test the behaviour with a null subject*found <null>*");
@@ -649,7 +664,11 @@ namespace FluentAssertions.Specs.Collections
             int[] collection = null;
 
             // Act
-            Action act = () => collection.Should().HaveCountGreaterOrEqualTo(1, "we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().HaveCountGreaterOrEqualTo(1, "we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("*at least*1*we want to test the behaviour with a null subject*found <null>*");
@@ -703,7 +722,11 @@ namespace FluentAssertions.Specs.Collections
             int[] collection = null;
 
             // Act
-            Action act = () => collection.Should().HaveCountLessThan(1, "we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().HaveCountLessThan(1, "we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("*fewer than*1*we want to test the behaviour with a null subject*found <null>*");
@@ -757,7 +780,11 @@ namespace FluentAssertions.Specs.Collections
             int[] collection = null;
 
             // Act
-            Action act = () => collection.Should().HaveCountLessOrEqualTo(1, "we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().HaveCountLessOrEqualTo(1, "we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("*at most*1*we want to test the behaviour with a null subject*found <null>*");
@@ -845,14 +872,18 @@ namespace FluentAssertions.Specs.Collections
         public void When_asserting_collection_to_be_empty_but_collection_is_null_it_should_throw()
         {
             // Arrange
-            int[] collection = null;
+            IEnumerable<object> collection = null;
 
             // Act
-            Action act = () => collection.Should().BeEmpty("because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().BeEmpty("we want to test the failure {0}", "message");
+            };
 
             // Assert
-            act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to be empty because we want to test the behaviour with a null subject, but found <null>.");
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected collection to be empty *failure message*, but found <null>.");
         }
 
         [Fact]
@@ -866,6 +897,24 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             collection.GetEnumeratorCallCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void When_asserting_collection_to_not_be_empty_but_collection_is_null_it_should_throw()
+        {
+            // Arrange
+            IEnumerable<object> collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotBeEmpty("we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected collection not to be empty *failure message*, but found <null>.");
         }
 
         #endregion
@@ -1365,8 +1414,11 @@ namespace FluentAssertions.Specs.Collections
             var collection1 = new[] { 1, 2, 3 };
 
             // Act
-            Action act =
-                () => collection.Should().NotEqual(collection1, "because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotEqual(collection1, "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1590,7 +1642,10 @@ namespace FluentAssertions.Specs.Collections
 
             // Act
             Action act = () =>
-                    actual.Should().NotBeEquivalentTo(expectation, "because we want to test the behaviour with a null subject");
+            {
+                using var _ = new AssertionScope();
+                actual.Should().NotBeEquivalentTo(expectation, "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1659,6 +1714,24 @@ namespace FluentAssertions.Specs.Collections
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "*not to be equivalent*because we want to test the failure message*");
+        }
+
+        [Fact]
+        public void When_asserting_collections_not_to_be_equivalent_with_options_but_subject_collection_is_null_it_should_throw()
+        {
+            // Arrange
+            int[] actual = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                actual.Should().NotBeEquivalentTo(new[] { 1, 2, 3 }, opt => opt, "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected actual not to be equivalent *failure message*, but found <null>.");
         }
 
         #endregion
@@ -1750,7 +1823,10 @@ namespace FluentAssertions.Specs.Collections
 
             // Act
             Action act = () =>
+            {
+                using var _ = new AssertionScope();
                 collection.Should().ContainEquivalentOf(expectation, "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -1949,6 +2025,24 @@ namespace FluentAssertions.Specs.Collections
         }
 
         [Fact]
+        public void When_asserting_a_null_collection_to_not_contain_equivalent_of__then_it_should_fail()
+        {
+            // Arrange
+            int[] collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotContainEquivalentOf(1, config => config, "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected collection not to contain *failure message*, but collection is <null>.");
+        }
+
+        [Fact]
         public void When_collection_does_not_contain_object_equivalent_of_unexpected_it_should_succeed()
         {
             // Arrange
@@ -2117,8 +2211,11 @@ namespace FluentAssertions.Specs.Collections
             var collection1 = new[] { 1, 2, 3 };
 
             // Act
-            Action act =
-                () => collection.Should().BeSubsetOf(collection1, "because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().BeSubsetOf(collection1, "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -2139,6 +2236,24 @@ namespace FluentAssertions.Specs.Collections
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Did not expect*to be a subset of*because we want to test the behaviour with same objects*but they both reference the same object.");
+        }
+
+        [Fact]
+        public void When_asserting_collection_to_not_be_subset_against_null_collection_it_should_throw()
+        {
+            // Arrange
+            int[] collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotBeSubsetOf(new[] { 1, 2, 3 }, "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Cannot assert a <null> collection against a subset.");
         }
 
         #endregion
@@ -2186,8 +2301,11 @@ namespace FluentAssertions.Specs.Collections
             int[] collection = null;
 
             // Act
-            Action act = () => collection.Should()
-                .Contain(1, "because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().Contain(1, "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -2220,6 +2338,24 @@ namespace FluentAssertions.Specs.Collections
             // Assert
             act.Should().Throw<ArgumentException>().WithMessage(
                 "Cannot verify containment against an empty collection*");
+        }
+
+        [Fact]
+        public void When_asserting_collection_does_contain_a_list_of_items_against_null_collection_it_should_throw()
+        {
+            // Arrange
+            int[] collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().Contain(new[] { 1, 2 }, "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected collection to contain {1, 2} *failure message*, but found <null>.");
         }
 
         #endregion
@@ -2305,8 +2441,11 @@ namespace FluentAssertions.Specs.Collections
             int[] collection = null;
 
             // Act
-            Action act = () => collection.Should()
-                .NotContain(1, "because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotContain(1, "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -2326,6 +2465,42 @@ namespace FluentAssertions.Specs.Collections
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected collection {1, 2, 3} to not contain {1, 2, 4} because we don't like them, but found {1, 2}.");
+        }
+
+        [Fact]
+        public void When_asserting_collection_does_not_contain_predicate_item_against_null_collection_it_should_fail()
+        {
+            // Arrange
+            int[] collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotContain(item => item == 4, "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected collection not to contain (item == 4) *failure message*, but found <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_collection_does_not_contain_a_list_of_items_against_null_collection_it_should_fail()
+        {
+            // Arrange
+            int[] collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotContain(new[] { 1, 2, 4 }, "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected collection to not contain {1, 2, 4} *failure message*, but found <null>.");
         }
 
         #endregion
@@ -2427,8 +2602,11 @@ namespace FluentAssertions.Specs.Collections
             int[] ints = null;
 
             // Act
-            Action act =
-                () => ints.Should().ContainInOrder(new[] { 4 }, "because we're checking how it reacts to a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                ints.Should().ContainInOrder(new[] { 4 }, "because we're checking how it reacts to a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -2508,6 +2686,24 @@ namespace FluentAssertions.Specs.Collections
         }
 
         [Fact]
+        public void When_collection_is_null_then_not_contain_in_order_should_fail()
+        {
+            // Arrange
+            int[] collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotContainInOrder(new[] { 1, 2, 3 }, "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Cannot verify absence of ordered containment in a <null> collection.");
+        }
+
+        [Fact]
         public void When_collection_contains_contain_the_same_items_in_the_same_order_with_null_value_it_should_throw()
         {
             // Arrange
@@ -2577,7 +2773,11 @@ namespace FluentAssertions.Specs.Collections
             List<int> result = null;
 
             // Act
-            Action act = () => result.Should().BeInAscendingOrder();
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                result.Should().BeInAscendingOrder();
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -2830,6 +3030,24 @@ namespace FluentAssertions.Specs.Collections
         }
 
         [Fact]
+        public void When_collection_is_null_then_intersect_with_should_fail()
+        {
+            // Arrange
+            IEnumerable<int> collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().IntersectWith(new[] { 4, 5 }, "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected collection to intersect with {4, 5} *failure message*, but found <null>.");
+        }
+
+        [Fact]
         public void When_asserting_the_items_in_an_two_non_intersecting_collections_do_not_intersect_it_should_succeed()
         {
             // Arrange
@@ -2870,6 +3088,24 @@ namespace FluentAssertions.Specs.Collections
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Did not expect*to intersect with*because we want to test the behaviour with same objects*but they both reference the same object.");
+        }
+
+        [Fact]
+        public void When_collection_is_null_then_not_intersect_with_should_fail()
+        {
+            // Arrange
+            IEnumerable<int> collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotIntersectWith(new[] { 4, 5 }, "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not expect collection to intersect with {4, 5} *failure message*, but found <null>.");
         }
 
         #endregion
@@ -3005,8 +3241,11 @@ namespace FluentAssertions.Specs.Collections
             int[] collection = null;
 
             // Act
-            Action act = () => collection.Should()
-                .ContainItemsAssignableTo<string>("because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().ContainItemsAssignableTo<string>("because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -3062,8 +3301,11 @@ namespace FluentAssertions.Specs.Collections
             int[] collection = null;
 
             // Act
-            Action act =
-                () => collection.Should().OnlyHaveUniqueItems("because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().OnlyHaveUniqueItems("because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -3269,7 +3511,11 @@ namespace FluentAssertions.Specs.Collections
             string[] collection = null;
 
             // Act
-            Action act = () => collection.Should().StartWith("john");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().StartWith("john");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -3458,7 +3704,11 @@ namespace FluentAssertions.Specs.Collections
             string[] collection = null;
 
             // Act
-            Action act = () => collection.Should().EndWith("john");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().EndWith("john");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -3540,8 +3790,11 @@ namespace FluentAssertions.Specs.Collections
             int[] collection = null;
 
             // Act
-            Action act = () => collection.Should().HaveElementAt(1, 1,
-                "because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().HaveElementAt(1, 1, "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -3691,6 +3944,25 @@ namespace FluentAssertions.Specs.Collections
                 .WithMessage("Expected*cris*precede*null*but found*mick*");
         }
 
+        [Fact]
+        public void When_collection_is_null_then_have_element_preceding_should_fail()
+        {
+            // Arrange
+            IEnumerable<string> collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().HaveElementPreceding("mick", "cris", "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected collection to have \"cris\" precede \"mick\" *failure message*, but the collection is <null>.");
+        }
+
         #endregion
 
         #region HaveElementSucceeding
@@ -3807,6 +4079,25 @@ namespace FluentAssertions.Specs.Collections
                 .WithMessage("Expected*cris*succeed*null*but found*john*");
         }
 
+        [Fact]
+        public void When_collection_is_null_then_have_element_succeeding_should_fail()
+        {
+            // Arrange
+            IEnumerable<string> collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().HaveElementSucceeding("mick", "cris", "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected collection to have \"cris\" succeed \"mick\" *failure message*, but the collection is <null>.");
+        }
+
         #endregion
 
         #region Miscellaneous
@@ -3878,8 +4169,11 @@ namespace FluentAssertions.Specs.Collections
             var collection1 = new[] { 1, 2, 3 };
 
             // Act
-            Action act = () => collection.Should().HaveSameCount(collection1,
-                "because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().HaveSameCount(collection1, "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -3954,8 +4248,11 @@ namespace FluentAssertions.Specs.Collections
             var collection1 = new[] { 1, 2, 3 };
 
             // Act
-            Action act = () => collection.Should().NotHaveSameCount(collection1,
-                "because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotHaveSameCount(collection1, "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -4009,6 +4306,24 @@ namespace FluentAssertions.Specs.Collections
             // Assert
             act.Should().Throw<ArgumentNullException>()
                 .WithParameterName("expectedType");
+        }
+
+        [Fact]
+        public void When_collection_is_null_then_all_be_assignable_to_should_fail()
+        {
+            // Arrange
+            IEnumerable<object> collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().AllBeAssignableTo(typeof(object), "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to be \"*.Object\" *failure message*, but found collection is <null>.");
         }
 
         [Fact]
@@ -4114,6 +4429,24 @@ namespace FluentAssertions.Specs.Collections
             collection.Should().AllBeAssignableTo<Exception>();
         }
 
+        [Fact]
+        public void When_collection_is_null_then_all_be_assignable_toOfT_should_fail()
+        {
+            // Arrange
+            IEnumerable<object> collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().AllBeAssignableTo<object>("we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to be \"*.Object\" *failure message*, but found collection is <null>.");
+        }
+
         #endregion
 
         #region ShouldAllBeOfType
@@ -4130,6 +4463,24 @@ namespace FluentAssertions.Specs.Collections
             // Assert
             act.Should().Throw<ArgumentNullException>()
                 .WithParameterName("expectedType");
+        }
+
+        [Fact]
+        public void When_collection_is_null_then_all_be_of_type_should_fail()
+        {
+            // Arrange
+            IEnumerable<object> collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().AllBeOfType(typeof(object), "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to be \"*.Object\" *failure message*, but found collection is <null>.");
         }
 
         [Fact]
@@ -4213,6 +4564,24 @@ namespace FluentAssertions.Specs.Collections
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected type to be \"System.ArgumentException\", but found \"[System.Exception, System.ArgumentException]\".");
+        }
+
+        [Fact]
+        public void When_collection_is_null_then_all_be_of_typeOfT_should_fail()
+        {
+            // Arrange
+            IEnumerable<object> collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().AllBeOfType<object>("we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected type to be \"*.Object\" *failure message*, but found collection is <null>.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionOfStringSpecs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using FluentAssertions.Collections;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -1770,7 +1771,11 @@ namespace FluentAssertions.Specs.Collections
             IEnumerable<string> collection = null;
 
             // Act
-            Action action = () => collection.Should().ContainMatch("* failed", "because {0}", "we do");
+            Action action = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().ContainMatch("* failed", "because {0}", "we do");
+            };
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -1882,7 +1887,7 @@ namespace FluentAssertions.Specs.Collections
         public void When_asserting_collection_to_not_have_null_match_it_should_throw()
         {
             // Arrange
-            IEnumerable<string> collection = null;
+            IEnumerable<string> collection = new string[] { "build succeded", "test failed" };
 
             // Act
             Action action = () => collection.Should().NotContainMatch(null);
@@ -1906,6 +1911,24 @@ namespace FluentAssertions.Specs.Collections
             action.Should().Throw<ArgumentException>()
                 .WithMessage("Cannot match strings in collection against an empty string. Provide a wildcard pattern or use the NotContain method.*")
                 .WithParameterName("wildcardPattern");
+        }
+
+        [Fact]
+        public void When_asserting_null_collection_to_not_have_null_match_it_should_throw()
+        {
+            // Arrange
+            IEnumerable<string> collection = null;
+
+            // Act
+            Action action = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotContainMatch("* Failed", "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("Did not expect collection to contain a match of \"* failed\" *failure message*, but found <null>.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using FluentAssertions.Execution;
 using FluentAssertions.Specs.Equivalency;
 using Xunit;
 using Xunit.Sdk;
@@ -109,7 +110,11 @@ namespace FluentAssertions.Specs.Collections
             const IEnumerable<string> strings = null;
 
             // Act
-            Action act = () => strings.Should().Contain("string4", "because we're checking how it reacts to a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                strings.Should().Contain("string4", "because we're checking how it reacts to a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -138,7 +143,11 @@ namespace FluentAssertions.Specs.Collections
             const IEnumerable<string> strings = null;
 
             // Act
-            Action act = () => strings.Should().Contain(x => x == "xxx", "because we're checking how it reacts to a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                strings.Should().Contain(x => x == "xxx", "because we're checking how it reacts to a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -281,6 +290,26 @@ namespace FluentAssertions.Specs.Collections
             act.Should().NotThrow();
         }
 
+        [Fact]
+        public void When_a_collection_is_null_then_only_contains_should_fail()
+        {
+            // Arrange
+            int[] collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().OnlyContain(i => i <= 10, "we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage(
+                    "Expected collection to contain only items matching (i <= 10) *failure message*," +
+                    " but the collection is <null>.");
+        }
+
         #endregion
 
         #region Contain Single
@@ -338,7 +367,11 @@ namespace FluentAssertions.Specs.Collections
             Expression<Func<int, bool>> expression = item => item == 2;
 
             // Act
-            Action act = () => collection.Should().ContainSingle(expression);
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().ContainSingle(expression);
+            };
 
             // Assert
             string expectedMessage =
@@ -460,7 +493,11 @@ namespace FluentAssertions.Specs.Collections
             const IEnumerable<int> collection = null;
 
             // Act
-            Action act = () => collection.Should().ContainSingle("more is not allowed");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().ContainSingle("more is not allowed");
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -1535,7 +1572,11 @@ namespace FluentAssertions.Specs.Collections
             const IEnumerable<SomeClass> collection = null;
 
             // Act
-            Action act = () => collection.Should().NotBeInAscendingOrder(o => o.Text);
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotBeInAscendingOrder(o => o.Text);
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -1549,7 +1590,11 @@ namespace FluentAssertions.Specs.Collections
             const IEnumerable<SomeClass> collection = null;
 
             // Act
-            Action act = () => collection.Should().NotBeInAscendingOrder(Comparer<SomeClass>.Default);
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotBeInAscendingOrder(Comparer<SomeClass>.Default);
+            };
 
             // Assert
             act.Should().Throw<XunitException>()
@@ -1973,13 +2018,35 @@ namespace FluentAssertions.Specs.Collections
         }
 
         [Fact]
-        public void When_asserting_collection_to_not_contain_nulls_but_collection_is_null_it_should_throw()
+        public void When_asserting_collection_to_not_contain_nulls_but_collection_is_null_it_should_fail()
+        {
+            // Arrange
+            SomeClass[] collection = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotContainNulls("we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected collection not to contain <null>s *failure message*, but collection is <null>.");
+        }
+
+        [Fact]
+        public void When_asserting_collection_to_not_contain_nulls_with_predicate_but_collection_is_null_it_should_throw()
         {
             // Arrange
             IEnumerable<SomeClass> collection = null;
 
             // Act
-            Action act = () => collection.Should().NotContainNulls(e => e.Text, "because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().NotContainNulls(e => e.Text, "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -2068,8 +2135,11 @@ namespace FluentAssertions.Specs.Collections
             IEnumerable<SomeClass> collection = null;
 
             // Act
-            Action act =
-                () => collection.Should().OnlyHaveUniqueItems(e => e.Text, "because we want to test the behaviour with a null subject");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().OnlyHaveUniqueItems(e => e.Text, "because we want to test the behaviour with a null subject");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
@@ -2115,11 +2185,15 @@ namespace FluentAssertions.Specs.Collections
             IEnumerable<int> collection = null;
 
             // Act
-            Action act = () => collection.Should().SatisfyRespectively(
-                new Action<int>[]
-                {
-                    x => x.Should().Be(1)
-                }, "because we want to test the failure {0}", "message");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().SatisfyRespectively(
+                    new Action<int>[]
+                    {
+                        x => x.Should().Be(1)
+                    }, "because we want to test the failure {0}", "message");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionSatisfyAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionSatisfyAssertionSpecs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions.Collections;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Sdk;
 
@@ -183,14 +184,18 @@ namespace FluentAssertions.Specs.Collections
             IEnumerable<int> collection = null;
 
             // Act
-            Action act = () => collection.Should().Satisfy(
-                new Expression<Func<int, bool>>[]
-                {
-                    element => element == 1,
-                    element => element == 2,
-                },
-                because: "we want to test the failure message ({0})",
-                becauseArgs: "args");
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                collection.Should().Satisfy(
+                    new Expression<Func<int, bool>>[]
+                    {
+                        element => element == 1,
+                        element => element == 2,
+                    },
+                    because: "we want to test the failure message ({0})",
+                    becauseArgs: "args");
+            };
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization;
 using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
-
+using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
 using FluentAssertions.Primitives;
 using Xunit;
@@ -535,6 +535,24 @@ namespace FluentAssertions.Specs.Primitives
         }
 
         [Fact]
+        public void When_a_null_instance_is_asserted_to_be_assignableOfT_it_should_fail()
+        {
+            // Arrange
+            object someObject = null;
+
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                someObject.Should().BeAssignableTo<DateTime>("because we want to test the failure {0}", "message");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage($"*assignable to {typeof(DateTime)}*failure message*found <null>*");
+        }
+
+        [Fact]
         public void When_its_own_type_instance_it_should_succeed()
         {
             // Arrange
@@ -579,9 +597,15 @@ namespace FluentAssertions.Specs.Primitives
         {
             // Arrange
             object someObject = null;
-            Action act = () => someObject.Should().BeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
 
-            // Act / Assert
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                someObject.Should().BeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
+            };
+
+            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage($"*assignable to {typeof(DateTime)}*failure message*found <null>*");
         }
@@ -742,9 +766,15 @@ namespace FluentAssertions.Specs.Primitives
         {
             // Arrange
             object someObject = null;
-            Action act = () => someObject.Should().NotBeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
 
-            // Act / Assert
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                someObject.Should().NotBeAssignableTo(typeof(DateTime), "because we want to test the failure {0}", "message");
+            };
+
+            // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage($"*not be assignable to {typeof(DateTime)}*failure message*found <null>*");
         }

--- a/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ReferenceTypeAssertionsSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
@@ -116,7 +117,11 @@ namespace FluentAssertions.Specs.Primitives
             string aString = null;
 
             // Act
-            Action action = () => aString.Should().BeOfType(typeof(string));
+            Action action = () =>
+            {
+                using var _ = new AssertionScope();
+                aString.Should().BeOfType(typeof(string));
+            };
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -238,7 +243,11 @@ namespace FluentAssertions.Specs.Primitives
             string aString = null;
 
             // Act
-            Action action = () => aString.Should().NotBeOfType(typeof(string));
+            Action action = () =>
+            {
+                using var _ = new AssertionScope();
+                aString.Should().NotBeOfType(typeof(string));
+            };
 
             // Assert
             action.Should().Throw<XunitException>()


### PR DESCRIPTION
Working on #1039

**ReferenceTypeAssertions**
- [x] `BeOfType<T>`
- [x] `BeOfType`
- [x] `NotBeOfType<T>`
- [x] `NotBeOfType`
- [x] `BeAssignableTo<T>`
- [x] `BeAssignableTo`
- [x] `NotBeAssignableTo<T>`
- [x] `NotBeAssignableTo`

**StringCollectionAssertions**
- [x] `ContainMatch`
- [x] `NotContainMatch`

**GenericCollectionAssertions**
- [x] `AllBeAssignableTo`
- [x] `AllBeAssignableTo<T>`
- [x] `AllBeOfType`
- [x] `AllBeOfType<T>`
- [x] `BeEmpty`
- [x] `BeInAscendingOrder`
- [x] `BeInDescendingOrder`
- [x] `BeSubsetOf`
- [x] `Contain` (3x)
- [x] `ContainEquivalentOf`
- [x] `ContainInOrder`
- [x] `ContainItemsAssignableTo<T>`
- [x] `ContainSingle`
- [x] `HaveCount`
- [x] `HaveCountGreaterOrEqualTo`
- [x] `HaveCountGreaterThan`
- [x] `HaveCountLessOrEqualTo`
- [x] `HaveCountLessThan`
- [x] `HaveElementAt`
- [x] `HaveElementPreceding`
- [x] Receive Microsoft MVP award
- [x] `HaveElementSucceeding`
- [x] `HaveSameCount`
- [x] `IntersectWith`
- [x] `NotBeEmpty`
- [x] `NotBeInAscendingOrder`
- [x] `NotBeInDescendingOrder`
- [x] `NotBeNullOrEmpty`
- [x] `NotBeSubsetOf`
- [x] `NotContain`
- [x] `NotContainEquivalentOf`
- [x] `NotContainNulls`
- [x] `NotEqual`
- [x] `NotHaveCount`
- [x] `NotHaveSameCount`
- [x] `NotIntersectWith`
- [x] `OnlyContain`
- [x] `OnlyHaveUniqueItems`
- [x] `SatisfyRespectively`
- [x] `Satisfy`

Also small updates to documentation tags where appropriate.