### PR TITLE
Avoid double call to concurrent dictionary by using GetOrAdd

### DIFF
--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
@@ -95,25 +95,21 @@ namespace FluentAssertions.Equivalency.Steps
 
         private static DictionaryInterfaceInfo[] GetDictionaryInterfacesFrom(Type target)
         {
-            if (!Cache.TryGetValue(target, out DictionaryInterfaceInfo[] dictionaries))
+            return Cache.GetOrAdd(target, key =>
             {
-                if (Type.GetTypeCode(target) != TypeCode.Object)
+                if (Type.GetTypeCode(key) != TypeCode.Object)
                 {
-                    dictionaries = new DictionaryInterfaceInfo[0];
+                    return new DictionaryInterfaceInfo[0];
                 }
                 else
                 {
-                    dictionaries = target
+                    return key
                         .GetClosedGenericInterfaces(typeof(IDictionary<,>))
                         .Select(@interface => @interface.GetGenericArguments())
                         .Select(arguments => new DictionaryInterfaceInfo(arguments[0], arguments[1]))
                         .ToArray();
                 }
-
-                Cache.TryAdd(target, dictionaries);
-            }
-
-            return dictionaries;
+            });
         }
 
         /// <summary>

--- a/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericDictionaryEquivalencyStep.cs
@@ -112,11 +112,11 @@ namespace FluentAssertions.Equivalency.Steps
 
         private static bool AssertSameLength<TSubjectKey, TSubjectValue, TExpectedKey, TExpectedValue>(
             IDictionary<TSubjectKey, TSubjectValue> subject, IDictionary<TExpectedKey, TExpectedValue> expectation)
-            where TExpectedKey : TSubjectKey
 
-        // Type constraint of TExpectedKey is asymmetric in regards to TSubjectKey
-        // but it is valid. This constraint is implicitly enforced by the dictionary interface info which is called before
-        // the AssertSameLength method.
+            // Type constraint of TExpectedKey is asymmetric in regards to TSubjectKey
+            // but it is valid. This constraint is implicitly enforced by the dictionary interface info which is called before
+            // the AssertSameLength method.
+            where TExpectedKey : TSubjectKey
         {
             if (expectation.Count == subject.Count)
             {

--- a/Tests/FluentAssertions.Specs/Formatting/PredicateLambdaExpressionValueFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/PredicateLambdaExpressionValueFormatterSpecs.cs
@@ -9,7 +9,7 @@ namespace FluentAssertions.Specs.Formatting
 {
     public class PredicateLambdaExpressionValueFormatterSpecs
     {
-        private PredicateLambdaExpressionValueFormatter formatter = new();
+        private readonly PredicateLambdaExpressionValueFormatter formatter = new();
 
         [Fact]
         public void When_first_level_properties_are_tested_for_equality_against_constants_then_output_should_be_readable()


### PR DESCRIPTION
Reviewing #1603 revealing nothing problematic to me, but we can save a call to the `ConcurrentDictionary` `Cache` by using `GetOrAdd` instead.

... and some analyzer/styling nits.