### PR TITLE
Removed the type from the failure message in equivalency checks

### DIFF
--- a/Src/FluentAssertions/Equivalency/Field.cs
+++ b/Src/FluentAssertions/Equivalency/Field.cs
@@ -29,7 +29,7 @@ namespace FluentAssertions.Equivalency
 
         public Type DeclaringType { get; set; }
 
-        public override string Description => $"field {GetSubjectId().Combine(PathAndName)} (of type {Type.ToFriendlyName()})";
+        public override string Description => $"field {GetSubjectId().Combine(PathAndName)}";
 
         public CSharpAccessModifier GetterAccessibility => fieldInfo.GetCSharpAccessModifier();
 

--- a/Src/FluentAssertions/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Equivalency/Node.cs
@@ -20,7 +20,7 @@ namespace FluentAssertions.Equivalency
 
         public string Name { get; protected set; }
 
-        public virtual string Description => $"{GetSubjectId().Combine(PathAndName)} (of type {Type.ToFriendlyName()})";
+        public virtual string Description => $"{GetSubjectId().Combine(PathAndName)}";
 
         public bool IsRoot
         {

--- a/Src/FluentAssertions/Equivalency/Property.cs
+++ b/Src/FluentAssertions/Equivalency/Property.cs
@@ -30,7 +30,7 @@ namespace FluentAssertions.Equivalency
 
         public Type DeclaringType { get; private set; }
 
-        public override string Description => $"property {GetSubjectId().Combine(PathAndName)} (of type {Type.ToFriendlyName()})";
+        public override string Description => $"property {GetSubjectId().Combine(PathAndName)}";
 
         public CSharpAccessModifier GetterAccessibility => propertyInfo.GetGetMethod(nonPublic: true).GetCSharpAccessModifier();
 

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.cs
@@ -1534,7 +1534,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject (of type IEnumerable<int>) to be a collection with 0 item(s), but*contains 3 item(s)*");
+                "Expected subject to be a collection with 0 item(s), but*contains 3 item(s)*");
         }
 
         [Fact]
@@ -1579,7 +1579,7 @@ namespace FluentAssertions.Specs.Collections
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected collection (of type IEnumerable<int>) not to be <null>*");
+                "Expected collection not to be <null>*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
@@ -43,7 +43,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected subject (of type object) to be <null>, but found { }*");
+                "Expected subject to be <null>, but found { }*");
         }
 
         [Fact]
@@ -666,7 +666,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expectation has field onlyAProperty.Value (of type int) that the other object does not have.*");
+                .WithMessage("Expectation has field onlyAProperty.Value that the other object does not have.*");
         }
 
         [Fact]
@@ -681,7 +681,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expectation has property onlyAField.Value (of type int) that the other object does not have*");
+                .WithMessage("Expectation has property onlyAField.Value that the other object does not have*");
         }
 
         [Fact]
@@ -1753,7 +1753,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expectation has property subject.City (of type string) that the other object does not have*");
+                "Expectation has property subject.City that the other object does not have*");
         }
 
         [Fact]
@@ -1776,7 +1776,7 @@ namespace FluentAssertions.Specs.Equivalency
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected property subject.Type (of type int) to be 36, but found*\"A\"*");
+                .WithMessage("Expected property subject.Type to be 36, but found*\"A\"*");
         }
 
         [Fact]
@@ -2175,7 +2175,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected*Time (of type DateTime?) to be <null>, but found <2013-12-09 15:58:00>.*");
+                "Expected*Time to be <null>, but found <2013-12-09 15:58:00>.*");
         }
 
         [Fact]
@@ -2387,7 +2387,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected property subject.Name (of type string) to be <null>*we want to test the failure message*, but found \"Dennis\"*");
+                "Expected property subject.Name to be <null>*we want to test the failure message*, but found \"Dennis\"*");
         }
 
         [Fact]
@@ -2438,7 +2438,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected*Name (of type string) to be \"Dennis\", but \"Dennes\" differs near \"es\" (index 4)*");
+                "Expected*Name to be \"Dennis\", but \"Dennes\" differs near \"es\" (index 4)*");
         }
 
         [Fact]
@@ -3005,7 +3005,7 @@ namespace FluentAssertions.Specs.Equivalency
                 // but in that case it was done on purpose, so that we have at least have a single
                 // test confirming that whole mechanism of gathering description from
                 // equivalency steps works.
