### PR TITLE
Faking time because timing executions can be flaky on AppVeyor

### DIFF
--- a/Src/FluentAssertions/AssertionExtensions.cs
+++ b/Src/FluentAssertions/AssertionExtensions.cs
@@ -119,7 +119,7 @@ namespace FluentAssertions
             Guard.ThrowIfArgumentIsNull(subject, nameof(subject));
             Guard.ThrowIfArgumentIsNull(action, nameof(action));
 
-            return new MemberExecutionTime<T>(subject, action);
+            return new MemberExecutionTime<T>(subject, action, () => new StopwatchTimer());
         }
 
         /// <summary>
@@ -131,9 +131,11 @@ namespace FluentAssertions
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
         [MustUseReturnValue /* do not use Pure because this method executes the action before returning to the caller */]
-        public static ExecutionTime ExecutionTime(this Action action)
+        public static ExecutionTime ExecutionTime(this Action action, StartTimer createTimer = null)
         {
-            return new ExecutionTime(action);
+            createTimer ??= () => new StopwatchTimer();
+
+            return new(action, createTimer);
         }
 
         /// <summary>
@@ -147,7 +149,7 @@ namespace FluentAssertions
         [MustUseReturnValue /* do not use Pure because this method executes the action before returning to the caller */]
         public static ExecutionTime ExecutionTime(this Func<Task> action)
         {
-            return new ExecutionTime(action);
+            return new(action, () => new StopwatchTimer());
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Common/ITimer.cs
+++ b/Src/FluentAssertions/Common/ITimer.cs
@@ -3,9 +3,9 @@
 namespace FluentAssertions.Common
 {
     /// <summary>
-    /// Abstracts a stopwatch
+    /// Abstracts a stopwatch so we can control time in unit tests.
     /// </summary>
-    public interface ITimer
+    public interface ITimer : IDisposable
     {
         /// <summary>
         /// The time elapsed since the timer was created through <see cref="IClock.StartTimer"/>.

--- a/Src/FluentAssertions/Common/StartTimer.cs
+++ b/Src/FluentAssertions/Common/StartTimer.cs
@@ -1,0 +1,7 @@
+﻿namespace FluentAssertions.Common
+{
+    /// <summary>
+    /// Factory for starting a timer on demand.
+    /// </summary>
+    public delegate ITimer StartTimer();
+}

--- a/Src/FluentAssertions/Common/StopwatchTimer.cs
+++ b/Src/FluentAssertions/Common/StopwatchTimer.cs
@@ -13,5 +13,15 @@ namespace FluentAssertions.Common
         }
 
         public TimeSpan Elapsed => stopwatch.Elapsed;
+
+        public void Dispose()
+        {
+            if (stopwatch.IsRunning)
+            {
+                // We want to keep the elapsed time available after the timer is disposed, so disposing
+                // just stops it.
+                stopwatch.Stop();
+            }
+        }
     }
 }

--- a/Src/FluentAssertions/Specialized/MemberExecutionTime.cs
+++ b/Src/FluentAssertions/Specialized/MemberExecutionTime.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq.Expressions;
+using FluentAssertions.Common;
 
 namespace FluentAssertions.Specialized
 {
@@ -12,8 +13,8 @@ namespace FluentAssertions.Specialized
         /// <param name="action">A reference to the method or property to measure the execution time of.</param>
         /// <exception cref="NullReferenceException"><paramref name="subject"/> is <c>null</c>.</exception>
         /// <exception cref="NullReferenceException"><paramref name="action"/> is <c>null</c>.</exception>
-        public MemberExecutionTime(T subject, Expression<Action<T>> action)
-            : base(() => action.Compile()(subject), "(" + action.Body + ")")
+        public MemberExecutionTime(T subject, Expression<Action<T>> action, StartTimer createTimer)
+            : base(() => action.Compile()(subject), "(" + action.Body + ")", createTimer)
         {
         }
     }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -32,8 +32,8 @@ namespace FluentAssertions
         public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
         public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
         public static System.Action Enumerating<T, TResult>(this T subject, System.Func<T, System.Collections.Generic.IEnumerable<TResult>> enumerable) { }
-        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
         public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action, FluentAssertions.Common.StartTimer createTimer = null) { }
         public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
         public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
         public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
