### PR TITLE
Add ShouldNotBeNull extension to get rid of the nullable warnings

### DIFF
--- a/Src/FluentAssertions/AssertionNullableExtensions.cs
+++ b/Src/FluentAssertions/AssertionNullableExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using FluentAssertions.Primitives;
+
+#nullable enable
+
+namespace FluentAssertions
+{
+#if NETCOREAPP3_0
+
+    public static class AssertionNullableExtensions
+    {
+        /// <summary>
+        /// Asserts that the current object has been initialized.
+        /// </summary>
+        /// <param name="because">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="becauseArgs">
+        /// Zero or more objects to format using the placeholders in <paramref name="because" />.
+        /// </param>
+        public static AndConstraint<ObjectAssertions> ShouldNotBeNull(
+            [NotNull] this object? actualValue,
+            string because = "",
+            params object[] becauseArgs)
+        {
+            var result = actualValue.Should().NotBeNull(because, becauseArgs);
+
+            if (actualValue == null)
+            {
+                throw new ArgumentNullException(nameof(actualValue)); // Will never be thrown, needed only to trick the compiler
+            }
+
+            return result;
+        }
+    }
+
+#endif
+}

--- a/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Primitives/ObjectAssertionSpecs.cs
@@ -202,6 +202,31 @@ namespace FluentAssertions.Specs.Primitives
             someObject.Should().NotBeNull();
         }
 
+#if NETCOREAPP3_0_OR_GREATER
+
+        #nullable enable
+
+        [Fact]
+        public void Should_suppress_null_warning_when_asserting_null_object_not_to_be_null()
+        {
+            // Arrange
+            object? someObject = null;
+
+            // Act
+            Action act = () =>
+            {
+                someObject.ShouldNotBeNull();
+                var result = someObject.ToString();
+            };
+
+            // Assert
+            act.Should().Throw<XunitException>().WithMessage("Expected *");
+        }
+
+        #nullable disable
+
+#endif
+
         [Fact]
         public void Should_fail_when_asserting_null_object_not_to_be_null()
         {


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [ ] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).