-                .Should().Match(@"Expected property subject.Level.Text (of type string) to be ""Level2"", but ""Level1"" differs near ""1"" (index 5).*" +
+                .Should().Match(@"Expected property subject.Level.Text to be ""Level2"", but ""Level1"" differs near ""1"" (index 5).*" +
                     "With configuration:*" +
                     "- Use declared types and members*" +
                         "- Compare enums by value*" +
@@ -3164,7 +3164,7 @@ namespace FluentAssertions.Specs.Equivalency
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expectation has property subject.Level.OtherProperty (of type string) that the other object does not have*");
+                .WithMessage("Expectation has property subject.Level.OtherProperty that the other object does not have*");
         }
 
         [Fact]
@@ -3263,7 +3263,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected property c1.RefOne.ValTwo (of type int) to be 2, but found 3*");
+                .WithMessage("Expected property c1.RefOne.ValTwo to be 2, but found 3*");
         }
 
         #endregion
@@ -3302,7 +3302,7 @@ namespace FluentAssertions.Specs.Equivalency
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected property cyclicRoot.Level.Root (of type CyclicRootDto) to be*but it contains a cyclic reference*");
+                .WithMessage("Expected property cyclicRoot.Level.Root to be*but it contains a cyclic reference*");
         }
 
         [Fact]
@@ -3692,7 +3692,7 @@ namespace FluentAssertions.Specs.Equivalency
                 .ComparingByValue<MyRecord>());
 
             act.Should().Throw<XunitException>()
-                .WithMessage("*Expected*of type MyRecord*but found*MyRecord*")
+                .WithMessage("*Expected*MyRecord*but found*MyRecord*")
                 .WithMessage("*Compare*MyRecord by value*");
         }
 
@@ -3715,7 +3715,7 @@ namespace FluentAssertions.Specs.Equivalency
                 .ComparingRecordsByValue());
 
             act.Should().Throw<XunitException>()
-                .WithMessage("*Expected*of type MyRecord*but found*MyRecord*")
+                .WithMessage("*Expected*MyRecord*but found*MyRecord*")
                 .WithMessage("*Compare records by value*");
         }
 
@@ -4259,7 +4259,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expectation has property subject.Age (of type int) that the other object does not have*");
+                .WithMessage("Expectation has property subject.Age that the other object does not have*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
@@ -883,7 +883,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             action.Should().Throw<XunitException>().Which
-                .Message.Should().Contain("subject[9] (of type string) to be \"one\", but \"two\" differs near \"two\" (index 0)")
+                .Message.Should().Contain("subject[9] to be \"one\", but \"two\" differs near \"two\" (index 0)")
                 .And.NotContain("subject[10]");
         }
 
@@ -987,7 +987,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             action.Should().Throw<XunitException>().Which
-                .Message.Should().Contain("subject[9] (of type int) to be 1, but found 2")
+                .Message.Should().Contain("subject[9] to be 1, but found 2")
                 .And.NotContain("item[10]");
         }
 

--- a/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataColumn.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataColumn.cs
@@ -47,7 +47,7 @@ namespace FluentAssertions.Specs
 
                 // Assert
                 action.Should().Throw<XunitException>().WithMessage(
-                    "Expected *of type DataColumn*to be non-null, but found null*");
+                    "Expected *to be non-null, but found null*");
             }
 
             [Fact]

--- a/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataRow.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataRow.cs
@@ -47,7 +47,7 @@ namespace FluentAssertions.Specs
 
                 // Assert
                 action.Should().Throw<XunitException>().WithMessage(
-                    "Expected *of type DataRow*to be non-null, but found null*");
+                    "Expected *to be non-null, but found null*");
             }
 
             [Fact]

--- a/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataSet.Typed.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataSet.Typed.cs
@@ -45,7 +45,7 @@ namespace FluentAssertions.Specs
 
                 // Assert
                 action.Should().Throw<XunitException>().WithMessage(
-                    "Expected *of type DataSet*to be non-null, but found null*");
+                    "Expected *to be non-null, but found null*");
             }
 
             [Fact]

--- a/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataSet.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataSet.cs
@@ -50,7 +50,7 @@ namespace FluentAssertions.Specs
 
                 // Assert
                 action.Should().Throw<XunitException>().WithMessage(
-                    "Expected *of type DataSet*to be non-null, but found null*");
+                    "Expected *to be non-null, but found null*");
             }
 
             [Fact]

