### PR TITLE
Add extension method `WithInnerExceptionExactly` for async exception assertions

### DIFF
--- a/Src/FluentAssertions/ExceptionAssertionsExtensions.cs
+++ b/Src/FluentAssertions/ExceptionAssertionsExtensions.cs
@@ -81,6 +81,29 @@ namespace FluentAssertions
         }
 
         /// <summary>
+        /// Asserts that the thrown exception contains an inner exception of the exact type <typeparamref name="TInnerException" /> (and not a derived exception type).
+        /// </summary>
+        /// <typeparam name="TException">The expected type of the exception.</typeparam>
+        /// <typeparam name="TInnerException">The expected type of the inner exception.</typeparam>
+        /// <param name="task">The <see cref="ExceptionAssertions{TException}"/> containing the thrown exception.</param>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public static async Task<ExceptionAssertions<TInnerException>> WithInnerExceptionExactly<TException, TInnerException>(
+            this Task<ExceptionAssertions<TException>> task,
+            string because = "",
+            params object[] becauseArgs)
+            where TException : Exception
+            where TInnerException : Exception
+        {
+            return (await task).WithInnerExceptionExactly<TInnerException>(because, becauseArgs);
+        }
+
+        /// <summary>
         /// Asserts that the thrown exception has a parameter which name matches <paramref name="paramName" />.
         /// </summary>
         /// <param name="parent">The <see cref="ExceptionAssertions{TException}"/> containing the thrown exception.</param>

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -239,6 +239,9 @@ namespace FluentAssertions
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerException<TException, TInnerException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
             where TException : System.Exception
             where TInnerException : System.Exception { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerExceptionExactly<TException, TInnerException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
+            where TException : System.Exception
+            where TInnerException : System.Exception { }
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public static FluentAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this FluentAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -239,6 +239,9 @@ namespace FluentAssertions
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerException<TException, TInnerException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
             where TException : System.Exception
             where TInnerException : System.Exception { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerExceptionExactly<TException, TInnerException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
+            where TException : System.Exception
+            where TInnerException : System.Exception { }
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public static FluentAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this FluentAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -239,6 +239,9 @@ namespace FluentAssertions
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerException<TException, TInnerException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
             where TException : System.Exception
             where TInnerException : System.Exception { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerExceptionExactly<TException, TInnerException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
+            where TException : System.Exception
+            where TInnerException : System.Exception { }
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public static FluentAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this FluentAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -232,6 +232,9 @@ namespace FluentAssertions
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerException<TException, TInnerException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
             where TException : System.Exception
             where TInnerException : System.Exception { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerExceptionExactly<TException, TInnerException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
+            where TException : System.Exception
+            where TInnerException : System.Exception { }
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public static FluentAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this FluentAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, string because = "", params object[] becauseArgs)

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -239,6 +239,9 @@ namespace FluentAssertions
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerException<TException, TInnerException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
             where TException : System.Exception
             where TInnerException : System.Exception { }
+        public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TInnerException>> WithInnerExceptionExactly<TException, TInnerException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string because = "", params object[] becauseArgs)
+            where TException : System.Exception
+            where TInnerException : System.Exception { }
         public static System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> WithMessage<TException>(this System.Threading.Tasks.Task<FluentAssertions.Specialized.ExceptionAssertions<TException>> task, string expectedWildcardPattern, string because = "", params object[] becauseArgs)
             where TException : System.Exception { }
         public static FluentAssertions.Specialized.ExceptionAssertions<TException> WithParameterName<TException>(this FluentAssertions.Specialized.ExceptionAssertions<TException> parent, string paramName, string because = "", params object[] becauseArgs)

--- a/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Exceptions/AsyncFunctionExceptionAssertionSpecs.cs
@@ -833,6 +833,21 @@ namespace FluentAssertions.Specs.Exceptions
         }
 
         [Fact]
+        public async Task When_async_method_throws_the_expected_inner_exception_exactly_it_should_succeed()
+        {
+            // Arrange
+            Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentException()));
+
+            // Act
+            Func<Task> action = () => task
+                .Should().ThrowAsync<AggregateException>()
+                .WithInnerExceptionExactly<AggregateException, ArgumentException>();
+
+            // Assert
+            await action.Should().NotThrowAsync();
+        }
+
+        [Fact]
         public async Task When_async_method_throws_aggregate_exception_containing_expected_exception_it_should_succeed()
         {
             // Arrange
@@ -873,6 +888,21 @@ namespace FluentAssertions.Specs.Exceptions
 
             // Assert
             await action.Should().ThrowAsync<XunitException>().WithMessage("*InvalidOperation*Argument*");
+        }
+
+        [Fact]
+        public async Task When_async_method_does_not_throw_the_expected_inner_exception_exactly_it_should_fail()
+        {
+            // Arrange
+            Func<Task> task = () => Throw.Async(new AggregateException(new ArgumentNullException()));
+
+            // Act
+            Func<Task> action = () => task
+                .Should().ThrowAsync<AggregateException>()
+                .WithInnerExceptionExactly<AggregateException, ArgumentException>();
+
+            // Assert
+            await action.Should().ThrowAsync<XunitException>().WithMessage("*ArgumentException*ArgumentNullException*");
         }
 
         [Fact]

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -12,6 +12,7 @@ sidebar:
 ### What's New
 
 * Prevent asserting directly on `AndConstraint` - [#1649](https://github.com/fluentassertions/fluentassertions/pull/1649)
+* Added `WithInnerExceptionExactly` extension method on `Task<ExceptionAssertions<T>>` for easier use with `ThrowAsync` - [#1658](https://github.com/fluentassertions/fluentassertions/pull/1658)
 
 ## 6.0.0
 


### PR DESCRIPTION
Adds extension method for the remaining method `WithInnerExceptionExactly` for `ExceptionAssertions<T>` when using `ThrowAsync`.

Closes #1400 
