### PR TITLE
Add new BeExactly assertions for DateTimeOffset

### DIFF
--- a/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/DateTimeOffsetValueFormatter.cs
@@ -21,6 +21,7 @@ namespace FluentAssertions.Formatting
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {
             DateTimeOffset dateTimeOffset;
+            bool significantOffset = false;
 
             if (value is DateTime dateTime)
             {
@@ -29,6 +30,7 @@ namespace FluentAssertions.Formatting
             else
             {
                 dateTimeOffset = (DateTimeOffset)value;
+                significantOffset = true;
             }
 
             formattedGraph.AddFragment("<");
@@ -70,11 +72,18 @@ namespace FluentAssertions.Formatting
                 formattedGraph.AddFragment(" +");
                 formatChild("offset", dateTimeOffset.Offset, formattedGraph);
             }
-
-            if (dateTimeOffset.Offset < TimeSpan.Zero)
+            else if (dateTimeOffset.Offset < TimeSpan.Zero)
             {
                 formattedGraph.AddFragment(" ");
                 formatChild("offset", dateTimeOffset.Offset, formattedGraph);
+            }
+            else if (significantOffset && (hasDate || hasTime))
+            {
+                formattedGraph.AddFragment(" +0h");
+            }
+            else
+            {
+                // No offset added, since it was deemed unnecessary
             }
 
             if (!hasDate && !hasTime)

--- a/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Src/FluentAssertions/Primitives/DateTimeOffsetAssertions.cs
@@ -45,7 +45,7 @@ namespace FluentAssertions.Primitives
         public DateTimeOffset? Subject { get; }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTimeOffset"/> is exactly equal to the <paramref name="expected"/> value.
+        /// Asserts that the current <see cref="DateTimeOffset"/> represents the same point in time as the <paramref name="expected"/> value.
         /// </summary>
         /// <param name="expected">The expected value</param>
         /// <param name="because">
@@ -59,16 +59,21 @@ namespace FluentAssertions.Primitives
             params object[] becauseArgs)
         {
             Execute.Assertion
-                .ForCondition(Subject == expected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:the date and time} to be {0}{reason}, but it was {1}.",
-                    expected, Subject);
+                .WithExpectation("Expected {context:the date and time} to represent the same point in time as {0}{reason}, ", expected)
+                .ForCondition(Subject.HasValue)
+                .FailWith("but found a <null> DateTimeOffset.")
+                .Then
+                .ForCondition(Subject == expected)
+                .FailWith("but {0} does not.", Subject)
+                .Then
+                .ClearExpectation();
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTimeOffset"/> is exactly equal to the <paramref name="expected"/> value.
+        /// Asserts that the current <see cref="DateTimeOffset"/> represents the same point in time as the <paramref name="expected"/> value.
         /// </summary>
         /// <param name="expected">The expected value</param>
         /// <param name="because">
@@ -81,17 +86,32 @@ namespace FluentAssertions.Primitives
         public AndConstraint<TAssertions> Be(DateTimeOffset? expected, string because = "",
             params object[] becauseArgs)
         {
-            Execute.Assertion
-                .ForCondition(Subject == expected)
-                .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:the date and time} to be {0}{reason}, but it was {1}.",
-                    expected, Subject);
+            if (!expected.HasValue)
+            {
+                Execute.Assertion
+                   .BecauseOf(because, becauseArgs)
+                   .ForCondition(!Subject.HasValue)
+                   .FailWith("Expected {context:the date and time} to be <null>{reason}, but it was {0}.", Subject);
+            }
+            else
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .WithExpectation("Expected {context:the date and time} to represent the same point in time as {0}{reason}, ", expected)
+                    .ForCondition(Subject.HasValue)
+                    .FailWith("but found a <null> DateTimeOffset.")
+                    .Then
+                    .ForCondition(Subject == expected)
+                    .FailWith("but {0} does not.", Subject)
+                    .Then
+                    .ClearExpectation();
+            }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTimeOffset"/> is not equal to the <paramref name="unexpected"/> value.
+        /// Asserts that the current <see cref="DateTimeOffset"/> does not represent the same point in time as the <paramref name="unexpected"/> value.
         /// </summary>
         /// <param name="unexpected">The unexpected value</param>
         /// <param name="because">