@@ -548,7 +548,7 @@ namespace FluentAssertions.Common
     {
         System.Collections.Generic.IEnumerable<System.Type> GetAllTypesFromAppDomain(System.Func<System.Reflection.Assembly, bool> predicate);
     }
-    public interface ITimer
+    public interface ITimer : System.IDisposable
     {
         System.TimeSpan Elapsed { get; }
     }
@@ -560,6 +560,7 @@ namespace FluentAssertions.Common
         public static System.Action<string> ThrowException { get; set; }
         public static void ResetToDefaults() { }
     }
+    public delegate FluentAssertions.Common.ITimer StartTimer();
     public enum ValueFormatterDetectionMode
     {
         Disabled = 0,
@@ -2115,10 +2116,10 @@ namespace FluentAssertions.Specialized
     }
     public class ExecutionTime
     {
-        public ExecutionTime(System.Action action) { }
-        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action) { }
-        protected ExecutionTime(System.Action action, string actionDescription) { }
-        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription) { }
+        public ExecutionTime(System.Action action, FluentAssertions.Common.StartTimer createTimer) { }
+        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action, FluentAssertions.Common.StartTimer createTimer) { }
+        protected ExecutionTime(System.Action action, string actionDescription, FluentAssertions.Common.StartTimer createTimer) { }
+        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription, FluentAssertions.Common.StartTimer createTimer) { }
     }
     public class ExecutionTimeAssertions
     {
@@ -2153,7 +2154,7 @@ namespace FluentAssertions.Specialized
     }
     public class MemberExecutionTime<T> : FluentAssertions.Specialized.ExecutionTime
     {
-        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action, FluentAssertions.Common.StartTimer createTimer) { }
     }
     public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<System.Threading.Tasks.Task, FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -32,8 +32,8 @@ namespace FluentAssertions
         public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
         public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
         public static System.Action Enumerating<T, TResult>(this T subject, System.Func<T, System.Collections.Generic.IEnumerable<TResult>> enumerable) { }
-        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
         public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action, FluentAssertions.Common.StartTimer createTimer = null) { }
         public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
         public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
         public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
@@ -548,7 +548,7 @@ namespace FluentAssertions.Common
     {
         System.Collections.Generic.IEnumerable<System.Type> GetAllTypesFromAppDomain(System.Func<System.Reflection.Assembly, bool> predicate);
     }
-    public interface ITimer
+    public interface ITimer : System.IDisposable
     {
         System.TimeSpan Elapsed { get; }
     }
@@ -560,6 +560,7 @@ namespace FluentAssertions.Common
         public static System.Action<string> ThrowException { get; set; }
         public static void ResetToDefaults() { }
     }
+    public delegate FluentAssertions.Common.ITimer StartTimer();
     public enum ValueFormatterDetectionMode
     {
         Disabled = 0,
@@ -2115,10 +2116,10 @@ namespace FluentAssertions.Specialized
     }
     public class ExecutionTime
     {
-        public ExecutionTime(System.Action action) { }
-        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action) { }
-        protected ExecutionTime(System.Action action, string actionDescription) { }
-        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription) { }
+        public ExecutionTime(System.Action action, FluentAssertions.Common.StartTimer createTimer) { }
+        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action, FluentAssertions.Common.StartTimer createTimer) { }
+        protected ExecutionTime(System.Action action, string actionDescription, FluentAssertions.Common.StartTimer createTimer) { }
+        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription, FluentAssertions.Common.StartTimer createTimer) { }
     }
     public class ExecutionTimeAssertions
     {
@@ -2153,7 +2154,7 @@ namespace FluentAssertions.Specialized
     }
     public class MemberExecutionTime<T> : FluentAssertions.Specialized.ExecutionTime
     {
-        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action, FluentAssertions.Common.StartTimer createTimer) { }
     }
     public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<System.Threading.Tasks.Task, FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -32,8 +32,8 @@ namespace FluentAssertions
         public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
         public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
         public static System.Action Enumerating<T, TResult>(this T subject, System.Func<T, System.Collections.Generic.IEnumerable<TResult>> enumerable) { }
-        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
         public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action, FluentAssertions.Common.StartTimer createTimer = null) { }
         public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
         public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
         public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
