### PR TITLE
Improved Stack Trace for Collection Comparison

### DIFF
--- a/Src/FluentAssertions/Common/ExceptionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExceptionExtensions.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 
 namespace FluentAssertions.Common
 {
     internal static class ExceptionExtensions
     {
-        public static Exception Unwrap(this TargetInvocationException exception)
+        public static ExceptionDispatchInfo Unwrap(this TargetInvocationException exception)
         {
             Exception result = exception;
             while (result is TargetInvocationException)
@@ -13,7 +14,7 @@ namespace FluentAssertions.Common
                 result = result.InnerException;
             }
 
-            return result;
+            return ExceptionDispatchInfo.Capture(result);
         }
     }
 }

--- a/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
@@ -49,7 +49,7 @@ namespace FluentAssertions.Equivalency.Steps
                 }
                 catch (TargetInvocationException e)
                 {
-                    throw e.Unwrap();
+                    e.Unwrap().Throw();
                 }
             }
 

--- a/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
@@ -190,6 +190,13 @@ namespace FluentAssertions.Specs.Equivalency
             }
         }
 
+        public class ExceptionThrowingClass
+        {
+#pragma warning disable CA1065 // this is for testing purposes.
+            public object ExceptionThrowingProperty => throw new NotImplementedException();
+#pragma warning restore CA1065
+        }
+
         [Fact]
         public void When_the_expectation_is_an_array_of_interface_type_it_should_respect_declared_types()
         {
@@ -2791,6 +2798,22 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void When_an_exception_is_thrown_during_data_access_the_stack_trace_contains_the_original_site()
+        {
+            // Arrange
+            var genericCollectionA = new List<ExceptionThrowingClass>() { new ExceptionThrowingClass() };
+            var genericCollectionB = new List<ExceptionThrowingClass>() { new ExceptionThrowingClass() };
+
+            var expectedTargetSite = typeof(ExceptionThrowingClass).GetProperty(nameof(ExceptionThrowingClass.ExceptionThrowingProperty)).GetMethod;
+
+            // Act
+            Action act = () => genericCollectionA.Should().BeEquivalentTo(genericCollectionB);
+
+            // Assert
+            act.Should().Throw<NotImplementedException>().And.TargetSite.Should().Be(expectedTargetSite);
         }
 
         public static IEnumerable<object[]> ArrayTestData()

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -18,6 +18,7 @@ Changes since 6.0.0 Beta 1
 * Added parameter checking for `Be(string)` for GuidAssertions - [#1597](https://github.com/fluentassertions/fluentassertions/pull/1597).
 * Improved consistency of XML documentation on `AssertionScope`, `ContinuedAssertionScope`, and `GivenSelector<T>` methods. - [#1606](https://github.com/fluentassertions/fluentassertions/pull/1606).
 * Handle `WithDefaultIdentifier` and `WithExpectation` correctly when an `AssertionScope` continues - [#1610](https://github.com/fluentassertions/fluentassertions/pull/1610).
+* Improved stack trace when a property of an element of a generic collection throws an exception during `GenericEnumerableEquivalencyStep` in `GenericCollectionAssertions` - [#1615](https://github.com/fluentassertions/fluentassertions/pull/1615).
 
 ## 6.0.0 Beta 1
 Changes since 6.0.0 Alpha 2


### PR DESCRIPTION
This fixes #1613.

When an instance to compare throws an exception during the invocation of the HandleMethod in the Handle method of GenericEnumerableEquivalencyStep, the TargetInvocationException is unwrapped (to give the innermost exception) and rethrown. This previously lead to a wrong stack trace that would indicate, that something is wrong in GenericEnumerableEquivalencyStep.

The first commit provides a test that shows this.

The second commit fixes it by using ExceptionDispatchInfo to capture the stack trace. Since the class ExceptionExtensions is internal, the signature change of the Unwrap method is not changing the public API.

If you do not like the change of the method signature, there is a hack to keep it.

I read that I should add this fix to the release notes. In this branch or another branch?