### PR TITLE
Added `TypeEquivalencyStep` for asserting types are equal when asserting equivalency. Useful when working with polymorphic models that do not implement equality.

### DIFF
--- a/Src/FluentAssertions/Equivalency/Steps/TypeEquivalencyStep.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/TypeEquivalencyStep.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FluentAssertions.Equivalency.Steps
+{
+    /// <summary>
+    /// A equivalency step for Fluent Assertions that asserts an object must be the same type to be equivalent.
+    /// This differs from Fluent Assertions default equivalency assertion that states 2 objects are equivalent if the have the same properties and values, reguardless of type.
+    /// Useful when working with polymorphic models that may or may not have inner properties. - https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/object-oriented/polymorphism
+    /// </summary>
+    public class TypeEquivalencyStep : IEquivalencyStep
+    {
+        EquivalencyResult IEquivalencyStep.Handle(Comparands comparands, IEquivalencyValidationContext context, IEquivalencyValidator nestedValidator)
+        {
+            // When comparing using a collection we want to compare the children of the collection not the collection itself (the root object)
+            // Value Types should be directly compared otherwise `GetSelectedMembers(comparands, context).Any()` will return false and skip actual value checking
+            if (comparands.Subject is IEnumerable || comparands.RuntimeType.IsValueType)
+            {
+                return EquivalencyResult.ContinueWithNext;
+            }
+
+            // If both are null or same reference or are comparable, no need to have this step check anything
+            if (comparands.Subject == comparands.Expectation)
+            {
+                return EquivalencyResult.ContinueWithNext;
+            }
+
+            // The above checked if both were null, if only 1 is null then no need to have this step check anything
+            if (comparands.Subject == null || comparands.Expectation == null)
+            {
+                return EquivalencyResult.ContinueWithNext;
+            }
+
+            // Actually assert the type - Will throw an exception if they do not match
+            comparands.Subject.GetType().Should().Be(comparands.Expectation.GetType(), context.Reason.FormattedMessage, context.Reason.Arguments);
+
+            // We have asserted they are the same type and there are no members to compare so no other equivalency steps need to be made.
+            // The default equivalency steps will throw an exception for objects with no members to compare, so important we return `AssertionCompleted` here.
+            if (!GetSelectedMembers(comparands, context).Any())
+            {
+                return EquivalencyResult.AssertionCompleted;
+            }
+            
+            // The object has other members (fields & properties) to compare.
+            // Returning `ContinueWithNext` means other steps will need to run on this object, which will assert structural equivalency.
+            return EquivalencyResult.ContinueWithNext;
+        }
+
+        /// <summary>
+        /// The members (fields and properties) on the context subject that is used to compare structural equivalency.
+        /// </summary>
+        private static IEnumerable<IMember> GetSelectedMembers(Comparands comparands, IEquivalencyValidationContext context)
+        {
+            IEnumerable<IMember> members = Enumerable.Empty<IMember>();
+
+            foreach (IMemberSelectionRule selectionRule in context.Options.SelectionRules)
+            {
+                members = selectionRule.SelectMembers(context.CurrentNode, members, new MemberSelectionContext(comparands.CompileTimeType, comparands.RuntimeType, context.Options));
+            }
+
+            return members;
+        }
+    }
+}

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -319,6 +319,10 @@ namespace FluentAssertions
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInOrderSameTypeEquivalentTo<T>(this FluentAssertions.Collections.GenericCollectionAssertions<T> collection, params T[] expectations) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInOrderSameTypeEquivalentTo<T>(this FluentAssertions.Collections.GenericCollectionAssertions<T> collection, System.Collections.Generic.IEnumerable<T> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> config, string because = "", params object[] becauseArgs) { }
+        public static void BeSameTypeEquivalentTo<T>(this FluentAssertions.Primitives.ObjectAssertions objectAssertions, T expectation, string because = "", params object[] becauseArgs) { }
+        public static void BeSameTypeEquivalentTo<T>(this FluentAssertions.Primitives.ObjectAssertions objectAssertions, T expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> config, string because = "", params object[] becauseArgs) { }
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeXmlSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
     }
     public abstract class OccurrenceConstraint
