### PR TITLE
Homogenize predicate formatting

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -674,7 +674,7 @@ namespace FluentAssertions.Collections
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to contain {0}{reason}, but found {1}.", predicate.Body, Subject);
+                    .FailWith("Expected {context:collection} to contain {0}{reason}, but found {1}.", predicate, Subject);
             }
 
             Func<T, bool> func = predicate.Compile();
@@ -682,7 +682,7 @@ namespace FluentAssertions.Collections
             Execute.Assertion
                 .ForCondition(Subject.Any(func))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:collection} {0} to have an item matching {1}{reason}.", Subject, predicate.Body);
+                .FailWith("Expected {context:collection} {0} to have an item matching {1}{reason}.", Subject, predicate);
 
             return new AndWhichConstraint<TAssertions, T>((TAssertions)this, Subject.Where(func));
         }
@@ -2257,7 +2257,7 @@ namespace FluentAssertions.Collections
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} not to contain <null>s on {0}{reason}, but found {1}.",
-                        predicate.Body,
+                        predicate,
                         values);
             }
 
@@ -2545,7 +2545,7 @@ namespace FluentAssertions.Collections
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:collection} to only have unique items on {0}{reason}, but items {1} are not unique.",
-                            predicate.Body,
+                            predicate,
                             groupWithMultipleItems.SelectMany(g => g));
                 }
                 else
@@ -2553,7 +2553,7 @@ namespace FluentAssertions.Collections
                     Execute.Assertion
                         .BecauseOf(because, becauseArgs)
                         .FailWith("Expected {context:collection} to only have unique items on {0}{reason}, but item {1} is not unique.",
-                            predicate.Body,
+                            predicate,
                             groupWithMultipleItems[0].First());
                 }
             }

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -992,14 +992,14 @@ namespace FluentAssertions.Collections
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith(expectationPrefix + "but found {1}.", predicate.Body, Subject);
+                    .FailWith(expectationPrefix + "but found {1}.", predicate, Subject);
             }
 
             ICollection<T> actualItems = Subject.ConvertOrCastToCollection();
             Execute.Assertion
                 .ForCondition(actualItems.Any())
                 .BecauseOf(because, becauseArgs)
-                .FailWith(expectationPrefix + "but the collection is empty.", predicate.Body);
+                .FailWith(expectationPrefix + "but the collection is empty.", predicate);
 
             T[] matchingElements = actualItems.Where(predicate.Compile()).ToArray();
             int count = matchingElements.Length;
@@ -1007,13 +1007,13 @@ namespace FluentAssertions.Collections
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith(expectationPrefix + "but no such item was found.", predicate.Body);
+                    .FailWith(expectationPrefix + "but no such item was found.", predicate);
             }
             else if (count > 1)
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith(expectationPrefix + "but " + count.ToString(CultureInfo.InvariantCulture) + " such items were found.", predicate.Body);
+                    .FailWith(expectationPrefix + "but " + count.ToString(CultureInfo.InvariantCulture) + " such items were found.", predicate);
             }
             else
             {
@@ -1193,7 +1193,7 @@ namespace FluentAssertions.Collections
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} to contain {0} items{reason}, but found {1}.", countPredicate.Body, Subject);
+                    .FailWith("Expected {context:collection} to contain {0} items{reason}, but found {1}.", countPredicate, Subject);
             }
 
             Func<int, bool> compiledPredicate = countPredicate.Compile();
@@ -1205,7 +1205,7 @@ namespace FluentAssertions.Collections
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} {0} to have a count {1}{reason}, but count is {2}.",
-                        Subject, countPredicate.Body, actualCount);
+                        Subject, countPredicate, actualCount);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -1956,7 +1956,7 @@ namespace FluentAssertions.Collections
             {
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
-                    .FailWith("Expected {context:collection} not to contain {0}{reason}, but found {1}.", predicate.Body, Subject);
+                    .FailWith("Expected {context:collection} not to contain {0}{reason}, but found {1}.", predicate, Subject);
             }
 
             Func<T, bool> compiledPredicate = predicate.Compile();
@@ -1967,7 +1967,7 @@ namespace FluentAssertions.Collections
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} {0} to not have any items matching {1}{reason}, but found {2}.",
-                        Subject, predicate.Body, unexpectedItems);
+                        Subject, predicate, unexpectedItems);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);
@@ -2495,7 +2495,7 @@ namespace FluentAssertions.Collections
                 .ForCondition(collection.Any())
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected {context:collection} to contain only items matching {0}{reason}, but the collection is empty.",
-                    predicate.Body);
+                    predicate);
 
             IEnumerable<T> mismatchingItems = collection.Where(item => !compiledPredicate(item));
             if (mismatchingItems.Any())
