### PR TITLE
Optimize BeEquivalentTo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,6 @@ docs/node_modules
 
 # Documentation file needed for StyleCop.Analyzers
 Tests/FluentAssertions.Specs/FluentAssertions.Specs.xml
+
+# BenchmarkDotNet
+Tests/Benchmarks/BenchmarkDotNet.Artifacts/

--- a/Src/FluentAssertions/CallerIdentifier.cs
+++ b/Src/FluentAssertions/CallerIdentifier.cs
@@ -237,7 +237,7 @@ namespace FluentAssertions
 
         private static bool UsesNewKeyword(string candidate)
         {
-            return Regex.IsMatch(candidate, @"new(\s?\[|\s?\{|\s\w+)");
+            return Regex.IsMatch(candidate, @"new(?:\s?\[|\s?\{|\s\w+)");
         }
 
         private static bool IsStringLiteral(string candidate)

--- a/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/StringEqualityEquivalencyStep.cs
@@ -1,5 +1,4 @@
 using System;
-using FluentAssertions.Common;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Equivalency.Steps
@@ -20,7 +19,7 @@ namespace FluentAssertions.Equivalency.Steps
                 return EquivalencyResult.AssertionCompleted;
             }
 
-            bool subjectIsString = ValidateAgainstType<string>(comparands, context.CurrentNode);
+            bool subjectIsString = ValidateSubjectIsString(comparands, context.CurrentNode);
             if (subjectIsString)
             {
                 string subject = (string)comparands.Subject;
@@ -51,18 +50,15 @@ namespace FluentAssertions.Equivalency.Steps
             return true;
         }
 
-        private static bool ValidateAgainstType<T>(Comparands comparands, INode currentNode)
+        private static bool ValidateSubjectIsString(Comparands comparands, INode currentNode)
         {
-            bool subjectIsNull = comparands.Subject is null;
-            if (subjectIsNull)
+            if (comparands.Subject is string)
             {
-                // Do not know the declared type of the expectation.
                 return true;
             }
 
             return
                 AssertionScope.Current
-                    .ForCondition(comparands.Subject.GetType().IsSameOrInherits(typeof(T)))
                     .FailWith($"Expected {currentNode} to be {{0}}, but found {{1}}.",
                         comparands.RuntimeType, comparands.Subject.GetType());
         }

