### PR TITLE
Add Guid .Be input checking and .NotBe

### DIFF
--- a/Src/FluentAssertions/Primitives/GuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/GuidAssertions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using FluentAssertions.Execution;
 
@@ -120,6 +120,28 @@ namespace FluentAssertions.Primitives
                 .FailWith("Expected {context:Guid} to be {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the <see cref="Guid"/> is not equal to the <paramref name="unexpected"/> GUID.
+        /// </summary>
+        /// <param name="unexpected">The unexpected value to compare the actual value with.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        /// <exception cref="ArgumentException">The format of <paramref name="unexpected"/> is invalid.</exception>
+        public AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs)
+        {
+            if (!Guid.TryParse(unexpected, out Guid unexpectedGuid))
+            {
+                throw new ArgumentException($"Unable to parse \"{unexpected}\" as a valid GUID", nameof(unexpected));
+            }
+
+            return NotBe(unexpectedGuid, because, becauseArgs);
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Primitives/GuidAssertions.cs
+++ b/Src/FluentAssertions/Primitives/GuidAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using FluentAssertions.Execution;
 
@@ -90,9 +90,14 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
+        /// <exception cref="ArgumentException">The format of <paramref name="expected"/> is invalid.</exception>
         public AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs)
         {
-            var expectedGuid = new Guid(expected);
+            if (!Guid.TryParse(expected, out Guid expectedGuid))
+            {
+                throw new ArgumentException($"Unable to parse \"{expected}\" as a valid GUID", nameof(expected));
+            }
+
             return Be(expectedGuid, because, becauseArgs);
         }
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1826,6 +1826,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
     }
     public class NullableBooleanAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<FluentAssertions.Primitives.NullableBooleanAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1826,6 +1826,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
     }
     public class NullableBooleanAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<FluentAssertions.Primitives.NullableBooleanAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1826,6 +1826,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
     }
     public class NullableBooleanAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<FluentAssertions.Primitives.NullableBooleanAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1779,6 +1779,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
     }
     public class NullableBooleanAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<FluentAssertions.Primitives.NullableBooleanAssertions>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1826,6 +1826,7 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> Be(string expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeEmpty(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.Guid unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBe(string unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeEmpty(string because = "", params object[] becauseArgs) { }
     }
     public class NullableBooleanAssertions : FluentAssertions.Primitives.NullableBooleanAssertions<FluentAssertions.Primitives.NullableBooleanAssertions>

--- a/Tests/FluentAssertions.Specs/Primitives/GuidAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/GuidAssertionSpecs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 using Xunit.Sdk;
 
@@ -100,6 +100,20 @@ namespace FluentAssertions.Specs.Primitives
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected Guid to be {55555555-ffff-eeee-dddd-444444444444} because we want to test the failure message, but found {11111111-aaaa-bbbb-cccc-999999999999}.");
+        }
+
+        [Fact]
+        public void Should_throw_when_asserting_guid_equals_a_string_that_is_not_a_valid_guid()
+        {
+            // Arrange
+            var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
+
+            // Act
+            Action act = () => guid.Should().Be(string.Empty, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<ArgumentException>()
+                .WithParameterName("expected");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Primitives/GuidAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/GuidAssertionSpecs.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Xunit;
 using Xunit.Sdk;
 
@@ -144,6 +144,49 @@ namespace FluentAssertions.Specs.Primitives
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Did not expect Guid to be {11111111-aaaa-bbbb-cccc-999999999999} because we want to test the failure message.");
+        }
+
+        [Fact]
+        public void Should_throw_when_asserting_guid_does_not_equal_a_string_that_is_not_a_valid_guid()
+        {
+            // Arrange
+            var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
+
+            // Act
+            Action act = () => guid.Should().NotBe(string.Empty, "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<ArgumentException>()
+                .WithParameterName("unexpected");
+        }
+
+        [Fact]
+        public void Should_succeed_when_asserting_guid_does_not_equal_a_different_guid_in_string_format()
+        {
+            // Arrange
+            var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
+
+            // Act
+            Action act = () =>
+                guid.Should().NotBe("55555555-ffff-eeee-dddd-444444444444");
+
+            // Assert
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void Should_succeed_when_asserting_guid_does_not_equal_the_same_guid_in_string_format()
+        {
+            // Arrange
+            var guid = new Guid("11111111-aaaa-bbbb-cccc-999999999999");
+
+            // Act
+            Action act = () =>
+                guid.Should().NotBe("11111111-aaaa-bbbb-cccc-999999999999", "we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Did not expect Guid to be {11111111-aaaa-bbbb-cccc-999999999999} *failure message*.");
         }
 
         #endregion

--- a/docs/_pages/guids.md
+++ b/docs/_pages/guids.md
@@ -20,4 +20,7 @@ theGuid.Should().NotBe(otherGuid);
 theGuid.Should().NotBeEmpty();
 
 Guid.Empty.Should().BeEmpty();
+
+theGuid.Should().Be("11111111-aaaa-bbbb-cccc-999999999999");
+theGuid.Should().NotBe("00000000-0000-0000-0000-000000000001");
 ```

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -7,6 +7,16 @@ sidebar:
   nav: "sidebar"
 ---
 
+
+## 6.0.0 Beta 2
+Changes since 6.0.0 Beta 1
+
+**What's New**
+* Added `NotBe(string)` for symmetry with `Be(string)` for GuidAssertions - [#1597](https://github.com/fluentassertions/fluentassertions/pull/1597).
+
+**Fixes**
+* Added parameter checking for `Be(string)` for GuidAssertions - [#1597](https://github.com/fluentassertions/fluentassertions/pull/1597).
+
 ## 6.0.0 Beta 1
 Changes since 6.0.0 Alpha 2
 


### PR DESCRIPTION
* Added parameter checking to `Be`
* Added `NotBe` for symmetry.

Should close #1553

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).