@@ -107,13 +127,13 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject != unexpected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {context:the date and time} to be {0}{reason}, but it was.", unexpected);
+                .FailWith("Did not expect {context:the date and time} to represent the same point in time as {0}{reason}, but it did.", unexpected);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
 
         /// <summary>
-        /// Asserts that the current <see cref="DateTimeOffset"/> is not equal to the <paramref name="unexpected"/> value.
+        /// Asserts that the current <see cref="DateTimeOffset"/> does not represent the same point in time as the <paramref name="unexpected"/> value.
         /// </summary>
         /// <param name="unexpected">The unexpected value</param>
         /// <param name="because">
@@ -129,7 +149,119 @@ namespace FluentAssertions.Primitives
             Execute.Assertion
                 .ForCondition(Subject != unexpected)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Did not expect {context:the date and time} to be {0}{reason}, but it was.", unexpected);
+                .FailWith("Did not expect {context:the date and time} to represent the same point in time as {0}{reason}, but it did.", unexpected);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="DateTimeOffset"/> is exactly equal to the <paramref name="expected"/> value, including its offset.
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> BeExactly(DateTimeOffset expected, string because = "",
+            params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .WithExpectation("Expected {context:the date and time} to be exactly {0}{reason}, ", expected)
+                .ForCondition(Subject.HasValue)
+                .FailWith("but found a <null> DateTimeOffset.")
+                .Then
+                .ForCondition(Subject.Value.EqualsExact(expected))
+                .FailWith("but it was {0}.", Subject)
+                .Then
+                .ClearExpectation();
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="DateTimeOffset"/> is exactly equal to the <paramref name="expected"/> value, including its offset.
+        /// Comparison is performed using <see cref="DateTimeOffset.EqualsExact(DateTimeOffset)"/>
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> BeExactly(DateTimeOffset? expected, string because = "",
+            params object[] becauseArgs)
+        {
+            if (!expected.HasValue)
+            {
+                Execute.Assertion
+                   .BecauseOf(because, becauseArgs)
+                   .ForCondition(!Subject.HasValue)
+                   .FailWith("Expected {context:the date and time} to be <null>{reason}, but it was {0}.", Subject);
+            }
+            else
+            {
+                Execute.Assertion
+                    .BecauseOf(because, becauseArgs)
+                    .WithExpectation("Expected {context:the date and time} to be exactly {0}{reason}, ", expected)
+                    .ForCondition(Subject.HasValue)
+                    .FailWith("but found a <null> DateTimeOffset.")
+                    .Then
+                    .ForCondition(Subject.Value.EqualsExact(expected.Value))
+                    .FailWith("but it was {0}.", Subject)
+                    .Then
+                    .ClearExpectation();
+            }
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="DateTimeOffset"/> is not exactly equal to the <paramref name="unexpected"/> value.
+        /// Comparison is performed using <see cref="DateTimeOffset.EqualsExact(DateTimeOffset)"/>
+        /// </summary>
+        /// <param name="unexpected">The unexpected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotBeExactly(DateTimeOffset unexpected, string because = "",
+            params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(Subject?.EqualsExact(unexpected) != true)
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Did not expect {context:the date and time} to be exactly {0}{reason}, but it was.", unexpected);
+
+            return new AndConstraint<TAssertions>((TAssertions)this);
+        }
+
+        /// <summary>
+        /// Asserts that the current <see cref="DateTimeOffset"/> is not equal to the <paramref name="unexpected"/> value.
+        /// </summary>
+        /// <param name="unexpected">The unexpected value</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public AndConstraint<TAssertions> NotBeExactly(DateTimeOffset? unexpected, string because = "",
+            params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(!((Subject == null && unexpected == null) || (Subject != null && unexpected != null && Subject.Value.EqualsExact(unexpected.Value))))
+                .BecauseOf(because, becauseArgs)
+                .FailWith("Did not expect {context:the date and time} to be exactly {0}{reason}, but it was.", unexpected);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
@@ -858,7 +990,7 @@ namespace FluentAssertions.Primitives
                 .FailWith("but found a <null> DateTimeOffset.", expectedDate)
                 .Then
                 .ForCondition(Subject.Value.Date == expectedDate)
-                .FailWith("but it was {0}.", Subject.Value)
+                .FailWith("but it was {0}.", Subject.Value.Date)
                 .Then
                 .ClearExpectation();
 

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1738,6 +1738,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -1760,6 +1762,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeExactly(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeExactly(System.DateTimeOffset? unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1738,6 +1738,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -1760,6 +1762,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeExactly(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeExactly(System.DateTimeOffset? unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1738,6 +1738,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -1760,6 +1762,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeExactly(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeExactly(System.DateTimeOffset? unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1691,6 +1691,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -1713,6 +1715,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeExactly(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeExactly(System.DateTimeOffset? unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1738,6 +1738,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeBefore(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.DateTimeOffset nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeExactly(System.TimeSpan timeSpan) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeExactly(System.DateTimeOffset? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeLessThan(System.TimeSpan timeSpan) { }
         public FluentAssertions.Primitives.DateTimeOffsetRangeAssertions<TAssertions> BeMoreThan(System.TimeSpan timeSpan) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOnOrAfter(System.DateTimeOffset expected, string because = "", params object[] becauseArgs) { }
@@ -1760,6 +1762,8 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> NotBeAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeCloseTo(System.DateTimeOffset distantTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeExactly(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> NotBeExactly(System.DateTimeOffset? unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrAfter(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeOnOrBefore(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeSameDateAs(System.DateTimeOffset unexpected, string because = "", params object[] becauseArgs) { }

--- a/Tests/FluentAssertions.Specs/Formatting/DateTimeOffsetValueFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/DateTimeOffsetValueFormatterSpecs.cs
@@ -22,7 +22,7 @@ namespace FluentAssertions.Specs.Formatting
         public void When_the_offset_is_not_relevant_it_should_not_be_included_in_the_output()
         {
             // Act
-            string result = Formatter.ToString(new DateTimeOffset(1973, 9, 20, 12, 59, 59, 0.Hours()));
+            string result = Formatter.ToString(new DateTime(1973, 9, 20, 12, 59, 59));
 
             // Assert
             result.Should().Be("<1973-09-20 12:59:59>");
@@ -148,35 +148,6 @@ namespace FluentAssertions.Specs.Formatting
 
             // Assert
             result.Should().Be(expected);
-        }
-
-        [Fact]
-        public void
-            When_a_DateTime_is_used_it_should_format_the_same_as_a_DateTimeOffset()
-        {
-            // Arrange
-            var dateOnly = ToUtcWithoutChangingTime(new DateTime(1973, 9, 20));
-            var timeOnly = ToUtcWithoutChangingTime(1.January(0001).At(08, 20, 01));
-            var withoutMilliseconds = ToUtcWithoutChangingTime(1.May(2012).At(20, 15, 30));
-            var withMilliseconds = ToUtcWithoutChangingTime(1.May(2012).At(20, 15, 30, 318));
-
-            // Act / Assert
-            Formatter.ToString(dateOnly)
-                .Should().Be(Formatter.ToString((DateTimeOffset)dateOnly));
-
-            Formatter.ToString(timeOnly).Should()
-                .Be(Formatter.ToString((DateTimeOffset)timeOnly));
-
-            Formatter.ToString(withoutMilliseconds).Should()
-                .Be(Formatter.ToString((DateTimeOffset)withoutMilliseconds));
-
-            Formatter.ToString(withMilliseconds).Should()
-                .Be(Formatter.ToString((DateTimeOffset)withMilliseconds));
-        }
-
-        private static DateTime ToUtcWithoutChangingTime(DateTime date)
-        {
-            return DateTime.SpecifyKind(date, DateTimeKind.Utc);
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/DateTimeOffsetAssertionSpecs.cs
@@ -194,7 +194,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dateTime to be <2012-03-11 +1h>*failure message, but it was <2012-03-10 +1h>.");
+                "Expected dateTime to represent the same point in time as <2012-03-11 +1h>*failure message, but <2012-03-10 +1h> does not.");
         }
 
         [Fact]
@@ -209,7 +209,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected dateTime to be <2012-03-11 +1h>*failure message, but it was <2012-03-10 +1h>.");
+                "Expected dateTime to represent the same point in time as <2012-03-11 +1h>*failure message, but <2012-03-10 +1h> does not.");
         }
 
         [Fact]
@@ -253,7 +253,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect dateTime to be <2012-03-10 +1h> because we want to test the failure message, but it was.");
+                "Did not expect dateTime to represent the same point in time as <2012-03-10 +1h> because we want to test the failure message, but it did.");
         }
 
         [Fact]
@@ -269,11 +269,11 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect dateTime to be <2012-03-10 +1h> because we want to test the failure message, but it was.");
+                "Did not expect dateTime to represent the same point in time as <2012-03-10 +1h> because we want to test the failure message, but it did.");
         }
 
         [Fact]
-        public void Should_succeed_when_asserting_nullable_numeric_value_equals_the_same_value()
+        public void Should_succeed_when_asserting_nullable_datetimeoffset_value_equals_the_same_value()
         {
             // Arrange
             DateTimeOffset? nullableDateTimeA = new DateTime(2016, 06, 04);
@@ -288,22 +288,18 @@ namespace FluentAssertions.Specs.Primitives
         }
 
         [Fact]
-        public void Should_succeed_when_asserting_nullable_numeric_null_value_equals_null()
+        public void Should_succeed_when_asserting_nullable_datetimeoffset_null_value_equals_null()
         {
             // Arrange
             DateTimeOffset? nullableDateTimeA = null;
             DateTimeOffset? nullableDateTimeB = null;
 
-            // Act
-            Action action = () =>
-                nullableDateTimeA.Should().Be(nullableDateTimeB);
-
-            // Assert
-            action.Should().NotThrow();
+            // Act / Assert
+            nullableDateTimeA.Should().Be(nullableDateTimeB);
         }
 
         [Fact]
-        public void Should_fail_when_asserting_nullable_numeric_value_equals_a_different_value()
+        public void Should_fail_when_asserting_nullable_datetimeoffset_value_equals_a_different_value()
         {
             // Arrange
             DateTimeOffset? nullableDateTimeA = new DateTime(2016, 06, 04);
@@ -330,7 +326,23 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected nullableDateTime to be <2016-03-27 +1h> because we want to test the failure message, but it was <null>.");
+                .WithMessage("Expected nullableDateTime to represent the same point in time as <2016-03-27 +1h> because we want to test the failure message, but found a <null> DateTimeOffset.");
+        }
+
+        [Fact]
+        public void Should_fail_with_descriptive_message_when_asserting_non_null_value_is_equal_to_null_value()
+        {
+            // Arrange
+            DateTimeOffset? nullableDateTime = 27.March(2016).ToDateTimeOffset(1.Hours());
+            DateTimeOffset? expectation = null;
+
+            // Act
+            Action action = () =>
+                nullableDateTime.Should().Be(expectation, "because we want to test the failure {0}", "message");
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected nullableDateTime to be <null> because we want to test the failure message, but it was <2016-03-27 +1h>.");
         }
 
         [Fact]
@@ -360,6 +372,169 @@ namespace FluentAssertions.Specs.Primitives
 
             // Act / Assert
             dateWithZeroHourOffset.Should().NotBe(dateWithOneHourOffset);
+        }
+
+        #endregion
+
+        #region (Not) BeExactly
+
+        [Fact]
+        public void Should_succeed_when_asserting_value_is_exactly_equal_to_the_same_value()
+        {
+            // Arrange
+            DateTimeOffset dateTime = new DateTime(2016, 06, 04);
+            DateTimeOffset sameDateTime = new DateTime(2016, 06, 04);
+
+            // Act / Assert
+            dateTime.Should().BeExactly(sameDateTime);
+        }
+
+        [Fact]
+        public void Should_succeed_when_asserting_value_is_exactly_equal_to_the_same_nullable_value()
+        {
+            // Arrange
+            DateTimeOffset dateTime = 4.June(2016);
+            DateTimeOffset? sameDateTime = 4.June(2016);
+
+            // Act / Assert
+            dateTime.Should().BeExactly(sameDateTime);
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_value_is_exactly_equal_to_a_different_value()
+        {
+            // Arrange
+            var dateTime = 10.March(2012).WithOffset(1.Hours());
+            var otherDateTime = dateTime.ToUniversalTime();
+
+            // Act
+            Action act = () => dateTime.Should().BeExactly(otherDateTime, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected dateTime to be exactly <2012-03-09 23:00:00 +0h>*failure message, but it was <2012-03-10 +1h>.");
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_value_is_exactly_equal_to_a_different_nullable_value()
+        {
+            // Arrange
+            DateTimeOffset dateTime = 10.March(2012).WithOffset(1.Hours());
+            DateTimeOffset? otherDateTime = dateTime.ToUniversalTime();
+
+            // Act
+            Action act = () => dateTime.Should().BeExactly(otherDateTime, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Expected dateTime to be exactly <2012-03-09 23:00:00 +0h>*failure message, but it was <2012-03-10 +1h>.");
+        }
+
+        [Fact]
+        public void Should_succeed_when_asserting_value_is_not_exactly_equal_to_a_different_value()
+        {
+            // Arrange
+            DateTimeOffset dateTime = 10.March(2012).WithOffset(1.Hours());
+            DateTimeOffset otherDateTime = dateTime.ToUniversalTime();
+
+            // Act / Assert
+            dateTime.Should().NotBeExactly(otherDateTime);
+        }
+
+        [Fact]
+        public void Should_succeed_when_asserting_value_is_not_exactly_equal_to_a_different_nullable_value()
+        {
+            // Arrange
+            DateTimeOffset dateTime = 10.March(2012).WithOffset(1.Hours());
+            DateTimeOffset? otherDateTime = dateTime.ToUniversalTime();
+
+            // Act / Assert
+            dateTime.Should().NotBeExactly(otherDateTime);
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_value_is_not_exactly_equal_to_the_same_value()
+        {
+            // Arrange
+            var dateTime = new DateTimeOffset(10.March(2012), 1.Hours());
+            var sameDateTime = new DateTimeOffset(10.March(2012), 1.Hours());
+
+            // Act
+            Action act =
+                () => dateTime.Should().NotBeExactly(sameDateTime, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect dateTime to be exactly <2012-03-10 +1h> because we want to test the failure message, but it was.");
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_value_is_not_exactly_equal_to_the_same_nullable_value()
+        {
+            // Arrange
+            DateTimeOffset dateTime = new DateTimeOffset(10.March(2012), 1.Hours());
+            DateTimeOffset? sameDateTime = new DateTimeOffset(10.March(2012), 1.Hours());
+
+            // Act
+            Action act =
+                () => dateTime.Should().NotBeExactly(sameDateTime, "because we want to test the failure {0}", "message");
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage(
+                "Did not expect dateTime to be exactly <2012-03-10 +1h> because we want to test the failure message, but it was.");
+        }
+
+        [Fact]
+        public void Should_succeed_when_asserting_nullable_value_is_exactly_equal_to_the_same_nullable_value()
+        {
+            // Arrange
+            DateTimeOffset? nullableDateTimeA = new DateTime(2016, 06, 04);
+            DateTimeOffset? nullableDateTimeB = new DateTime(2016, 06, 04);
+
+            // Act / Assert
+            nullableDateTimeA.Should().BeExactly(nullableDateTimeB);
+        }
+
+        [Fact]
+        public void Should_succeed_when_asserting_nullable_null_value_exactly_equals_null()
+        {
+            // Arrange
+            DateTimeOffset? nullableDateTimeA = null;
+            DateTimeOffset? nullableDateTimeB = null;
+
+            // Act / Assert
+            nullableDateTimeA.Should().BeExactly(nullableDateTimeB);
+        }
+
+        [Fact]
+        public void Should_fail_when_asserting_nullable_value_exactly_equals_a_different_value()
+        {
+            // Arrange
+            DateTimeOffset? nullableDateTimeA = new DateTime(2016, 06, 04);
+            DateTimeOffset? nullableDateTimeB = new DateTime(2016, 06, 06);
+
+            // Act
+            Action action = () =>
+                nullableDateTimeA.Should().BeExactly(nullableDateTimeB);
+
+            // Assert
+            action.Should().Throw<XunitException>();
+        }
+
+        [Fact]
+        public void Should_fail_with_descriptive_message_when_asserting_null_value_is_exactly_equal_to_another_value()
+        {
+            // Arrange
+            DateTimeOffset? nullableDateTime = null;
+            DateTimeOffset expectation = 27.March(2016).ToDateTimeOffset(1.Hours());
+
+            // Act
+            Action action = () =>
+                nullableDateTime.Should().BeExactly(expectation, "because we want to test the failure {0}", "message");
+
+            // Assert
+            action.Should().Throw<XunitException>()
+                .WithMessage("Expected nullableDateTime to be exactly <2016-03-27 +1h> because we want to test the failure message, but found a <null> DateTimeOffset.");
         }
 
         #endregion
@@ -534,7 +709,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect time to be within 20ms from <2016-06-04 12:15:31>, but it was <2016-06-04 12:15:30.980>.");
+                .WithMessage("Did not expect time to be within 20ms from <2016-06-04 12:15:31 +0h>, but it was <2016-06-04 12:15:30.980 +0h>.");
         }
 
         [Fact]
@@ -549,7 +724,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Did not expect time to be within 20ms from <2016-06-04 12:15:31>, but it was <2016-06-04 12:15:30.980>.");
+                "Did not expect time to be within 20ms from <2016-06-04 12:15:31 +0h>, but it was <2016-06-04 12:15:30.980 +0h>.");
         }
 
         [Fact]
@@ -578,7 +753,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect time to be within 20ms from <2016-06-04 12:15:31>, but it was <2016-06-04 12:15:31.020>.");
+                .WithMessage("Did not expect time to be within 20ms from <2016-06-04 12:15:31 +0h>, but it was <2016-06-04 12:15:31.020 +0h>.");
         }
 
         [Fact]
@@ -742,7 +917,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect time to be within 100ms from <0001-01-01 00:00:00.000>, but it was <00:00:00.050>.");
+                .WithMessage("Did not expect time to be within 100ms from <0001-01-01 00:00:00.000>, but it was <00:00:00.050 +0h>.");
         }
 
         [Fact]
@@ -771,7 +946,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Did not expect time to be within 100ms from <9999-12-31 23:59:59.9999999>, but it was <9999-12-31 23:59:59.9499999>.");
+                .WithMessage("Did not expect time to be within 100ms from <9999-12-31 23:59:59.9999999 +0h>, but it was <9999-12-31 23:59:59.9499999 +0h>.");
         }
         #endregion
 
@@ -802,7 +977,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected earlierDate to be on or after <2016-06-04 00:05:00>, but it was <2016-06-04>.");
+                "Expected earlierDate to be on or after <2016-06-04 00:05:00 +0h>, but it was <2016-06-04 +0h>.");
         }
 
         [Fact]
@@ -817,7 +992,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected subject to be before <2016-06-03>, but it was <2016-06-04>.");
+                .WithMessage("Expected subject to be before <2016-06-03 +0h>, but it was <2016-06-04 +0h>.");
         }
 
         [Fact]
@@ -846,7 +1021,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected subject to be before <2016-06-04>, but it was <2016-06-04>.");
+                .WithMessage("Expected subject to be before <2016-06-04 +0h>, but it was <2016-06-04 +0h>.");
         }
 
         [Fact]
@@ -891,7 +1066,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected subject to be after <2016-06-05>, but it was <2016-06-04>.");
+                .WithMessage("Expected subject to be after <2016-06-05 +0h>, but it was <2016-06-04 +0h>.");
         }
 
         [Fact]
@@ -920,7 +1095,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected subject to be after <2016-06-04>, but it was <2016-06-04>.");
+                .WithMessage("Expected subject to be after <2016-06-04 +0h>, but it was <2016-06-04 +0h>.");
         }
 
         [Fact]
@@ -935,7 +1110,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected subject to be on or before <2016-06-03>, but it was <2016-06-04>.");
+                .WithMessage("Expected subject to be on or before <2016-06-03 +0h>, but it was <2016-06-04 +0h>.");
         }
 
         [Fact]
@@ -980,7 +1155,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject to be on or before <2016-06-03>, but it was <2016-06-04>.");
+                "Expected subject to be on or before <2016-06-03 +0h>, but it was <2016-06-04 +0h>.");
         }
 
         [Fact]