@@ -1134,6 +1138,10 @@ namespace FluentAssertions.Equivalency.Steps
     {
         public StructuralEqualityEquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class TypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public TypeEquivalencyStep() { }
     }
     public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -319,6 +319,10 @@ namespace FluentAssertions
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInOrderSameTypeEquivalentTo<T>(this FluentAssertions.Collections.GenericCollectionAssertions<T> collection, params T[] expectations) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInOrderSameTypeEquivalentTo<T>(this FluentAssertions.Collections.GenericCollectionAssertions<T> collection, System.Collections.Generic.IEnumerable<T> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> config, string because = "", params object[] becauseArgs) { }
+        public static void BeSameTypeEquivalentTo<T>(this FluentAssertions.Primitives.ObjectAssertions objectAssertions, T expectation, string because = "", params object[] becauseArgs) { }
+        public static void BeSameTypeEquivalentTo<T>(this FluentAssertions.Primitives.ObjectAssertions objectAssertions, T expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> config, string because = "", params object[] becauseArgs) { }
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeXmlSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
     }
     public abstract class OccurrenceConstraint
@@ -1134,6 +1138,10 @@ namespace FluentAssertions.Equivalency.Steps
     {
         public StructuralEqualityEquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class TypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public TypeEquivalencyStep() { }
     }
     public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -319,6 +319,10 @@ namespace FluentAssertions
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInOrderSameTypeEquivalentTo<T>(this FluentAssertions.Collections.GenericCollectionAssertions<T> collection, params T[] expectations) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInOrderSameTypeEquivalentTo<T>(this FluentAssertions.Collections.GenericCollectionAssertions<T> collection, System.Collections.Generic.IEnumerable<T> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> config, string because = "", params object[] becauseArgs) { }
+        public static void BeSameTypeEquivalentTo<T>(this FluentAssertions.Primitives.ObjectAssertions objectAssertions, T expectation, string because = "", params object[] becauseArgs) { }
+        public static void BeSameTypeEquivalentTo<T>(this FluentAssertions.Primitives.ObjectAssertions objectAssertions, T expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> config, string because = "", params object[] becauseArgs) { }
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeXmlSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
     }
     public abstract class OccurrenceConstraint
@@ -1134,6 +1138,10 @@ namespace FluentAssertions.Equivalency.Steps
     {
         public StructuralEqualityEquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class TypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public TypeEquivalencyStep() { }
     }
     public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -312,6 +312,10 @@ namespace FluentAssertions
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInOrderSameTypeEquivalentTo<T>(this FluentAssertions.Collections.GenericCollectionAssertions<T> collection, params T[] expectations) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInOrderSameTypeEquivalentTo<T>(this FluentAssertions.Collections.GenericCollectionAssertions<T> collection, System.Collections.Generic.IEnumerable<T> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> config, string because = "", params object[] becauseArgs) { }
+        public static void BeSameTypeEquivalentTo<T>(this FluentAssertions.Primitives.ObjectAssertions objectAssertions, T expectation, string because = "", params object[] becauseArgs) { }
+        public static void BeSameTypeEquivalentTo<T>(this FluentAssertions.Primitives.ObjectAssertions objectAssertions, T expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> config, string because = "", params object[] becauseArgs) { }
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeXmlSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
     }
     public abstract class OccurrenceConstraint
