### PR TITLE
Fixed example for Awaiting method to assert exceptions

### DIFF
--- a/docs/_pages/exceptions.md
+++ b/docs/_pages/exceptions.md
@@ -115,7 +115,7 @@ await act.Should().NotThrowAsync();
 Alternatively, you can use the `Awaiting` method like this:
 
 ```csharp
-Func<Task> act = () => asyncObject.Awaiting(x => x.ThrowAsync<ArgumentException>());
+Func<Task> act = asyncObject.Awaiting(x => x.ThrowAsync<ArgumentException>());
 await act.Should().ThrowAsync<ArgumentException>();
 ```
 


### PR DESCRIPTION
## IMPORTANT 

* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).