### PR TITLE
Support covariant and inherited property exclusion and inclusion in BeEquivalentTo

### DIFF
--- a/Src/FluentAssertions/Common/ExpressionExtensions.cs
+++ b/Src/FluentAssertions/Common/ExpressionExtensions.cs
@@ -100,7 +100,7 @@ namespace FluentAssertions.Common
             string[] reversedSegments = segments.AsEnumerable().Reverse().ToArray();
             string segmentPath = string.Join(".", reversedSegments);
 
-            return new MemberPath(declaringType, segmentPath.Replace(".[", "[", StringComparison.Ordinal));
+            return new MemberPath(typeof(TDeclaringType), declaringType, segmentPath.Replace(".[", "[", StringComparison.Ordinal));
         }
 
         private static string GetUnsupportedExpressionMessage(Expression expression) =>

--- a/Src/FluentAssertions/Common/MemberPath.cs
+++ b/Src/FluentAssertions/Common/MemberPath.cs
@@ -20,9 +20,13 @@ namespace FluentAssertions.Common
             this.dottedPath = dottedPath;
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the current object represents a child member of the <paramref name="candidate"/>
+        /// or that it is the parent of that candidate.
+        /// </summary>
         public bool IsParentOrChildOf(MemberPath candidate)
         {
-            return IsParent(candidate) || IsChild(candidate);
+            return IsParentOf(candidate) || IsChildOf(candidate);
         }
 
         public bool IsSameAs(MemberPath candidate)
@@ -38,19 +42,17 @@ namespace FluentAssertions.Common
             return candidateSegments.SequenceEqual(segments);
         }
 
-        private bool IsChild(MemberPath candidate)
+        private bool IsParentOf(MemberPath candidate)
         {
-            string[] segments = GetSegments();
-            string[] candidateSegments = candidate.GetSegments();
+            string[] candidateSegments = candidate.segments;
 
             return candidateSegments.Length > segments.Length &&
                    candidateSegments.Take(segments.Length).SequenceEqual(segments);
         }
 
-        private bool IsParent(MemberPath candidate)
+        private bool IsChildOf(MemberPath candidate)
         {
-            string[] segments = GetSegments();
-            string[] candidateSegments = candidate.GetSegments();
+            string[] candidateSegments = candidate.segments;
 
             return candidateSegments.Length < segments.Length
                    && candidateSegments.SequenceEqual(segments.Take(candidateSegments.Length));

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -360,7 +360,7 @@ namespace FluentAssertions.Common
             return type.GetParameterlessMethod(methodName) is not null;
         }
 
-        public static PropertyInfo GetPropertyByName(this Type type, string propertyName)
+        public static PropertyInfo FindPropertyByName(this Type type, string propertyName)
         {
             return type.GetProperty(propertyName, AllStaticAndInstanceMembersFlag);
         }

