### PR TITLE
Add test of clearing cache when calling `ComparingByMembers`

### DIFF
--- a/Src/FluentAssertions/Common/TypeExtensions.cs
+++ b/Src/FluentAssertions/Common/TypeExtensions.cs
@@ -217,7 +217,7 @@ namespace FluentAssertions.Common
 
         public static IEnumerable<PropertyInfo> GetNonPrivateProperties(this Type typeToReflect, MemberVisibility visibility)
         {
-            return NonPrivatePropertiesCache.GetOrAdd((typeToReflect, visibility), key =>
+            return NonPrivatePropertiesCache.GetOrAdd((typeToReflect, visibility), static key =>
             {
                 IEnumerable<PropertyInfo> query =
                     from propertyInfo in GetPropertiesFromHierarchy(key.Type, key.Visibility)
@@ -245,7 +245,7 @@ namespace FluentAssertions.Common
 
         public static IEnumerable<FieldInfo> GetNonPrivateFields(this Type typeToReflect, MemberVisibility visibility)
         {
-            return NonPrivateFieldsCache.GetOrAdd((typeToReflect, visibility), key =>
+            return NonPrivateFieldsCache.GetOrAdd((typeToReflect, visibility), static key =>
             {
                 IEnumerable<FieldInfo> query =
                     from fieldInfo in GetFieldsFromHierarchy(key.Type, key.Visibility)
@@ -533,7 +533,7 @@ namespace FluentAssertions.Common
 
         public static bool HasValueSemantics(this Type type)
         {
-            return HasValueSemanticsCache.GetOrAdd(type, t =>
+            return HasValueSemanticsCache.GetOrAdd(type, static t =>
                 t.OverridesEquals() &&
                 !t.IsAnonymousType() &&
                 !t.IsTuple() &&
@@ -583,7 +583,7 @@ namespace FluentAssertions.Common
 
         public static bool IsRecord(this Type type)
         {
-            return TypeIsRecordCache.GetOrAdd(type, t =>
+            return TypeIsRecordCache.GetOrAdd(type, static t =>
                 t.GetMethod("<Clone>$") is not null &&
                 t.GetTypeInfo()
                      .DeclaredProperties

--- a/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/FluentAssertions/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -166,6 +166,8 @@ namespace FluentAssertions.Equivalency
 
         EqualityStrategy IEquivalencyAssertionOptions.GetEqualityStrategy(Type requestedType)
         {
+            // As the valueFactory parameter captures instance members,
+            // be aware if the cache must be cleared on mutating the members.
             return equalityStrategyCache.GetOrAdd(requestedType, type =>
             {
                 EqualityStrategy strategy;

--- a/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
+++ b/Src/FluentAssertions/Equivalency/Steps/DictionaryInterfaceInfo.cs
@@ -95,7 +95,7 @@ namespace FluentAssertions.Equivalency.Steps
 
         private static DictionaryInterfaceInfo[] GetDictionaryInterfacesFrom(Type target)
         {
-            return Cache.GetOrAdd(target, key =>
+            return Cache.GetOrAdd(target, static key =>
             {
                 if (Type.GetTypeCode(key) != TypeCode.Object)
                 {

--- a/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
+++ b/Tests/FluentAssertions.Specs/AssertionOptionsSpecs.cs
@@ -54,9 +54,46 @@ namespace FluentAssertions.Specs
         }
 
         [Collection("AssertionOptionsSpecs")]
-        public class When_modifying_global_settings_a_previous_assertion_should_not_have_any_effect : Given_temporary_global_assertion_options
+        public class When_modifying_global_reference_type_settings_a_previous_assertion_should_not_have_any_effect
+            : Given_temporary_global_assertion_options
         {
-            public When_modifying_global_settings_a_previous_assertion_should_not_have_any_effect()
+            public When_modifying_global_reference_type_settings_a_previous_assertion_should_not_have_any_effect()
+            {
+                Given(() =>
+                {
+                    // Trigger a first equivalency check using the default global settings
+                    new MyValueType { Value = 1 }.Should().BeEquivalentTo(new MyValueType { Value = 2 });
+                });
+
+                When(() =>
+                {
+                    AssertionOptions.AssertEquivalencyUsing(o => o.ComparingByMembers<MyValueType>());
+                });
+            }
+
+            [Fact]
+            public void It_should_try_to_compare_the_classes_by_member_semantics_and_thus_throw()
+            {
+                Action act = () => new MyValueType { Value = 1 }.Should().BeEquivalentTo(new MyValueType { Value = 2 });
+
+                act.Should().Throw<XunitException>();
+            }
+        }
+
+        internal class MyValueType
+        {
+            public int Value { get; set; }
+
+            public override bool Equals(object obj) => true;
+
+            public override int GetHashCode() => 0;
+        }
+
+        [Collection("AssertionOptionsSpecs")]
+        public class When_modifying_global_value_type_settings_a_previous_assertion_should_not_have_any_effect
+            : Given_temporary_global_assertion_options
+        {
+            public When_modifying_global_value_type_settings_a_previous_assertion_should_not_have_any_effect()
             {
                 Given(() =>
                 {

--- a/Tests/FluentAssertions.Specs/CultureAwareTesting/DictionaryExtensions.cs
+++ b/Tests/FluentAssertions.Specs/CultureAwareTesting/DictionaryExtensions.cs
@@ -10,7 +10,7 @@ namespace FluentAssertions.Specs.CultureAwareTesting
 
         public static TValue GetOrAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
             where TValue : new() =>
-            dictionary.GetOrAdd(key, () => new TValue());
+            dictionary.GetOrAdd(key, static () => new TValue());
 
         public static TValue GetOrAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, Func<TValue> newValue)
         {


### PR DESCRIPTION
In addition I noted that it doesn't seem necessary to clear the cache on calling `ComparingRecordsByValue`/`ComparingRecordsByMembers` as:
* `compareRecordsByValue` is initialized to `defaults.CompareRecordsByValue` and
* `GetEqualityStrategy` does not call recursively to determine strategy when `type.IsRecord()`.