@@ -995,7 +1170,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject to be after <2016-06-05>, but it was <2016-06-04>.");
+                "Expected subject to be after <2016-06-05 +0h>, but it was <2016-06-04 +0h>.");
         }
 
         [Fact]
@@ -1024,7 +1199,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject to be after <2016-06-04>, but it was <2016-06-04>.");
+                "Expected subject to be after <2016-06-04 +0h>, but it was <2016-06-04 +0h>.");
         }
 
         [Fact]
@@ -1069,7 +1244,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected subject to be before <2016-06-03>, but it was <2016-06-04>.");
+                .WithMessage("Expected subject to be before <2016-06-03 +0h>, but it was <2016-06-04 +0h>.");
         }
 
         [Fact]
@@ -1098,7 +1273,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected subject to be before <2016-06-04>, but it was <2016-06-04>.");
+                .WithMessage("Expected subject to be before <2016-06-04 +0h>, but it was <2016-06-04 +0h>.");
         }
 
         [Fact]
@@ -1113,7 +1288,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected subject to be on or after <2016-06-05>, but it was <2016-06-04>.");
+                .WithMessage("Expected subject to be on or after <2016-06-05 +0h>, but it was <2016-06-04 +0h>.");
         }
 
         [Fact]
@@ -1893,7 +2068,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject <2009-10-01> to be more than 1d before <2009-10-02> because we like that, but it is behind by 1d.");
+                "Expected subject <2009-10-01 +0h> to be more than 1d before <2009-10-02 +0h> because we like that, but it is behind by 1d.");
         }
 
         [Fact]
