### PR TITLE
Fix compiler warnings

### DIFF
--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -329,11 +329,6 @@ namespace FluentAssertions.Common
             return members;
         }
 
-        private static Type[] GetInterfaces(Type type)
-        {
-            return type.GetInterfaces();
-        }
-
         private static bool HasNonPrivateGetter(PropertyInfo propertyInfo)
         {
             MethodInfo getMethod = propertyInfo.GetGetMethod(nonPublic: true);

--- a/Tests/FluentAssertions.Specs/IsExternalInit.cs
+++ b/Tests/FluentAssertions.Specs/IsExternalInit.cs
@@ -1,8 +1,8 @@
-﻿// ReSharper disable once CheckNamespace
+﻿using System.ComponentModel;
+
+// ReSharper disable once CheckNamespace
 namespace System.Runtime.CompilerServices
 {
-    using System.ComponentModel;
-
     /// <summary>
     /// Reserved to be used by the compiler for tracking metadata.
     /// This class should not be used by developers in source code.


### PR DESCRIPTION
`GetInterfaces` was unused
Vanilla VS does not understand `ReSharper comments`, so changed it to be (hopefully) cross-IDE warning-free.