@@ -2503,7 +2503,7 @@ namespace FluentAssertions.Collections
                 Execute.Assertion
                     .BecauseOf(because, becauseArgs)
                     .FailWith("Expected {context:collection} to contain only items matching {0}{reason}, but {1} do(es) not match.",
-                        predicate.Body, mismatchingItems);
+                        predicate, mismatchingItems);
             }
 
             return new AndConstraint<TAssertions>((TAssertions)this);

--- a/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -10,7 +10,7 @@ namespace FluentAssertions.Formatting
     /// </summary>
     public class PredicateLambdaExpressionValueFormatter : IValueFormatter
     {
-        public bool CanHandle(object value) => value is LambdaExpression lambdaExpression && lambdaExpression.ReturnType == typeof(bool);
+        public bool CanHandle(object value) => value is LambdaExpression lambdaExpression;
 
         public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
         {

--- a/Src/FluentAssertions/Numeric/NullableNumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NullableNumericAssertions.cs
@@ -120,7 +120,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(predicate.Compile()(Subject))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected value to match {0}{reason}, but found {1}.", predicate.Body, Subject);
+                .FailWith("Expected value to match {0}{reason}, but found {1}.", predicate, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -434,7 +434,7 @@ namespace FluentAssertions.Numeric
             Execute.Assertion
                 .ForCondition(predicate.Compile()((T)SubjectInternal))
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to match {0}{reason}, but found {1}.", predicate.Body, SubjectInternal);
+                .FailWith("Expected {context:value} to match {0}{reason}, but found {1}.", predicate, SubjectInternal);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ReferenceTypeAssertions.cs
@@ -398,7 +398,7 @@ namespace FluentAssertions.Primitives
                 .ForCondition(predicate.Compile()((T)Subject))
                 .BecauseOf(because, becauseArgs)
                 .WithDefaultIdentifier(Identifier)
-                .FailWith("Expected {context:object} to match {1}{reason}, but found {0}.", Subject, predicate.Body);
+                .FailWith("Expected {context:object} to match {1}{reason}, but found {0}.", Subject, predicate);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }

--- a/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExceptionAssertions.cs
@@ -186,7 +186,7 @@ namespace FluentAssertions.Specialized
                 .ForCondition(condition(SingleSubject))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Expected exception where {0}{reason}, but the condition was not met by:{1}{1}{2}.",
-                    exceptionExpression.Body, Environment.NewLine, Subject);
+                    exceptionExpression, Environment.NewLine, Subject);
 
             return this;
         }

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -269,7 +269,7 @@ namespace FluentAssertions.Types
                 .ForCondition(attributes.Any())
                 .FailWith(
                     "Expected type {0} to be decorated with {1} that matches {2}{reason}, but no matching attribute was found.",
-                    Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
+                    Subject, typeof(TAttribute), isMatchingAttributePredicate);
 
             return new AndWhichConstraint<TypeAssertions, TAttribute>(this, attributes);
         }
@@ -328,7 +328,7 @@ namespace FluentAssertions.Types
                 .ForCondition(attributes.Any())
                 .FailWith(
                     "Expected type {0} to be decorated with or inherit {1} that matches {2}{reason}" +
-                    ", but no matching attribute was found.", Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
+                    ", but no matching attribute was found.", Subject, typeof(TAttribute), isMatchingAttributePredicate);
 
             return new AndWhichConstraint<TypeAssertions, TAttribute>(this, attributes);
         }
@@ -380,7 +380,7 @@ namespace FluentAssertions.Types
                 .ForCondition(!Subject.IsDecoratedWith(isMatchingAttributePredicate))
                 .FailWith(
                     "Expected type {0} to not be decorated with {1} that matches {2}{reason}, but a matching attribute was found.",
-                    Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
+                    Subject, typeof(TAttribute), isMatchingAttributePredicate);
 
             return new AndConstraint<TypeAssertions>(this);
         }
@@ -435,7 +435,7 @@ namespace FluentAssertions.Types
                 .ForCondition(!Subject.IsDecoratedWithOrInherit(isMatchingAttributePredicate))
                 .FailWith(
                     "Expected type {0} to not be decorated with or inherit {1} that matches {2}{reason}" +
-                    ", but a matching attribute was found.", Subject, typeof(TAttribute), isMatchingAttributePredicate.Body);
+                    ", but a matching attribute was found.", Subject, typeof(TAttribute), isMatchingAttributePredicate);
 
             return new AndConstraint<TypeAssertions>(this);
         }