--- a/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataTable.Typed.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataTable.Typed.cs
@@ -52,7 +52,7 @@ namespace FluentAssertions.Specs
 
                 // Assert
                 action.Should().Throw<XunitException>().WithMessage(
-                    "Expected *of type DataTable*to be non-null, but found null*");
+                    "Expected *to be non-null, but found null*");
             }
 
             [Fact]

--- a/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataTable.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DataEquivalencySpecs.DataTable.cs
@@ -51,7 +51,7 @@ namespace FluentAssertions.Specs
 
                 // Assert
                 action.Should().Throw<XunitException>().WithMessage(
-                    "Expected *of type DataTable*to be non-null, but found null*");
+                    "Expected *to be non-null, but found null*");
             }
 
             [Fact]

--- a/Tests/FluentAssertions.Specs/Equivalency/DictionaryEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/DictionaryEquivalencySpecs.cs
@@ -372,7 +372,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             act.Should().Throw<XunitException>()
-                .WithMessage("Expected*Dictionary*not to be*null*valid dictionary*");
+                .WithMessage("Expected*not to be*null*valid dictionary*");
         }
 
         [Fact]
@@ -1082,7 +1082,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected actual*Dictionary*key*c*because we're expecting c*");
+                "Expected actual*key*c*because we're expecting c*");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/ExtensibilityRelatedEquivalencySpecs.cs
@@ -300,7 +300,7 @@ namespace FluentAssertions.Specs.Equivalency
             // Assert
             act.Should().Throw<XunitException>()
                 .Which.Message.Should()
-                .Contain("Expected property subject.Id (of type double?) to be <null>, but found \"foo\"")
+                .Contain("Expected property subject.Id to be <null>, but found \"foo\"")
                     .And.NotContain("from expectation");
         }
 
@@ -327,7 +327,7 @@ namespace FluentAssertions.Specs.Equivalency
             // Assert
             act.Should().Throw<XunitException>()
                 .Which.Message.Should()
-                .Contain("Expected property subject.Id (of type string) to be \"bar\", but found <null>")
+                .Contain("Expected property subject.Id to be \"bar\", but found <null>")
                     .And.NotContain("from subject");
         }
 

--- a/Tests/FluentAssertions.Specs/Equivalency/XmlEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/XmlEquivalencySpecs.cs
@@ -44,7 +44,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected EndElement \"parent\" in property subject.Document (of type XDocument) at \"/parent\", but found Element \"child2\".*");
+                "Expected EndElement \"parent\" in property subject.Document at \"/parent\", but found Element \"child2\".*");
         }
 
         [Fact]
@@ -85,7 +85,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected EndElement \"parent\" in property subject.Element (of type XElement) at \"/parent\", but found Element \"child2\"*");
+                "Expected EndElement \"parent\" in property subject.Element at \"/parent\", but found Element \"child2\"*");
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                $"Expected property subject.Attribute (of type XAttribute) to be name2=\"value\" because we want to test the failure message, but found name=\"value\"*");
+                $"Expected property subject.Attribute to be name2=\"value\" because we want to test the failure message, but found name=\"value\"*");
         }
     }
 }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -19,6 +19,7 @@ Changes since 6.0.0 Beta 1
 * Improved consistency of XML documentation on `AssertionScope`, `ContinuedAssertionScope`, and `GivenSelector<T>` methods. - [#1606](https://github.com/fluentassertions/fluentassertions/pull/1606).
 * Handle `WithDefaultIdentifier` and `WithExpectation` correctly when an `AssertionScope` continues - [#1610](https://github.com/fluentassertions/fluentassertions/pull/1610).
 * Improved stack trace when a property of an element of a generic collection throws an exception during `GenericEnumerableEquivalencyStep` in `GenericCollectionAssertions` - [#1615](https://github.com/fluentassertions/fluentassertions/pull/1615).
+* Removed the type info from the failure message in equivalency checks - [#1621](https://github.com/fluentassertions/fluentassertions/pull/1621).
 
 ## 6.0.0 Beta 1
 Changes since 6.0.0 Alpha 2


### PR DESCRIPTION
Because the equivalency validator will use the expectation to traverse the object graph, the `INode.Type` property (and the `Description` derived from that) always refers to the type of the node from the perspective of the expectation. But this was sometimes used to refer to the subject's node, causing weird failure messages where the type matched the expectation but not the subject. 