--- a/Src/FluentAssertions/Execution/MessageBuilder.cs
+++ b/Src/FluentAssertions/Execution/MessageBuilder.cs
@@ -45,7 +45,7 @@ namespace FluentAssertions.Execution
 
         private static string SubstituteIdentifier(string message, string identifier, string fallbackIdentifier)
         {
-            const string pattern = @"(\s|^)\{context(?:\:(?<default>[a-z|A-Z|\s]+))?\}";
+            const string pattern = @"(?:\s|^)\{context(?:\:(?<default>[a-z|A-Z|\s]+))?\}";
 
             message = Regex.Replace(message, pattern, match =>
             {

--- a/Tests/Benchmarks/Benchmarks.csproj
+++ b/Tests/Benchmarks/Benchmarks.csproj
@@ -6,14 +6,11 @@
     <AssemblyOriginatorKeyFile>..\..\Src\FluentAssertions\FluentAssertions.snk</AssemblyOriginatorKeyFile>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Src\FluentAssertions\FluentAssertions.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Include="Bogus" Version="32.0.2" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
   </ItemGroup>

--- a/Tests/Benchmarks/CollectionEqual.cs
+++ b/Tests/Benchmarks/CollectionEqual.cs
@@ -8,7 +8,7 @@ namespace Benchmarks
 {
     [MemoryDiagnoser]
     [SimpleJob(RuntimeMoniker.Net472)]
-    [SimpleJob(RuntimeMoniker.NetCoreApp50)]
+    [SimpleJob(RuntimeMoniker.Net50)]
     public class CollectionEqualBenchmarks
     {
         private IEnumerable<int> collection1;

--- a/Tests/Benchmarks/Issue1657.cs
+++ b/Tests/Benchmarks/Issue1657.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using FluentAssertions;
+using FluentAssertions.Collections;
+
+namespace Benchmarks
+{
+    [MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.Net472)]
+    [SimpleJob(RuntimeMoniker.Net50)]
+    public class Issue1657
+    {
+        private List<ExampleObject> list;
+        private List<ExampleObject> list2;
+
+        [Params(1, 10, 50)]
+        public int N { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            list = Enumerable.Range(0, N).Select(i => GetObject(i)).ToList();
+            list2 = Enumerable.Range(0, N).Select(i => GetObject(N - 1 - i)).ToList();
+        }
+
+        [Benchmark]
+        public AndConstraint<GenericCollectionAssertions<ExampleObject>> BeEquivalentTo() =>
+            list.Should().BeEquivalentTo(list2);
+
+        private static ExampleObject GetObject(int i)
+        {
+            return new ExampleObject
+            {
+                Id = i.ToString("D2"),
+                Value1 = i.ToString("D2"),
+                Value2 = i.ToString("D2"),
+                Value3 = i.ToString("D2"),
+                Value4 = i.ToString("D2"),
+                Value5 = i.ToString("D2"),
+                Value6 = i.ToString("D2"),
+                Value7 = i.ToString("D2"),
+                Value8 = i.ToString("D2"),
+                Value9 = i.ToString("D2"),
+                Value10 = i.ToString("D2"),
+                Value11 = i.ToString("D2"),
+                Value12 = i.ToString("D2"),
+            };
+        }
+    }
+
+    public class ExampleObject
+    {
+        public string Id { get; set; }
+
+        public string Value1 { get; set; }
+
+        public string Value2 { get; set; }
+
+        public string Value3 { get; set; }
+
+        public string Value4 { get; set; }
+
+        public string Value5 { get; set; }
+
+        public string Value6 { get; set; }
+
+        public string Value7 { get; set; }
+
+        public string Value8 { get; set; }
+
+        public string Value9 { get; set; }
+
+        public string Value10 { get; set; }
+
+        public string Value11 { get; set; }
+
+        public string Value12 { get; set; }
+    }
+}

--- a/Tests/Benchmarks/Program.cs
+++ b/Tests/Benchmarks/Program.cs
@@ -6,7 +6,7 @@ namespace Benchmarks
     {
         public static void Main()
         {
-            _ = BenchmarkRunner.Run<CollectionEqualBenchmarks>();
+            _ = BenchmarkRunner.Run<Issue1657>();
         }
     }
 }


### PR DESCRIPTION
More optimizations in addition to #1660 

#1657 

Benchmark results:

**#1660**
```
|              Runtime |  N |         Mean |       Error |      StdDev |      Gen 0 |     Gen 1 |  Allocated |
|--------------------- |--- |-------------:|------------:|------------:|-----------:|----------:|-----------:|
|             .NET 5.0 |  1 |     219.9 us |     0.86 us |     0.76 us |    26.6113 |    1.2207 |     164 KB |
| .NET Framework 4.7.2 |  1 |     276.5 us |     1.54 us |     1.36 us |    28.8086 |    0.9766 |     178 KB |
|             .NET 5.0 | 10 |  11,887.3 us |    98.84 us |    92.45 us |  1546.8750 |  140.6250 |   9,535 KB |
| .NET Framework 4.7.2 | 10 |  16,133.7 us |    31.25 us |    27.71 us |  1875.0000 |  156.2500 |  11,552 KB |
|             .NET 5.0 | 50 | 302,525.7 us | 1,266.79 us | 1,184.95 us | 38000.0000 | 2500.0000 | 235,048 KB |
| .NET Framework 4.7.2 | 50 | 420,015.7 us | 1,012.14 us |   946.76 us | 47000.0000 | 2000.0000 | 289,532 KB |
```

**2c02139bb5f015379406f2009a84173cd6053594**
```
|              Runtime |  N |          Mean |        Error |       StdDev |      Gen 0 |     Gen 1 |  Allocated |
|--------------------- |--- |--------------:|-------------:|-------------:|-----------:|----------:|-----------:|
|             .NET 5.0 |  1 |      77.50 us |     1.030 us |     0.964 us |    17.7002 |    0.4883 |     109 KB |
| .NET Framework 4.7.2 |  1 |     100.02 us |     0.818 us |     0.765 us |    18.3105 |    0.4883 |     113 KB |
|             .NET 5.0 | 10 |  11,473.69 us |    74.099 us |    61.876 us |  1484.3750 |  140.6250 |   9,134 KB |
| .NET Framework 4.7.2 | 10 |  15,942.24 us |    57.994 us |    54.248 us |  1812.5000 |  156.2500 |  11,149 KB |
|             .NET 5.0 | 50 | 299,437.31 us | 2,796.149 us | 2,615.519 us | 36000.0000 | 2000.0000 | 225,708 KB |
| .NET Framework 4.7.2 | 50 | 410,502.04 us | 1,209.430 us | 1,072.128 us | 45000.0000 | 2000.0000 | 279,940 KB |
```

**0ee102ac91e126b7d354e355deaa0a680aa28d7c**
```
|              Runtime |  N |          Mean |        Error |       StdDev |      Gen 0 |     Gen 1 |  Allocated |
|--------------------- |--- |--------------:|-------------:|-------------:|-----------:|----------:|-----------:|
|             .NET 5.0 |  1 |      77.50 us |     0.486 us |     0.431 us |    17.7002 |    0.4883 |     109 KB |
| .NET Framework 4.7.2 |  1 |     100.43 us |     1.231 us |     1.151 us |    18.3105 |    0.4883 |     113 KB |
|             .NET 5.0 | 10 |  11,295.65 us |    50.847 us |    42.460 us |  1484.3750 |  140.6250 |   9,107 KB |
| .NET Framework 4.7.2 | 10 |  15,628.73 us |   140.952 us |   131.847 us |  1796.8750 |  156.2500 |  11,121 KB |
|             .NET 5.0 | 50 | 290,311.10 us | 2,931.077 us | 2,741.731 us | 36500.0000 | 3000.0000 | 224,950 KB |
| .NET Framework 4.7.2 | 50 | 402,446.02 us | 1,302.002 us | 1,154.191 us | 45000.0000 | 2000.0000 | 279,188 KB |
```