### PR TITLE
Fix formatting a lambda expression with lifted operators

### DIFF
--- a/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
+++ b/Src/FluentAssertions/Formatting/PredicateLambdaExpressionValueFormatter.cs
@@ -86,13 +86,21 @@ namespace FluentAssertions.Formatting
                     return null;
                 }
 
-                if (ExpressionIsConstant(node))
+                if (node is ConstantExpression)
+                {
+                    return node;
+                }
+
+                if (!HasLiftedOperator(node) && ExpressionIsConstant(node))
                 {
                     return Expression.Constant(Expression.Lambda(node).Compile().DynamicInvoke());
                 }
 
                 return base.Visit(node);
             }
+
+            private static bool HasLiftedOperator(Expression expression) =>
+                expression is BinaryExpression { IsLifted: true } or UnaryExpression { IsLifted: true };
 
             private static bool ExpressionIsConstant(Expression expression)
             {

--- a/Tests/FluentAssertions.Specs/Formatting/PredicateLambdaExpressionValueFormatterSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Formatting/PredicateLambdaExpressionValueFormatterSpecs.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using FluentAssertions.Formatting;
 using Xunit;
+using Xunit.Sdk;
 
 namespace FluentAssertions.Specs.Formatting
 {
@@ -68,6 +69,20 @@ namespace FluentAssertions.Specs.Formatting
             result.Should().Be("value(System.Int32[]).Contains(a)");
         }
 
+        [Fact]
+        public void Formatting_a_lifted_binary_operator()
+        {
+            // Arrange
+            var subject = new ClassWithNullables { Number = 42 };
+
+            // Act
+            Action act = () => subject.Should().Match<ClassWithNullables>(e => e.Number > 43);
+
+            // Assert
+            act.Should().Throw<XunitException>()
+                .WithMessage("*e.Number > *43*");
+        }
+
         private string Format(Expression<Func<SomeClass, bool>> expression) => Format<SomeClass>(expression);
 
         private string Format<T>(Expression<Func<T, bool>> expression)
@@ -78,6 +93,11 @@ namespace FluentAssertions.Specs.Formatting
 
             return graph.ToString();
         }
+    }
+
+    internal class ClassWithNullables
+    {
+        public int? Number { get; set; }
     }
 
     internal class SomeClass

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -22,6 +22,7 @@ sidebar:
 * Prevent `ArgumentNullException` when formatting a lambda expression containing an extension method - [#1696](https://github.com/fluentassertions/fluentassertions/pull/1696)
 * `IgnoringCyclicReferences` in `BeEquivalentTo` now works while comparing value types using `ComparingByMembers` - [#1708](https://github.com/fluentassertions/fluentassertions/pull/1708) 
 * Using `BeEquivalentTo` on a collection with nested collections would complain about missing members - [#1713](https://github.com/fluentassertions/fluentassertions/pull/1713)
+* Formatting a lambda expression containing lifted operators - [#1714](https://github.com/fluentassertions/fluentassertions/pull/1714).
 
 ## 6.1.0
 


### PR DESCRIPTION
My analysis in #1712 was not spot on.

Lifted operators are fine to use in `Expressions`, but only as long as we keep the LHS and RHS lifted.
The compiler converts `e => e.Number > 43` into `e => e.Number > Convert(43)`, which is the expression form of `e => e.Number > (int?)43`.
So the problem was that we tried to reduce `(int?)43` to `43`, which is not allowed.

This also add a check to avoid reducing already constant expressions.

This fixes #1712 