### PR TITLE
Keep DateTimeKind and Ticks precision in At

### DIFF
--- a/Src/FluentAssertions/Extensions/FluentDateTimeExtensions.cs
+++ b/Src/FluentAssertions/Extensions/FluentDateTimeExtensions.cs
@@ -135,7 +135,7 @@ namespace FluentAssertions.Extensions
         /// </summary>
         public static DateTime At(this DateTime date, TimeSpan time)
         {
-            return new DateTime(date.Year, date.Month, date.Day, time.Hours, time.Minutes, time.Seconds);
+            return new DateTime(date.Year, date.Month, date.Day, time.Hours, time.Minutes, time.Seconds, date.Kind);
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace FluentAssertions.Extensions
                 throw new ArgumentOutOfRangeException(nameof(nanoseconds), "Valid values are between 0 and 999");
             }
 
-            var value = new DateTime(date.Year, date.Month, date.Day, hours, minutes, seconds, milliseconds);
+            var value = new DateTime(date.Year, date.Month, date.Day, hours, minutes, seconds, milliseconds, date.Kind);
 
             if (microseconds != 0)
             {

--- a/Src/FluentAssertions/Extensions/FluentDateTimeExtensions.cs
+++ b/Src/FluentAssertions/Extensions/FluentDateTimeExtensions.cs
@@ -135,7 +135,7 @@ namespace FluentAssertions.Extensions
         /// </summary>
         public static DateTime At(this DateTime date, TimeSpan time)
         {
-            return new DateTime(date.Year, date.Month, date.Day, time.Hours, time.Minutes, time.Seconds, date.Kind);
+            return date.Date + time;
         }
 
         /// <summary>

--- a/Tests/FluentAssertions.Specs/Extensions/FluentDateTimeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Extensions/FluentDateTimeSpecs.cs
@@ -294,6 +294,17 @@ namespace FluentAssertions.Specs.Extensions
         }
 
         [Fact]
+        public void Specyfing_the_time_of_day_retains_the_full_precision()
+        {
+            // Act
+            DateTime subject = 10.December(2011).At(1.Ticks());
+            DateTime expected = 10.December(2011) + 1.Ticks();
+
+            // Assert
+            subject.Should().Be(expected);
+        }
+
+        [Fact]
         public void Specifying_the_time_of_day_retains_the_datetime_kind()
         {
             // Act

--- a/Tests/FluentAssertions.Specs/Extensions/FluentDateTimeSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Extensions/FluentDateTimeSpecs.cs
@@ -292,5 +292,25 @@ namespace FluentAssertions.Specs.Extensions
             // Assert
             dateTime.Should().Be(new DateTime(2011, 12, 10, 9, 30, 45));
         }
+
+        [Fact]
+        public void Specifying_the_time_of_day_retains_the_datetime_kind()
+        {
+            // Act
+            DateTime dateTime = 10.December(2011).AsUtc().At(TimeSpan.Zero);
+
+            // Assert
+            dateTime.Should().BeIn(DateTimeKind.Utc);
+        }
+
+        [Fact]
+        public void Specifying_the_time_of_day_in_hours_and_minutes_retains_the_datetime_kind()
+        {
+            // Act
+            DateTime dateTime = 10.December(2011).AsUtc().At(0, 0);
+
+            // Assert
+            dateTime.Should().BeIn(DateTimeKind.Utc);
+        }
     }
 }

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -16,6 +16,7 @@ sidebar:
 ### Fixes
 
 * Prevent exceptions when asserting on `ImmutableArray<T>` - [#1668](https://github.com/fluentassertions/fluentassertions/pull/1668)
+* `At` now retains the `DateTimeKind` and keeps sub-second precision when using a `TimeSpan` - [#1687](https://github.com/fluentassertions/fluentassertions/pull/1687).
 
 ## 6.1.0
 


### PR DESCRIPTION
* `At(this DateTime date, TimeSpan time)` disregarded sub-seconds.
* Both `At` overloads created a new `DateTime` without retaining `DateTimeKind` from `date`.