### PR TITLE
Fix building on linux/WSL

### DIFF
--- a/Tests/TestFrameworks/MSTestV2.Specs/MSTestV2.Specs.csproj
+++ b/Tests/TestFrameworks/MSTestV2.Specs/MSTestV2.Specs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>MSTestV2.Specs</RootNamespace>
     <AssemblyName>MSTestV2.Specs</AssemblyName>
     <CodeAnalysisRuleSet>..\..\..\TestRules.ruleset</CodeAnalysisRuleSet>

--- a/Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj
+++ b/Tests/TestFrameworks/MSpec.Specs/MSpec.Specs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>MSpec.Specs</RootNamespace>
     <AssemblyName>MSpec.Specs</AssemblyName>
     <CodeAnalysisRuleSet>Rules.ruleset</CodeAnalysisRuleSet>

--- a/Tests/TestFrameworks/NUnit3.Specs/NUnit3.Specs.csproj
+++ b/Tests/TestFrameworks/NUnit3.Specs/NUnit3.Specs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>NUnit3.Specs</RootNamespace>
     <AssemblyName>NUnit3.Specs</AssemblyName>
     <CodeAnalysisRuleSet>..\..\..\TestRules.ruleset</CodeAnalysisRuleSet>

--- a/Tests/TestFrameworks/XUnit2.Specs/XUnit2.Specs.csproj
+++ b/Tests/TestFrameworks/XUnit2.Specs/XUnit2.Specs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net47;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net47;net5.0</TargetFrameworks>
     <RootNamespace>XUnit2.Specs</RootNamespace>
     <AssemblyName>XUnit2.Specs</AssemblyName>
     <CodeAnalysisRuleSet>..\..\..\TestRules.ruleset</CodeAnalysisRuleSet>

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 # CONFIGURATION
 ###########################################################################
 
-BUILD_PROJECT_FILE="$SCRIPT_DIR/build/_build.csproj"
+BUILD_PROJECT_FILE="$SCRIPT_DIR/Build/_build.csproj"
 TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
 
 DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"


### PR DESCRIPTION
With these changes one can now run `./build.sh` from linux.
As I wanted to be able to run tests without having mono installed, the .NET Frameworks tests are excluded when running on linux.

The upgrade from netcoreapp2.1 to net5.0 is solely to silence a build warning about net core 2.1 being EOL.

Tested on
* Ubuntu 20.04.3 (through WSL)
* Linux Mint 20.2