### PR TITLE
Improve continuation of AssertionScope and add specs

### DIFF
--- a/Src/FluentAssertions/Execution/ContinuedAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/ContinuedAssertionScope.cs
@@ -108,7 +108,12 @@ namespace FluentAssertions.Execution
         /// <inheritdoc/>
         public IAssertionScope WithExpectation(string message, params object[] args)
         {
-            return predecessor.WithExpectation(message, args);
+            if (continueAsserting)
+            {
+                return predecessor.WithExpectation(message, args);
+            }
+
+            return this;
         }
 
         /// <inheritdoc/>

--- a/Src/FluentAssertions/Execution/ContinuedAssertionScope.cs
+++ b/Src/FluentAssertions/Execution/ContinuedAssertionScope.cs
@@ -119,7 +119,12 @@ namespace FluentAssertions.Execution
         /// <inheritdoc/>
         public IAssertionScope WithDefaultIdentifier(string identifier)
         {
-            return predecessor.WithDefaultIdentifier(identifier);
+            if (continueAsserting)
+            {
+                return predecessor.WithDefaultIdentifier(identifier);
+            }
+
+            return this;
         }
 
         /// <inheritdoc/>

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -836,6 +836,51 @@ namespace FluentAssertions.Specs.Execution
         }
 
         [Fact]
+        public void When_the_previous_assertion_succeeded_it_should_not_affect_the_next_one_with_arguments()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .ForCondition(true)
+                .FailWith("First assertion")
+                .Then
+                .FailWith("Second {0}", "assertion");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Second \"assertion\"");
+        }
+
+        [Fact]
+        public void When_the_previous_assertion_succeeded_it_should_not_affect_the_next_one_with_argument_providers()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .ForCondition(true)
+                .FailWith("First assertion")
+                .Then
+                .FailWith("Second {0}", () => "assertion");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Second \"assertion\"");
+        }
+
+        [Fact]
+        public void When_the_previous_assertion_succeeded_it_should_not_affect_the_next_one_with_a_fail_reason_function()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .ForCondition(true)
+                .FailWith("First assertion")
+                .Then
+                .FailWith(() => new FailReason("Second {0}", "assertion"));
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Second \"assertion\"");
+        }
+
+        [Fact]
         public void When_a_given_is_used_before_an_assertion_then_the_result_should_be_available_for_evaluation()
         {
             // Act
@@ -908,6 +953,63 @@ namespace FluentAssertions.Specs.Execution
 
             Assert.Single(failures);
             Assert.Contains("First assertion", failures);
+        }
+
+        [Fact]
+        public void When_the_previous_assertion_failed_it_should_not_execute_the_succeeding_failure_with_arguments()
+        {
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                Execute.Assertion
+                    .ForCondition(false)
+                    .FailWith("First assertion")
+                    .Then
+                    .FailWith("Second {0}", "assertion");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("First assertion");
+        }
+
+        [Fact]
+        public void When_the_previous_assertion_failed_it_should_not_execute_the_succeeding_failure_with_argument_providers()
+        {
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                Execute.Assertion
+                    .ForCondition(false)
+                    .FailWith("First assertion")
+                    .Then
+                    .FailWith("Second {0}", () => "assertion");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("First assertion");
+        }
+
+        [Fact]
+        public void When_the_previous_assertion_failed_it_should_not_execute_the_succeeding_failure_with_a_fail_reason_function()
+        {
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                Execute.Assertion
+                    .ForCondition(false)
+                    .FailWith("First assertion")
+                    .Then
+                    .FailWith(() => new FailReason("Second {0}", "assertion"));
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("First assertion");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -621,7 +621,7 @@ namespace FluentAssertions.Specs.Execution
 
             // Assert
             act.Should().ThrowExactly<XunitException>()
-                .WithMessage("*MyValue*");
+                .WithMessage("MyValue*");
         }
 
         [Fact]
@@ -639,7 +639,56 @@ namespace FluentAssertions.Specs.Execution
 
             // Assert
             act.Should().ThrowExactly<XunitException>()
