### PR TITLE
Make xml documentation more consistent for AssertionScope and friends

### DIFF
--- a/Src/FluentAssertions/Execution/AssertionScope.cs
+++ b/Src/FluentAssertions/Execution/AssertionScope.cs
@@ -11,8 +11,8 @@ namespace FluentAssertions.Execution
     /// Represents an implicit or explicit scope within which multiple assertions can be collected.
     /// </summary>
     /// <remarks>
-    /// This class is supposed to have a very short life time and is not safe to be used in assertion that cross thread-boundaries such as when
-    /// using <c>async</c> or <c>await</c>.
+    /// This class is supposed to have a very short life time and is not safe to be used in assertion that cross thread-boundaries
+    /// such as when using <c>async</c> or <c>await</c>.
     /// </remarks>
     public sealed class AssertionScope : IAssertionScope
     {
@@ -84,7 +84,8 @@ namespace FluentAssertions.Execution
         }
 
         /// <summary>
-        /// Starts a named scope within which multiple assertions can be executed and which will not throw until the scope is disposed.
+        /// Starts a named scope within which multiple assertions can be executed
+        /// and which will not throw until the scope is disposed.
         /// </summary>
         public AssertionScope(string context)
             : this()
@@ -96,7 +97,8 @@ namespace FluentAssertions.Execution
         }
 
         /// <summary>
-        /// Starts a named scope within which multiple assertions can be executed and which will not throw until the scope is disposed.
+        /// Starts a named scope within which multiple assertions can be executed
+        /// and which will not throw until the scope is disposed.
         /// </summary>
         public AssertionScope(Lazy<string> context)
             : this()
@@ -122,12 +124,7 @@ namespace FluentAssertions.Execution
             private set => SetCurrentAssertionScope(value);
         }
 
-        /// <summary>
-        /// Forces the formatters that support it to add the necessary line breaks.
-        /// </summary>
-        /// <remarks>
-        /// This is just shorthand for modifying the <see cref="FormattingOptions"/> property.
-        /// </remarks>
+        /// <inheritdoc cref="IAssertionScope.UsingLineBreaks"/>
         public AssertionScope UsingLineBreaks
         {
             get
@@ -155,9 +152,7 @@ namespace FluentAssertions.Execution
             return BecauseOf(reason.FormattedMessage, reason.Arguments);
         }
 
-        /// <summary>
-        /// Adds an explanation of why the assertion is supposed to succeed to the scope.
-        /// </summary>
+        /// <inheritdoc cref="IAssertionScope.BecauseOf(string, object[])"/>
         public AssertionScope BecauseOf(string because, params object[] becauseArgs)
         {
             reason = () =>
@@ -175,22 +170,7 @@ namespace FluentAssertions.Execution
             return this;
         }
 
-        /// <summary>
-        /// Sets the expectation part of the failure message when the assertion is not met.
-        /// </summary>
-        /// <remarks>
-        /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a few
-        /// specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as passed
-        /// to <see cref="BecauseOf(FluentAssertions.Execution.Reason)"/>. Other named placeholders will be replaced with the <see cref="Current"/> scope data
-        /// passed through <see cref="AddNonReportable"/> and <see cref="AddReportable(string,string)"/>. Finally, a description of the
-        /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
-        /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
-        /// Note that only 10 <paramref name="args"/> are supported in combination with a {reason}.
-        /// If an expectation was set through a prior call to <see cref="WithExpectation"/>, then the failure message is appended to that
-        /// expectation.
-        /// </remarks>
-        /// <param name="message">The format string that represents the failure message.</param>
-        /// <param name="args">Optional arguments to any numbered placeholders.</param>
+        /// <inheritdoc cref="IAssertionScope.WithExpectation(string, object[])"/>
         public AssertionScope WithExpectation(string message, params object[] args)
         {
             Func<string> localReason = reason;
@@ -212,6 +192,7 @@ namespace FluentAssertions.Execution
             contextData.Add(new ContextDataItems.DataItem("expectation", expectation, reportable: false, requiresFormatting: true));
         }
 