--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -227,7 +227,7 @@ namespace FluentAssertions.Common
             return GetMembersFromHierarchy(typeToReflect, type =>
             {
                 return type
-                    .GetProperties(AllInstanceMembersFlag)
+                    .GetProperties(AllInstanceMembersFlag | BindingFlags.DeclaredOnly)
                     .Where(property => property.GetMethod?.IsPrivate == false)
                     .Where(property => includeInternals || (property.GetMethod?.IsAssembly == false && property.GetMethod?.IsFamilyOrAssembly == false))
                     .ToArray();
@@ -266,38 +266,67 @@ namespace FluentAssertions.Common
         {
             if (typeToReflect.IsInterface)
             {
-                var propertyInfos = new List<TMemberInfo>();
+                return GetInterfaceMembers(typeToReflect, getMembers);
+            }
+            else
+            {
+                return GetClassMembers(typeToReflect, getMembers);
+            }
+        }
 
-                var considered = new List<Type>();
-                var queue = new Queue<Type>();
-                considered.Add(typeToReflect);
-                queue.Enqueue(typeToReflect);
+        private static List<TMemberInfo> GetInterfaceMembers<TMemberInfo>(Type typeToReflect, Func<Type, IEnumerable<TMemberInfo>> getMembers)
+            where TMemberInfo : MemberInfo
+        {
+            List<TMemberInfo> members = new();
 
-                while (queue.Count > 0)
+            var considered = new List<Type>();
+            var queue = new Queue<Type>();
+            considered.Add(typeToReflect);
+            queue.Enqueue(typeToReflect);
+
+            while (queue.Count > 0)
+            {
+                Type subType = queue.Dequeue();
+                foreach (Type subInterface in subType.GetInterfaces())
                 {
-                    Type subType = queue.Dequeue();
-                    foreach (Type subInterface in GetInterfaces(subType))
+                    if (considered.Contains(subInterface))
                     {
-                        if (considered.Contains(subInterface))
-                        {
-                            continue;
-                        }
-
-                        considered.Add(subInterface);
-                        queue.Enqueue(subInterface);
+                        continue;
                     }
 
-                    IEnumerable<TMemberInfo> typeProperties = getMembers(subType);
-
-                    IEnumerable<TMemberInfo> newPropertyInfos = typeProperties.Where(x => !propertyInfos.Contains(x));
-
-                    propertyInfos.InsertRange(0, newPropertyInfos);
+                    considered.Add(subInterface);
+                    queue.Enqueue(subInterface);
                 }
 
-                return propertyInfos.ToArray();
+                IEnumerable<TMemberInfo> typeMembers = getMembers(subType);
+
+                IEnumerable<TMemberInfo> newPropertyInfos = typeMembers.Where(x => !members.Contains(x));
+
+                members.InsertRange(0, newPropertyInfos);
             }
 
-            return getMembers(typeToReflect);
+            return members;
+        }
+
+        private static List<TMemberInfo> GetClassMembers<TMemberInfo>(Type typeToReflect, Func<Type, IEnumerable<TMemberInfo>> getMembers)
+            where TMemberInfo : MemberInfo
+        {
+            List<TMemberInfo> members = new();
+
+            while (typeToReflect != null)
+            {
+                foreach (var memberInfo in getMembers(typeToReflect))
+                {
+                    if (members.All(mi => mi.Name != memberInfo.Name))
+                    {
+                        members.Add(memberInfo);
+                    }
+                }
+
+                typeToReflect = typeToReflect.BaseType;
+            }
+
+            return members;
         }
 
         private static Type[] GetInterfaces(Type type)

--- a/Src/FluentAssertions/Equivalency/Field.cs
+++ b/Src/FluentAssertions/Equivalency/Field.cs
@@ -12,15 +12,23 @@ namespace FluentAssertions.Equivalency
         private readonly FieldInfo fieldInfo;
 
         public Field(FieldInfo fieldInfo, INode parent)
+            : this(fieldInfo.ReflectedType, fieldInfo, parent)
+        {
+        }
+
+        public Field(Type reflectedType, FieldInfo fieldInfo, INode parent)
         {
             this.fieldInfo = fieldInfo;
             DeclaringType = fieldInfo.DeclaringType;
+            ReflectedType = reflectedType;
             Path = parent.PathAndName;
             GetSubjectId = parent.GetSubjectId;
             Name = fieldInfo.Name;
             Type = fieldInfo.FieldType;
             RootIsCollection = parent.RootIsCollection;
         }
+
+        public Type ReflectedType { get; }
 
         public object GetValue(object obj)
         {

--- a/Src/FluentAssertions/Equivalency/IMember.cs
+++ b/Src/FluentAssertions/Equivalency/IMember.cs
@@ -14,6 +14,11 @@ namespace FluentAssertions.Equivalency
         Type DeclaringType { get; }
 
         /// <summary>
+        /// Gets the type that was used to determine this member.
+        /// </summary>
+        Type ReflectedType { get; }
+
+        /// <summary>
         /// Gets the value of the member from the provided <paramref name="obj"/>
         /// </summary>
         object GetValue(object obj);

--- a/Src/FluentAssertions/Equivalency/Property.cs
+++ b/Src/FluentAssertions/Equivalency/Property.cs
@@ -13,7 +13,13 @@ namespace FluentAssertions.Equivalency
         private readonly PropertyInfo propertyInfo;
 
         public Property(PropertyInfo propertyInfo, INode parent)
+            : this(propertyInfo.ReflectedType, propertyInfo, parent)
         {
+        }
+
+        public Property(Type reflectedType, PropertyInfo propertyInfo, INode parent)
+        {
+            ReflectedType = reflectedType;
             this.propertyInfo = propertyInfo;
             DeclaringType = propertyInfo.DeclaringType;
             Name = propertyInfo.Name;
@@ -29,6 +35,8 @@ namespace FluentAssertions.Equivalency
         }
 
         public Type DeclaringType { get; private set; }
+
+        public Type ReflectedType { get; }
 
         public override string Description => $"property {GetSubjectId().Combine(PathAndName)}";
 

--- a/Src/FluentAssertions/Equivalency/Selection/AllPropertiesSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/AllPropertiesSelectionRule.cs
@@ -16,7 +16,7 @@ namespace FluentAssertions.Equivalency.Selection
         {
             IEnumerable<IMember> selectedNonPrivateProperties = context.Type
                 .GetNonPrivateProperties(context.IncludedProperties)
-                .Select(info => new Property(info, currentNode));
+                .Select(info => new Property(context.Type, info, currentNode));
 
             return selectedMembers.Union(selectedNonPrivateProperties).ToList();
         }

--- a/Src/FluentAssertions/Equivalency/Selection/ExcludeMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/ExcludeMemberByPathSelectionRule.cs
@@ -20,7 +20,7 @@ namespace FluentAssertions.Equivalency.Selection
             MemberSelectionContext context)
         {
             selectedMembers.RemoveAll(member =>
-                memberToExclude.IsSameAs(new MemberPath(member.DeclaringType, parentPath.Combine(member.Name))));
+                memberToExclude.IsSameAs(new MemberPath(member, parentPath)));
         }
 
         public override string ToString()

--- a/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
+++ b/Src/FluentAssertions/Equivalency/Selection/IncludeMemberByPathSelectionRule.cs
@@ -23,7 +23,7 @@ namespace FluentAssertions.Equivalency.Selection
         {
             foreach (MemberInfo memberInfo in context.Type.GetNonPrivateMembers(MemberVisibility.Public | MemberVisibility.Internal))
             {
-                var memberPath = new MemberPath(memberInfo.DeclaringType, parentPath.Combine(memberInfo.Name));
+                var memberPath = new MemberPath(context.Type, memberInfo.DeclaringType, parentPath.Combine(memberInfo.Name));
                 if (memberToInclude.IsSameAs(memberPath) || memberToInclude.IsParentOrChildOf(memberPath))
                 {
                     selectedMembers.Add(MemberFactory.Create(memberInfo, parent));

--- a/Src/FluentAssertions/Types/TypeAssertions.cs
+++ b/Src/FluentAssertions/Types/TypeAssertions.cs
@@ -411,7 +411,7 @@ namespace FluentAssertions.Types
 
         /// <summary>
         /// Asserts that the current <see cref="Type"/> is not decorated with and does not inherit from a parent class, an
-        /// attribute of type <typeparamref name="TAttribute"/> that matches the specified 
+        /// attribute of type <typeparamref name="TAttribute"/> that matches the specified
         /// <paramref name="isMatchingAttributePredicate"/>.
         /// </summary>
         /// <param name="isMatchingAttributePredicate">
@@ -863,7 +863,7 @@ namespace FluentAssertions.Types
 
             if (success)
             {
-                propertyInfo = Subject.GetPropertyByName(name);
+                propertyInfo = Subject.FindPropertyByName(name);
                 var propertyInfoDescription = PropertyInfoAssertions.GetDescriptionFor(propertyInfo);
 
                 Execute.Assertion
@@ -921,7 +921,7 @@ namespace FluentAssertions.Types
 
             if (success)
             {
-                PropertyInfo propertyInfo = Subject.GetPropertyByName(name);
+                PropertyInfo propertyInfo = Subject.FindPropertyByName(name);
                 var propertyInfoDescription = PropertyInfoAssertions.GetDescriptionFor(propertyInfo);
 
                 Execute.Assertion

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -734,9 +734,11 @@ namespace FluentAssertions.Equivalency
     public class Field : FluentAssertions.Equivalency.Node, FluentAssertions.Equivalency.IMember, FluentAssertions.Equivalency.INode
     {
         public Field(System.Reflection.FieldInfo fieldInfo, FluentAssertions.Equivalency.INode parent) { }
+        public Field(System.Type reflectedType, System.Reflection.FieldInfo fieldInfo, FluentAssertions.Equivalency.INode parent) { }
         public System.Type DeclaringType { get; set; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
     }
@@ -791,6 +793,7 @@ namespace FluentAssertions.Equivalency
     {
         System.Type DeclaringType { get; }
         FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        System.Type ReflectedType { get; }
         FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
     }
@@ -889,9 +892,11 @@ namespace FluentAssertions.Equivalency
     public class Property : FluentAssertions.Equivalency.Node, FluentAssertions.Equivalency.IMember, FluentAssertions.Equivalency.INode
     {
         public Property(System.Reflection.PropertyInfo propertyInfo, FluentAssertions.Equivalency.INode parent) { }
+        public Property(System.Type reflectedType, System.Reflection.PropertyInfo propertyInfo, FluentAssertions.Equivalency.INode parent) { }
         public System.Type DeclaringType { get; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
     }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -734,9 +734,11 @@ namespace FluentAssertions.Equivalency
     public class Field : FluentAssertions.Equivalency.Node, FluentAssertions.Equivalency.IMember, FluentAssertions.Equivalency.INode
     {
         public Field(System.Reflection.FieldInfo fieldInfo, FluentAssertions.Equivalency.INode parent) { }
+        public Field(System.Type reflectedType, System.Reflection.FieldInfo fieldInfo, FluentAssertions.Equivalency.INode parent) { }
         public System.Type DeclaringType { get; set; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
     }
@@ -791,6 +793,7 @@ namespace FluentAssertions.Equivalency
     {
         System.Type DeclaringType { get; }
         FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        System.Type ReflectedType { get; }
         FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
     }
@@ -889,9 +892,11 @@ namespace FluentAssertions.Equivalency
     public class Property : FluentAssertions.Equivalency.Node, FluentAssertions.Equivalency.IMember, FluentAssertions.Equivalency.INode
     {
         public Property(System.Reflection.PropertyInfo propertyInfo, FluentAssertions.Equivalency.INode parent) { }
+        public Property(System.Type reflectedType, System.Reflection.PropertyInfo propertyInfo, FluentAssertions.Equivalency.INode parent) { }
         public System.Type DeclaringType { get; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
     }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -734,9 +734,11 @@ namespace FluentAssertions.Equivalency
     public class Field : FluentAssertions.Equivalency.Node, FluentAssertions.Equivalency.IMember, FluentAssertions.Equivalency.INode
     {
         public Field(System.Reflection.FieldInfo fieldInfo, FluentAssertions.Equivalency.INode parent) { }
+        public Field(System.Type reflectedType, System.Reflection.FieldInfo fieldInfo, FluentAssertions.Equivalency.INode parent) { }
         public System.Type DeclaringType { get; set; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
     }
@@ -791,6 +793,7 @@ namespace FluentAssertions.Equivalency
     {
         System.Type DeclaringType { get; }
         FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        System.Type ReflectedType { get; }
         FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
     }
@@ -889,9 +892,11 @@ namespace FluentAssertions.Equivalency
     public class Property : FluentAssertions.Equivalency.Node, FluentAssertions.Equivalency.IMember, FluentAssertions.Equivalency.INode
     {
         public Property(System.Reflection.PropertyInfo propertyInfo, FluentAssertions.Equivalency.INode parent) { }
+        public Property(System.Type reflectedType, System.Reflection.PropertyInfo propertyInfo, FluentAssertions.Equivalency.INode parent) { }
         public System.Type DeclaringType { get; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
     }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -727,9 +727,11 @@ namespace FluentAssertions.Equivalency
     public class Field : FluentAssertions.Equivalency.Node, FluentAssertions.Equivalency.IMember, FluentAssertions.Equivalency.INode
     {
         public Field(System.Reflection.FieldInfo fieldInfo, FluentAssertions.Equivalency.INode parent) { }
+        public Field(System.Type reflectedType, System.Reflection.FieldInfo fieldInfo, FluentAssertions.Equivalency.INode parent) { }
         public System.Type DeclaringType { get; set; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
     }
@@ -784,6 +786,7 @@ namespace FluentAssertions.Equivalency
     {
         System.Type DeclaringType { get; }
         FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        System.Type ReflectedType { get; }
         FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
     }
@@ -882,9 +885,11 @@ namespace FluentAssertions.Equivalency
     public class Property : FluentAssertions.Equivalency.Node, FluentAssertions.Equivalency.IMember, FluentAssertions.Equivalency.INode
     {
         public Property(System.Reflection.PropertyInfo propertyInfo, FluentAssertions.Equivalency.INode parent) { }
+        public Property(System.Type reflectedType, System.Reflection.PropertyInfo propertyInfo, FluentAssertions.Equivalency.INode parent) { }
         public System.Type DeclaringType { get; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
     }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -734,9 +734,11 @@ namespace FluentAssertions.Equivalency
     public class Field : FluentAssertions.Equivalency.Node, FluentAssertions.Equivalency.IMember, FluentAssertions.Equivalency.INode
     {
         public Field(System.Reflection.FieldInfo fieldInfo, FluentAssertions.Equivalency.INode parent) { }
+        public Field(System.Type reflectedType, System.Reflection.FieldInfo fieldInfo, FluentAssertions.Equivalency.INode parent) { }
         public System.Type DeclaringType { get; set; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
     }
@@ -791,6 +793,7 @@ namespace FluentAssertions.Equivalency
     {
         System.Type DeclaringType { get; }
         FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        System.Type ReflectedType { get; }
         FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         object GetValue(object obj);
     }
@@ -889,9 +892,11 @@ namespace FluentAssertions.Equivalency
     public class Property : FluentAssertions.Equivalency.Node, FluentAssertions.Equivalency.IMember, FluentAssertions.Equivalency.INode
     {
         public Property(System.Reflection.PropertyInfo propertyInfo, FluentAssertions.Equivalency.INode parent) { }
+        public Property(System.Type reflectedType, System.Reflection.PropertyInfo propertyInfo, FluentAssertions.Equivalency.INode parent) { }
         public System.Type DeclaringType { get; }
         public override string Description { get; }
         public FluentAssertions.Common.CSharpAccessModifier GetterAccessibility { get; }
+        public System.Type ReflectedType { get; }
         public FluentAssertions.Common.CSharpAccessModifier SetterAccessibility { get; }
         public object GetValue(object obj) { }
     }

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
@@ -874,6 +874,8 @@ namespace FluentAssertions.Specs.Collections
             dictionary.Should().NotBeEmpty();
         }
 
+        #if !NET5_0_OR_GREATER
+
         [Fact]
         public void When_asserting_dictionary_with_items_is_not_empty_it_should_enumerate_the_dictionary_only_once()
         {
@@ -886,6 +888,8 @@ namespace FluentAssertions.Specs.Collections
             // Assert
             trackingDictionary.Enumerator.LoopCount.Should().Be(1);
         }
+
+        #endif
 
         [Fact]
         public void When_asserting_dictionary_without_items_is_not_empty_it_should_fail()

--- a/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
@@ -2088,6 +2088,7 @@ namespace FluentAssertions.Specs.Equivalency
         [Fact]
         public void Excluding_a_covariant_property_should_work()
         {
+            // Arrange
             var actual = new DerivedWithCovariantOverride(new DerivedWithProperty { DerivedProperty = "a", BaseProperty = "a_base" })
             {
                 OtherProp = "other"
@@ -2098,8 +2099,31 @@ namespace FluentAssertions.Specs.Equivalency
                 OtherProp = "other"
             };
 
+            // Act / Assert
             actual.Should().BeEquivalentTo(expectation, opts => opts
                 .Excluding(d => d.Property));
+        }
+
+        [Fact]
+        public void Excluding_a_covariant_property_through_the_base_class_excludes_the_base_class_property()
+        {
+            // Arrange
+            var actual = new DerivedWithCovariantOverride(new DerivedWithProperty { DerivedProperty = "a", BaseProperty = "a_base" })
+            {
+                OtherProp = "other"
+            };
+
+            BaseWithAbstractProperty expectation = new DerivedWithCovariantOverride(new DerivedWithProperty { DerivedProperty = "b", BaseProperty = "b_base" })
+            {
+                OtherProp = "other"
+            };
+
+            // Act
+            Action act= () => actual.Should().BeEquivalentTo(expectation, opts => opts
+                .Excluding(d => d.Property));
+
+            // Assert
+            act.Should().Throw<InvalidOperationException>().WithMessage("No members*");
         }
 
         private class BaseWithProperty
@@ -2152,41 +2176,43 @@ namespace FluentAssertions.Specs.Equivalency
         }
 
         [Fact]
-        public void Exclude()
+        public void Excluding_an_interface_property_through_inheritance_should_work()
         {
+            // Arrange
             var actual = new IInterfaceWithTwoProperties[]
             {
-                new DerivedClassImplementingInterface() { Value1 = 1, Value2 = 2 }
-            };
-            var expected = new IInterfaceWithTwoProperties[]
-            {
-                new DerivedClassImplementingInterface() { Value1 = 999, Value2 = 2 }
+                new DerivedClassImplementingInterface { Value1 = 1, Value2 = 2 }
             };
 
-            actual.Should().BeEquivalentTo(
-                expected,
-                options => options
-                    .Excluding(a => a.Value1)
-                    .RespectingRuntimeTypes());
+            var expected = new IInterfaceWithTwoProperties[]
+            {
+                new DerivedClassImplementingInterface { Value1 = 999, Value2 = 2 }
+            };
+
+            // Act / Assert
+            actual.Should().BeEquivalentTo(expected, options => options
+                .Excluding(a => a.Value1)
+                .RespectingRuntimeTypes());
         }
 
         [Fact]
-        public void Include()
+        public void Including_an_interface_property_through_inheritance_should_work()
         {
+            // Arrange
             var actual = new IInterfaceWithTwoProperties[]
             {
-                new DerivedClassImplementingInterface() { Value1 = 1, Value2 = 2 }
-            };
-            var expected = new IInterfaceWithTwoProperties[]
-            {
-                new DerivedClassImplementingInterface() { Value1 = 999, Value2 = 2 }
+                new DerivedClassImplementingInterface { Value1 = 1, Value2 = 2 }
             };
 
-            actual.Should().BeEquivalentTo(
-                expected,
-                options => options
-                    .Including(a => a.Value2)
-                    .RespectingRuntimeTypes());
+            var expected = new IInterfaceWithTwoProperties[]
+            {
+                new DerivedClassImplementingInterface { Value1 = 999, Value2 = 2 }
+            };
+
+            // Act / Assert
+            actual.Should().BeEquivalentTo(expected, options => options
+                .Including(a => a.Value2)
+                .RespectingRuntimeTypes());
         }
 
         #region Matching Rules

--- a/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
+++ b/Tests/FluentAssertions.Specs/FluentAssertions.Specs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net47;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net47;net5.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Src\FluentAssertions\FluentAssertions.snk</AssemblyOriginatorKeyFile>
@@ -47,7 +47,7 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Tests/FluentAssertions.Specs/Types/MethodBaseAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodBaseAssertionSpecs.cs
@@ -398,7 +398,7 @@ namespace FluentAssertions.Specs.Types
         public void When_asserting_a_protected_member_is_protected_it_succeeds()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).GetPropertyByName("ProtectedSetProperty");
+            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("ProtectedSetProperty");
 
             MethodInfo setMethod = propertyInfo.SetMethod;
 
@@ -414,7 +414,7 @@ namespace FluentAssertions.Specs.Types
         public void When_asserting_a_protected_member_is_public_it_throws_with_a_useful_message()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).GetPropertyByName("ProtectedSetProperty");
+            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("ProtectedSetProperty");
 
             MethodInfo setMethod = propertyInfo.SetMethod;
 
@@ -434,7 +434,7 @@ namespace FluentAssertions.Specs.Types
         public void When_asserting_a_public_member_is_public_it_succeeds()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).GetPropertyByName("PublicGetProperty");
+            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("PublicGetProperty");
 
             MethodInfo getMethod = propertyInfo.GetMethod;
 
@@ -450,7 +450,7 @@ namespace FluentAssertions.Specs.Types
         public void When_asserting_a_public_member_is_internal_it_throws_with_a_useful_message()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).GetPropertyByName("PublicGetProperty");
+            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("PublicGetProperty");
 
             MethodInfo getMethod = propertyInfo.GetMethod;
 
@@ -608,7 +608,7 @@ namespace FluentAssertions.Specs.Types
         public void When_asserting_a_protected_member_is_not_internal_it_succeeds()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).GetPropertyByName("ProtectedSetProperty");
+            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("ProtectedSetProperty");
             MethodInfo setMethod = propertyInfo.SetMethod;
 
             // Act
@@ -623,7 +623,7 @@ namespace FluentAssertions.Specs.Types
         public void When_asserting_a_protected_member_is_not_protected_it_throws_with_a_useful_message()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).GetPropertyByName("ProtectedSetProperty");
+            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("ProtectedSetProperty");
             MethodInfo setMethod = propertyInfo.SetMethod;
 
             // Act
@@ -641,7 +641,7 @@ namespace FluentAssertions.Specs.Types
         public void When_asserting_a_public_member_is_not_private_it_succeeds()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).GetPropertyByName("PublicGetProperty");
+            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("PublicGetProperty");
             MethodInfo getMethod = propertyInfo.GetMethod;
 
             // Act
@@ -656,7 +656,7 @@ namespace FluentAssertions.Specs.Types
         public void When_asserting_a_private_protected_member_is_not_private_it_succeeds()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).GetPropertyByName("PublicGetPrivateProtectedSet");
+            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("PublicGetPrivateProtectedSet");
             MethodInfo setMethod = propertyInfo.SetMethod;
 
             // Act
@@ -671,7 +671,7 @@ namespace FluentAssertions.Specs.Types
         public void When_asserting_a_public_member_is_not_public_it_throws_with_a_useful_message()
         {
             // Arrange
-            PropertyInfo propertyInfo = typeof(TestClass).GetPropertyByName("PublicGetProperty");
+            PropertyInfo propertyInfo = typeof(TestClass).FindPropertyByName("PublicGetProperty");
             MethodInfo getMethod = propertyInfo.GetMethod;
 
             // Act

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -22,6 +22,7 @@ Changes since 6.0.0 Beta 1
 * Removed the type info from the failure message in equivalency checks - [#1621](https://github.com/fluentassertions/fluentassertions/pull/1621).
 * Fixed a regression so that collections of similarly typed key-value pairs should be equivalent to a dictionary - [#1603](https://github.com/fluentassertions/fluentassertions/pull/1603).
 * Fixed a regression where a nested class without suitable members inside a collection raised an exception - [#1627](https://github.com/fluentassertions/fluentassertions/pull/1627).
+* Fixed support for covariant and inherited property exclusion and inclusion in `BeEquivalentTo` - [#1631](https://github.com/fluentassertions/fluentassertions/pull/1631).
 
 
 ## 6.0.0 Beta 1


### PR DESCRIPTION
`Excluding()` or `Including()` covariant properties in a `BeEquivalentTo` call didn't work. To reproduce this, I had to include .NET 5 to the frameworks the unit test project targets. Also, covariant properties behave completely different from normal properties. In fact, from a Reflection point of view, it looks like a covariant property is a completely different property, a bit like `new` properties. See also this [SO thread](https://stackoverflow.com/questions/68592010/how-to-find-the-base-class-property-of-a-covariant-property-override-in-c-sharp?noredirect=1#comment121223522_68592010). 

Then while looking at #1363, I discovered another problem. Simply calling `GetProperties` on a hierarchy that includes covariant or "new" properties will also include the hidden properties, causing weird side-effects later on. The new implementation traverses the class hierarchy and will only return the fields and properties that are really visible from a certain type.

Fixes #1562 and #1363