--- a/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeSelectorAssertions.cs
@@ -90,7 +90,7 @@ namespace FluentAssertions.Types
                 .FailWith("Expected all types to be decorated with {0} that matches {1}{reason}," +
                     " but no matching attribute was found on the following types:{2}{3}.",
                     typeof(TAttribute),
-                    isMatchingAttributePredicate.Body,
+                    isMatchingAttributePredicate,
                     Environment.NewLine,
                     GetDescriptionsFor(typesWithoutMatchingAttribute));
 
@@ -156,7 +156,7 @@ namespace FluentAssertions.Types
                 .FailWith("Expected all types to be decorated with or inherit {0} that matches {1}{reason}," +
                     " but no matching attribute was found on the following types:{2}{3}.",
                     typeof(TAttribute),
-                    isMatchingAttributePredicate.Body,
+                    isMatchingAttributePredicate,
                     Environment.NewLine,
                     GetDescriptionsFor(typesWithoutMatchingAttribute));
 
@@ -222,7 +222,7 @@ namespace FluentAssertions.Types
                 .FailWith("Expected all types to not be decorated with {0} that matches {1}{reason}," +
                     " but a matching attribute was found on the following types:{2}{3}.",
                     typeof(TAttribute),
-                    isMatchingAttributePredicate.Body,
+                    isMatchingAttributePredicate,
                     Environment.NewLine,
                     GetDescriptionsFor(typesWithMatchingAttribute));
 