@@ -1919,7 +2094,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject <2009-10-01 01:00:00> to be at least 1d before <2009-10-02> because we like that, but it is behind by 23h.");
+                "Expected subject <2009-10-01 01:00:00 +0h> to be at least 1d before <2009-10-02 +0h> because we like that, but it is behind by 23h.");
         }
 
         [Fact]
@@ -1946,7 +2121,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject <12:36:00> to be exactly 20m before <12:55:00> because 20 minutes is enough, but it is behind by 19m.");
+                "Expected subject <12:36:00 +0h> to be exactly 20m before <12:55:00 +0h> because 20 minutes is enough, but it is behind by 19m.");
         }
 
         [Fact]
@@ -1973,7 +2148,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject <2010-04-08 09:59:59> to be within 2d and 2h before <2010-04-10 12:00:00> because 50 hours is enough, but it is behind by 2d, 2h and 1s.");
+                "Expected subject <2010-04-08 09:59:59 +0h> to be within 2d and 2h before <2010-04-10 12:00:00 +0h> because 50 hours is enough, but it is behind by 2d, 2h and 1s.");
         }
 
         [Fact]
@@ -2002,7 +2177,7 @@ namespace FluentAssertions.Specs.Primitives
         public void When_a_utc_date_is_within_0s_before_itself_it_should_not_throw()
         {
             // Arrange
-            var date = DateTimeOffset.UtcNow; // local timezone differs from UTC
+            var date = DateTimeOffset.UtcNow; // local timezone differs from +0h
 
             // Act / Assert
             date.Should().BeWithin(TimeSpan.Zero).Before(date);
@@ -2012,7 +2187,7 @@ namespace FluentAssertions.Specs.Primitives
         public void When_a_utc_date_is_within_0s_after_itself_it_should_not_throw()
         {
             // Arrange
-            var date = DateTimeOffset.UtcNow; // local timezone differs from UTC
+            var date = DateTimeOffset.UtcNow; // local timezone differs from +0h
 
             // Act / Assert
             date.Should().BeWithin(TimeSpan.Zero).After(date);
@@ -2057,7 +2232,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:15> to be more than 10s after <00:00:30>, but it is behind by 15s.");
+                .WithMessage("Expected subject <00:00:15 +0h> to be more than 10s after <00:00:30 +0h>, but it is behind by 15s.");
         }
 
         [Theory]
@@ -2074,7 +2249,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s after <00:00:30>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage($"Expected subject <00:00:{subjectSeconds} +0h> to be at least 10s after <00:00:30 +0h>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -2089,7 +2264,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:20> to be exactly 10s after <00:00:30>, but it is behind by 10s.");
+                .WithMessage("Expected subject <00:00:20 +0h> to be exactly 10s after <00:00:30 +0h>, but it is behind by 10s.");
         }
 
         [Theory]
