### PR TITLE
Change names of "OrEqualTo" assertion methods

### DIFF
--- a/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
+++ b/Src/FluentAssertions/Collections/GenericCollectionAssertions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
@@ -1276,7 +1277,7 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
-        /// Asserts that the number of items in the collection is greater or equal to the supplied <paramref name="expected" /> amount.
+        /// Asserts that the number of items in the collection is greater than or equal to the supplied <paramref name="expected" /> amount.
         /// </summary>
         /// <param name="expected">The number to which the actual number items in the collection will be compared.</param>
         /// <param name="because">
@@ -1286,7 +1287,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveCountGreaterThanOrEqualTo(int expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -1303,6 +1304,9 @@ namespace FluentAssertions.Collections
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) => HaveCountGreaterThanOrEqualTo(expected, because, becauseArgs);
 
         /// <summary>
         /// Asserts that the number of items in the collection is greater than the supplied <paramref name="expected" /> amount.
@@ -1334,7 +1338,7 @@ namespace FluentAssertions.Collections
         }
 
         /// <summary>
-        /// Asserts that the number of items in the collection is less or equal to the supplied <paramref name="expected" /> amount.
+        /// Asserts that the number of items in the collection is less than or equal to the supplied <paramref name="expected" /> amount.
         /// </summary>
         /// <param name="expected">The number to which the actual number items in the collection will be compared.</param>
         /// <param name="because">
@@ -1344,7 +1348,7 @@ namespace FluentAssertions.Collections
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> HaveCountLessThanOrEqualTo(int expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
@@ -1361,6 +1365,9 @@ namespace FluentAssertions.Collections
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) => HaveCountLessThanOrEqualTo(expected, because, becauseArgs);
 
         /// <summary>
         /// Asserts that the number of items in the collection is less than the supplied <paramref name="expected" /> amount.

--- a/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
+++ b/Src/FluentAssertions/Numeric/ComparableTypeAssertions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using FluentAssertions.Common;
 using FluentAssertions.Equivalency;
@@ -233,15 +234,18 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeLessThanOrEqualTo(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) <= Equal)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:object} {0} to be less or equal to {1}{reason}.", Subject, expected);
+                .FailWith("Expected {context:object} {0} to be less than or equal to {1}{reason}.", Subject, expected);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) => BeLessThanOrEqualTo(expected, because, becauseArgs);
 
         /// <summary>
         /// Asserts that the subject is greater than another object according to its implementation of <see cref="IComparable{T}"/>.
@@ -279,15 +283,18 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeGreaterThanOrEqualTo(T expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.CompareTo(expected) >= Equal)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:object} {0} to be greater or equal to {1}{reason}.", Subject, expected);
+                .FailWith("Expected {context:object} {0} to be greater than or equal to {1}{reason}.", Subject, expected);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) => BeGreaterThanOrEqualTo(expected, because, becauseArgs);
 
         /// <summary>
         /// Asserts that a value is within a range.

--- a/Src/FluentAssertions/Numeric/NumericAssertions.cs
+++ b/Src/FluentAssertions/Numeric/NumericAssertions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
@@ -201,16 +202,19 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "",
+        public AndConstraint<TAssertions> BeLessThanOrEqualTo(T expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) <= 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be less or equal to {0}{reason}, but found {1}.", expected, Subject);
+                .FailWith("Expected {context:value} to be less than or equal to {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) => BeLessThanOrEqualTo(expected, because, becauseArgs);
 
         /// <summary>
         /// Asserts that the numeric value is greater than the specified <paramref name="expected"/> value.
@@ -245,16 +249,19 @@ namespace FluentAssertions.Numeric
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "",
+        public AndConstraint<TAssertions> BeGreaterThanOrEqualTo(T expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
                 .ForCondition(Subject.HasValue && Subject.Value.CompareTo(expected) >= 0)
                 .BecauseOf(because, becauseArgs)
-                .FailWith("Expected {context:value} to be greater or equal to {0}{reason}, but found {1}.", expected, Subject);
+                .FailWith("Expected {context:value} to be greater than or equal to {0}{reason}, but found {1}.", expected, Subject);
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) => BeGreaterThanOrEqualTo(expected, because, becauseArgs);
 
         /// <summary>
         /// Asserts that a value is within a range.

--- a/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
+++ b/Src/FluentAssertions/Primitives/SimpleTimeSpanAssertions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using FluentAssertions.Execution;
 
@@ -175,11 +176,11 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> BeLessOrEqualTo(TimeSpan expected, string because = "", params object[] becauseArgs)
+        public AndConstraint<TAssertions> BeLessThanOrEqualTo(TimeSpan expected, string because = "", params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:time} to be less or equal to {0}{reason}, ", expected)
+                .WithExpectation("Expected {context:time} to be less than or equal to {0}{reason}, ", expected)
                 .ForCondition(Subject.HasValue)
                 .FailWith("but found <null>.")
                 .Then
@@ -190,6 +191,9 @@ namespace FluentAssertions.Primitives
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public AndConstraint<TAssertions> BeLessOrEqualTo(TimeSpan expected, string because = "", params object[] becauseArgs) => BeLessThanOrEqualTo(expected, because, becauseArgs);
 
         /// <summary>
         /// Asserts that the time difference of the current <see cref="TimeSpan"/> is greater than the
@@ -231,12 +235,12 @@ namespace FluentAssertions.Primitives
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because" />.
         /// </param>
-        public AndConstraint<TAssertions> BeGreaterOrEqualTo(TimeSpan expected, string because = "",
+        public AndConstraint<TAssertions> BeGreaterThanOrEqualTo(TimeSpan expected, string because = "",
             params object[] becauseArgs)
         {
             Execute.Assertion
                 .BecauseOf(because, becauseArgs)
-                .WithExpectation("Expected {context:time} to be greater or equal to {0}{reason}, ", expected)
+                .WithExpectation("Expected {context:time} to be greater than or equal to {0}{reason}, ", expected)
                 .ForCondition(Subject.HasValue)
                 .FailWith("but found <null>.")
                 .Then
@@ -247,6 +251,9 @@ namespace FluentAssertions.Primitives
 
             return new AndConstraint<TAssertions>((TAssertions)this);
         }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public AndConstraint<TAssertions> BeGreaterOrEqualTo(TimeSpan expected, string because = "", params object[] becauseArgs) => BeGreaterThanOrEqualTo(expected, because, becauseArgs);
 
         /// <summary>
         /// Asserts that the current <see cref="TimeSpan"/> is within the specified time

--- a/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
+++ b/Src/FluentAssertions/Specialized/ExecutionTimeAssertions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using FluentAssertions.Execution;
 
 namespace FluentAssertions.Specialized
@@ -53,7 +54,7 @@ namespace FluentAssertions.Specialized
         }
 
         /// <summary>
-        /// Asserts that the execution time of the operation is less or equal to a specified amount of time.
+        /// Asserts that the execution time of the operation is less than or equal to a specified amount of time.
         /// </summary>
         /// <param name="maxDuration">
         /// The maximum allowed duration.
@@ -65,7 +66,7 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        public AndConstraint<ExecutionTimeAssertions> BeLessOrEqualTo(TimeSpan maxDuration, string because = "", params object[] becauseArgs)
+        public AndConstraint<ExecutionTimeAssertions> BeLessThanOrEqualTo(TimeSpan maxDuration, string because = "", params object[] becauseArgs)
         {
             bool Condition(TimeSpan duration) => duration.CompareTo(maxDuration) <= 0;
             (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: false, rate: maxDuration);
@@ -74,13 +75,16 @@ namespace FluentAssertions.Specialized
                 .ForCondition(Condition(elapsed))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Execution of " +
-                          execution.ActionDescription + " should be less or equal to {0}{reason}, but it required " +
+                          execution.ActionDescription + " should be less than or equal to {0}{reason}, but it required " +
                           (isRunning ? "more than " : "exactly ") + "{1}.",
                     maxDuration,
                     elapsed);
 
             return new AndConstraint<ExecutionTimeAssertions>(this);
         }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public AndConstraint<ExecutionTimeAssertions> BeLessOrEqualTo(TimeSpan maxDuration, string because = "", params object[] becauseArgs) => BeLessThanOrEqualTo(maxDuration, because, becauseArgs);
 
         /// <summary>
         /// Asserts that the execution time of the operation is less than a specified amount of time.