@@ -288,7 +288,7 @@ namespace FluentAssertions.Types
                 .FailWith("Expected all types to not be decorated with or inherit {0} that matches {1}{reason}," +
                     " but a matching attribute was found on the following types:{2}{3}.",
                     typeof(TAttribute),
-                    isMatchingAttributePredicate.Body,
+                    isMatchingAttributePredicate,
                     Environment.NewLine,
                     GetDescriptionsFor(typesWithMatchingAttribute));
 

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
@@ -318,14 +318,15 @@ namespace FluentAssertions.Specs.Collections
         {
             // Arrange
             IEnumerable<int> collection = Enumerable.Empty<int>();
-            Expression<Func<int, bool>> expression = item => item == 2;
+            var targetValue = 2;
+            Expression<Func<int, bool>> expression = item => item == targetValue;
 
             // Act
             Action act = () => collection.Should().ContainSingle(expression);
 
             // Assert
             string expectedMessage =
-                $"Expected collection to contain a single item matching {expression.Body}, but the collection is empty.";
+                $"Expected collection to contain a single item matching (item == 2), but the collection is empty.";
 
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }
@@ -335,14 +336,15 @@ namespace FluentAssertions.Specs.Collections
         {
             // Arrange
             const IEnumerable<int> collection = null;
-            Expression<Func<int, bool>> expression = item => item == 2;
+            var targetValue = 2;
+            Expression<Func<int, bool>> expression = item => item == targetValue;
 
             // Act
             Action act = () => collection.Should().ContainSingle(expression);
 
             // Assert
             string expectedMessage =
-                $"Expected collection to contain a single item matching {expression.Body}, but found <null>.";
+                $"Expected collection to contain a single item matching (item == 2), but found <null>.";
 
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }
@@ -352,14 +354,15 @@ namespace FluentAssertions.Specs.Collections
         {
             // Arrange
             IEnumerable<int> collection = new[] { 1, 3 };
-            Expression<Func<int, bool>> expression = item => item == 2;
+            var targetValue = 2;
+            Expression<Func<int, bool>> expression = item => item == targetValue;
 
             // Act
             Action act = () => collection.Should().ContainSingle(expression);
 
             // Assert
             string expectedMessage =
-                $"Expected collection to contain a single item matching {expression.Body}, but no such item was found.";
+                $"Expected collection to contain a single item matching (item == 2), but no such item was found.";
 
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }
@@ -369,14 +372,15 @@ namespace FluentAssertions.Specs.Collections
         {
             // Arrange
             IEnumerable<int> collection = new[] { 1, 2, 2, 2, 3 };
-            Expression<Func<int, bool>> expression = item => item == 2;
+            var targetValue = 2;
+            Expression<Func<int, bool>> expression = item => item == targetValue;
 
             // Act
             Action act = () => collection.Should().ContainSingle(expression);
 
             // Assert
             string expectedMessage =
-                $"Expected collection to contain a single item matching {expression.Body}, but 3 such items were found.";
+                $"Expected collection to contain a single item matching (item == 2), but 3 such items were found.";
 
             act.Should().Throw<XunitException>().WithMessage(expectedMessage);
         }

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
@@ -318,8 +318,7 @@ namespace FluentAssertions.Specs.Collections
         {
             // Arrange
             IEnumerable<int> collection = Enumerable.Empty<int>();
-            var targetValue = 2;
-            Expression<Func<int, bool>> expression = item => item == targetValue;
+            Expression<Func<int, bool>> expression = item => item == 2;
 
             // Act
             Action act = () => collection.Should().ContainSingle(expression);
@@ -336,8 +335,7 @@ namespace FluentAssertions.Specs.Collections
         {
             // Arrange
             const IEnumerable<int> collection = null;
-            var targetValue = 2;
-            Expression<Func<int, bool>> expression = item => item == targetValue;
+            Expression<Func<int, bool>> expression = item => item == 2;
 
             // Act
             Action act = () => collection.Should().ContainSingle(expression);
@@ -354,8 +352,7 @@ namespace FluentAssertions.Specs.Collections
         {
             // Arrange
             IEnumerable<int> collection = new[] { 1, 3 };
-            var targetValue = 2;
-            Expression<Func<int, bool>> expression = item => item == targetValue;
+            Expression<Func<int, bool>> expression = item => item == 2;
 
             // Act
             Action act = () => collection.Should().ContainSingle(expression);
@@ -372,8 +369,7 @@ namespace FluentAssertions.Specs.Collections
         {
             // Arrange
             IEnumerable<int> collection = new[] { 1, 2, 2, 2, 3 };
-            var targetValue = 2;
-            Expression<Func<int, bool>> expression = item => item == targetValue;
+            Expression<Func<int, bool>> expression = item => item == 2;
 
             // Act
             Action act = () => collection.Should().ContainSingle(expression);

--- a/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericCollectionAssertionsSpecs.cs
@@ -419,7 +419,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection to contain a single item matching (item == Format(\"{0}\", Convert(123*))), but no such item was found.");
+                "Expected collection to contain a single item matching (item == \"123\"), but no such item was found.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeDecoratedWith.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeDecoratedWith.cs
@@ -118,7 +118,7 @@ namespace FluentAssertions.Specs.Types
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected type *.ClassWithAttribute to be decorated with *.DummyClassAttribute that matches " +
-                    "((a.Name == \"Unexpected\")*a.IsEnabled), but no matching attribute was found.");
+                    "(a.Name == \"Unexpected\")*a.IsEnabled, but no matching attribute was found.");
         }
 
         #endregion
@@ -201,7 +201,7 @@ namespace FluentAssertions.Specs.Types
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected type *.ClassWithAttribute to not be decorated with *.DummyClassAttribute that matches " +
-                    "((a.Name == \"Expected\") * a.IsEnabled), but a matching attribute was found.");
+                    "(a.Name == \"Expected\") * a.IsEnabled, but a matching attribute was found.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeDecoratedWithOrInherit.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeAssertionSpecs.BeDecoratedWithOrInherit.cs
@@ -118,7 +118,7 @@ namespace FluentAssertions.Specs.Types
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected type *.ClassWithInheritedAttribute to be decorated with or inherit *.DummyClassAttribute " +
-                    "that matches ((a.Name == \"Unexpected\")*a.IsEnabled), but no matching attribute was found.");
+                    "that matches (a.Name == \"Unexpected\")*a.IsEnabled, but no matching attribute was found.");
         }
 
         #endregion
@@ -202,7 +202,7 @@ namespace FluentAssertions.Specs.Types
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected type *.ClassWithInheritedAttribute to not be decorated with or inherit *.DummyClassAttribute " +
-                    "that matches ((a.Name == \"Expected\") * a.IsEnabled), but a matching attribute was found.");
+                    "that matches (a.Name == \"Expected\") * a.IsEnabled, but a matching attribute was found.");
         }
 
         #endregion

--- a/Tests/FluentAssertions.Specs/Types/TypeSelectorAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/TypeSelectorAssertionSpecs.cs
@@ -159,7 +159,7 @@ namespace FluentAssertions.Specs.Types
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected all types to be decorated with *.DummyClassAttribute that matches " +
-                    "((a.Name == \"Expected\") * a.IsEnabled) *failure message*, but no matching attribute was found on " +
+                    "(a.Name == \"Expected\") * a.IsEnabled *failure message*, but no matching attribute was found on " +
                     "the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
         }
 