@@ -1127,6 +1131,10 @@ namespace FluentAssertions.Equivalency.Steps
     {
         public StructuralEqualityEquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class TypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public TypeEquivalencyStep() { }
     }
     public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -319,6 +319,10 @@ namespace FluentAssertions
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeBinarySerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeDataContractSerializable<T>(this FluentAssertions.Primitives.ObjectAssertions assertions, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> options, string because = "", params object[] becauseArgs) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInOrderSameTypeEquivalentTo<T>(this FluentAssertions.Collections.GenericCollectionAssertions<T> collection, params T[] expectations) { }
+        public static FluentAssertions.AndConstraint<FluentAssertions.Collections.GenericCollectionAssertions<T>> BeInOrderSameTypeEquivalentTo<T>(this FluentAssertions.Collections.GenericCollectionAssertions<T> collection, System.Collections.Generic.IEnumerable<T> expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> config, string because = "", params object[] becauseArgs) { }
+        public static void BeSameTypeEquivalentTo<T>(this FluentAssertions.Primitives.ObjectAssertions objectAssertions, T expectation, string because = "", params object[] becauseArgs) { }
+        public static void BeSameTypeEquivalentTo<T>(this FluentAssertions.Primitives.ObjectAssertions objectAssertions, T expectation, System.Func<FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>, FluentAssertions.Equivalency.EquivalencyAssertionOptions<T>> config, string because = "", params object[] becauseArgs) { }
         public static FluentAssertions.AndConstraint<FluentAssertions.Primitives.ObjectAssertions> BeXmlSerializable(this FluentAssertions.Primitives.ObjectAssertions assertions, string because = "", params object[] becauseArgs) { }
     }
     public abstract class OccurrenceConstraint