@@ -548,7 +548,7 @@ namespace FluentAssertions.Common
     {
         System.Collections.Generic.IEnumerable<System.Type> GetAllTypesFromAppDomain(System.Func<System.Reflection.Assembly, bool> predicate);
     }
-    public interface ITimer
+    public interface ITimer : System.IDisposable
     {
         System.TimeSpan Elapsed { get; }
     }
@@ -560,6 +560,7 @@ namespace FluentAssertions.Common
         public static System.Action<string> ThrowException { get; set; }
         public static void ResetToDefaults() { }
     }
+    public delegate FluentAssertions.Common.ITimer StartTimer();
     public enum ValueFormatterDetectionMode
     {
         Disabled = 0,
@@ -2115,10 +2116,10 @@ namespace FluentAssertions.Specialized
     }
     public class ExecutionTime
     {
-        public ExecutionTime(System.Action action) { }
-        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action) { }
-        protected ExecutionTime(System.Action action, string actionDescription) { }
-        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription) { }
+        public ExecutionTime(System.Action action, FluentAssertions.Common.StartTimer createTimer) { }
+        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action, FluentAssertions.Common.StartTimer createTimer) { }
+        protected ExecutionTime(System.Action action, string actionDescription, FluentAssertions.Common.StartTimer createTimer) { }
+        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription, FluentAssertions.Common.StartTimer createTimer) { }
     }
     public class ExecutionTimeAssertions
     {
@@ -2153,7 +2154,7 @@ namespace FluentAssertions.Specialized
     }
     public class MemberExecutionTime<T> : FluentAssertions.Specialized.ExecutionTime
     {
-        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action, FluentAssertions.Common.StartTimer createTimer) { }
     }
     public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<System.Threading.Tasks.Task, FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -32,8 +32,8 @@ namespace FluentAssertions
         public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
         public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
         public static System.Action Enumerating<T, TResult>(this T subject, System.Func<T, System.Collections.Generic.IEnumerable<TResult>> enumerable) { }
-        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
         public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action, FluentAssertions.Common.StartTimer createTimer = null) { }
         public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
         public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
         public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
@@ -541,7 +541,7 @@ namespace FluentAssertions.Common
     {
         System.Collections.Generic.IEnumerable<System.Type> GetAllTypesFromAppDomain(System.Func<System.Reflection.Assembly, bool> predicate);
     }
-    public interface ITimer
+    public interface ITimer : System.IDisposable
     {
         System.TimeSpan Elapsed { get; }
     }
@@ -553,6 +553,7 @@ namespace FluentAssertions.Common
         public static System.Action<string> ThrowException { get; set; }
         public static void ResetToDefaults() { }
     }
+    public delegate FluentAssertions.Common.ITimer StartTimer();
     public enum ValueFormatterDetectionMode
     {
         Disabled = 0,
@@ -2068,10 +2069,10 @@ namespace FluentAssertions.Specialized
     }
     public class ExecutionTime
     {
-        public ExecutionTime(System.Action action) { }
-        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action) { }
-        protected ExecutionTime(System.Action action, string actionDescription) { }
-        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription) { }
+        public ExecutionTime(System.Action action, FluentAssertions.Common.StartTimer createTimer) { }
+        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action, FluentAssertions.Common.StartTimer createTimer) { }
+        protected ExecutionTime(System.Action action, string actionDescription, FluentAssertions.Common.StartTimer createTimer) { }
+        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription, FluentAssertions.Common.StartTimer createTimer) { }
     }
     public class ExecutionTimeAssertions
     {
@@ -2106,7 +2107,7 @@ namespace FluentAssertions.Specialized
     }
     public class MemberExecutionTime<T> : FluentAssertions.Specialized.ExecutionTime
     {
-        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action, FluentAssertions.Common.StartTimer createTimer) { }
     }
     public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<System.Threading.Tasks.Task, FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -32,8 +32,8 @@ namespace FluentAssertions
         public static System.Action Enumerating(this System.Func<System.Collections.IEnumerable> enumerable) { }
         public static System.Action Enumerating<T>(this System.Func<System.Collections.Generic.IEnumerable<T>> enumerable) { }
         public static System.Action Enumerating<T, TResult>(this T subject, System.Func<T, System.Collections.Generic.IEnumerable<TResult>> enumerable) { }
