### PR TITLE
Satisfy doesn't support extension methods #1688

### DIFF
--- a/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -81,6 +81,11 @@ namespace FluentAssertions.Formatting
         {
             public override Expression Visit(Expression node)
             {
+                if (node is null)
+                {
+                    return null;
+                }
+
                 if (ExpressionIsConstant(node))
                 {
                     return Expression.Constant(Expression.Lambda(node).Compile().DynamicInvoke());

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -18,6 +18,7 @@ sidebar:
 * Prevent exceptions when asserting on `ImmutableArray<T>` - [#1668](https://github.com/fluentassertions/fluentassertions/pull/1668)
 * `At` now retains the `DateTimeKind` and keeps sub-second precision when using a `TimeSpan` - [#1687](https://github.com/fluentassertions/fluentassertions/pull/1687).
 * Removed iteration over enumerable when generating the `BeEmpty` assertion failure message - [#1692](https://github.com/fluentassertions/fluentassertions/pull/1692).
+* Enable support for extension methods in `Satisfy` - [#1696](https://github.com/fluentassertions/fluentassertions/pull/1696)
 
 ## 6.1.0
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -18,7 +18,7 @@ sidebar:
 * Prevent exceptions when asserting on `ImmutableArray<T>` - [#1668](https://github.com/fluentassertions/fluentassertions/pull/1668)
 * `At` now retains the `DateTimeKind` and keeps sub-second precision when using a `TimeSpan` - [#1687](https://github.com/fluentassertions/fluentassertions/pull/1687).
 * Removed iteration over enumerable when generating the `BeEmpty` assertion failure message - [#1692](https://github.com/fluentassertions/fluentassertions/pull/1692).
-* Enable support for extension methods in `Satisfy` - [#1696](https://github.com/fluentassertions/fluentassertions/pull/1696)
+* Prevent `ArgumentNullException` when formatting a lambda expression containing an extension method - [#1696](https://github.com/fluentassertions/fluentassertions/pull/1696)
 
 ## 6.1.0
 


### PR DESCRIPTION
## Problem
Calling an extension method from the expression provided to `Satisfy` causes an exception. Solves #1688 

## Solution
Ignore null expressions in the constant visitor.

## Not in scope
User-friendly formatting of an external lambda expression parameter is not solved as part of this pull request. I can see that it is also not yet cleanly solved in other APIs. 
E.g. `Should().Contain(a => allowed.Contains(a))` would fail with the following error message: 
```
"Expected actual {4} to have an item matching value(FluentAssertions.Specs.Formatting.PredicateLambdaExpressionValueFormatterSpecs+<>c__DisplayClass5_0).allowed.Contains(i).";
```

## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).