@@ -244,7 +244,7 @@ namespace FluentAssertions.Specs.Types
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected all types to be decorated with or inherit *.DummyClassAttribute that matches " +
-                    "((a.Name == \"Expected\")*a.IsEnabled) *failure message*, but no matching attribute was found " +
+                    "(a.Name == \"Expected\")*a.IsEnabled *failure message*, but no matching attribute was found " +
                     "on the following types:*\"*.ClassWithoutAttribute*.OtherClassWithoutAttribute\".");
         }
 
@@ -326,7 +326,7 @@ namespace FluentAssertions.Specs.Types
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected all types to not be decorated with *.DummyClassAttribute that matches " +
-                    "((a.Name == \"Expected\") * a.IsEnabled) *failure message*, but a matching attribute was found " +
+                    "(a.Name == \"Expected\") * a.IsEnabled *failure message*, but a matching attribute was found " +
                     "on the following types:*\"*.ClassWithAttribute\".");
         }
 
@@ -388,7 +388,7 @@ namespace FluentAssertions.Specs.Types
             act.Should().Throw<XunitException>()
                 .WithMessage(
                     "Expected all types to not be decorated with or inherit *.DummyClassAttribute that matches " +
-                    "((a.Name == \"Expected\") * a.IsEnabled) *failure message*, but a matching attribute was found " +
+                    "(a.Name == \"Expected\") * a.IsEnabled *failure message*, but a matching attribute was found " +
                     "on the following types:*\"*.ClassWithInheritedAttribute\".");
         }
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,6 +11,7 @@ sidebar:
 Changes since 6.0.0 Alpha 2
 
 **What's New**
+* Homegenized assertion message formatting of predicate expressions - [#1619](https://github.com/fluentassertions/fluentassertions/pull/1619).
 * Added `WithParameterName` extension to ease asserting on the parameter name for a thrown `ArgumentException` - [#1466](https://github.com/fluentassertions/fluentassertions/pull/1466).
 * Added `NotCompleteWithinAsync` to `TaskCompletionSourceAssertions` - [#1474](https://github.com/fluentassertions/fluentassertions/pull/1474).
 * Added `HaveValue(decimal)`, `HaveSameValueAs` and `HaveSameNameAs` to `EnumAssertions` - [#1479](https://github.com/fluentassertions/fluentassertions/pull/1479).

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,7 +11,7 @@ sidebar:
 Changes since 6.0.0 Alpha 2
 
 **What's New**
-* Homegenized assertion message formatting of predicate expressions - [#1619](https://github.com/fluentassertions/fluentassertions/pull/1619).
+* Homogenized assertion message formatting of predicate expressions - [#1619](https://github.com/fluentassertions/fluentassertions/pull/1619).
 * Added `WithParameterName` extension to ease asserting on the parameter name for a thrown `ArgumentException` - [#1466](https://github.com/fluentassertions/fluentassertions/pull/1466).
 * Added `NotCompleteWithinAsync` to `TaskCompletionSourceAssertions` - [#1474](https://github.com/fluentassertions/fluentassertions/pull/1474).
 * Added `HaveValue(decimal)`, `HaveSameValueAs` and `HaveSameNameAs` to `EnumAssertions` - [#1479](https://github.com/fluentassertions/fluentassertions/pull/1479).


### PR DESCRIPTION
Many predicate assertions uses `predicate.Body` to format their messages, thereby circumventing the formatting offered by `PredicateLambdaExpressionValueFormatter`.  More specifically, it's the part which resolves constant values which is sorely missing, e.g when using `collection.Should().Contain(x => x.Name == expectedName && x.Value == expectedValue)`.

This could be fixed by adding a new formatter or modifying the existing, but I think it makes more sense to provide the full lambda to the formatter.

Possible additions would be:

1. Include the lambda parameter part in the output. 
2. ...or removing it when possible, outputting `Name == "Expected"` instead of `a.Name == "Expected"`
3. ...and/or renaming the lambda parameter, e.g so that its always named "item", when used in a collection assertion.

There's one test, `When_single_item_contains_string_interpolation_it_should_format_brackets_properly`, which asserted a specific "Format" output. It can't do that now, but I'm not sure it makes much sense to keep the formatting call as is. This was discussed in #1404. Either way, I think it makes sense to centralize the predicate formatting and deal with any special cases in the formatter.