### PR TITLE
Remove the custom output path

### DIFF
--- a/Src/FluentAssertions/FluentAssertions.csproj
+++ b/Src/FluentAssertions/FluentAssertions.csproj
@@ -11,7 +11,6 @@
     <CodeAnalysisRuleSet>..\..\Rules.ruleset</CodeAnalysisRuleSet>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <OutputPath>..\..\Artifacts\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>Dennis Doomen;Jonas Nyrup</Authors>

--- a/Tests/Approval.Tests/ApiApproval.cs
+++ b/Tests/Approval.Tests/ApiApproval.cs
@@ -34,7 +34,7 @@ namespace Approval.Tests
             var assemblyFile = Path.GetFullPath(
                 Path.Combine(
                     GetSourceDirectory(),
-                    Path.Combine("..", "..", "Artifacts", configurationName, frameworkVersion, "FluentAssertions.dll")));
+                    Path.Combine("..", "..", "Src", "FluentAssertions", "bin", configurationName, frameworkVersion, "FluentAssertions.dll")));
 
             var assembly = Assembly.LoadFile(Path.GetFullPath(assemblyFile));
             var publicApi = assembly.GeneratePublicApi(options: null);


### PR DESCRIPTION
Closes #1592 

* [x] Visual Studio Build / Unit Test still works
* [x] Nuke (Build.ps1) still works
* [x] NuPkg output is still in the Artifacts folder
* [x] Live Unit Testing works