@@ -113,7 +117,7 @@ namespace FluentAssertions.Specialized
         }
 
         /// <summary>
-        /// Asserts that the execution time of the operation is greater or equal to a specified amount of time.
+        /// Asserts that the execution time of the operation is greater than or equal to a specified amount of time.
         /// </summary>
         /// <param name="minDuration">
         /// The minimum allowed duration.
@@ -125,7 +129,7 @@ namespace FluentAssertions.Specialized
         /// <param name="becauseArgs">
         /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
         /// </param>
-        public AndConstraint<ExecutionTimeAssertions> BeGreaterOrEqualTo(TimeSpan minDuration, string because = "", params object[] becauseArgs)
+        public AndConstraint<ExecutionTimeAssertions> BeGreaterThanOrEqualTo(TimeSpan minDuration, string because = "", params object[] becauseArgs)
         {
             bool Condition(TimeSpan duration) => duration.CompareTo(minDuration) >= 0;
             (bool isRunning, TimeSpan elapsed) = PollUntil(Condition, expectedResult: true, rate: minDuration);
@@ -134,13 +138,16 @@ namespace FluentAssertions.Specialized
                 .ForCondition(Condition(elapsed))
                 .BecauseOf(because, becauseArgs)
                 .FailWith("Execution of " +
-                          execution.ActionDescription + " should be greater or equal to {0}{reason}, but it required " +
+                          execution.ActionDescription + " should be greater than or equal to {0}{reason}, but it required " +
                           (isRunning ? "more than " : "exactly ") + "{1}.",
                     minDuration,
                     elapsed);
 
             return new AndConstraint<ExecutionTimeAssertions>(this);
         }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public AndConstraint<ExecutionTimeAssertions> BeGreaterOrEqualTo(TimeSpan minDuration, string because = "", params object[] becauseArgs) => BeGreaterThanOrEqualTo(minDuration, because, becauseArgs);
 
         /// <summary>
         /// Asserts that the execution time of the operation is greater than a specified amount of time.

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -1,4 +1,4 @@
-[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETFramework,Version=v4.7", FrameworkDisplayName=".NET Framework 4.7")]
@@ -419,8 +419,10 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThanOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThanOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> HaveElementAt(int index, T element, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(T successor, T expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(T predecessor, T expectation, string because = "", params object[] becauseArgs) { }
@@ -1658,9 +1660,11 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
@@ -1697,9 +1701,11 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params T[] validValues) { }
@@ -2026,8 +2032,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
@@ -2188,8 +2196,10 @@ namespace FluentAssertions.Specialized
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThanOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThanOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
     public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>, FluentAssertions.Specialized.FunctionAssertions<T>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -1,4 +1,4 @@
-[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v2.1", FrameworkDisplayName="")]
@@ -419,8 +419,10 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThanOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThanOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> HaveElementAt(int index, T element, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(T successor, T expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(T predecessor, T expectation, string because = "", params object[] becauseArgs) { }
@@ -1658,9 +1660,11 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
@@ -1697,9 +1701,11 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params T[] validValues) { }
@@ -2026,8 +2032,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
@@ -2188,8 +2196,10 @@ namespace FluentAssertions.Specialized
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThanOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThanOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
     public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>, FluentAssertions.Specialized.FunctionAssertions<T>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -1,4 +1,4 @@
-[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v3.0", FrameworkDisplayName="")]
@@ -419,8 +419,10 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThanOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThanOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> HaveElementAt(int index, T element, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(T successor, T expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(T predecessor, T expectation, string because = "", params object[] becauseArgs) { }
@@ -1658,9 +1660,11 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
@@ -1697,9 +1701,11 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params T[] validValues) { }
@@ -2026,8 +2032,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
@@ -2188,8 +2196,10 @@ namespace FluentAssertions.Specialized
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThanOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThanOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
     public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>, FluentAssertions.Specialized.FunctionAssertions<T>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -1,4 +1,4 @@
-[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
@@ -412,8 +412,10 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThanOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThanOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> HaveElementAt(int index, T element, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(T successor, T expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(T predecessor, T expectation, string because = "", params object[] becauseArgs) { }
@@ -1611,9 +1613,11 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
@@ -1650,9 +1654,11 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params T[] validValues) { }
@@ -1979,8 +1985,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
@@ -2141,8 +2149,10 @@ namespace FluentAssertions.Specialized
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThanOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThanOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
     public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>, FluentAssertions.Specialized.FunctionAssertions<T>>
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -1,4 +1,4 @@
-[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/fluentassertions/fluentassertions")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Benchmarks, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"FluentAssertions.Specs, PublicKey=00240000048000009400000006020000002400005253413100040000010001002d25ff515c85b13ba08f61d466cff5d80a7f28ba197bbf8796085213e7a3406f970d2a4874932fed35db546e89af2da88c194bf1b7f7ac70de7988c78406f7629c547283061282a825616eb7eb48a9514a7570942936020a9bb37dca9ff60b778309900851575614491c6d25018fadb75828f4c7a17bf2d7dc86e7b6eafc5d8f")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
@@ -419,8 +419,10 @@ namespace FluentAssertions.Collections
         public FluentAssertions.AndConstraint<TAssertions> HaveCount(System.Linq.Expressions.Expression<System.Func<int, bool>> countPredicate, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountGreaterThanOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThan(int expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> HaveCountLessThanOrEqualTo(int expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndWhichConstraint<TAssertions, T> HaveElementAt(int index, T element, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementPreceding(T successor, T expectation, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> HaveElementSucceeding(T predecessor, T expectation, string because = "", params object[] becauseArgs) { }
@@ -1658,9 +1660,11 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> BeEquivalentTo<TExpectation>(TExpectation expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<TExpectation>> config, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeRankedEquallyTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(T unexpected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
@@ -1697,9 +1701,11 @@ namespace FluentAssertions.Numeric
         public FluentAssertions.AndConstraint<TAssertions> Be(T? expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeInRange(T minimumValue, T maximumValue, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessThan(T expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(T expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOfType(System.Type expectedType, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeOneOf(params T[] validValues) { }
@@ -2026,8 +2032,10 @@ namespace FluentAssertions.Primitives
         public FluentAssertions.AndConstraint<TAssertions> BeCloseTo(System.TimeSpan nearbyTime, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeGreaterThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeGreaterThanOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeLessThan(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<TAssertions> BeLessThanOrEqualTo(System.TimeSpan expected, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BeNegative(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> BePositive(string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<TAssertions> NotBe(System.TimeSpan unexpected, string because = "", params object[] becauseArgs) { }
@@ -2188,8 +2196,10 @@ namespace FluentAssertions.Specialized
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeCloseTo(System.TimeSpan expectedDuration, System.TimeSpan precision, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThan(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeGreaterThanOrEqualTo(System.TimeSpan minDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
         public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThan(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
+        public FluentAssertions.AndConstraint<FluentAssertions.Specialized.ExecutionTimeAssertions> BeLessThanOrEqualTo(System.TimeSpan maxDuration, string because = "", params object[] becauseArgs) { }
     }
     public class FunctionAssertions<T> : FluentAssertions.Specialized.DelegateAssertions<System.Func<T>, FluentAssertions.Specialized.FunctionAssertions<T>>
     {

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountGreaterThanOrEqualTo.cs
@@ -6,43 +6,43 @@ using Xunit.Sdk;
 namespace FluentAssertions.Specs.Collections
 {
     /// <content>
-    /// The HaveCountGreaterOrEqualTo specs.
+    /// The HaveCountGreaterThanOrEqualTo specs.
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Have Count Greater Or Equal To
+        #region Have Count Greater Than Or Equal To
 
         [Fact]
-        public void Should_succeed_when_asserting_collection_has_a_count_greater_or_equal_to_less_the_number_of_items()
+        public void Should_succeed_when_asserting_collection_has_a_count_greater_than_or_equal_to_less_the_number_of_items()
         {
             // Arrange
             var collection = new[] { 1, 2, 3 };
 
             // Act / Assert
-            collection.Should().HaveCountGreaterOrEqualTo(3);
+            collection.Should().HaveCountGreaterThanOrEqualTo(3);
         }
 
         [Fact]
-        public void Should_fail_when_asserting_collection_has_a_count_greater_or_equal_to_the_number_of_items()
+        public void Should_fail_when_asserting_collection_has_a_count_greater_than_or_equal_to_the_number_of_items()
         {
             // Arrange
             var collection = new[] { 1, 2, 3 };
 
             // Act
-            Action act = () => collection.Should().HaveCountGreaterOrEqualTo(4);
+            Action act = () => collection.Should().HaveCountGreaterThanOrEqualTo(4);
 
             // Assert
             act.Should().Throw<XunitException>();
         }
 
         [Fact]
-        public void When_collection_has_a_count_greater_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
+        public void When_collection_has_a_count_greater_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
         {
             // Arrange
             var collection = new[] { 1, 2, 3 };
 
             // Act
-            Action action = () => collection.Should().HaveCountGreaterOrEqualTo(4, "because we want to test the failure {0}", "message");
+            Action action = () => collection.Should().HaveCountGreaterThanOrEqualTo(4, "because we want to test the failure {0}", "message");
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -50,7 +50,7 @@ namespace FluentAssertions.Specs.Collections
         }
 
         [Fact]
-        public void When_collection_count_is_greater_or_equal_to_and_collection_is_null_it_should_throw()
+        public void When_collection_count_is_greater_than_or_equal_to_and_collection_is_null_it_should_throw()
         {
             // Arrange
             int[] collection = null;
@@ -59,7 +59,7 @@ namespace FluentAssertions.Specs.Collections
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().HaveCountGreaterOrEqualTo(1, "we want to test the behaviour with a null subject");
+                collection.Should().HaveCountGreaterThanOrEqualTo(1, "we want to test the behaviour with a null subject");
             };
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThanOrEqualTo.cs
+++ b/Tests/FluentAssertions.Specs/Collections/CollectionAssertionSpecs.HaveCountLessThanOrEqualTo.cs
@@ -10,39 +10,39 @@ namespace FluentAssertions.Specs.Collections
     /// </content>
     public partial class CollectionAssertionSpecs
     {
-        #region Have Count Less Or Equal To
+        #region Have Count Less Than Or Equal To
 
         [Fact]
-        public void Should_succeed_when_asserting_collection_has_a_count_less_or_equal_to_less_the_number_of_items()
+        public void Should_succeed_when_asserting_collection_has_a_count_less_than_or_equal_to_less_the_number_of_items()
         {
             // Arrange
             var collection = new[] { 1, 2, 3 };
 
             // Act / Assert
-            collection.Should().HaveCountLessOrEqualTo(3);
+            collection.Should().HaveCountLessThanOrEqualTo(3);
         }
 
         [Fact]
-        public void Should_fail_when_asserting_collection_has_a_count_less_or_equal_to_the_number_of_items()
+        public void Should_fail_when_asserting_collection_has_a_count_less_than_or_equal_to_the_number_of_items()
         {
             // Arrange
             var collection = new[] { 1, 2, 3 };
 
             // Act
-            Action act = () => collection.Should().HaveCountLessOrEqualTo(2);
+            Action act = () => collection.Should().HaveCountLessThanOrEqualTo(2);
 
             // Assert
             act.Should().Throw<XunitException>();
         }
 
         [Fact]
-        public void When_collection_has_a_count_less_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
+        public void When_collection_has_a_count_less_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
         {
             // Arrange
             var collection = new[] { 1, 2, 3 };
 
             // Act
-            Action action = () => collection.Should().HaveCountLessOrEqualTo(2, "because we want to test the failure {0}", "message");
+            Action action = () => collection.Should().HaveCountLessThanOrEqualTo(2, "because we want to test the failure {0}", "message");
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -50,7 +50,7 @@ namespace FluentAssertions.Specs.Collections
         }
 
         [Fact]
-        public void When_collection_count_is_less_or_equal_to_and_collection_is_null_it_should_throw()
+        public void When_collection_count_is_less_than_or_equal_to_and_collection_is_null_it_should_throw()
         {
             // Arrange
             int[] collection = null;
@@ -59,7 +59,7 @@ namespace FluentAssertions.Specs.Collections
             Action act = () =>
             {
                 using var _ = new AssertionScope();
-                collection.Should().HaveCountLessOrEqualTo(1, "we want to test the behaviour with a null subject");
+                collection.Should().HaveCountLessThanOrEqualTo(1, "we want to test the behaviour with a null subject");
             };
 
             // Assert

--- a/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Collections/GenericDictionaryAssertionSpecs.cs
@@ -396,10 +396,10 @@ namespace FluentAssertions.Specs.Collections
 
         #endregion
 
-        #region Have Count Greater Or Equal To
+        #region Have Count Greater Than Or Equal To
 
         [Fact]
-        public void Should_succeed_when_asserting_dictionary_has_a_count_greater_or_equal_to_less_the_number_of_items()
+        public void Should_succeed_when_asserting_dictionary_has_a_count_greater_than_or_equal_to_less_the_number_of_items()
         {
             // Arrange
             var dictionary = new Dictionary<int, string>
@@ -410,11 +410,11 @@ namespace FluentAssertions.Specs.Collections
             };
 
             // Act / Assert
-            dictionary.Should().HaveCountGreaterOrEqualTo(3);
+            dictionary.Should().HaveCountGreaterThanOrEqualTo(3);
         }
 
         [Fact]
-        public void Should_fail_when_asserting_dictionary_has_a_count_greater_or_equal_to_the_number_of_items()
+        public void Should_fail_when_asserting_dictionary_has_a_count_greater_than_or_equal_to_the_number_of_items()
         {
             // Arrange
             var dictionary = new Dictionary<int, string>
@@ -425,14 +425,14 @@ namespace FluentAssertions.Specs.Collections
             };
 
             // Act
-            Action act = () => dictionary.Should().HaveCountGreaterOrEqualTo(4);
+            Action act = () => dictionary.Should().HaveCountGreaterThanOrEqualTo(4);
 
             // Assert
             act.Should().Throw<XunitException>();
         }
 
         [Fact]
-        public void When_dictionary_has_a_count_greater_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
+        public void When_dictionary_has_a_count_greater_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
         {
             // Arrange
             var dictionary = new Dictionary<int, string>
@@ -443,7 +443,7 @@ namespace FluentAssertions.Specs.Collections
             };
 
             // Act
-            Action action = () => dictionary.Should().HaveCountGreaterOrEqualTo(4, "because we want to test the failure {0}", "message");
+            Action action = () => dictionary.Should().HaveCountGreaterThanOrEqualTo(4, "because we want to test the failure {0}", "message");
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -451,13 +451,13 @@ namespace FluentAssertions.Specs.Collections
         }
 
         [Fact]
-        public void When_dictionary_count_is_greater_or_equal_to_and_dictionary_is_null_it_should_throw()
+        public void When_dictionary_count_is_greater_than_or_equal_to_and_dictionary_is_null_it_should_throw()
         {
             // Arrange
             Dictionary<int, string> dictionary = null;
 
             // Act
-            Action act = () => dictionary.Should().HaveCountGreaterOrEqualTo(1, "we want to test the behaviour with a null subject");
+            Action act = () => dictionary.Should().HaveCountGreaterThanOrEqualTo(1, "we want to test the behaviour with a null subject");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("*at least*1*we want to test the behaviour with a null subject*found <null>*");
@@ -534,10 +534,10 @@ namespace FluentAssertions.Specs.Collections
 
         #endregion
 
-        #region Have Count Less Or Equal To
+        #region Have Count Less Than Or Equal To
 
         [Fact]
-        public void Should_succeed_when_asserting_dictionary_has_a_count_less_or_equal_to_less_the_number_of_items()
+        public void Should_succeed_when_asserting_dictionary_has_a_count_less_than_or_equal_to_less_the_number_of_items()
         {
             // Arrange
             var dictionary = new Dictionary<int, string>
@@ -548,11 +548,11 @@ namespace FluentAssertions.Specs.Collections
             };
 
             // Act / Assert
-            dictionary.Should().HaveCountLessOrEqualTo(3);
+            dictionary.Should().HaveCountLessThanOrEqualTo(3);
         }
 
         [Fact]
-        public void Should_fail_when_asserting_dictionary_has_a_count_less_or_equal_to_the_number_of_items()
+        public void Should_fail_when_asserting_dictionary_has_a_count_less_than_or_equal_to_the_number_of_items()
         {
             // Arrange
             var dictionary = new Dictionary<int, string>
@@ -563,14 +563,14 @@ namespace FluentAssertions.Specs.Collections
             };
 
             // Act
-            Action act = () => dictionary.Should().HaveCountLessOrEqualTo(2);
+            Action act = () => dictionary.Should().HaveCountLessThanOrEqualTo(2);
 
             // Assert
             act.Should().Throw<XunitException>();
         }
 
         [Fact]
-        public void When_dictionary_has_a_count_less_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
+        public void When_dictionary_has_a_count_less_than_or_equal_to_the_number_of_items_it_should_fail_with_descriptive_message_()
         {
             // Arrange
             var dictionary = new Dictionary<int, string>
@@ -581,7 +581,7 @@ namespace FluentAssertions.Specs.Collections
             };
 
             // Act
-            Action action = () => dictionary.Should().HaveCountLessOrEqualTo(2, "because we want to test the failure {0}", "message");
+            Action action = () => dictionary.Should().HaveCountLessThanOrEqualTo(2, "because we want to test the failure {0}", "message");
 
             // Assert
             action.Should().Throw<XunitException>()
@@ -589,13 +589,13 @@ namespace FluentAssertions.Specs.Collections
         }
 
         [Fact]
-        public void When_dictionary_count_is_less_or_equal_to_and_dictionary_is_null_it_should_throw()
+        public void When_dictionary_count_is_less_than_or_equal_to_and_dictionary_is_null_it_should_throw()
         {
             // Arrange
             Dictionary<int, string> dictionary = null;
 
             // Act
-            Action act = () => dictionary.Should().HaveCountLessOrEqualTo(1, "we want to test the behaviour with a null subject");
+            Action act = () => dictionary.Should().HaveCountLessThanOrEqualTo(1, "we want to test the behaviour with a null subject");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage("*at most*1*we want to test the behaviour with a null subject*found <null>*");

--- a/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/ComparableSpecs.cs
@@ -461,7 +461,7 @@ namespace FluentAssertions.Specs.Numeric
 
         #endregion
 
-        #region Be Less Or Equal To
+        #region Be Less Than Or Equal To
 
         [Fact]
         public void When_subject_is_greater_than_another_subject_and_that_is_not_expected_it_should_throw()
@@ -471,12 +471,12 @@ namespace FluentAssertions.Specs.Numeric
             var other = new ComparableOfString("City");
 
             // Act
-            Action act = () => subject.Should().BeLessOrEqualTo(other, "we want to order them");
+            Action act = () => subject.Should().BeLessThanOrEqualTo(other, "we want to order them");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected subject*World*to be less or equal to*City*because we want to order them.");
+                .WithMessage("Expected subject*World*to be less than or equal to*City*because we want to order them.");
         }
 
         [Fact]
@@ -487,21 +487,21 @@ namespace FluentAssertions.Specs.Numeric
             var other = new ComparableOfString("World");
 
             // Act
-            Action act = () => subject.Should().BeLessOrEqualTo(other);
+            Action act = () => subject.Should().BeLessThanOrEqualTo(other);
 
             // Assert
             act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_subject_is_less_than_another_subject_and_less_or_equal_is_expected_it_should_not_throw()
+        public void When_subject_is_less_than_another_subject_and_less_than_or_equal_is_expected_it_should_not_throw()
         {
             // Arrange
             var subject = new ComparableOfString("City");
             var other = new ComparableOfString("World");
 
             // Act
-            Action act = () => subject.Should().BeLessOrEqualTo(other);
+            Action act = () => subject.Should().BeLessThanOrEqualTo(other);
 
             // Assert
             act.Should().NotThrow();
@@ -557,7 +557,7 @@ namespace FluentAssertions.Specs.Numeric
 
         #endregion
 
-        #region Be Greater Or Equal To
+        #region Be Greater Than Or Equal To
 
         [Fact]
         public void When_subject_is_less_than_another_subject_and_that_is_not_expected_it_should_throw()
@@ -567,12 +567,12 @@ namespace FluentAssertions.Specs.Numeric
             var other = new ComparableOfString("def");
 
             // Act
-            Action act = () => subject.Should().BeGreaterOrEqualTo(other, "'d' is bigger then 'a'");
+            Action act = () => subject.Should().BeGreaterThanOrEqualTo(other, "'d' is bigger then 'a'");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected subject*abc*to be greater or equal to*def*because 'd' is bigger then 'a'.");
+                .WithMessage("Expected subject*abc*to be greater than or equal to*def*because 'd' is bigger then 'a'.");
         }
 
         [Fact]
@@ -583,21 +583,21 @@ namespace FluentAssertions.Specs.Numeric
             var other = new ComparableOfString("def");
 
             // Act
-            Action act = () => subject.Should().BeGreaterOrEqualTo(other);
+            Action act = () => subject.Should().BeGreaterThanOrEqualTo(other);
 
             // Assert
             act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_subject_is_greater_than_another_subject_and_greater_or_equal_is_expected_it_should_not_throw()
+        public void When_subject_is_greater_than_another_subject_and_greater_than_or_equal_is_expected_it_should_not_throw()
         {
             // Arrange
             var subject = new ComparableOfString("xyz");
             var other = new ComparableOfString("abc");
 
             // Act
-            Action act = () => subject.Should().BeGreaterOrEqualTo(other);
+            Action act = () => subject.Should().BeGreaterThanOrEqualTo(other);
 
             // Assert
             act.Should().NotThrow();

--- a/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Numeric/NumericAssertionSpecs.cs
@@ -446,49 +446,49 @@ namespace FluentAssertions.Specs.Numeric
         }
 
         [Fact]
-        public void When_a_value_is_greater_or_equal_to_smaller_value_it_should_not_throw()
+        public void When_a_value_is_greater_than_or_equal_to_smaller_value_it_should_not_throw()
         {
             // Arrange
             int value = 2;
             int smallerValue = 1;
 
             // Act
-            Action act = () => value.Should().BeGreaterOrEqualTo(smallerValue);
+            Action act = () => value.Should().BeGreaterThanOrEqualTo(smallerValue);
 
             // Assert
             act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_a_value_is_greater_or_equal_to_same_value_it_should_not_throw()
+        public void When_a_value_is_greater_than_or_equal_to_same_value_it_should_not_throw()
         {
             // Arrange
             int value = 2;
             int sameValue = 2;
 
             // Act
-            Action act = () => value.Should().BeGreaterOrEqualTo(sameValue);
+            Action act = () => value.Should().BeGreaterThanOrEqualTo(sameValue);
 
             // Assert
             act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_a_value_is_greater_or_equal_to_greater_value_it_should_throw()
+        public void When_a_value_is_greater_than_or_equal_to_greater_value_it_should_throw()
         {
             // Arrange
             int value = 2;
             int greaterValue = 3;
 
             // Act
-            Action act = () => value.Should().BeGreaterOrEqualTo(greaterValue);
+            Action act = () => value.Should().BeGreaterThanOrEqualTo(greaterValue);
 
             // Assert
             act.Should().Throw<XunitException>();
         }
 
         [Fact]
-        public void When_a_value_is_greater_or_equal_to_greater_value_it_should_throw_with_descriptive_message()
+        public void When_a_value_is_greater_than_or_equal_to_greater_value_it_should_throw_with_descriptive_message()
         {
             // Arrange
             int value = 2;
@@ -496,12 +496,12 @@ namespace FluentAssertions.Specs.Numeric
 
             // Act
             Action act =
-                () => value.Should().BeGreaterOrEqualTo(greaterValue, "because we want to test the failure {0}", "message");
+                () => value.Should().BeGreaterThanOrEqualTo(greaterValue, "because we want to test the failure {0}", "message");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be greater or equal to 3 because we want to test the failure message, but found 2.");
+                .WithMessage("Expected value to be greater than or equal to 3 because we want to test the failure message, but found 2.");
         }
 
         [Fact]
@@ -520,13 +520,13 @@ namespace FluentAssertions.Specs.Numeric
         }
 
         [Fact]
-        public void When_a_nullable_numeric_null_value_is_not_greater_or_equal_to_it_should_throw()
+        public void When_a_nullable_numeric_null_value_is_not_greater_than_or_equal_to_it_should_throw()
         {
             // Arrange
             int? value = null;
 
             // Act
-            Action act = () => value.Should().BeGreaterOrEqualTo(0);
+            Action act = () => value.Should().BeGreaterThanOrEqualTo(0);
 
             // Assert
             act
@@ -597,61 +597,61 @@ namespace FluentAssertions.Specs.Numeric
         }
 
         [Fact]
-        public void When_a_value_is_less_or_equal_to_greater_value_it_should_not_throw()
+        public void When_a_value_is_less_than_or_equal_to_greater_value_it_should_not_throw()
         {
             // Arrange
             int value = 1;
             int greaterValue = 2;
 
             // Act
-            Action act = () => value.Should().BeLessOrEqualTo(greaterValue);
+            Action act = () => value.Should().BeLessThanOrEqualTo(greaterValue);
 
             // Assert
             act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_a_value_is_less_or_equal_to_same_value_it_should_not_throw()
+        public void When_a_value_is_less_than_or_equal_to_same_value_it_should_not_throw()
         {
             // Arrange
             int value = 2;
             int sameValue = 2;
 
             // Act
-            Action act = () => value.Should().BeLessOrEqualTo(sameValue);
+            Action act = () => value.Should().BeLessThanOrEqualTo(sameValue);
 
             // Assert
             act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_a_value_is_less_or_equal_to_smaller_value_it_should_throw()
+        public void When_a_value_is_less_than_or_equal_to_smaller_value_it_should_throw()
         {
             // Arrange
             int value = 2;
             int smallerValue = 1;
 
             // Act
-            Action act = () => value.Should().BeLessOrEqualTo(smallerValue);
+            Action act = () => value.Should().BeLessThanOrEqualTo(smallerValue);
 
             // Assert
             act.Should().Throw<XunitException>();
         }
 
         [Fact]
-        public void When_a_value_is_less_or_equal_to_smaller_value_it_should_throw_with_descriptive_message()
+        public void When_a_value_is_less_than_or_equal_to_smaller_value_it_should_throw_with_descriptive_message()
         {
             // Arrange
             int value = 2;
             int smallerValue = 1;
 
             // Act
-            Action act = () => value.Should().BeLessOrEqualTo(smallerValue, "because we want to test the failure {0}", "message");
+            Action act = () => value.Should().BeLessThanOrEqualTo(smallerValue, "because we want to test the failure {0}", "message");
 
             // Assert
             act
                 .Should().Throw<XunitException>()
-                .WithMessage("Expected value to be less or equal to 1 because we want to test the failure message, but found 2.");
+                .WithMessage("Expected value to be less than or equal to 1 because we want to test the failure message, but found 2.");
         }
 
         [Fact]
@@ -670,13 +670,13 @@ namespace FluentAssertions.Specs.Numeric
         }
 
         [Fact]
-        public void When_a_nullable_numeric_null_value_is_not_less_or_equal_to_it_should_throw()
+        public void When_a_nullable_numeric_null_value_is_not_less_than_or_equal_to_it_should_throw()
         {
             // Arrange
             int? value = null;
 
             // Act
-            Action act = () => value.Should().BeLessOrEqualTo(0);
+            Action act = () => value.Should().BeLessThanOrEqualTo(0);
 
             // Assert
             act

--- a/Tests/FluentAssertions.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/SimpleTimeSpanAssertionSpecs.cs
@@ -306,67 +306,67 @@ namespace FluentAssertions.Specs.Primitives
         }
 
         [Fact]
-        public void When_asserting_value_to_be_greater_or_equal_to_smaller_value_it_should_succeed()
+        public void When_asserting_value_to_be_greater_than_or_equal_to_smaller_value_it_should_succeed()
         {
             // Arrange
             TimeSpan actual = 2.Seconds();
             TimeSpan smaller = 1.Seconds();
 
             // Act / Assert
-            actual.Should().BeGreaterOrEqualTo(smaller);
+            actual.Should().BeGreaterThanOrEqualTo(smaller);
         }
 
         [Fact]
-        public void When_asserting_null_value_to_be_greater_or_equal_to_other_value_it_should_fail()
+        public void When_asserting_null_value_to_be_greater_than_or_equal_to_other_value_it_should_fail()
         {
             // Arrange
             TimeSpan? nullTimeSpan = null;
             TimeSpan expected = 1.Seconds();
 
             // Act
-            Action act = () => nullTimeSpan.Should().BeGreaterOrEqualTo(expected, "because we want to test the failure {0}", "message");
+            Action act = () => nullTimeSpan.Should().BeGreaterThanOrEqualTo(expected, "because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected nullTimeSpan to be greater or equal to 1s because we want to test the failure message, but found <null>.");
+                "Expected nullTimeSpan to be greater than or equal to 1s because we want to test the failure message, but found <null>.");
         }
 
         [Fact]
-        public void When_asserting_value_to_be_greater_or_equal_to_same_value_it_should_succeed()
+        public void When_asserting_value_to_be_greater_than_or_equal_to_same_value_it_should_succeed()
         {
             // Arrange
             var twoSeconds = 2.Seconds();
 
             // Act / Assert
-            twoSeconds.Should().BeGreaterOrEqualTo(twoSeconds);
+            twoSeconds.Should().BeGreaterThanOrEqualTo(twoSeconds);
         }
 
         [Fact]
-        public void When_asserting_value_to_be_greater_or_equal_to_greater_value_it_should_fail()
+        public void When_asserting_value_to_be_greater_than_or_equal_to_greater_value_it_should_fail()
         {
             // Arrange
             TimeSpan actual = 1.Seconds();
             TimeSpan expected = 2.Seconds();
 
             // Act
-            Action act = () => actual.Should().BeGreaterOrEqualTo(expected);
+            Action act = () => actual.Should().BeGreaterThanOrEqualTo(expected);
 
             // Assert
             act.Should().Throw<XunitException>();
         }
 
         [Fact]
-        public void When_asserting_value_to_be_greater_or_equal_to_greater_value_it_should_fail_with_descriptive_message()
+        public void When_asserting_value_to_be_greater_than_or_equal_to_greater_value_it_should_fail_with_descriptive_message()
         {
             // Arrange
             TimeSpan actual = 1.Seconds();
 
             // Act
-            Action act = () => actual.Should().BeGreaterOrEqualTo(2.Seconds(), "because we want to test the failure {0}", "message");
+            Action act = () => actual.Should().BeGreaterThanOrEqualTo(2.Seconds(), "because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected actual to be greater or equal to 2s because we want to test the failure message, but found 1s.");
+                "Expected actual to be greater than or equal to 2s because we want to test the failure message, but found 1s.");
         }
 
         [Fact]
@@ -437,67 +437,67 @@ namespace FluentAssertions.Specs.Primitives
         }
 
         [Fact]
-        public void When_asserting_value_to_be_less_or_equal_to_greater_value_it_should_succeed()
+        public void When_asserting_value_to_be_less_than_or_equal_to_greater_value_it_should_succeed()
         {
             // Arrange
             TimeSpan actual = 1.Seconds();
             TimeSpan greater = 2.Seconds();
 
             // Act / Assert
-            actual.Should().BeLessOrEqualTo(greater);
+            actual.Should().BeLessThanOrEqualTo(greater);
         }
 
         [Fact]
-        public void When_asserting_null_value_to_be_less_or_equal_to_other_value_it_should_fail()
+        public void When_asserting_null_value_to_be_less_than_or_equal_to_other_value_it_should_fail()
         {
             // Arrange
             TimeSpan? nullTimeSpan = null;
             TimeSpan expected = 1.Seconds();
 
             // Act
-            Action act = () => nullTimeSpan.Should().BeLessOrEqualTo(expected, "because we want to test the failure {0}", "message");
+            Action act = () => nullTimeSpan.Should().BeLessThanOrEqualTo(expected, "because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected nullTimeSpan to be less or equal to 1s because we want to test the failure message, but found <null>.");
+                "Expected nullTimeSpan to be less than or equal to 1s because we want to test the failure message, but found <null>.");
         }
 
         [Fact]
-        public void When_asserting_value_to_be_less_or_equal_to_same_value_it_should_succeed()
+        public void When_asserting_value_to_be_less_than_or_equal_to_same_value_it_should_succeed()
         {
             // Arrange
             var twoSeconds = 2.Seconds();
 
             // Act / Assert
-            twoSeconds.Should().BeLessOrEqualTo(twoSeconds);
+            twoSeconds.Should().BeLessThanOrEqualTo(twoSeconds);
         }
 
         [Fact]
-        public void When_asserting_value_to_be_less_or_equal_to_smaller_value_it_should_fail()
+        public void When_asserting_value_to_be_less_than_or_equal_to_smaller_value_it_should_fail()
         {
             // Arrange
             TimeSpan actual = 2.Seconds();
             TimeSpan expected = 1.Seconds();
 
             // Act
-            Action act = () => actual.Should().BeLessOrEqualTo(expected);
+            Action act = () => actual.Should().BeLessThanOrEqualTo(expected);
 
             // Assert
             act.Should().Throw<XunitException>();
         }
 
         [Fact]
-        public void When_asserting_value_to_be_less_or_equal_to_smaller_value_it_should_fail_with_descriptive_message()
+        public void When_asserting_value_to_be_less_than_or_equal_to_smaller_value_it_should_fail_with_descriptive_message()
         {
             // Arrange
             TimeSpan actual = 2.Seconds();
 
             // Act
-            Action act = () => actual.Should().BeLessOrEqualTo(1.Seconds(), "because we want to test the failure {0}", "message");
+            Action act = () => actual.Should().BeLessThanOrEqualTo(1.Seconds(), "because we want to test the failure {0}", "message");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "Expected actual to be less or equal to 1s because we want to test the failure message, but found 2s.");
+                "Expected actual to be less than or equal to 1s because we want to test the failure message, but found 2s.");
         }
 
         #region Be Close To

--- a/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Specialized/ExecutionTimeAssertionsSpecs.cs
@@ -10,64 +10,64 @@ namespace FluentAssertions.Specs.Specialized
 {
     public class ExecutionTimeAssertionsSpecs
     {
-        #region BeLessOrEqualTo
+        #region BeLessThanOrEqualTo
         [Fact]
-        public void When_the_execution_time_of_a_member_is_not_less_or_equal_to_a_limit_it_should_throw()
+        public void When_the_execution_time_of_a_member_is_not_less_than_or_equal_to_a_limit_it_should_throw()
         {
             // Arrange
             var subject = new SleepingClass();
 
             // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(610)).Should().BeLessOrEqualTo(500.Milliseconds(),
+            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(610)).Should().BeLessThanOrEqualTo(500.Milliseconds(),
                 "we like speed");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*(s.Sleep(610)) should be less or equal to 500ms because we like speed, but it required*");
+                "*(s.Sleep(610)) should be less than or equal to 500ms because we like speed, but it required*");
         }
 
         [Fact]
-        public void When_the_execution_time_of_a_member_is_less_or_equal_to_a_limit_it_should_not_throw()
+        public void When_the_execution_time_of_a_member_is_less_than_or_equal_to_a_limit_it_should_not_throw()
         {
             // Arrange
             var subject = new SleepingClass();
 
             // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(0)).Should().BeLessOrEqualTo(500.Milliseconds());
+            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(0)).Should().BeLessThanOrEqualTo(500.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_the_execution_time_of_an_action_is_not_less_or_equal_to_a_limit_it_should_throw()
+        public void When_the_execution_time_of_an_action_is_not_less_than_or_equal_to_a_limit_it_should_throw()
         {
             // Arrange
             Action someAction = () => Thread.Sleep(510);
 
             // Act
-            Action act = () => someAction.ExecutionTime().Should().BeLessOrEqualTo(100.Milliseconds());
+            Action act = () => someAction.ExecutionTime().Should().BeLessThanOrEqualTo(100.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*action should be less or equal to 100ms, but it required*");
+                "*action should be less than or equal to 100ms, but it required*");
         }
 
         [Fact]
-        public void When_the_execution_time_of_an_action_is_less_or_equal_to_a_limit_it_should_not_throw()
+        public void When_the_execution_time_of_an_action_is_less_than_or_equal_to_a_limit_it_should_not_throw()
         {
             // Arrange
             Action someAction = () => Thread.Sleep(100);
 
             // Act
-            Action act = () => someAction.ExecutionTime().Should().BeLessOrEqualTo(1.Seconds());
+            Action act = () => someAction.ExecutionTime().Should().BeLessThanOrEqualTo(1.Seconds());
 
             // Assert
             act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_action_runs_indefinitely_it_should_be_stopped_and_throw_if_there_is_less_or_equal_condition()
+        public void When_action_runs_indefinitely_it_should_be_stopped_and_throw_if_there_is_less_than_or_equal_condition()
         {
             // Arrange
             Action someAction = () =>
@@ -78,11 +78,11 @@ namespace FluentAssertions.Specs.Specialized
             };
 
             // Act
-            Action act = () => someAction.ExecutionTime().Should().BeLessOrEqualTo(100.Milliseconds());
+            Action act = () => someAction.ExecutionTime().Should().BeLessThanOrEqualTo(100.Milliseconds());
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*action should be less or equal to 100ms, but it required more than*");
+                "*action should be less than or equal to 100ms, but it required more than*");
         }
         #endregion
 
@@ -189,64 +189,64 @@ namespace FluentAssertions.Specs.Specialized
         }
         #endregion
 
-        #region BeGreaterOrEqualTo
+        #region BeGreaterThanOrEqualTo
         [Fact]
-        public void When_the_execution_time_of_a_member_is_not_greater_or_equal_to_a_limit_it_should_throw()
+        public void When_the_execution_time_of_a_member_is_not_greater_than_or_equal_to_a_limit_it_should_throw()
         {
             // Arrange
             var subject = new SleepingClass();
 
             // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(100)).Should().BeGreaterOrEqualTo(1.Seconds(),
+            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(100)).Should().BeGreaterThanOrEqualTo(1.Seconds(),
                 "we like speed");
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*(s.Sleep(100)) should be greater or equal to 1s because we like speed, but it required*");
+                "*(s.Sleep(100)) should be greater than or equal to 1s because we like speed, but it required*");
         }
 
         [Fact]
-        public void When_the_execution_time_of_a_member_is_greater_or_equal_to_a_limit_it_should_not_throw()
+        public void When_the_execution_time_of_a_member_is_greater_than_or_equal_to_a_limit_it_should_not_throw()
         {
             // Arrange
             var subject = new SleepingClass();
 
             // Act
-            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(100)).Should().BeGreaterOrEqualTo(50.Milliseconds());
+            Action act = () => subject.ExecutionTimeOf(s => s.Sleep(100)).Should().BeGreaterThanOrEqualTo(50.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_the_execution_time_of_an_action_is_not_greater_or_equal_to_a_limit_it_should_throw()
+        public void When_the_execution_time_of_an_action_is_not_greater_than_or_equal_to_a_limit_it_should_throw()
         {
             // Arrange
             Action someAction = () => Thread.Sleep(100);
 
             // Act
-            Action act = () => someAction.ExecutionTime().Should().BeGreaterOrEqualTo(1.Seconds());
+            Action act = () => someAction.ExecutionTime().Should().BeGreaterThanOrEqualTo(1.Seconds());
 
             // Assert
             act.Should().Throw<XunitException>().WithMessage(
-                "*action should be greater or equal to 1s, but it required*");
+                "*action should be greater than or equal to 1s, but it required*");
         }
 
         [Fact]
-        public void When_the_execution_time_of_an_action_is_greater_or_equal_to_a_limit_it_should_not_throw()
+        public void When_the_execution_time_of_an_action_is_greater_than_or_equal_to_a_limit_it_should_not_throw()
         {
             // Arrange
             Action someAction = () => Thread.Sleep(100);
 
             // Act
-            Action act = () => someAction.ExecutionTime().Should().BeGreaterOrEqualTo(50.Milliseconds());
+            Action act = () => someAction.ExecutionTime().Should().BeGreaterThanOrEqualTo(50.Milliseconds());
 
             // Assert
             act.Should().NotThrow();
         }
 
         [Fact]
-        public void When_action_runs_indefinitely_it_should_be_stopped_and_not_throw_if_there_is_greater_or_equal_condition()
+        public void When_action_runs_indefinitely_it_should_be_stopped_and_not_throw_if_there_is_greater_than_or_equal_condition()
         {
             // Arrange
             Action someAction = () =>
@@ -257,7 +257,7 @@ namespace FluentAssertions.Specs.Specialized
             };
 
             // Act
-            Action act = () => someAction.ExecutionTime().Should().BeGreaterOrEqualTo(100.Milliseconds());
+            Action act = () => someAction.ExecutionTime().Should().BeGreaterThanOrEqualTo(100.Milliseconds());
 
             // Assert
             act.Should().NotThrow<XunitException>();

--- a/docs/_pages/collections.md
+++ b/docs/_pages/collections.md
@@ -28,8 +28,8 @@ collection.Should().HaveCount(c => c > 3)
   .And.OnlyHaveUniqueItems();
 
 collection.Should().HaveCountGreaterThan(3);
-collection.Should().HaveCountGreaterOrEqualTo(4);
-collection.Should().HaveCountLessOrEqualTo(4);
+collection.Should().HaveCountGreaterThanOrEqualTo(4);
+collection.Should().HaveCountLessThanOrEqualTo(4);
 collection.Should().HaveCountLessThan(5);
 collection.Should().NotHaveCount(3);
 collection.Should().HaveSameCount(new[] { 6, 2, 0, 5 });

--- a/docs/_pages/datetimespans.md
+++ b/docs/_pages/datetimespans.md
@@ -105,9 +105,9 @@ timeSpan.Should().BeNegative();
 timeSpan.Should().Be(12.Hours());
 timeSpan.Should().NotBe(1.Days());
 timeSpan.Should().BeLessThan(someOtherTimeSpan);
-timeSpan.Should().BeLessOrEqualTo(someOtherTimeSpan);
+timeSpan.Should().BeLessThanOrEqualTo(someOtherTimeSpan);
 timeSpan.Should().BeGreaterThan(someOtherTimeSpan);
-timeSpan.Should().BeGreaterOrEqualTo(someOtherTimeSpan);
+timeSpan.Should().BeGreaterThanOrEqualTo(someOtherTimeSpan);
 ```
 
 Similarly to the [date and time assertions](#dates-and-times), `BeCloseTo` and `NotBeCloseTo` are also available for time spans:

--- a/docs/_pages/executiontime.md
+++ b/docs/_pages/executiontime.md
@@ -28,23 +28,22 @@ public class SomePotentiallyVerySlowClass
     }
 }
 var subject = new SomePotentiallyVerySlowClass();
-subject.ExecutionTimeOf(s => s.ExpensiveMethod()).Should().BeLessOrEqualTo(500.Milliseconds());
+subject.ExecutionTimeOf(s => s.ExpensiveMethod()).Should().BeLessThanOrEqualTo(500.Milliseconds());
 ```
 
 Alternatively, to verify the execution time of an arbitrary action, use this syntax:
 
 ```csharp
 Action someAction = () => Thread.Sleep(100);
-someAction.ExecutionTime().Should().BeLessOrEqualTo(200.Milliseconds());
+someAction.ExecutionTime().Should().BeLessThanOrEqualTo(200.Milliseconds());
 ```
 
 The supported assertions on `ExecutionTime()` are a subset of those found for `TimeSpan`s, namely:
-
 ```csharp
-someAction.ExecutionTime().Should().BeLessOrEqualTo(200.Milliseconds());
+someAction.ExecutionTime().Should().BeLessThanOrEqualTo(200.Milliseconds());
 someAction.ExecutionTime().Should().BeLessThan(200.Milliseconds());
 someAction.ExecutionTime().Should().BeGreaterThan(100.Milliseconds());
-someAction.ExecutionTime().Should().BeGreaterOrEqualTo(100.Milliseconds());
+someAction.ExecutionTime().Should().BeGreaterThanOrEqualTo(100.Milliseconds());
 someAction.ExecutionTime().Should().BeCloseTo(150.Milliseconds(), 50.Milliseconds());
 ```
 

--- a/docs/_pages/numerictypes.md
+++ b/docs/_pages/numerictypes.md
@@ -9,10 +9,10 @@ sidebar:
 
 ```csharp
 int theInt = 5;
-theInt.Should().BeGreaterOrEqualTo(5);
-theInt.Should().BeGreaterOrEqualTo(3);
+theInt.Should().BeGreaterThanOrEqualTo(5);
+theInt.Should().BeGreaterThanOrEqualTo(3);
 theInt.Should().BeGreaterThan(4);
-theInt.Should().BeLessOrEqualTo(5);
+theInt.Should().BeLessThanOrEqualTo(5);
 theInt.Should().BeLessThan(6);
 theInt.Should().BePositive();
 theInt.Should().Be(5);

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -11,6 +11,8 @@ sidebar:
 
 ### What's New
 
+* Adding new overloads to all `GreaterOrEqualTo` and `LessOrEqualTo` assertions, adding the word `Than` - [#1673](https://github.com/fluentassertions/fluentassertions/pull/1673)
+
 ### Fixes
 
 ## 6.1.0


### PR DESCRIPTION
The names of the GreaterOrEqualsTo methods (and similar) is a bit off, but more importantly they don't follow the established terminology.