+        /// <inheritdoc/>
         public Continuation ClearExpectation()
         {
             expectation = null;
@@ -225,6 +206,7 @@ namespace FluentAssertions.Execution
             return new GivenSelector<T>(selector, this, continueAsserting: succeeded != false);
         }
 
+        /// <inheritdoc cref="IAssertionScope.ForCondition(bool)"/>
         public AssertionScope ForCondition(bool condition)
         {
             succeeded = condition;
@@ -234,8 +216,11 @@ namespace FluentAssertions.Execution
 
         /// <summary>
         /// Makes assertion fail when <paramref name="actualOccurrences"/> does not match <paramref name="constraint"/>.
-        /// The occurrence description in natural language could then be inserted in failure message by using {expectedOccurrence} placeholder in
-        /// message parameters of <see cref="FluentAssertions.Execution.AssertionScope.FailWith(string, object[])"/> and its overloaded versions.
+        /// <para>
+        /// The occurrence description in natural language could then be inserted in failure message by using
+        /// <em>{expectedOccurrence}</em> placeholder in message parameters of <see cref="FailWith(string, object[])"/> and its
+        /// overloaded versions.
+        /// </para>
         /// </summary>
         /// <param name="constraint"><see cref="OccurrenceConstraint"/> defining the number of expected occurrences.</param>
         /// <param name="actualOccurrences">The number of actual occurrences.</param>
@@ -247,6 +232,7 @@ namespace FluentAssertions.Execution
             return this;
         }
 
+        /// <inheritdoc/>
         public Continuation FailWith(Func<FailReason> failReasonFunc)
         {
             return FailWith(() =>
@@ -290,25 +276,19 @@ namespace FluentAssertions.Execution
             }
         }
 
-        /// <summary>
-        /// Registers a failure message that does not contain any formatting placeholders.
-        /// </summary>
+        /// <inheritdoc/>
         public Continuation FailWith(string message)
         {
             return FailWith(() => new FailReason(message, new object[0]));
         }
 
-        /// <summary>
-        /// Registers a failure message with optional formatting arguments.
-        /// </summary>
+        /// <inheritdoc/>
         public Continuation FailWith(string message, params object[] args)
         {
             return FailWith(() => new FailReason(message, args));
         }
 