-                .WithMessage("*SomeValue*AnotherValue*");
+                .WithMessage("SomeValueAnotherValue*");
+        }
+
+        [Fact]
+        public void When_adding_reportable_values_they_should_be_reported_after_the_message()
+        {
+            // Arrange
+            var scope = new AssertionScope();
+            scope.AddReportable("SomeKey", "SomeValue");
+            scope.AddReportable("AnotherKey", "AnotherValue");
+
+            AssertionScope.Current.FailWith("{SomeKey}{AnotherKey}");
+
+            // Act
+            Action act = scope.Dispose;
+
+            // Assert
+            act.Should().ThrowExactly<XunitException>()
+                .WithMessage("*With SomeKey:\nSomeValue\nWith AnotherKey:\nAnotherValue");
+        }
+
+        [Fact]
+        public void When_adding_non_reportable_value_it_should_not_be_reported_after_the_message()
+        {
+            // Arrange
+            var scope = new AssertionScope();
+            scope.AddNonReportable("SomeKey", "SomeValue");
+
+            AssertionScope.Current.FailWith("{SomeKey}");
+
+            // Act
+            Action act = scope.Dispose;
+
+            // Assert
+            act.Should().ThrowExactly<XunitException>()
+                .Which.Message.Should().NotContain("With SomeKey:\nSomeValue");
+        }
+
+        [Fact]
+        public void When_adding_non_reportable_value_it_should_be_retrievable_from_context()
+        {
+            // Arrange
+            var scope = new AssertionScope();
+            scope.AddNonReportable("SomeKey", "SomeValue");
+
+            // Act
+            var value = scope.Get<string>("SomeKey");
+
+            // Assert
+            value.Should().Be("SomeValue");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -765,6 +765,46 @@ namespace FluentAssertions.Specs.Execution
                 .WithMessage("Expectations are the \"root\" of disappointment");
         }
 
+        [Fact]
+        public void When_no_identifier_can_be_resolved_replace_context_with_object()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .ForCondition(false)
+                .FailWith("Expected {context}");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected object");
+        }
+
+        [Fact]
+        public void When_no_identifier_can_be_resolved_replace_context_with_inline_declared_fallback_identifier()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .ForCondition(false)
+                .FailWith("Expected {context:fallback}");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected fallback");
+        }
+
+        [Fact]
+        public void When_no_identifier_can_be_resolved_replace_context_with_defined_default_identifier()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .WithDefaultIdentifier("identifier")
+                .ForCondition(false)
+                .FailWith("Expected {context}");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected identifier");
+        }
+
         #endregion
 
         #region Chaining API
@@ -913,6 +953,27 @@ namespace FluentAssertions.Specs.Execution
         }
 
         [Fact]
+        public void When_the_previous_assertion_failed_it_should_not_execute_the_succeeding_default_identifier()
+        {
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                Execute.Assertion
+                    .WithDefaultIdentifier("identifier")
+                    .ForCondition(false)
+                    .FailWith("Expected {context}")
+                    .Then
+                    .WithDefaultIdentifier("other")
+                    .FailWith("Expected {context}");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected identifier");
+        }
+
+        [Fact]
         public void When_the_previous_assertion_succeeded_it_should_evaluate_the_succeeding_given_statement()
         {
             // Act
@@ -958,6 +1019,26 @@ namespace FluentAssertions.Specs.Execution
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Assumptions are the \"root\" of all evil");
+        }
+
+        [Fact]
+        public void When_the_previous_assertion_succeeded_it_should_not_affect_the_succeeding_default_identifier()
+        {
+            // Act
+            Action act = () =>
+            {
+                Execute.Assertion
+                    .WithDefaultIdentifier("identifier")
+                    .ForCondition(true)
+                    .FailWith("Expected {context}")
+                    .Then
+                    .WithDefaultIdentifier("other")
+                    .FailWith("Expected {context}");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected other");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -737,6 +737,34 @@ namespace FluentAssertions.Specs.Execution
             deferredValueInvoked.Should().BeTrue();
         }
 
+        [Fact]
+        public void When_an_expectation_is_defined_it_should_be_preceeding_the_failure_message()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .WithExpectation("Expectations are the root ")
+                .ForCondition(false)
+                .FailWith("of disappointment");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expectations are the root of disappointment");
+        }
+
+        [Fact]
+        public void When_an_expectation_with_arguments_is_defined_it_should_be_preceeding_the_failure_message()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .WithExpectation("Expectations are the {0} ", "root")
+                .ForCondition(false)
+                .FailWith("of disappointment");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expectations are the \"root\" of disappointment");
+        }
+
         #endregion
 
         #region Chaining API
