### PR TITLE
#645 Add non generic methods for TypeSelector

### DIFF
--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -25,6 +25,11 @@ namespace FluentAssertions.Common
             return type.IsDefined(typeof(TAttribute), inherit: false);
         }
 
+        public static bool IsDecoratedWith(this Type type, Type attribute)
+        {
+            return type.IsDefined(attribute, inherit: false);
+        }
+
         public static bool IsDecoratedWith<TAttribute>(this MemberInfo type)
             where TAttribute : Attribute
         {
@@ -38,6 +43,11 @@ namespace FluentAssertions.Common
             where TAttribute : Attribute
         {
             return type.IsDefined(typeof(TAttribute), inherit: true);
+        }
+
+        public static bool IsDecoratedWithOrInherit(this Type type, Type attribute)
+        {
+            return type.IsDefined(attribute, inherit: true);
         }
 
         public static bool IsDecoratedWithOrInherit<TAttribute>(this MemberInfo type)

--- a/Src/FluentAssertions/Types/TypeSelector.cs
+++ b/Src/FluentAssertions/Types/TypeSelector.cs
@@ -40,8 +40,7 @@ namespace FluentAssertions.Types
         /// </summary>
         public TypeSelector ThatDeriveFrom<TBase>()
         {
-            types = types.Where(type => type.IsSubclassOf(typeof(TBase))).ToList();
-            return this;
+            return ThatDeriveFrom(typeof(TBase));
         }
 
         /// <summary>
@@ -49,8 +48,7 @@ namespace FluentAssertions.Types
         /// </summary>
         public TypeSelector ThatDoNotDeriveFrom<TBase>()
         {
-            types = types.Where(type => !type.IsSubclassOf(typeof(TBase))).ToList();
-            return this;
+            return ThatDoNotDeriveFrom(typeof(TBase));
         }
 
         /// <summary>
@@ -58,11 +56,7 @@ namespace FluentAssertions.Types
         /// </summary>
         public TypeSelector ThatImplement<TInterface>()
         {
-            types = types
-                .Where(t => typeof(TInterface).IsAssignableFrom(t) && (t != typeof(TInterface)))
-                .ToList();
-
-            return this;
+            return ThatImplement(typeof(TInterface));
         }
 
         /// <summary>
@@ -70,11 +64,7 @@ namespace FluentAssertions.Types
         /// </summary>
         public TypeSelector ThatDoNotImplement<TInterface>()
         {
-            types = types
-                .Where(t => !typeof(TInterface).IsAssignableFrom(t) && (t != typeof(TInterface)))
-                .ToList();
-
-            return this;
+            return ThatDoNotImplement(typeof(TInterface));
         }
 
         /// <summary>
@@ -83,11 +73,7 @@ namespace FluentAssertions.Types
         public TypeSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : Attribute
         {
-            types = types
-                .Where(t => t.IsDecoratedWith<TAttribute>())
-                .ToList();
-
-            return this;
+            return ThatAreDecoratedWith(typeof(TAttribute));
         }
 
         /// <summary>
@@ -96,11 +82,7 @@ namespace FluentAssertions.Types
         public TypeSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : Attribute
         {
-            types = types
-                .Where(t => t.IsDecoratedWithOrInherit<TAttribute>())
-                .ToList();
-
-            return this;
+            return ThatAreDecoratedWithOrInherit(typeof(TAttribute));
         }
 
         /// <summary>
@@ -109,11 +91,7 @@ namespace FluentAssertions.Types
         public TypeSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : Attribute
         {
-            types = types
-                .Where(t => !t.IsDecoratedWith<TAttribute>())
-                .ToList();
-
-            return this;
+            return ThatAreNotDecoratedWith(typeof(TAttribute));
         }
 
         /// <summary>
@@ -122,8 +100,94 @@ namespace FluentAssertions.Types
         public TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : Attribute
         {
+            return ThatAreNotDecoratedWithOrInherit(typeof(TAttribute));
+        }
+
+        /// <summary>
+        /// Determines whether a type is a subclass of another type, but NOT the same type.
+        /// </summary>
+        public TypeSelector ThatDeriveFrom(Type baseType)
+        {
+            types = types.Where(type => type.IsSubclassOf(baseType)).ToList();
+            return this;
+        }
+
+        /// <summary>
+        /// Determines whether a type is not a subclass of another type.
+        /// </summary>
+        public TypeSelector ThatDoNotDeriveFrom(Type baseType)
+        {
+            types = types.Where(type => !type.IsSubclassOf(baseType)).ToList();
+            return this;
+        }
+
+        /// <summary>
+        /// Determines whether a type implements an interface (but is not the interface itself).
+        /// </summary>
+        public TypeSelector ThatImplement(Type interfaceType)
+        {
             types = types
-                .Where(t => !t.IsDecoratedWithOrInherit<TAttribute>())
+                .Where(t => interfaceType.IsAssignableFrom(t) && (t != interfaceType))
+                .ToList();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Determines whether a type does not implement an interface (but is not the interface itself).
+        /// </summary>
+        public TypeSelector ThatDoNotImplement(Type interfaceType)
+        {
+            types = types
+                .Where(t => !interfaceType.IsAssignableFrom(t) && (t != interfaceType))
+                .ToList();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Determines whether a type is decorated with a particular attribute.
+        /// </summary>
+        public TypeSelector ThatAreDecoratedWith(Type attribute)
+        {
+            types = types
+                .Where(t => t.IsDecoratedWith(attribute))
+                .ToList();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Determines whether a type is decorated with, or inherits from a parent class, a particular attribute.
+        /// </summary>
+        public TypeSelector ThatAreDecoratedWithOrInherit(Type attribute)
+        {
+            types = types
+                .Where(t => t.IsDecoratedWithOrInherit(attribute))
+                .ToList();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Determines whether a type is not decorated with a particular attribute.
+        /// </summary>
+        public TypeSelector ThatAreNotDecoratedWith(Type attribute)
+        {
+            types = types
+                .Where(t => !t.IsDecoratedWith(attribute))
+                .ToList();
+
+            return this;
+        }
+
+        /// <summary>
+        /// Determines whether a type is not decorated with and does not inherit from a parent class, a particular attribute.
+        /// </summary>
+        public TypeSelector ThatAreNotDecoratedWithOrInherit(Type attribute)
+        {
+            types = types
+                .Where(t => !t.IsDecoratedWithOrInherit(attribute))
                 .ToList();
 
             return this;

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2431,14 +2431,18 @@ namespace FluentAssertions.Types
         public TypeSelector(System.Type type) { }
         public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
         public FluentAssertions.Types.TypeSelector ThatAreClasses() { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.TypeSelector ThatAreInNamespace(string @namespace) { }
         public FluentAssertions.Types.TypeSelector ThatAreNotClasses() { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
@@ -2446,9 +2450,13 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
         public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatDeriveFrom(System.Type baseType) { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom(System.Type baseType) { }
         public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotImplement(System.Type interfaceType) { }
         public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatImplement(System.Type interfaceType) { }
         public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
         public FluentAssertions.Types.TypeSelector ThatSatisfy(System.Func<System.Type, bool> predicate) { }
         public System.Type[] ToArray() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -2433,14 +2433,18 @@ namespace FluentAssertions.Types
         public TypeSelector(System.Type type) { }
         public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
         public FluentAssertions.Types.TypeSelector ThatAreClasses() { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.TypeSelector ThatAreInNamespace(string @namespace) { }
         public FluentAssertions.Types.TypeSelector ThatAreNotClasses() { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
@@ -2448,9 +2452,13 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
         public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatDeriveFrom(System.Type baseType) { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom(System.Type baseType) { }
         public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotImplement(System.Type interfaceType) { }
         public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatImplement(System.Type interfaceType) { }
         public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
         public FluentAssertions.Types.TypeSelector ThatSatisfy(System.Func<System.Type, bool> predicate) { }
         public System.Type[] ToArray() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -2433,14 +2433,18 @@ namespace FluentAssertions.Types
         public TypeSelector(System.Type type) { }
         public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
         public FluentAssertions.Types.TypeSelector ThatAreClasses() { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.TypeSelector ThatAreInNamespace(string @namespace) { }
         public FluentAssertions.Types.TypeSelector ThatAreNotClasses() { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
@@ -2448,9 +2452,13 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
         public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatDeriveFrom(System.Type baseType) { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom(System.Type baseType) { }
         public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotImplement(System.Type interfaceType) { }
         public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatImplement(System.Type interfaceType) { }
         public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
         public FluentAssertions.Types.TypeSelector ThatSatisfy(System.Func<System.Type, bool> predicate) { }
         public System.Type[] ToArray() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2384,14 +2384,18 @@ namespace FluentAssertions.Types
         public TypeSelector(System.Type type) { }
         public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
         public FluentAssertions.Types.TypeSelector ThatAreClasses() { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.TypeSelector ThatAreInNamespace(string @namespace) { }
         public FluentAssertions.Types.TypeSelector ThatAreNotClasses() { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
@@ -2399,9 +2403,13 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
         public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatDeriveFrom(System.Type baseType) { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom(System.Type baseType) { }
         public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotImplement(System.Type interfaceType) { }
         public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatImplement(System.Type interfaceType) { }
         public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
         public FluentAssertions.Types.TypeSelector ThatSatisfy(System.Func<System.Type, bool> predicate) { }
         public System.Type[] ToArray() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2433,14 +2433,18 @@ namespace FluentAssertions.Types
         public TypeSelector(System.Type type) { }
         public System.Collections.Generic.IEnumerator<System.Type> GetEnumerator() { }
         public FluentAssertions.Types.TypeSelector ThatAreClasses() { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.TypeSelector ThatAreInNamespace(string @namespace) { }
         public FluentAssertions.Types.TypeSelector ThatAreNotClasses() { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit(System.Type attribute) { }
         public FluentAssertions.Types.TypeSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.TypeSelector ThatAreNotInNamespace(string @namespace) { }
@@ -2448,9 +2452,13 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.TypeSelector ThatAreNotUnderNamespace(string @namespace) { }
         public FluentAssertions.Types.TypeSelector ThatAreStatic() { }
         public FluentAssertions.Types.TypeSelector ThatAreUnderNamespace(string @namespace) { }
+        public FluentAssertions.Types.TypeSelector ThatDeriveFrom(System.Type baseType) { }
         public FluentAssertions.Types.TypeSelector ThatDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom(System.Type baseType) { }
         public FluentAssertions.Types.TypeSelector ThatDoNotDeriveFrom<TBase>() { }
+        public FluentAssertions.Types.TypeSelector ThatDoNotImplement(System.Type interfaceType) { }
         public FluentAssertions.Types.TypeSelector ThatDoNotImplement<TInterface>() { }
+        public FluentAssertions.Types.TypeSelector ThatImplement(System.Type interfaceType) { }
         public FluentAssertions.Types.TypeSelector ThatImplement<TInterface>() { }
         public FluentAssertions.Types.TypeSelector ThatSatisfy(System.Func<System.Type, bool> predicate) { }
         public System.Type[] ToArray() { }


### PR DESCRIPTION
Sometimes it is convenient to wrap the templated code for tests in theory, I use for example the method `typeof(Startup).Assembly.Types().ThatImplement<IMessageHandler>()`, which does not allow me to use `InlineDataAttribute` for the test method.

I would like to get an output code of the form:
```
[Theory]
[InlineData(typeof(IMessageHandler))]
public void SimplifiedExampleTest(Type implementType)
{
var types = typeof(Startup).Assembly.Types().ThatImplement(implementType);

types.Should().BeEmpty();
```

+ public TypeSelector ThatImplement(Type interfaceType)
+ public TypeSelector ThatDoNotImplement(Type interfaceType)
+ public TypeSelector ThatAreDecoratedWith(Type attribute)
+ public TypeSelector ThatAreDecoratedWithOrInherit(Type attribute)
+ public TypeSelector ThatAreNotDecoratedWith(Type attribute)
+ public TypeSelector ThatAreNotDecoratedWithOrInherit(Type attribute)

## IMPORTANT 

* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).