-        /// <summary>
-        /// Registers a failure message, but postpones evaluation of the formatting arguments until the assertion really fails.
-        /// </summary>
+        /// <inheritdoc/>
         public Continuation FailWith(string message, params Func<object>[] argProviders)
         {
             return FailWith(() => new FailReason(message,
@@ -379,9 +359,7 @@ namespace FluentAssertions.Execution
             return contextData.Get<T>(key);
         }
 
-        /// <summary>
-        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-        /// </summary>
+        /// <inheritdoc/>
         public void Dispose()
         {
             SetCurrentAssertionScope(parent);
@@ -401,6 +379,7 @@ namespace FluentAssertions.Execution
             }
         }
 
+        /// <inheritdoc cref="IAssertionScope.WithDefaultIdentifier(string)"/>
         public AssertionScope WithDefaultIdentifier(string identifier)
         {
             fallbackIdentifier = identifier;

--- a/Src/FluentAssertions/Execution/ContinuedAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/ContinuedAssertionScope.cs
@@ -6,8 +6,8 @@ namespace FluentAssertions.Execution
     /// Allows chaining multiple assertion scopes together using <see cref="Continuation.Then"/>.
     /// </summary>
     /// <remarks>
-    /// If the parent scope has captured a failed assertion, this class ensures that successive assertions
-    /// are no longer evaluated.
+    /// If the parent scope has captured a failed assertion,
+    /// this class ensures that successive assertions are no longer evaluated.
     /// </remarks>
     public sealed class ContinuedAssertionScope : IAssertionScope
     {
@@ -20,6 +20,7 @@ namespace FluentAssertions.Execution
             this.continueAsserting = continueAsserting;
         }
 
+        /// <inheritdoc/>
         public GivenSelector<T> Given<T>(Func<T> selector)
         {
             if (continueAsserting)
@@ -30,6 +31,7 @@ namespace FluentAssertions.Execution
             return new GivenSelector<T>(() => default, predecessor, continueAsserting: false);
         }
 
+        /// <inheritdoc/>
         public IAssertionScope ForCondition(bool condition)
         {
             if (continueAsserting)
@@ -40,6 +42,7 @@ namespace FluentAssertions.Execution
             return this;
         }
 
+        /// <inheritdoc/>
         public Continuation FailWith(string message)
         {
             if (continueAsserting)
@@ -50,6 +53,7 @@ namespace FluentAssertions.Execution
             return new Continuation(predecessor, continueAsserting: false);
         }
 
+        /// <inheritdoc/>
         public Continuation FailWith(string message, params Func<object>[] argProviders)
         {
             if (continueAsserting)
@@ -60,6 +64,7 @@ namespace FluentAssertions.Execution
             return new Continuation(predecessor, continueAsserting: false);
         }
 
+        /// <inheritdoc/>
         public Continuation FailWith(Func<FailReason> failReasonFunc)
         {
             if (continueAsserting)
@@ -70,6 +75,7 @@ namespace FluentAssertions.Execution
             return new Continuation(predecessor, continueAsserting: false);
         }
 
+        /// <inheritdoc/>
         public Continuation FailWith(string message, params object[] args)
         {
             if (continueAsserting)
@@ -80,6 +86,7 @@ namespace FluentAssertions.Execution
             return new Continuation(predecessor, continueAsserting: false);
         }
 
+        /// <inheritdoc/>
         public IAssertionScope BecauseOf(string because, params object[] becauseArgs)
         {
             if (continueAsserting)
@@ -90,6 +97,7 @@ namespace FluentAssertions.Execution
             return this;
         }
 
+        /// <inheritdoc/>
         public Continuation ClearExpectation()
         {
             predecessor.ClearExpectation();
@@ -97,23 +105,28 @@ namespace FluentAssertions.Execution
             return new Continuation(predecessor, continueAsserting);
         }
 
+        /// <inheritdoc/>
         public IAssertionScope WithExpectation(string message, params object[] args)
         {
             return predecessor.WithExpectation(message, args);
         }
 
+        /// <inheritdoc/>
         public IAssertionScope WithDefaultIdentifier(string identifier)
         {
             return predecessor.WithDefaultIdentifier(identifier);
         }
 
+        /// <inheritdoc/>
         public IAssertionScope UsingLineBreaks => predecessor.UsingLineBreaks;
 
+        /// <inheritdoc/>
         public string[] Discard()
         {
             return predecessor.Discard();
         }
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             predecessor.Dispose();

--- a/Src/FluentAssertions/Execution/FailReason.cs
+++ b/Src/FluentAssertions/Execution/FailReason.cs
@@ -1,22 +1,32 @@
 ﻿namespace FluentAssertions.Execution
 {
     /// <summary>
-    /// Represents assertion fail reason. Contains the message and arguments for
-    /// message's numbered placeholders.
+    /// Represents assertion fail reason. Contains the message and arguments for message's numbered placeholders.
     /// </summary>
     /// <remarks>
-    /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a few
-    /// specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as passed
-    /// to BecauseOf. Other named placeholders will be replaced with
-    /// the <see cref="FluentAssertions.Execution.AssertionScope.Current"/> scope data passed through
-    /// <see cref="FluentAssertions.Execution.AssertionScope.AddNonReportable"/> and
-    /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable(string,string)"/>. Finally, a description of the
-    /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
-    /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
-    /// Note that only 10 arguments are supported in combination with a {reason}.
+    /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a
+    /// few specialized placeholders as well. For instance, <em>{reason}</em> will be replaced with the reason of the
+    /// assertion as passed to <see cref="AssertionScope.BecauseOf(string, object[])"/>.
+    /// <para>
+    /// Other named placeholders will be replaced with the <see cref="AssertionScope.Current"/> scope data passed through
+    /// <see cref="AssertionScope.AddNonReportable"/> and <see cref="AssertionScope.AddReportable(string,string)"/>.
+    /// </para>
+    /// <para>
+    /// Finally, a description of the current subject can be passed through the <em>{context:description}</em> placeholder.
+    /// This is used in the message if no explicit context is specified through the <see cref="AssertionScope"/> constructor.
+    /// </para>
+    /// <para>
+    /// Note that only 10 <c>args</c> are supported in combination with a <em>{reason}</em>.
+    /// </para>
     /// </remarks>
     public class FailReason
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FailReason"/> class.
+        /// </summary>
+        /// <remarks>
+        /// <inheritdoc cref="FailReason"/>
+        /// </remarks>
         public FailReason(string message, params object[] args)
         {
             Message = message;
@@ -24,15 +34,13 @@
         }
 
         /// <summary>
-        /// Message to be displayed in case of failed assertion. May contain
-        /// numbered <see cref="string.Format(string,object[])"/>-style placeholders as well
-        /// as specialized placeholders.
+        /// Message to be displayed in case of failed assertion. May contain numbered
+        /// <see cref="string.Format(string,object[])"/>-style placeholders as well as specialized placeholders.
         /// </summary>
         public string Message { get; }
 
         /// <summary>
-        /// Arguments for the numbered <see cref="string.Format(string,object[])"/>-style placeholders
-        /// of <see cref="Message"/>.
+        /// Arguments for the numbered <see cref="string.Format(string,object[])"/>-style placeholders of <see cref="Message"/>.
         /// </summary>
         public object[] Args { get; }
     }

--- a/Src/FluentAssertions/Execution/GivenSelector.cs
+++ b/Src/FluentAssertions/Execution/GivenSelector.cs
@@ -31,7 +31,7 @@ namespace FluentAssertions.Execution
         /// </param>
         /// <remarks>
         /// The condition will not be evaluated if the prior assertion failed,
-        /// nor will <see cref="FailWith(string, System.Func{T, object}[])"/> throw any exceptions.
+        /// nor will <see cref="FailWith(string, Func{T, object}[])"/> throw any exceptions.
         /// </remarks>
         public GivenSelector<T> ForCondition(Func<T, bool> predicate)
         {
@@ -45,16 +45,11 @@ namespace FluentAssertions.Execution
             return this;
         }
 
-        /// <summary>
-        /// Allows to safely refine the subject for successive assertions, even when the prior assertion has failed.
-        /// </summary>
-        /// <paramref name="selector">
-        /// Selector which result is passed to successive calls to <see cref="ForCondition"/>.
-        /// </paramref>
         /// <remarks>
-        /// The selector will not be invoked if the prior assertion failed,
-        /// nor will <see cref="FailWith(string,System.Func{T,object}[])"/> throw any exceptions.
+        /// The <paramref name="selector"/> will not be invoked if the prior assertion failed,
+        /// nor will <see cref="FailWith(string, Func{T,object}[])"/> throw any exceptions.
         /// </remarks>
+        /// <inheritdoc cref="IAssertionScope.Given"/>
         public GivenSelector<TOut> Given<TOut>(Func<T, TOut> selector)
         {
             Guard.ThrowIfArgumentIsNull(selector, nameof(selector));
@@ -62,39 +57,18 @@ namespace FluentAssertions.Execution
             return new GivenSelector<TOut>(() => selector(subject), predecessor, continueAsserting);
         }
 
-        /// <summary>
-        /// Sets the failure message when the assertion is not met, or completes the failure message set to a
-        /// prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>.
-        /// </summary>
-        /// <remarks>
-        /// If an expectation was set through a prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>,
-        /// then the failure message is appended to that expectation.
-        /// </remarks>
-        /// <param name="message">The format string that represents the failure message.</param>
+        /// <inheritdoc cref="IAssertionScope.FailWith(string)"/>
         public ContinuationOfGiven<T> FailWith(string message)
         {
             return FailWith(message, new object[0]);
         }
 
-        /// <summary>
-        /// Sets the failure message when the assertion is not met, or completes the failure message set to a
-        /// prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>.
-        /// </summary>
         /// <remarks>
-        /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a few
-        /// specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as passed
-        /// to <see cref="AssertionScope.BecauseOf(FluentAssertions.Execution.Reason)"/>. Other named placeholders will be replaced with
-        /// the <see cref="FluentAssertions.Execution.AssertionScope.Current"/> scope data passed through
-        /// <see cref="FluentAssertions.Execution.AssertionScope.AddNonReportable"/> and
-        /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable(string,string)"/>. Finally, a description of the current subject
-        /// can be passed through the {context:description} placeholder. This is used in the message if no explicit context
-        /// is specified through the <see cref="AssertionScope"/> constructor.
-        /// Note that only 10 <paramref name="args"/> are supported in combination with a {reason}.
-        /// If an expectation was set through a prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>,
-        /// then the failure message is appended to that expectation.
+        /// <inheritdoc cref="IAssertionScope.FailWith(string, object[])"/>
+        /// The <paramref name="args"/> will not be invoked if the prior assertion failed,
+        /// nor will <see cref="FailWith(string, Func{T,object}[])"/> throw any exceptions.
         /// </remarks>
-        /// <param name="message">The format string that represents the failure message.</param>
-        /// <param name="args">Optional arguments to any numbered placeholders.</param>
+        /// <inheritdoc cref="IAssertionScope.FailWith(string, object[])"/>
         public ContinuationOfGiven<T> FailWith(string message, params Func<T, object>[] args)
         {
             if (continueAsserting)
@@ -106,26 +80,12 @@ namespace FluentAssertions.Execution
             return new ContinuationOfGiven<T>(this, succeeded: false);
         }
 
-        /// <summary>
-        /// Sets the failure message when the assertion is not met, or completes the failure message set to a
-        /// prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>.
-        /// </summary>
         /// <remarks>
-        /// In addition to the numbered <see cref="string.Format(string, object[])"/>-style placeholders, messages may contain
-        /// a few specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as
-        /// passed to <see cref="AssertionScope.BecauseOf(FluentAssertions.Execution.Reason)"/>. Other named placeholders will be
-        /// replaced with the <see cref="FluentAssertions.Execution.AssertionScope.Current"/> scope data passed through
-        /// <see cref="FluentAssertions.Execution.AssertionScope.AddNonReportable"/> and
-        /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable(string,string)"/>. Finally, a description of the
-        /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
-        /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
-        /// Note that only 10 <paramref name="args"/> are supported in combination with a {reason}.
-        /// If an expectation was set through a prior call to
-        /// <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>, then the failure message is appended
-        /// to that expectation.
+        /// <inheritdoc cref="IAssertionScope.FailWith(string, object[])"/>
+        /// The <paramref name="args"/> will not be invoked if the prior assertion failed,
+        /// nor will <see cref="FailWith(string, object[])"/> throw any exceptions.
         /// </remarks>
-        /// <param name="message">The format string that represents the failure message.</param>
-        /// <param name="args">Optional arguments to any numbered placeholders.</param>
+        /// <inheritdoc cref="IAssertionScope.FailWith(string, object[])"/>
         public ContinuationOfGiven<T> FailWith(string message, params object[] args)
         {
             if (continueAsserting)
@@ -137,9 +97,7 @@ namespace FluentAssertions.Execution
             return new ContinuationOfGiven<T>(this, succeeded: false);
         }
 
-        /// <summary>
-        /// Clears the expectation set by <see cref="AssertionScope.WithExpectation"/>.
-        /// </summary>
+        /// <inheritdoc cref="IAssertionScope.ClearExpectation()"/>
         public ContinuationOfGiven<T> ClearExpectation()
         {
             predecessor.ClearExpectation();

--- a/Src/FluentAssertions/Execution/IAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/IAssertionScope.cs
@@ -5,7 +5,7 @@ namespace FluentAssertions.Execution
     public interface IAssertionScope : IDisposable
     {
         /// <summary>
-        /// Allows to safely select the subject for successive assertions, even when the prior assertion has failed.
+        /// Allows to safely select the subject for successive assertions.
         /// </summary>
         /// <paramref name="selector">
         /// Selector which result is passed to successive calls to <see cref="ForCondition"/>.
@@ -21,70 +21,88 @@ namespace FluentAssertions.Execution
         IAssertionScope ForCondition(bool condition);
 
         /// <summary>
-        /// Sets the failure message when the assertion is not met, or completes the failure message set to a
-        /// prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>.
+        /// Sets the failure message when the assertion is not met, or completes the failure message set to a prior call to
+        /// <see cref="AssertionScope.WithExpectation"/>.
         /// </summary>
         /// <remarks>
-        /// Messages may contain a few specialized placeholders.
-        /// For instance, {reason} will be replaced with the reason of the assertion as passed
-        /// to <see cref="AssertionScope.BecauseOf(FluentAssertions.Execution.Reason)"/>. Other named placeholders will be replaced with
-        /// the <see cref="FluentAssertions.Execution.AssertionScope.Current"/> scope data passed through
-        /// <see cref="FluentAssertions.Execution.AssertionScope.AddNonReportable"/> and
-        /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable(string,string)"/>. Finally, a description of the
-        /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
-        /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
-        /// If an expectation was set through a prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>,
-        /// then the failure message is appended to that expectation.
+        /// Messages may contain a few specialized placeholders. For instance, <em>{reason}</em> will be replaced with the reason
+        /// of the assertion as passed to <see cref="AssertionScope.BecauseOf(string, object[])"/>.
+        /// <para>
+        /// Other named placeholders will be replaced with the <see cref="AssertionScope.Current"/> scope data passed through
+        /// <see cref="AssertionScope.AddNonReportable"/> and <see cref="AssertionScope.AddReportable(string,string)"/>.
+        /// </para>
+        /// <para>
+        /// Finally, a description of the current subject can be passed through the <em>{context:description}</em> placeholder.
+        /// This is used in the message if no explicit context is specified through the <see cref="AssertionScope"/> constructor.
+        /// </para>
+        /// <para>
+        /// If an expectation was set through a prior call to <see cref="AssertionScope.WithExpectation"/>, then the failure
+        /// message is appended to that expectation.
+        /// </para>
         /// </remarks>
         /// <param name="message">The format string that represents the failure message.</param>
         Continuation FailWith(string message);
 
         /// <summary>
-        /// Sets the failure message when the assertion is not met, or completes the failure message set to a
-        /// prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>.
+        /// Sets the failure message when the assertion is not met, or completes the failure message set to aprior call to
+        /// <see cref="AssertionScope.WithExpectation"/>.
         /// <paramref name="failReasonFunc"/> will not be called unless the assertion is not met.
         /// </summary>
         /// <param name="failReasonFunc">Function returning <see cref="FailReason"/> object on demand. Called only when the assertion is not met.</param>
         Continuation FailWith(Func<FailReason> failReasonFunc);
 
         /// <summary>
-        /// Sets the failure message when the assertion is not met, or completes the failure message set to a
-        /// prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>.
+        /// Sets the failure message when the assertion is not met, or completes the failure message set to a prior call to
+        /// <see cref="AssertionScope.WithExpectation"/>.
         /// </summary>
         /// <remarks>
-        /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a few
-        /// specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as passed
-        /// to <see cref="AssertionScope.BecauseOf(FluentAssertions.Execution.Reason)"/>. Other named placeholders will be replaced with
-        /// the <see cref="FluentAssertions.Execution.AssertionScope.Current"/> scope data passed through
-        /// <see cref="FluentAssertions.Execution.AssertionScope.AddNonReportable"/> and
-        /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable(string,string)"/>. Finally, a description of the
-        /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
-        /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
-        /// Note that only 10 <paramref name="args"/> are supported in combination with a {reason}.
-        /// If an expectation was set through a prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>,
-        /// then the failure message is appended to that expectation.
+        /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a
+        /// few specialized placeholders as well. For instance, <em>{reason}</em> will be replaced with the reason of the
+        /// assertion as passed to <see cref="AssertionScope.BecauseOf(string, object[])"/>.
+        /// <para>
+        /// Other named placeholders will be replaced with the <see cref="AssertionScope.Current"/> scope data passed through
+        /// <see cref="AssertionScope.AddNonReportable"/> and <see cref="AssertionScope.AddReportable(string, string)"/>.
+        /// </para>
+        /// <para>
+        /// Finally, a description of the current subject can be passed through the <em>{context:description}</em> placeholder.
+        /// This is used in the message if no explicit context is specified through the <see cref="AssertionScope"/> constructor.
+        /// </para>
+        /// <para>
+        /// Note that only 10 <paramref name="args"/> are supported in combination with a <em>{reason}</em>.
+        /// </para>
+        /// <para>
+        /// If an expectation was set through a prior call to <see cref="AssertionScope.WithExpectation"/>, then the failure
+        /// message is appended to that expectation.
+        /// </para>
         /// </remarks>
         /// <param name="message">The format string that represents the failure message.</param>
         /// <param name="args">Optional arguments to any numbered placeholders.</param>
         Continuation FailWith(string message, params object[] args);
 
         /// <summary>
-        /// Sets the failure message when the assertion is not met, or completes the failure message set to a
-        /// prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>,
+        /// Sets the failure message when the assertion is not met, or completes the failure message set to a prior call to
+        /// <see cref="AssertionScope.WithExpectation"/>,
         /// but postpones evaluation of the formatting arguments until the assertion really fails.
         /// </summary>
         /// <remarks>
-        /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a few
-        /// specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as passed
-        /// to <see cref="AssertionScope.BecauseOf(FluentAssertions.Execution.Reason)"/>. Other named placeholders will be replaced with
-        /// the <see cref="FluentAssertions.Execution.AssertionScope.Current"/> scope data passed through
-        /// <see cref="FluentAssertions.Execution.AssertionScope.AddNonReportable"/> and
-        /// <see cref="FluentAssertions.Execution.AssertionScope.AddReportable(string,string)"/>. Finally, a description of the
-        /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
-        /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
-        /// Note that only 10 <paramref name="argProviders"/> are supported in combination with a {reason}.
-        /// If an expectation was set through a prior call to <see cref="FluentAssertions.Execution.AssertionScope.WithExpectation"/>,
-        /// then the failure message is appended to that expectation.
+        /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a
+        /// few specialized placeholders as well. For instance, <em>{reason}</em> will be replaced with the reason of the
+        /// assertion as passed to <see cref="AssertionScope.BecauseOf(string, object[])"/>.
+        /// <para>
+        /// Other named placeholders will be replaced with the <see cref="AssertionScope.Current"/> scope data passed through
+        /// <see cref="AssertionScope.AddNonReportable"/> and <see cref="AssertionScope.AddReportable(string,string)"/>.
+        /// </para>
+        /// <para>
+        /// Finally, a description of the current subject can be passed through the <em>{context:description}</em> placeholder.
+        /// This is used in the message if no explicit context is specified through the <see cref="AssertionScope"/> constructor.
+        /// </para>
+        /// <para>
+        /// Note that only 10 <paramref name="argProviders"/> are supported in combination with a <em>{reason}</em>.
+        /// </para>
+        /// <para>
+        /// If an expectation was set through a prior call to <see cref="AssertionScope.WithExpectation"/>, then the failure
+        /// message is appended to that expectation.
+        /// </para>
         /// </remarks>
         /// <param name="message">The format string that represents the failure message.</param>
         /// <param name="argProviders">Optional lazily evaluated arguments to any numbered placeholders</param>
@@ -94,11 +112,12 @@ namespace FluentAssertions.Execution
         /// Specify the reason why you expect the condition to be <c>true</c>.
         /// </summary>
         /// <param name="because">
-        /// A formatted phrase compatible with <see cref="string.Format(string,object[])"/> explaining why
-        /// the condition should be satisfied. If the phrase does not start with the word <i>because</i>,
-        /// it is prepended to the message. If the format of <paramref name="because"/> or
-        /// <paramref name="becauseArgs"/> is not compatible with <see cref="string.Format(string,object[])"/>,
-        /// then a warning message is returned instead.
+        /// A formatted phrase compatible with <see cref="string.Format(string,object[])"/> explaining why the condition should
+        /// be satisfied. If the phrase does not start with the word <em>because</em>, it is prepended to the message.
+        /// <para>
+        /// If the format of <paramref name="because"/> or <paramref name="becauseArgs"/> is not compatible with
+        /// <see cref="string.Format(string,object[])"/>, then a warning message is returned instead.
+        /// </para>
         /// </param>
         /// <param name="becauseArgs">
         /// Zero or more values to use for filling in any <see cref="string.Format(string,object[])"/> compatible placeholders.
@@ -115,15 +134,20 @@ namespace FluentAssertions.Execution
         /// Sets the expectation part of the failure message when the assertion is not met.
         /// </summary>
         /// <remarks>
-        /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a few
-        /// specialized placeholders as well. For instance, {reason} will be replaced with the reason of the assertion as passed
-        /// to <see cref="AssertionScope.BecauseOf(FluentAssertions.Execution.Reason)"/>. Other named placeholders will be replaced with the <see cref="AssertionScope.Current"/> scope data
-        /// passed through <see cref="AssertionScope.AddNonReportable"/> and <see cref="AssertionScope.AddReportable(string,string)"/>. Finally, a description of the
-        /// current subject can be passed through the {context:description} placeholder. This is used in the message if no
-        /// explicit context is specified through the <see cref="AssertionScope"/> constructor.
-        /// Note that only 10 <paramref name="args"/> are supported in combination with a {reason}.
-        /// If an expectation was set through a prior call to <see cref="AssertionScope.WithExpectation"/>, then the failure message is appended to that
-        /// expectation.
+        /// In addition to the numbered <see cref="string.Format(string,object[])"/>-style placeholders, messages may contain a
+        /// few specialized placeholders as well. For instance, <em>{reason}</em> will be replaced with the reason of the
+        /// assertion as passed to <see cref="AssertionScope.BecauseOf(string, object[])"/>.
+        /// <para>
+        /// Other named placeholders will be replaced with the <see cref="AssertionScope.Current"/> scope data passed through
+        /// <see cref="AssertionScope.AddNonReportable"/> and <see cref="AssertionScope.AddReportable(string,string)"/>.
+        /// </para>
+        /// <para>
+        /// Finally, a description of the current subject can be passed through the <em>{context:description}</em> placeholder.
+        /// This is used in the message if no explicit context is specified through the <see cref="AssertionScope"/> constructor.
+        /// </para>
+        /// <para>
+        /// Note that only 10 <paramref name="args"/> are supported in combination with a <em>{reason}</em>.
+        /// </para>
         /// </remarks>
         /// <param name="message">The format string that represents the failure message.</param>
         /// <param name="args">Optional arguments to any numbered placeholders.</param>
@@ -135,8 +159,11 @@ namespace FluentAssertions.Execution
         IAssertionScope WithDefaultIdentifier(string identifier);
 
         /// <summary>
-        /// Indicates that every argument passed into <see cref="FailWith(string, object[])"/> is displayed on a separate line.
+        /// Forces the formatters, that support it, to add the necessary line breaks.
         /// </summary>
+        /// <remarks>
+        /// This is just shorthand for modifying the <see cref="AssertionScope.FormattingOptions"/> property.
+        /// </remarks>
         IAssertionScope UsingLineBreaks { get; }
 
         /// <summary>

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -16,6 +16,7 @@ Changes since 6.0.0 Beta 1
 
 **Fixes**
 * Added parameter checking for `Be(string)` for GuidAssertions - [#1597](https://github.com/fluentassertions/fluentassertions/pull/1597).
+* Improved consistency of XML documentation on `AssertionScope`, `ContinuedAssertionScope`, and `GivenSelector<T>` methods. - [#1606](https://github.com/fluentassertions/fluentassertions/pull/1606).
 
 ## 6.0.0 Beta 1
 Changes since 6.0.0 Alpha 2


### PR DESCRIPTION
* Used `<inhertdoc/>` where possible
* Added paragraphs to make long text more readable
* Added emphasis for certain words
* Shortened references where possible

- [x] Release notes

Close #1605