@@ -843,6 +871,48 @@ namespace FluentAssertions.Specs.Execution
         }
 
         [Fact]
+        public void When_the_previous_assertion_failed_it_should_not_execute_the_succeeding_expectation()
+        {
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                Execute.Assertion
+                    .WithExpectation("Expectations are the root ")
+                    .ForCondition(false)
+                    .FailWith("of disappointment")
+                    .Then
+                    .WithExpectation("Assumptions are the root ")
+                    .FailWith("of all evil");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expectations are the root of disappointment");
+        }
+
+        [Fact]
+        public void When_the_previous_assertion_failed_it_should_not_execute_the_succeeding_expectation_with_arguments()
+        {
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                Execute.Assertion
+                    .WithExpectation("Expectations are the {0} ", "root")
+                    .ForCondition(false)
+                    .FailWith("of disappointment")
+                    .Then
+                    .WithExpectation("Assumptions are the {0} ", "root")
+                    .FailWith("of all evil");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expectations are the \"root\" of disappointment");
+        }
+
+        [Fact]
         public void When_the_previous_assertion_succeeded_it_should_evaluate_the_succeeding_given_statement()
         {
             // Act
@@ -854,6 +924,40 @@ namespace FluentAssertions.Specs.Execution
 
             // Assert
             Assert.Throws<InvalidOperationException>(act);
+        }
+
+        [Fact]
+        public void When_the_previous_assertion_succeeded_it_should_not_affect_the_succeeding_expectation()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .WithExpectation("Expectations are the root ")
+                .ForCondition(true)
+                .FailWith("of disappointment")
+                .Then
+                .WithExpectation("Assumptions are the root ")
+                .FailWith("of all evil");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Assumptions are the root of all evil");
+        }
+
+        [Fact]
+        public void When_the_previous_assertion_succeeded_it_should_not_affect_the_succeeding_expectation_with_arguments()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .WithExpectation("Expectations are the {0} ", "root")
+                .ForCondition(true)
+                .FailWith("of disappointment")
+                .Then
+                .WithExpectation("Assumptions are the {0} ", "root")
+                .FailWith("of all evil");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Assumptions are the \"root\" of all evil");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -327,7 +327,7 @@ namespace FluentAssertions.Specs.Execution
         }
 
         [Fact]
-        public void When_an_assertion_fails_in_a_named_scope_it_should_use_the_name_as_the_assertion_context()
+        public void The_failure_message_should_use_the_name_of_the_scope_as_context()
         {
             // Act
             Action act = () =>
@@ -339,6 +339,21 @@ namespace FluentAssertions.Specs.Execution
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected foo to be equal to*");
+        }
+
+        [Fact]
+        public void The_failure_message_should_use_the_lazy_name_of_the_scope_as_context()
+        {
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope(new Lazy<string>(() => "lazy foo"));
+                new[] { 1, 2, 3 }.Should().Equal(3, 2, 1);
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected lazy foo to be equal to*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/AssertionScopeSpecs.cs
@@ -805,6 +805,32 @@ namespace FluentAssertions.Specs.Execution
                 .WithMessage("Expected identifier");
         }
 
