### PR TITLE
Simplify IsAsync

### DIFF
--- a/Src/FluentAssertions/Common/MethodInfoExtensions.cs
+++ b/Src/FluentAssertions/Common/MethodInfoExtensions.cs
@@ -18,7 +18,7 @@ namespace FluentAssertions.Common
 
         internal static bool IsAsync(this MethodInfo methodInfo)
         {
-            return methodInfo.GetMatchingAttributes<Attribute>(a => a.GetType().FullName == "System.Runtime.CompilerServices.AsyncStateMachineAttribute").Any();
+            return methodInfo.IsDecoratedWith<AsyncStateMachineAttribute>();
         }
 
         internal static IEnumerable<TAttribute> GetMatchingAttributes<TAttribute>(this MemberInfo memberInfo, Expression<Func<TAttribute, bool>> isMatchingAttributePredicate)


### PR DESCRIPTION
A possible reason for the somewhat odd implementation.
`IsAsync` was introduced in be215cf5ef9a21857bd6deddfd9bf48ba0cc3517 and released as part of 3.5.0.
`AsyncStateMachineAttribute` was introduced in net45, but with FA 3.5.0 we still supported net40.