### PR TITLE
A collection of similarly typed key-value pairs should be equivalent to a dictionary

### DIFF
--- a/FluentAssertions.sln.DotSettings
+++ b/FluentAssertions.sln.DotSettings
@@ -103,4 +103,5 @@ public void When_$scenario$_it_should_$behavior$()&#xD;
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Scope/=C3001E7C0DA78E4487072B7E050D86C5/@KeyIndexDefined">True</s:Boolean>
 	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Scope/=C3001E7C0DA78E4487072B7E050D86C5/Type/@EntryValue">InCSharpFile</s:String>
 	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=012E3B0572DEF2448B0B5D9AA88E6210/Scope/=C3001E7C0DA78E4487072B7E050D86C5/CustomProperties/=minimumLanguageVersion/@EntryIndexedValue">2.0</s:String>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Comparands/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Comparands/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=enumerables/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -138,7 +138,11 @@ namespace FluentAssertions.Common
                    property.Name == otherProperty.Name;
         }
 
-        public static Type[] GetClosedGenericInterfaces(Type type, Type openGenericType)
+        /// <summary>
+        /// Returns the interfaces that the <paramref name="type"/> implements that are concrete
+        /// versions of the <paramref name="openGenericType"/>.
+        /// </summary>
+        public static Type[] GetClosedGenericInterfaces(this Type type, Type openGenericType)
         {
             if (type.IsGenericType && type.GetGenericTypeDefinition() == openGenericType)
             {

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -62,7 +62,10 @@ namespace FluentAssertions.Equivalency
         {
             foreach (IEquivalencyStep step in AssertionOptions.EquivalencyPlan)
             {
-                if (step.Handle(comparands, context, this) == EquivalencyResult.AssertionCompleted)
+                var result = step.Handle(comparands, context, this);
+                context.Tracer.WriteLine(_ => $"Step {step.GetType().Name} returned {result}");
+
+                if (result == EquivalencyResult.AssertionCompleted)
                 {
                     return;
                 }

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions.Common;
+using FluentAssertions.Execution;
+
+namespace FluentAssertions.Equivalency.Steps
+{
+    /// <summary>
+    /// Provides Reflection-backed meta-data information about a type implementing the <see cref="IDictionary{TKey,TValue}"/> interface.
+    /// </summary>
+    internal class DictionaryInterfaceInfo
+    {
+        // ReSharper disable once PossibleNullReferenceException
+        private static readonly MethodInfo ConvertToDictionaryMethod =
+            new Func<IEnumerable<KeyValuePair<object, object>>, IDictionary<object, object>>(ConvertToDictionaryInternal)
+                .GetMethodInfo().GetGenericMethodDefinition();
+
+        private static readonly ConcurrentDictionary<Type, DictionaryInterfaceInfo[]> Cache = new();
+
+        private DictionaryInterfaceInfo(Type key, Type value)
+        {
+            Key = key;
+            Value = value;
+        }
+
+        public Type Value { get; }
+
+        public Type Key { get; }
+
+        /// <summary>
+        /// Tries to reflect on the provided <paramref name="target"/> and returns an instance of the <see cref="DictionaryInterfaceInfo"/>
+        /// representing the single dictionary interface. Will throw if the target implements more than one dictionary interface.
+        /// </summary>
+        /// <remarks>>
+        /// The <paramref name="role"/> is used to describe the <paramref name="target"/> in failure messages.
+        /// </remarks>
+        public static bool TryGetFrom(Type target, string role, out DictionaryInterfaceInfo result)
+        {
+            result = null;
+
+            var interfaces = GetDictionaryInterfacesFrom(target);
+            if (interfaces.Length > 1)
+            {
+                throw new ArgumentException(
+                    $"The {role} implements multiple dictionary types. It is not known which type should be " +
+                    $"use for equivalence.{Environment.NewLine}The following IDictionary interfaces are implemented: {string.Join(", ", (IEnumerable<DictionaryInterfaceInfo>)interfaces)}");
+            }
+
+            if (interfaces.Length == 1)
+            {
+                result = interfaces.Single();
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Tries to reflect on the provided <paramref name="target"/> and returns an instance of the <see cref="DictionaryInterfaceInfo"/>
+        /// representing the single dictionary interface keyed to <paramref name="key"/>.
+        /// Will throw if the target implements more than one dictionary interface.
+        /// </summary>
+        /// <remarks>>
+        /// The <paramref name="role"/> is used to describe the <paramref name="target"/> in failure messages.
+        /// </remarks>
+        public static bool TryGetFromWithKey(Type target, string role, Type key, out DictionaryInterfaceInfo result)
+        {
+            result = null;
+
+            var suitableDictionaryInterfaces = GetDictionaryInterfacesFrom(target)
+                .Where(info => info.Key.IsAssignableFrom(key))
+                .ToArray();
+
+            if (suitableDictionaryInterfaces.Length > 1)
+            {
+                // SMELL: Code could be written to handle this better, but is it really worth the effort?
+                AssertionScope.Current.FailWith(
+                    $"The {role} implements multiple IDictionary interfaces taking a key of {key}. ");
+
+                return false;
+            }
+
+            if (suitableDictionaryInterfaces.Length == 0)
+            {
+                return false;
+            }
+
+            result = suitableDictionaryInterfaces.Single();
+            return true;
+        }
+
+        private static DictionaryInterfaceInfo[] GetDictionaryInterfacesFrom(Type target)
+        {
+            if (!Cache.TryGetValue(target, out DictionaryInterfaceInfo[] dictionaries))
+            {
+                if (Type.GetTypeCode(target) != TypeCode.Object)
+                {
+                    dictionaries = new DictionaryInterfaceInfo[0];
+                }
+                else
+                {
+                    dictionaries = target
+                        .GetClosedGenericInterfaces(typeof(IDictionary<,>))
+                        .Select(@interface => @interface.GetGenericArguments())
+                        .Select(arguments => new DictionaryInterfaceInfo(arguments[0], arguments[1]))
+                        .ToArray();
+                }
+
+                Cache.TryAdd(target, dictionaries);
+            }
+
+            return dictionaries;
+        }
+
+        /// <summary>
+        /// Tries to convert an object into a dictionary typed to the <see cref="Key"/> and <see cref="Value"/> of the current <see cref="DictionaryInterfaceInfo"/>.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if the conversion succeeded or <c>false</c> otherwise.
+        /// </returns>
+        public bool TryConvertFrom(object convertable, out object dictionary)
+        {
+            Type[] enumerables = convertable.GetType().GetClosedGenericInterfaces(typeof(IEnumerable<>));
+
+            var suitableKeyValuePairCollection = enumerables
+                .Select(enumerable => enumerable.GenericTypeArguments[0])
+                .Where(itemType => itemType.IsGenericType && itemType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
+                .SingleOrDefault(itemType => itemType.GenericTypeArguments.First() == Key);
+
+            if (suitableKeyValuePairCollection != null)
+            {
+                Type pairValueType = suitableKeyValuePairCollection.GenericTypeArguments.Last();
+
+                var methodInfo = ConvertToDictionaryMethod.MakeGenericMethod(Key, pairValueType);
+                dictionary = methodInfo.Invoke(null, new[] { convertable });
+                return true;
+            }
+
+            dictionary = null;
+            return false;
+        }
+
+        private static IDictionary<TKey, TValue> ConvertToDictionaryInternal<TKey, TValue>(
+            IEnumerable<KeyValuePair<TKey, TValue>> collection)
+        {
+            return collection.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        }
+
+        public override string ToString() => $"IDictionary<{Key}, {Value}>";
+    }
+}

--- a/Tests/FluentAssertions.Specs/Equivalency/DictionaryEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DictionaryEquivalencySpecs.cs
@@ -449,6 +449,21 @@ namespace FluentAssertions.Specs.Equivalency
         }
 
         [Fact]
+        public void When_a_collection_of_key_value_pairs_is_equivalent_to_the_dictionary_it_should_succeed()
+        {
+            // Arrange
+            var collection = new List<KeyValuePair<string, int>> { new("hi", 1) };
+
+            // Act / Assert
+            Action act = () => collection.Should().BeEquivalentTo(new Dictionary<string, int>()
+            {
+                { "hi", 2 }
+            });
+
+            act.Should().Throw<XunitException>().WithMessage("Expected collection[hi]*to be 2, but found 1.*");
+        }
+
+        [Fact]
         public void
             When_a_generic_dictionary_is_typed_as_object_and_runtime_typing_has_is_specified_it_should_use_the_runtime_type()
         {
@@ -534,8 +549,8 @@ namespace FluentAssertions.Specs.Equivalency
             Action act = () => object1.Should().BeEquivalentTo(object2);
 
             // Assert
-            act.Should().Throw<XunitException>()
-                .WithMessage("*Object1*implements multiple dictionary types*");
+            act.Should().Throw<ArgumentException>()
+                .WithMessage("*expectation*implements multiple dictionary types*");
         }
 
         [Fact]
@@ -643,11 +658,11 @@ namespace FluentAssertions.Specs.Equivalency
             var expectation = new Dictionary<string, string> { ["greeting"] = "hello" };
 
             // Act
-            Action act = () => expectation.Should().BeEquivalentTo(actual);
+            Action act = () => actual.Should().BeEquivalentTo(expectation);
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("*expectation*keys*Int32*compatible types*IDictionary`2[System.String,System.String]*");
+                .WithMessage("Expected actual to be a dictionary or collection of key-value pairs that is keyed to type System.String*");
         }
 
         [Fact]
@@ -797,7 +812,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*Customers*Dictionary`2[System.String,System.String], but found*String*");
+                .WithMessage("Expected property subject.Customers to be a dictionary or collection of key-value pairs that is keyed to type System.String*");
         }
 
         [Fact]
@@ -913,7 +928,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("*the expectation is not keyed with any compatible types*");
+                .WithMessage("Expected dictionary2 to be a dictionary or collection of key-value pairs that is keyed to type FluentAssertions.Specs.Equivalency.DictionaryEquivalencySpecs+SomeBaseKeyClass.*");
         }
 
         [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -20,6 +20,8 @@ Changes since 6.0.0 Beta 1
 * Handle `WithDefaultIdentifier` and `WithExpectation` correctly when an `AssertionScope` continues - [#1610](https://github.com/fluentassertions/fluentassertions/pull/1610).
 * Improved stack trace when a property of an element of a generic collection throws an exception during `GenericEnumerableEquivalencyStep` in `GenericCollectionAssertions` - [#1615](https://github.com/fluentassertions/fluentassertions/pull/1615).
 * Removed the type info from the failure message in equivalency checks - [#1621](https://github.com/fluentassertions/fluentassertions/pull/1621).
+* Fixed a regression so that collections of similarly typed key-value pairs should be equivalent to a dictionary - [#1603](https://github.com/fluentassertions/fluentassertions/pull/1603).
+
 
 ## 6.0.0 Beta 1
 Changes since 6.0.0 Alpha 2


### PR DESCRIPTION
Because of some accidental design choices, in previous releases, when the expectation is a dictionary, it was picked up by the `GenericEnumerableEquivalencyStep`. This resulted in an `IDictionary<TKey, TValue>` being treated as a collection of `KeyValuePair<TKey, TValue>`. In 6.0, some of the semantics of the equivalency steps changed in such a way that a dictionary is now picked up by the `GenericEquivalencyStep`. This is expected, but had the side-effect that when a dictionary is expected, it really expects a dictionary. 

This PR changes `GenericEnumerableEquivalencyStep` so it tries to convert a collection of key-value pairs back to a dictionary and then does the equivalency check.

Fixes #1598
