### PR TITLE
Fixed a regression where a nested class without suitable members inside a collection throws

### DIFF
--- a/Src/FluentAssertions/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Equivalency/Node.cs
@@ -28,10 +28,11 @@ namespace FluentAssertions.Equivalency
             {
                 // If the root is a collection, we need treat the objects in that collection as the root of the graph because all options
                 // refer to the type of the collection items.
-                return PathAndName.Length == 0 ||
-                       (RootIsCollection && PathAndName.StartsWith("[", StringComparison.Ordinal));
+                return PathAndName.Length == 0 || (RootIsCollection && IsIndex);
             }
         }
+
+        private bool IsIndex => PathAndName.StartsWith("[", StringComparison.Ordinal) && PathAndName.EndsWith("]", StringComparison.Ordinal);
 
         public bool RootIsCollection { get; protected set; }
 

--- a/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
@@ -2050,6 +2050,39 @@ namespace FluentAssertions.Specs.Equivalency
                 .Excluding(o => o.DerivedProperty2));
         }
 
+        [Fact]
+        public void A_nested_class_without_properties_inside_a_collection_is_fine()
+        {
+            // Arrange
+            var sut = new List<BaseClassPointingToClassWithoutProperties>
+            {
+                new()
+                {
+                    Name = "theName"
+                }
+            };
+
+            // Act / Assert
+            sut.Should().BeEquivalentTo(new[]
+            {
+                new BaseClassPointingToClassWithoutProperties
+                {
+                    Name = "theName"
+                }
+            });
+        }
+
+        internal class BaseClassPointingToClassWithoutProperties
+        {
+            public string Name { get; set; }
+
+            public ClassWithoutProperty ClassWithoutProperty { get; } = new ClassWithoutProperty();
+        }
+
+        internal class ClassWithoutProperty
+        {
+        }
+
         #endregion
 
         #region Matching Rules

--- a/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
@@ -129,10 +129,10 @@ namespace FluentAssertions.Specs.Equivalency
         {
             public string MyString { get; set; }
 
-            public MyChildObject Child { get; set; }
+            public ClassIdentifiedById Child { get; set; }
         }
 
-        public class MyChildObject
+        public class ClassIdentifiedById
         {
             public int Id { get; set; }
 
@@ -140,7 +140,7 @@ namespace FluentAssertions.Specs.Equivalency
 
             public override bool Equals(object obj)
             {
-                return obj is MyChildObject other && other.Id == Id;
+                return obj is ClassIdentifiedById other && other.Id == Id;
             }
 
             public override int GetHashCode()
@@ -1414,7 +1414,7 @@ namespace FluentAssertions.Specs.Equivalency
             var actual = new MyObject
             {
                 MyString = "identical string",
-                Child = new MyChildObject
+                Child = new ClassIdentifiedById
                 {
                     Id = 1,
                     MyChildString = "identical string"
@@ -1424,7 +1424,7 @@ namespace FluentAssertions.Specs.Equivalency
             var expectation = new MyObject
             {
                 MyString = "identical string",
-                Child = new MyChildObject
+                Child = new ClassIdentifiedById
                 {
                     Id = 1,
                     MyChildString = "DIFFERENT STRING"

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -21,6 +21,7 @@ Changes since 6.0.0 Beta 1
 * Improved stack trace when a property of an element of a generic collection throws an exception during `GenericEnumerableEquivalencyStep` in `GenericCollectionAssertions` - [#1615](https://github.com/fluentassertions/fluentassertions/pull/1615).
 * Removed the type info from the failure message in equivalency checks - [#1621](https://github.com/fluentassertions/fluentassertions/pull/1621).
 * Fixed a regression so that collections of similarly typed key-value pairs should be equivalent to a dictionary - [#1603](https://github.com/fluentassertions/fluentassertions/pull/1603).
+* Fixed a regression where a nested class without suitable members inside a collection raised an exception - [#1627](https://github.com/fluentassertions/fluentassertions/pull/1627).
 
 
 ## 6.0.0 Beta 1


### PR DESCRIPTION
When a collection is compared using `BeEquivalentTo`, and the items in that collection point to a class without members, FA would throw the `No members were found for comparison.` exception. This was caused by the `IsRoot` property that was interpreting the member path incorrectly. It assumed that if the path started with `[`, we were looking at the root. But even if the path started with `[0].SomeProperty`, it would treat the current `INode` as "root". 

Fixes #1604 