### PR TITLE
Using `BeEquivalentTo` on a collection with nested collections would throw on missing members

### DIFF
--- a/Src/FluentAssertions/Equivalency/Node.cs
+++ b/Src/FluentAssertions/Equivalency/Node.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Linq;
+using System.Text.RegularExpressions;
 using FluentAssertions.Common;
 
 namespace FluentAssertions.Equivalency
@@ -10,6 +11,8 @@ namespace FluentAssertions.Equivalency
     /// </summary>
     public class Node : INode
     {
+        private static readonly Regex MatchFirstIndex = new(@"^\[\d+\]$");
+
         public GetSubjectId GetSubjectId { get; protected set; } = () => string.Empty;
 
         public Type Type { get; protected set; }
@@ -28,11 +31,11 @@ namespace FluentAssertions.Equivalency
             {
                 // If the root is a collection, we need treat the objects in that collection as the root of the graph because all options
                 // refer to the type of the collection items.
-                return PathAndName.Length == 0 || (RootIsCollection && IsIndex);
+                return PathAndName.Length == 0 || (RootIsCollection && IsFirstIndex);
             }
         }
 
-        private bool IsIndex => PathAndName.StartsWith("[", StringComparison.Ordinal) && PathAndName.EndsWith("]", StringComparison.Ordinal);
+        private bool IsFirstIndex => MatchFirstIndex.IsMatch(PathAndName);
 
         public bool RootIsCollection { get; protected set; }
 

--- a/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
+++ b/Tests/FluentAssertions.Specs/Equivalency/BasicEquivalencySpecs.cs
@@ -3429,6 +3429,37 @@ namespace FluentAssertions.Specs.Equivalency
                 .WithMessage("Expected property c1.RefOne.ValTwo to be 2, but found 3*");
         }
 
+        [Fact]
+        public void Should_support_nested_collections_containing_empty_objects()
+        {
+            // Arrange
+            var orig = new[]
+            {
+                new OuterWithObject
+                {
+                    MyProperty = new[] { new Inner() }
+                }
+            };
+
+            var expectation = new[]
+            {
+                new OuterWithObject
+                {
+                    MyProperty = new[] { new Inner() }
+                }
+            };
+
+            // Act / Assert
+            orig.Should().BeEquivalentTo(expectation);
+        }
+
+        public class Inner { }
+
+        public class OuterWithObject
+        {
+            public Inner[] MyProperty { get; set; }
+        }
+
         #endregion
 
         #region Cyclic References

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -21,6 +21,7 @@ sidebar:
 * Removed iteration over enumerable when generating the `BeEmpty` assertion failure message - [#1692](https://github.com/fluentassertions/fluentassertions/pull/1692).
 * Prevent `ArgumentNullException` when formatting a lambda expression containing an extension method - [#1696](https://github.com/fluentassertions/fluentassertions/pull/1696)
 * `IgnoringCyclicReferences` in `BeEquivalentTo` now works while comparing value types using `ComparingByMembers` - [#1708](https://github.com/fluentassertions/fluentassertions/pull/1708) 
+* Using `BeEquivalentTo` on a collection with nested collections would complain about missing members - [#1713](https://github.com/fluentassertions/fluentassertions/pull/1713)
 
 ## 6.1.0
 


### PR DESCRIPTION
If a collection contains another collection referring to objects without visible properties, `BeEquivalentTo` will throw and complain about missing members. This was caused by the `IsRoot` property on `INode` that misinterpreted the path string `[0].MyProperty[0]` as if we were processing the objects in the root collection. 

Fixed #1710 