@@ -1134,6 +1138,10 @@ namespace FluentAssertions.Equivalency.Steps
     {
         public StructuralEqualityEquivalencyStep() { }
         public FluentAssertions.Equivalency.EquivalencyResult Handle(FluentAssertions.Equivalency.Comparands comparands, FluentAssertions.Equivalency.IEquivalencyValidationContext context, FluentAssertions.Equivalency.IEquivalencyValidator nestedValidator) { }
+    }
+    public class TypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
+    {
+        public TypeEquivalencyStep() { }
     }
     public class ValueTypeEquivalencyStep : FluentAssertions.Equivalency.IEquivalencyStep
     {

--- a/Tests/FluentAssertions.Specs/Equivalency/TypeEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/TypeEquivalencySpecs.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace FluentAssertions.Specs.Equivalency
+{
+    public class TypeEquivalencySpecs
+    {
+        [Fact]
+        public void SameTypes_AndProperties_AreEquivalent()
+        {
+            State a1 = new State.A("Yellow", 56, 58, new TestModel("test", 1234));
+            State a2 = new State.A("Yellow", 56, 58, new TestModel("test", 1234));
+
+            a1
+                .Should()
+                .BeSameTypeEquivalentTo(a2);
+        }
+
+        [Fact]
+        public void EnumerableSameTypes_AndProperties_AreInOrderEquivalent()
+        {
+            State a1 = new State.A("Yellow", 56, 58, new TestModel("test", 1234));
+            State b1 = new State.B("Green", 800, 590, new TestModel("testing", 589));
+
+            State a2 = new State.A("Yellow", 56, 58, new TestModel("test", 1234));
+            State b2 = new State.B("Green", 800, 590, new TestModel("testing", 589));
+
+            new List<State> { a1, b1 }
+                .Should()
+                .BeInOrderSameTypeEquivalentTo(a2, b2);
+        }
+
+        [Fact]
+        public void SameTypes_DifferentValueTypeProperty_AreNotEquivalent()
+        {
+            State a1 = new State.A("Yellow", 56, 58, new TestModel("test", 1234));
+            State a2 = new State.A("Yellow", 56, 700, new TestModel("test", 1234));
+
+            Assert.ThrowsAny<Exception>(
+                () => a1.Should().BeSameTypeEquivalentTo(a2));
+        }
+
+        [Fact]
+        public void SameTypes_DifferentReferenceTypeProperty_AreNotEquivalent()
+        {
+            State a1 = new State.A("Yellow", 56, 58, new TestModel("test", 1234));
+            State a2 = new State.A("Green", 56, 58, new TestModel("test", 1234));
+
+            Assert.ThrowsAny<Exception>(
+                () => a1.Should().BeSameTypeEquivalentTo(a2));
+        }
+
+        [Fact]
+        public void SameTypes_DifferentSubModelProperty_AreNotEquivalent()
+        {
+            State a1 = new State.A("Yellow", 56, 58, new TestModel("test", 1234));
+            State a2 = new State.A("Green", 56, 58, new TestModel("hello", 1234));
+
+            Assert.ThrowsAny<Exception>(
+                () => a1.Should().BeSameTypeEquivalentTo(a2));
+        }
+
+        [Fact]
+        public void EnumerableSameTypes_DifferentProperties_AreNotEquivalent()
+        {
+            State a1 = new State.A("Yellow", 56, 58, new TestModel("test", 1234));
+            State b1 = new State.B("Green", 800, 590, new TestModel("testing", 589));
+
+            State a2 = new State.A("Yellow", 56, 58, new TestModel("test", 1234));
+            State b2 = new State.B("Blue", 801, 590, new TestModel("testing", 589));
+
+            Assert.ThrowsAny<Exception>(() =>
+                new List<State> { a1, b1 }
+                    .Should()
+                    .BeInOrderSameTypeEquivalentTo(a2, b2));
+        }
+
+        [Fact]
+        public void DifferentTypes_NoProperties_AreNotEquivalent()
+        {
+            State stateC = new State.C();
+            State stateD = new State.D();
+
+            Assert.ThrowsAny<Exception>(
+                () => stateC.Should().BeSameTypeEquivalentTo(stateD));
+        }
+
+        [Fact]
+        public void SameTypes_NoProperties_AreEquivalent()
+        {
+            State stateC1 = new State.C();
+            State stateC2 = new State.C();
+
+            stateC1.Should().BeSameTypeEquivalentTo(stateC2);
+        }
+
+        private abstract class State
+        {
+            public class A : State
+            {
+                public string Color { get; }
+
+                public int Count { get; }
+
+                public double Height { get; }
+
+                public TestModel TestModel { get; }
+
+                public A(string color, int count, double height, TestModel testModel)
+                {
+                    Color = color;
+                    Count = count;
+                    Height = height;
+                    TestModel = testModel;
+                }
+            }
+
+            public class B : State
+            {
+                public string Color { get; }
+
+                public int Count { get; }
+
+                public double Height { get; }
+
+                public TestModel TestModel { get; }
+
+                public B(string color, int count, double height, TestModel testModel)
+                {
+                    Color = color;
+                    Count = count;
+                    Height = height;
+                    TestModel = testModel;
+                }
+            }
+
+            public class C : State { }
+
+            public class D : State { }
+        }
+
+        private class TestModel
+        {
+            public string StringValue { get; }
+
+            public int IntValue { get; }
+
+            public TestModel(string stringValue, int intValue)
+            {
+                StringValue = stringValue;
+                IntValue = intValue;
+            }
+        }
+    }
+}

--- a/docs/_pages/objectgraphs.md
+++ b/docs/_pages/objectgraphs.md
@@ -192,6 +192,34 @@ orderDto.Should().BeEquivalentTo(order, options => options
     .WhenTypeIs<DateTime>());
 ```
 
+If working with polymorphic models where equality is often not needed by default but asserting the correct type is needed you can use the `TypeEquivalencyStep`.
+
+```csharp
+abstract class OrderStatus
+{
+    class OrderPlaced : Status {}
+
+    class OrderProcessing : Status {}
+
+    class Error : Status 
+    {
+        Exception Exception { get; }
+    }
+
+    class Success : Status 
+    {
+        string ConfirmationCode { get; }
+    }
+}
+
+orderStatusUpdates // new List<Status>{}
+    .Should()
+    .BeInOrderSameTypeEquivalentTo(
+        new Status.Placed(), 
+        new Status.OrderProcessing(), 
+        new Status.Success(confirmationCode: "Aj-78"));
+```
+
 ### Enums
 
 By default, `Should().BeEquivalentTo()` compares `Enum` members by the enum's underlying numeric value.

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -13,6 +13,7 @@ sidebar:
 
 * Adding new overloads to all `GreaterOrEqualTo` and `LessOrEqualTo` assertions, adding the word `Than` - [#1673](https://github.com/fluentassertions/fluentassertions/pull/1673)
 * `BeAsync()` and `NotBeAsync()` are now also available on `MethodInfoSelectorAssertions` - [#1700](https://github.com/fluentassertions/fluentassertions/pull/1700)
+* Added `TypeEquivalencyStep` for asserting types are equal when asserting equivalency. Useful when working with polymorphic models that do not implement equality. - [#1704](https://github.com/fluentassertions/fluentassertions/pull/1704)
 
 ### Fixes
 


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [x] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).