-        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action) { }
         public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Func<System.Threading.Tasks.Task> action) { }
+        public static FluentAssertions.Specialized.ExecutionTime ExecutionTime(this System.Action action, FluentAssertions.Common.StartTimer createTimer = null) { }
         public static FluentAssertions.Specialized.MemberExecutionTime<T> ExecutionTimeOf<T>(this T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
         public static System.Action Invoking<T>(this T subject, System.Action<T> action) { }
         public static System.Func<TResult> Invoking<T, TResult>(this T subject, System.Func<T, TResult> action) { }
@@ -548,7 +548,7 @@ namespace FluentAssertions.Common
     {
         System.Collections.Generic.IEnumerable<System.Type> GetAllTypesFromAppDomain(System.Func<System.Reflection.Assembly, bool> predicate);
     }
-    public interface ITimer
+    public interface ITimer : System.IDisposable
     {
         System.TimeSpan Elapsed { get; }
     }
@@ -560,6 +560,7 @@ namespace FluentAssertions.Common
         public static System.Action<string> ThrowException { get; set; }
         public static void ResetToDefaults() { }
     }
+    public delegate FluentAssertions.Common.ITimer StartTimer();
     public enum ValueFormatterDetectionMode
     {
         Disabled = 0,
@@ -2115,10 +2116,10 @@ namespace FluentAssertions.Specialized
     }
     public class ExecutionTime
     {
-        public ExecutionTime(System.Action action) { }
-        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action) { }
-        protected ExecutionTime(System.Action action, string actionDescription) { }
-        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription) { }
+        public ExecutionTime(System.Action action, FluentAssertions.Common.StartTimer createTimer) { }
+        public ExecutionTime(System.Func<System.Threading.Tasks.Task> action, FluentAssertions.Common.StartTimer createTimer) { }
+        protected ExecutionTime(System.Action action, string actionDescription, FluentAssertions.Common.StartTimer createTimer) { }
+        protected ExecutionTime(System.Func<System.Threading.Tasks.Task> action, string actionDescription, FluentAssertions.Common.StartTimer createTimer) { }
     }
     public class ExecutionTimeAssertions
     {
@@ -2153,7 +2154,7 @@ namespace FluentAssertions.Specialized
     }
     public class MemberExecutionTime<T> : FluentAssertions.Specialized.ExecutionTime
     {
-        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action) { }
+        public MemberExecutionTime(T subject, System.Linq.Expressions.Expression<System.Action<T>> action, FluentAssertions.Common.StartTimer createTimer) { }
     }
     public class NonGenericAsyncFunctionAssertions : FluentAssertions.Specialized.AsyncFunctionAssertions<System.Threading.Tasks.Task, FluentAssertions.Specialized.NonGenericAsyncFunctionAssertions>
     {

--- a/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
@@ -403,10 +403,11 @@ namespace FluentAssertions.Specs.Specialized
         public void When_the_execution_time_of_an_action_is_close_to_a_limit_it_should_not_throw()
         {
             // Arrange
-            Action someAction = () => Thread.Sleep(210);
+            Action someAction = () => { };
+            var timer = new TestTimer(() => 210.Milliseconds());
 
             // Act
-            Action act = () => someAction.ExecutionTime().Should().BeCloseTo(200.Milliseconds(), 150.Milliseconds());
+            Action act = () => someAction.ExecutionTime(() => timer).Should().BeCloseTo(200.Milliseconds(), 15.Milliseconds());
 
             // Assert
             act.Should().NotThrow();

--- a/Tests/FluentAssertions.Specs/TestTimer.cs
+++ b/Tests/FluentAssertions.Specs/TestTimer.cs
@@ -13,5 +13,9 @@ namespace FluentAssertions.Specs
         }
 
         public TimeSpan Elapsed => getElapsed();
+
+        public void Dispose()
+        {
+        }
     }
 }


### PR DESCRIPTION
On AppVeyor builds, we have observed some flakiness where timing a simple `Thread.Sleep(200)` can result in up to 400 milliseconds of execution time. For those specific unit tests, we have decided to replace `Stopwatch` usage with a fake timer abstraction for those specific cases. For the other execution timing tests, I've decided to keep using the real `Stopwatch`.

Fixes #1085

