### PR TITLE
Handle exceptions when asserting an ImmutableArray

### DIFF
--- a/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/EnumerableEquivalencyStep.cs
@@ -51,7 +51,20 @@ namespace FluentAssertions.Equivalency.Steps
 
         internal static object[] ToArray(object value)
         {
-            return value is not null ? ((IEnumerable)value).Cast<object>().ToArray() : null;
+            if (value == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                return ((IEnumerable)value).Cast<object>().ToArray();
+            }
+            catch (InvalidOperationException) when (value.GetType().Name.Equals("ImmutableArray`1", StringComparison.Ordinal))
+            {
+                // This is probably a default ImmutableArray<T>
+                return Array.Empty<object>();
+            }
         }
     }
 }

--- a/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/GenericEnumerableEquivalencyStep.cs
@@ -57,7 +57,7 @@ namespace FluentAssertions.Equivalency.Steps
         }
 
         private static void HandleImpl<T>(EnumerableEquivalencyValidator validator, object[] subject, IEnumerable<T> expectation)
-            => validator.Execute(subject, expectation?.ToArray());
+            => validator.Execute(subject, ToArray(expectation));
 
         private static bool AssertSubjectIsCollection(object subject)
         {
@@ -105,6 +105,19 @@ namespace FluentAssertions.Equivalency.Steps
             Type interfaceType = GetIEnumerableInterfaces(enumerableType).Single();
 
             return interfaceType.GetGenericArguments().Single();
+        }
+
+        private static T[] ToArray<T>(IEnumerable<T> value)
+        {
+            try
+            {
+                return value?.ToArray();
+            }
+            catch (InvalidOperationException) when (value.GetType().Name.Equals("ImmutableArray`1", StringComparison.Ordinal))
+            {
+                // This is probably a default ImmutableArray<T>
+                return Array.Empty<T>();
+            }
         }
     }
 }

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.BeEquivalentTo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Immutable;
 using System.Linq;
 using FluentAssertions.Execution;
 using Xunit;
@@ -133,6 +134,28 @@ namespace FluentAssertions.Specs.Collections
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
                 "Expected collection not to be <null>*");
+        }
+
+        [Fact]
+        public void Default_immutable_arrays_should_be_equivalent()
+        {
+            // Arrange
+            ImmutableArray<string> collection = default;
+            ImmutableArray<string> collection1 = default;
+
+            // Act / Assert
+            collection.Should().BeEquivalentTo(collection1);
+        }
+
+        [Fact]
+        public void Default_immutable_lists_should_be_equivalent()
+        {
+            // Arrange
+            ImmutableList<string> collection = default;
+            ImmutableList<string> collection1 = default;
+
+            // Act / Assert
+            collection.Should().BeEquivalentTo(collection1);
         }
 
         #endregion
@@ -289,6 +312,28 @@ namespace FluentAssertions.Specs.Collections
             // Assert
             act.Should().Throw<XunitException>()
                 .WithMessage("Expected actual not to be equivalent *failure message*, but found <null>.");
+        }
+
+        [Fact]
+        public void Default_immutable_array_should_not_be_equivalent_to_initialized_immutable_array()
+        {
+            // Arrange
+            ImmutableArray<string> collection = default;
+            ImmutableArray<string> collection1 = ImmutableArray.Create("a", "b", "c");
+
+            // Act / Assert
+            collection.Should().NotBeEquivalentTo(collection1);
+        }
+
+        [Fact]
+        public void Immutable_array_should_not_be_equivalent_to_default_immutable_array()
+        {
+            // Arrange
+            ImmutableArray<string> collection = ImmutableArray.Create("a", "b", "c");
+            ImmutableArray<string> collection1 = default;
+
+            // Act / Assert
+            collection.Should().NotBeEquivalentTo(collection1);
         }
 
         #endregion

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,6 +13,8 @@ sidebar:
 
 ### Fixes
 
+* Prevent exceptions when asserting on `ImmutableArray<T>` - [#1668](https://github.com/fluentassertions/fluentassertions/pull/1668)
+
 ## 6.1.0
 
 ### What's New


### PR DESCRIPTION
Detect specific exceptions with `.ToArray()` with `ImmutableArray<T>`.

Should fix #1655 

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).