@@ -2106,7 +2281,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s after <00:00:30>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage($"Expected subject <00:00:{subjectSeconds} +0h> to be within 10s after <00:00:30 +0h>, but it is behind by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -2121,7 +2296,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:25> to be less than 10s after <00:00:30>, but it is behind by 5s.");
+                .WithMessage("Expected subject <00:00:25 +0h> to be less than 10s after <00:00:30 +0h>, but it is behind by 5s.");
         }
 
         [Fact]
@@ -2136,7 +2311,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:45> to be more than 10s before <00:00:30>, but it is ahead by 15s.");
+                .WithMessage("Expected subject <00:00:45 +0h> to be more than 10s before <00:00:30 +0h>, but it is ahead by 15s.");
         }
 
         [Theory]
@@ -2153,7 +2328,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be at least 10s before <00:00:30>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage($"Expected subject <00:00:{subjectSeconds} +0h> to be at least 10s before <00:00:30 +0h>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -2168,7 +2343,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:40> to be exactly 10s before <00:00:30>, but it is ahead by 10s.");
+                .WithMessage("Expected subject <00:00:40 +0h> to be exactly 10s before <00:00:30 +0h>, but it is ahead by 10s.");
         }
 
         [Theory]
@@ -2185,7 +2360,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage($"Expected subject <00:00:{subjectSeconds}> to be within 10s before <00:00:30>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
+                .WithMessage($"Expected subject <00:00:{subjectSeconds} +0h> to be within 10s before <00:00:30 +0h>, but it is ahead by {Math.Abs(subjectSeconds - targetSeconds)}s.");
         }
 
         [Fact]
