### PR TITLE
Fix small grammatical error

### DIFF
--- a/docs/_pages/eventmonitoring.md
+++ b/docs/_pages/eventmonitoring.md
@@ -20,7 +20,7 @@ monitoredSubject.Should().Raise("NameChangedEvent");
 
 Notice that Fluent Assertions will keep monitoring the `subject` for as long as the `using` block lasts.
 
-Assuming that we’re dealing with a MVVM implementation, you might want to verify that it raised its `PropertyChanged` event for a particular property:
+Assuming that we’re dealing with an MVVM implementation, you might want to verify that it raised its `PropertyChanged` event for a particular property:
 
 ```csharp
 monitoredSubject


### PR DESCRIPTION
## IMPORTANT 

* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).