### PR TITLE
Resolved a significant performance degradation in `BeEquivalentTo`

### DIFF
--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -13,6 +13,7 @@ namespace FluentAssertions
     /// <summary>
     /// Tries to extract the name of the variable or invocation on which the assertion is executed.
     /// </summary>
+    // REFACTOR: Should be internal and treated as an implementation detail of the AssertionScope
     public static class CallerIdentifier
     {
         public static Action<string> Logger { get; set; } = _ => { };

--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -352,7 +352,7 @@ namespace FluentAssertions.Collections
 
             EquivalencyAssertionOptions<IEnumerable<TExpectation>> options = config(AssertionOptions.CloneDefaults<TExpectation>()).AsCollection();
 
-            var context = new EquivalencyValidationContext(Node.From<IEnumerable<TExpectation>>(() => CallerIdentifier.DetermineCallerIdentity()), options)
+            var context = new EquivalencyValidationContext(Node.From<IEnumerable<TExpectation>>(() => AssertionScope.Current.CallerIdentity), options)
             {
                 Reason = new Reason(because, becauseArgs),
                 TraceWriter = options.TraceWriter,
@@ -848,7 +848,7 @@ namespace FluentAssertions.Collections
 
                     foreach (T actualItem in Subject)
                     {
-                        var context = new EquivalencyValidationContext(Node.From<TExpectation>(() => CallerIdentifier.DetermineCallerIdentity()), options)
+                        var context = new EquivalencyValidationContext(Node.From<TExpectation>(() => AssertionScope.Current.CallerIdentity), options)
                         {
                             Reason = new Reason(because, becauseArgs),
                             TraceWriter = options.TraceWriter
@@ -2170,7 +2170,7 @@ namespace FluentAssertions.Collections
                     int index = 0;
                     foreach (T actualItem in Subject)
                     {
-                        var context = new EquivalencyValidationContext(Node.From<TExpectation>(() => CallerIdentifier.DetermineCallerIdentity()), options)
+                        var context = new EquivalencyValidationContext(Node.From<TExpectation>(() => AssertionScope.Current.CallerIdentity), options)
                         {
                             Reason = new Reason(because, becauseArgs),
                             TraceWriter = options.TraceWriter

--- a/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericDictionaryAssertions.cs
@@ -211,7 +211,7 @@ namespace FluentAssertions.Collections
 
             EquivalencyAssertionOptions<TExpectation> options = config(AssertionOptions.CloneDefaults<TExpectation>());
 
-            var context = new EquivalencyValidationContext(Node.From<TExpectation>(() => CallerIdentifier.DetermineCallerIdentity()), options)
+            var context = new EquivalencyValidationContext(Node.From<TExpectation>(() => AssertionScope.Current.CallerIdentity), options)
             {
                 Reason = new Reason(because, becauseArgs),
                 TraceWriter = options.TraceWriter

--- a/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/StringCollectionAssertions.cs
@@ -123,7 +123,7 @@ namespace FluentAssertions.Collections
 
             EquivalencyAssertionOptions<IEnumerable<string>> options = config(AssertionOptions.CloneDefaults<string>()).AsCollection();
 
-            var context = new EquivalencyValidationContext(Node.From<IEnumerable<string>>(() => CallerIdentifier.DetermineCallerIdentity()), options)
+            var context = new EquivalencyValidationContext(Node.From<IEnumerable<string>>(() => AssertionScope.Current.CallerIdentity), options)
             {
                 Reason = new Reason(because, becauseArgs),
                 TraceWriter = options.TraceWriter

--- a/Src/FluentAssertions/Data/DataColumnAssertions.cs
+++ b/Src/FluentAssertions/Data/DataColumnAssertions.cs
@@ -115,7 +115,7 @@ namespace FluentAssertions.Data
 
             IDataEquivalencyAssertionOptions<DataColumn> options = config(AssertionOptions.CloneDefaults<DataColumn, DataEquivalencyAssertionOptions<DataColumn>>(e => new(e)));
 
-            var context = new EquivalencyValidationContext(Node.From<DataColumn>(() => CallerIdentifier.DetermineCallerIdentity()), options)
+            var context = new EquivalencyValidationContext(Node.From<DataColumn>(() => AssertionScope.Current.CallerIdentity), options)
             {
                 Reason = new Reason(because, becauseArgs),
                 TraceWriter = options.TraceWriter

--- a/Src/FluentAssertions/Data/DataRowAssertions.cs
+++ b/Src/FluentAssertions/Data/DataRowAssertions.cs
@@ -180,7 +180,7 @@ namespace FluentAssertions.Data
 
             IDataEquivalencyAssertionOptions<DataRow> options = config(AssertionOptions.CloneDefaults<DataRow, DataEquivalencyAssertionOptions<DataRow>>(e => new(e)));
 
-            var context = new EquivalencyValidationContext(Node.From<DataRow>(() => CallerIdentifier.DetermineCallerIdentity()), options)
+            var context = new EquivalencyValidationContext(Node.From<DataRow>(() => AssertionScope.Current.CallerIdentity), options)
             {
                 Reason = new Reason(because, becauseArgs),
                 TraceWriter = options.TraceWriter

--- a/Src/FluentAssertions/Data/DataSetAssertions.cs
+++ b/Src/FluentAssertions/Data/DataSetAssertions.cs
@@ -239,7 +239,7 @@ namespace FluentAssertions.Data
                 CompileTimeType = typeof(TDataSet)
             };
 
-            var context = new EquivalencyValidationContext(Node.From<DataSet>(() => CallerIdentifier.DetermineCallerIdentity()), options)
+            var context = new EquivalencyValidationContext(Node.From<DataSet>(() => AssertionScope.Current.CallerIdentity), options)
             {
                 Reason = new Reason(because, becauseArgs),
                 TraceWriter = options.TraceWriter,

--- a/Src/FluentAssertions/Data/DataTableAssertions.cs
+++ b/Src/FluentAssertions/Data/DataTableAssertions.cs
@@ -245,7 +245,7 @@ namespace FluentAssertions.Data
 
             IDataEquivalencyAssertionOptions<DataTable> options = config(AssertionOptions.CloneDefaults<DataTable, DataEquivalencyAssertionOptions<DataTable>>(e => new(e)));
 
-            var context = new EquivalencyValidationContext(Node.From<DataTable>(() => CallerIdentifier.DetermineCallerIdentity()), options)
+            var context = new EquivalencyValidationContext(Node.From<DataTable>(() => AssertionScope.Current.CallerIdentity), options)
             {
                 Reason = new Reason(because, becauseArgs),
                 TraceWriter = options.TraceWriter

--- a/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
+++ b/Src/FluentAssertions/Equivalency/EquivalencyValidator.cs
@@ -13,6 +13,8 @@ namespace FluentAssertions.Equivalency
         public void AssertEquality(Comparands comparands, EquivalencyValidationContext context)
         {
             using var scope = new AssertionScope();
+
+            scope.AssumeSingleCaller();
             scope.AddReportable("configuration", context.Options.ToString());
             scope.BecauseOf(context.Reason);
 

--- a/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
@@ -108,7 +108,7 @@ namespace FluentAssertions.Numeric
             EquivalencyAssertionOptions<TExpectation> options = config(AssertionOptions.CloneDefaults<TExpectation>());
 
             var context = new EquivalencyValidationContext(
-                Node.From<TExpectation>(() => CallerIdentifier.DetermineCallerIdentity()), options)
+                Node.From<TExpectation>(() => AssertionScope.Current.CallerIdentity), options)
             {
                 Reason = new Reason(because, becauseArgs),
                 TraceWriter = options.TraceWriter

--- a/Src/FluentAssertions/Primitives/ObjectAssertions.cs
+++ b/Src/FluentAssertions/Primitives/ObjectAssertions.cs
@@ -129,7 +129,7 @@ namespace FluentAssertions.Primitives
             EquivalencyAssertionOptions<TExpectation> options = config(AssertionOptions.CloneDefaults<TExpectation>());
 
             var context = new EquivalencyValidationContext(Node.From<TExpectation>(() =>
-                CallerIdentifier.DetermineCallerIdentity()), options)
+                AssertionScope.Current.CallerIdentity), options)
             {
                 Reason = new Reason(because, becauseArgs),
                 TraceWriter = options.TraceWriter

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1223,6 +1223,7 @@ namespace FluentAssertions.Execution
         public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
         public AssertionScope(System.Lazy<string> context) { }
         public AssertionScope(string context) { }
+        public string CallerIdentity { get; }
         public System.Lazy<string> Context { get; set; }
         public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
@@ -1231,6 +1232,7 @@ namespace FluentAssertions.Execution
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
         public void AddReportable(string key, System.Func<string> valueFunc) { }
         public void AddReportable(string key, string value) { }
+        public void AssumeSingleCaller() { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(FluentAssertions.Execution.Reason reason) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }
         public FluentAssertions.Execution.Continuation ClearExpectation() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1223,6 +1223,7 @@ namespace FluentAssertions.Execution
         public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
         public AssertionScope(System.Lazy<string> context) { }
         public AssertionScope(string context) { }
+        public string CallerIdentity { get; }
         public System.Lazy<string> Context { get; set; }
         public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
@@ -1231,6 +1232,7 @@ namespace FluentAssertions.Execution
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
         public void AddReportable(string key, System.Func<string> valueFunc) { }
         public void AddReportable(string key, string value) { }
+        public void AssumeSingleCaller() { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(FluentAssertions.Execution.Reason reason) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }
         public FluentAssertions.Execution.Continuation ClearExpectation() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1223,6 +1223,7 @@ namespace FluentAssertions.Execution
         public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
         public AssertionScope(System.Lazy<string> context) { }
         public AssertionScope(string context) { }
+        public string CallerIdentity { get; }
         public System.Lazy<string> Context { get; set; }
         public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
@@ -1231,6 +1232,7 @@ namespace FluentAssertions.Execution
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
         public void AddReportable(string key, System.Func<string> valueFunc) { }
         public void AddReportable(string key, string value) { }
+        public void AssumeSingleCaller() { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(FluentAssertions.Execution.Reason reason) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }
         public FluentAssertions.Execution.Continuation ClearExpectation() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1176,6 +1176,7 @@ namespace FluentAssertions.Execution
         public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
         public AssertionScope(System.Lazy<string> context) { }
         public AssertionScope(string context) { }
+        public string CallerIdentity { get; }
         public System.Lazy<string> Context { get; set; }
         public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
@@ -1184,6 +1185,7 @@ namespace FluentAssertions.Execution
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
         public void AddReportable(string key, System.Func<string> valueFunc) { }
         public void AddReportable(string key, string value) { }
+        public void AssumeSingleCaller() { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(FluentAssertions.Execution.Reason reason) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }
         public FluentAssertions.Execution.Continuation ClearExpectation() { }

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1223,6 +1223,7 @@ namespace FluentAssertions.Execution
         public AssertionScope(FluentAssertions.Execution.IAssertionStrategy assertionStrategy) { }
         public AssertionScope(System.Lazy<string> context) { }
         public AssertionScope(string context) { }
+        public string CallerIdentity { get; }
         public System.Lazy<string> Context { get; set; }
         public FluentAssertions.Formatting.FormattingOptions FormattingOptions { get; }
         public FluentAssertions.Execution.AssertionScope UsingLineBreaks { get; }
@@ -1231,6 +1232,7 @@ namespace FluentAssertions.Execution
         public void AddPreFormattedFailure(string formattedFailureMessage) { }
         public void AddReportable(string key, System.Func<string> valueFunc) { }
         public void AddReportable(string key, string value) { }
+        public void AssumeSingleCaller() { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(FluentAssertions.Execution.Reason reason) { }
         public FluentAssertions.Execution.AssertionScope BecauseOf(string because, params object[] becauseArgs) { }
         public FluentAssertions.Execution.Continuation ClearExpectation() { }

--- a/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/CollectionEquivalencySpecs.cs
@@ -2830,5 +2830,77 @@ namespace FluentAssertions.Specs.Equivalency
                    from y in arrays
                    select new object[] { x, y };
         }
+
+        [Fact]
+        public void Comparing_lots_of_complex_objects_should_still_be_fast()
+        {
+            // Arrange
+            ClassWithLotsOfProperties GetObject(int i)
+            {
+                return new ClassWithLotsOfProperties
+                {
+#pragma warning disable CA1305
+                    Id = i.ToString(),
+                    Value1 = i.ToString(),
+                    Value2 = i.ToString(),
+                    Value3 = i.ToString(),
+                    Value4 = i.ToString(),
+                    Value5 = i.ToString(),
+                    Value6 = i.ToString(),
+                    Value7 = i.ToString(),
+                    Value8 = i.ToString(),
+                    Value9 = i.ToString(),
+                    Value10 = i.ToString(),
+                    Value11 = i.ToString(),
+                    Value12 = i.ToString(),
+#pragma warning restore CA1305
+                };
+            }
+
+            var actual = new List<ClassWithLotsOfProperties>();
+            var expectation = new List<ClassWithLotsOfProperties>();
+
+            var maxAmount = 100;
+            for (var i = 0; i < maxAmount; i++)
+            {
+                actual.Add(GetObject(i));
+                expectation.Add(GetObject(maxAmount - 1 - i));
+            }
+
+            // Act
+            Action act = () => actual.Should().BeEquivalentTo(expectation);
+
+            // Assert
+            act.ExecutionTime().Should().BeLessThan(20.Seconds());
+        }
+
+        private class ClassWithLotsOfProperties
+        {
+            public string Id { get; set; }
+
+            public string Value1 { get; set; }
+
+            public string Value2 { get; set; }
+
+            public string Value3 { get; set; }
+
+            public string Value4 { get; set; }
+
+            public string Value5 { get; set; }
+
+            public string Value6 { get; set; }
+
+            public string Value7 { get; set; }
+
+            public string Value8 { get; set; }
+
+            public string Value9 { get; set; }
+
+            public string Value10 { get; set; }
+
+            public string Value11 { get; set; }
+
+            public string Value12 { get; set; }
+        }
     }
 }

--- a/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Execution/CallerIdentifierSpecs.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Sdk;
@@ -485,7 +486,7 @@ namespace System
     {
         public static void DetermineCallerIdentityInNamespace()
         {
-            Func<string> actualCaller = () => CallerIdentifier.DetermineCallerIdentity();
+            Func<string> actualCaller = () => AssertionScope.Current.CallerIdentity;
             actualCaller.Should().BeNull("we want this check to fail for the test");
         }
     }
@@ -497,7 +498,7 @@ namespace SystemPrefixed
     {
         public static void DetermineCallerIdentityInNamespace()
         {
-            Func<string> actualCaller = () => CallerIdentifier.DetermineCallerIdentity();
+            Func<string> actualCaller = () => AssertionScope.Current.CallerIdentity;
             actualCaller.Should().BeNull("we want this check to fail for the test");
         }
     }
@@ -509,7 +510,7 @@ namespace System.Data
     {
         public static void DetermineCallerIdentityInNamespace()
         {
-            Func<string> actualCaller = () => CallerIdentifier.DetermineCallerIdentity();
+            Func<string> actualCaller = () => AssertionScope.Current.CallerIdentity;
             actualCaller.Should().BeNull("we want this check to fail for the test");
         }
     }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,6 +13,10 @@ sidebar:
 
 * Prevent asserting directly on `AndConstraint` - [#1649](https://github.com/fluentassertions/fluentassertions/pull/1649)
 
+### Fixes
+
+* Resolved a significant performance degradation in `BeEquivalentTo` - [#1660](https://github.com/fluentassertions/fluentassertions/pull/1660)
+
 ## 6.0.0
 
 ### What's New


### PR DESCRIPTION
This was caused by the increased dependency on the CallerIdentifier, and the additional work caller identification takes in v6.

#1657 