@@ -2200,7 +2375,7 @@ namespace FluentAssertions.Specs.Primitives
 
             // Assert
             action.Should().Throw<XunitException>()
-                .WithMessage("Expected subject <00:00:45> to be less than 10s before <00:00:30>, but it is ahead by 15s.");
+                .WithMessage("Expected subject <00:00:45 +0h> to be less than 10s before <00:00:30 +0h>, but it is ahead by 15s.");
         }
 
         #endregion

--- a/docs/_pages/datetimespans.md
+++ b/docs/_pages/datetimespans.md
@@ -11,6 +11,8 @@ sidebar:
 
 For asserting a `DateTime` or a `DateTimeOffset` against various constraints, Fluent Assertions offers a bunch of methods that, provided that you use the extension methods for representing dates and times, really help to keep your assertions readable.
 
+Since a `DateTimeOffset` both represents a point in time and a calendar date/time with a specific offset, both scenarios can be asserted.
+
 ```csharp
 var theDatetime = 1.March(2010).At(22, 15).AsLocal();
 
@@ -34,6 +36,16 @@ theDatetime.Should().BeOneOf(
     1.March(2010).At(22, 15),
     1.March(2010).At(23, 15)
 );
+
+var theDatetimeOffset = 1.March(2010).At(22, 15).WithOffset(2.Hours());     
+
+// Asserts the point in time. 
+theDatetimeOffset.Should().Be(1.March(2010).At(21, 15).WithOffset(1.Hours()));          
+theDatetimeOffset.Should().NotBe(1.March(2010).At(21, 15).WithOffset(1.Hours())); 
+
+//Asserts the calendar date/time and the offset
+theDatetimeOffset.Should().BeExactly(1.March(2010).At(21, 15).WithOffset(1.Hours()));   
+theDatetimeOffset.Should().NotBeExactly(1.March(2010).At(21, 15).WithOffset(1.Hours()));
 ```
 
 Notice how we use extension methods like `March`, `At` to represent dates in a more human readable form. There's a lot more like these, including `2000.Microseconds()`, `3.Nanoseconds` as well as methods like `AsLocal` and `AsUtc` to convert between representations. You can even do relative calculations like `2.Hours().Before(DateTime.Now)`.

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,6 +11,7 @@ sidebar:
 Changes since 6.0.0 Alpha 2
 
 **What's New**
+* Added `BeExactly` assertions to verify a `DateTimeOffset` exactly, i.e both its date/time and its offset - [#1609](https://github.com/fluentassertions/fluentassertions/pull/1609).
 * Added `WithParameterName` extension to ease asserting on the parameter name for a thrown `ArgumentException` - [#1466](https://github.com/fluentassertions/fluentassertions/pull/1466).
 * Added `NotCompleteWithinAsync` to `TaskCompletionSourceAssertions` - [#1474](https://github.com/fluentassertions/fluentassertions/pull/1474).
 * Added `HaveValue(decimal)`, `HaveSameValueAs` and `HaveSameNameAs` to `EnumAssertions` - [#1479](https://github.com/fluentassertions/fluentassertions/pull/1479).


### PR DESCRIPTION
Not quite ready yet. More a basis for discussion.

The value formatting was one issue. I don't think the offset should be hidden, even if it's zero. It's no less significant than a positive or negative offset.

The assertion could perhaps be made with a Then step and a "...but the offsets differ" message. 