+        [Fact]
+        public void The_failure_message_should_contain_the_reason()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .BecauseOf("because reasons")
+                .FailWith("Expected{reason}");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected because reasons");
+        }
+
+        [Fact]
+        public void The_failure_message_should_contain_the_reason_with_arguments()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .BecauseOf("because {0}", "reasons")
+                .FailWith("Expected{reason}");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected because reasons");
+        }
+
         #endregion
 
         #region Chaining API
@@ -878,6 +904,38 @@ namespace FluentAssertions.Specs.Execution
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Second \"assertion\"");
+        }
+
+        [Fact]
+        public void When_continuing_an_assertion_chain_the_reason_should_be_part_of_consecutive_failures()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .ForCondition(true)
+                .FailWith("First assertion")
+                .Then
+                .BecauseOf("because reasons")
+                .FailWith("Expected{reason}");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected because reasons");
+        }
+
+        [Fact]
+        public void When_continuing_an_assertion_chain_the_reason_with_arguments_should_be_part_of_consecutive_failures()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .ForCondition(true)
+                .FailWith("First assertion")
+                .Then
+                .BecauseOf("because {0}", "reasons")
+                .FailWith("Expected{reason}");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected because reasons");
         }
 
         [Fact]
@@ -1073,6 +1131,48 @@ namespace FluentAssertions.Specs.Execution
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected identifier");
+        }
+
+        [Fact]
+        public void When_continuing_a_failed_assertion_chain_consecutive_resons_are_ignored()
+        {
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                Execute.Assertion
+                    .BecauseOf("because {0}", "whatever")
+                    .ForCondition(false)
+                    .FailWith("Expected{reason}")
+                    .Then
+                    .BecauseOf("because reasons")
+                    .FailWith("Expected{reason}");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected because whatever");
+        }
+
+        [Fact]
+        public void When_continuing_a_failed_assertion_chain_consecutive_resons_with_arguments_are_ignored()
+        {
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                Execute.Assertion
+                    .BecauseOf("because {0}", "whatever")
+                    .ForCondition(false)
+                    .FailWith("Expected{reason}")
+                    .Then
+                    .BecauseOf("because {0}", "reasons")
+                    .FailWith("Expected{reason}");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expected because whatever");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Execution/GivenSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/GivenSelectorSpecs.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using FluentAssertions.Execution;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FluentAssertions.Specs.Execution
+{
+    public class GivenSelectorSpecs
+    {
+        [Fact]
+        public void A_consecutive_subject_should_be_selected()
+        {
+            // Arange
+            string value = string.Empty;
+
+            // Act
+            Execute.Assertion
+                .ForCondition(true)
+                .Given(() => "First selector")
+                .Given(_ => value = "Second selector");
+
+            // Assert
+            value.Should().Be("Second selector");
+        }
+
+        [Fact]
+        public void After_a_failed_condition_a_consecutive_subject_should_be_ignored()
+        {
+            // Arange
+            string value = string.Empty;
+
+            // Act
+            Execute.Assertion
+                .ForCondition(false)
+                .Given(() => "First selector")
+                .Given(_ => value = "Second selector");
+
+            // Assert
+            value.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void A_consecutive_condition_should_be_evaluated()
+        {
+            // Act / Assert
+            Execute.Assertion
+                .ForCondition(true)
+                .Given(() => "Subject")
+                .ForCondition(_ => true)
+                .FailWith("Failed");
+        }
+
+        [Fact]
+        public void After_a_failed_condition_a_consecutive_condition_should_be_ignored()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .ForCondition(false)
+                .Given(() => "Subject")
+                .ForCondition(_ => throw new ApplicationException())
+                .FailWith("Failed");
+
+            // Assert
+            act.Should().NotThrow<ApplicationException>();
+        }
+
+        [Fact]
+        public void When_continuing_an_assertion_chain_it_fails_with_a_message_after_selecting_the_subject()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .ForCondition(true)
+                .Given(() => "First")
+                .FailWith("First selector")
+                .Then
+                .Given(_ => "Second")
+                .FailWith("Second selector");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Second selector");
+        }
+
+        [Fact]
+        public void When_continuing_an_assertion_chain_it_fails_with_a_message_with_arguments_after_selecting_the_subject()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .ForCondition(true)
+                .Given(() => "First")
+                .FailWith("{0} selector", "First")
+                .Then
+                .Given(_ => "Second")
+                .FailWith("{0} selector", "Second");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("\"Second\" selector");
+        }
+
+        [Fact]
+        public void When_continuing_an_assertion_chain_it_fails_with_a_message_with_argument_selectors_after_selecting_the_subject()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .ForCondition(true)
+                .Given(() => "First")
+                .FailWith("{0} selector", _ => "First")
+                .Then
+                .Given(_ => "Second")
+                .FailWith("{0} selector", _ => "Second");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("\"Second\" selector");
+        }
+
+        [Fact]
+        public void When_continuing_a_failed_assertion_chain_consecutive_failure_messages_are_ignored()
+        {
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                Execute.Assertion
+                    .Given(() => "First")
+                    .FailWith("First selector")
+                    .Then
+                    .FailWith("Second selector");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("First selector");
+        }
+
+        [Fact]
+        public void When_continuing_a_failed_assertion_chain_consecutive_failure_messages_with_arguments_are_ignored()
+        {
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                Execute.Assertion
+                    .Given(() => "First")
+                    .FailWith("{0} selector", "First")
+                    .Then
+                    .FailWith("{0} selector", "Second");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("\"First\" selector");
+        }
+
+        [Fact]
+        public void When_continuing_a_failed_assertion_chain_consecutive_failure_messages_with_argument_selectors_are_ignored()
+        {
+            // Act
+            Action act = () =>
+            {
+                using var _ = new AssertionScope();
+                Execute.Assertion
+                    .Given(() => "First")
+                    .FailWith("{0} selector", _ => "First")
+                    .Then
+                    .FailWith("{0} selector", _ => "Second");
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("\"First\" selector");
+        }
+
+        [Fact]
+        public void The_failure_message_should_be_preceded_by_the_expectation_after_selecting_a_subject()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .WithExpectation("Expectation ")
+                .Given(() => "Subject")
+                .FailWith("Failure");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Expectation Failure");
+        }
+
+        [Fact]
+        public void The_failure_message_should_not_be_preceded_by_the_expectation_after_selecting_a_subject_and_clearing_the_expectation()
+        {
+            // Act
+            Action act = () => Execute.Assertion
+                .WithExpectation("Expectation ")
+                .Given(() => "Subject")
+                .ClearExpectation()
+                .Then
+                .FailWith("Failure");
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("Failure");
+        }
+    }
+}

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -17,6 +17,7 @@ Changes since 6.0.0 Beta 1
 **Fixes**
 * Added parameter checking for `Be(string)` for GuidAssertions - [#1597](https://github.com/fluentassertions/fluentassertions/pull/1597).
 * Improved consistency of XML documentation on `AssertionScope`, `ContinuedAssertionScope`, and `GivenSelector<T>` methods. - [#1606](https://github.com/fluentassertions/fluentassertions/pull/1606).
+* Handle `WithDefaultIdentifier` and `WithExpectation` correctly when an `AssertionScope` continues - [#1610](https://github.com/fluentassertions/fluentassertions/pull/1610).
 
 ## 6.0.0 Beta 1
 Changes since 6.0.0 Alpha 2


### PR DESCRIPTION
When digging into `AssertionScope` for #1596 I was missing a lot of specs to describe the expected behavior (hence #1599).

* Added specs for many methods/behaviors
* Fixed handling of `WithDefaultIdentifier` and `WithExpectation` after continuation

For the most recent commits I tried to follow [Making Better Unit Tests Part 2: Naming Unit Tests](https://codeburst.io/making-better-unit-tests-part-2-naming-unit-tests-8a7279c3ea4)
