### PR TITLE
Adding `ThatAreAsync()` and `ThatAreNotAsync()` to `MethodInfoSelector`

### DIFF
--- a/Src/FluentAssertions/Types/MethodInfoSelector.cs
+++ b/Src/FluentAssertions/Types/MethodInfoSelector.cs
@@ -134,6 +134,24 @@ namespace FluentAssertions.Types
         }
 
         /// <summary>
+        /// Only return methods that are async. 
+        /// </summary>
+        public MethodInfoSelector ThatAreAsync()
+        {
+            selectedMethods = selectedMethods.Where(method => method.IsAsync());
+            return this;
+        }
+
+        /// <summary>
+        /// Only return methods that are not async. 
+        /// </summary>
+        public MethodInfoSelector ThatAreNotAsync()
+        {
+            selectedMethods = selectedMethods.Where(method => !method.IsAsync());
+            return this;
+        }
+
+        /// <summary>
         /// Select return types of the methods
         /// </summary>
         public TypeSelector ReturnTypes()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/net47.verified.txt
@@ -2341,10 +2341,12 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
         public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
         public FluentAssertions.Types.TypeSelector ReturnTypes() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp2.1.verified.txt
@@ -2343,10 +2343,12 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
         public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
         public FluentAssertions.Types.TypeSelector ReturnTypes() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netcoreapp3.0.verified.txt
@@ -2343,10 +2343,12 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
         public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
         public FluentAssertions.Types.TypeSelector ReturnTypes() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.0.verified.txt
@@ -2294,10 +2294,12 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
         public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
         public FluentAssertions.Types.TypeSelector ReturnTypes() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()

--- a/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
+++ b/Tests/Approval.Tests/ApprovedApi/FluentAssertions/netstandard2.1.verified.txt
@@ -2343,10 +2343,12 @@ namespace FluentAssertions.Types
         public FluentAssertions.Types.MethodInfoSelector ThatReturnVoid { get; }
         public System.Collections.Generic.IEnumerator<System.Reflection.MethodInfo> GetEnumerator() { }
         public FluentAssertions.Types.TypeSelector ReturnTypes() { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreDecoratedWithOrInherit<TAttribute>()
             where TAttribute : System.Attribute { }
+        public FluentAssertions.Types.MethodInfoSelector ThatAreNotAsync() { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWith<TAttribute>()
             where TAttribute : System.Attribute { }
         public FluentAssertions.Types.MethodInfoSelector ThatAreNotDecoratedWithOrInherit<TAttribute>()

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading.Tasks;
 using FluentAssertions.Types;
 using Internal.Main.Test;
 using Xunit;
@@ -273,6 +274,32 @@ namespace FluentAssertions.Specs.Types
         }
 
         [Fact]
+        public void When_selecting_methods_that_are_async_it_should_only_return_the_applicable_methods()
+        {
+            // Arrange
+            Type type = typeof(TestClassForMethodSelectorWithAsync);
+
+            // Act
+            IEnumerable<MethodInfo> methods = type.Methods().ThatAreAsync().ToArray();
+
+            // Assert
+            methods.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void When_selecting_methods_that_are_not_async_it_should_only_return_the_applicable_methods()
+        {
+            // Arrange
+            Type type = typeof(TestClassForMethodSelector);
+
+            // Act
+            MethodInfo[] methods = type.Methods().ThatAreNotAsync().ToArray();
+
+            // Assert
+            methods.Length.Should().Be(7);
+        }
+
+        [Fact]
         public void When_selecting_methods_not_decorated_with_or_inheriting_a_noninheritable_attribute_it_should_only_return_the_applicable_methods()
         {
             // Arrange
@@ -365,6 +392,14 @@ namespace FluentAssertions.Specs.Types
     internal class TestClassForMethodSelectorWithNonInheritableAttributeDerived : TestClassForMethodSelectorWithNonInheritableAttribute
     {
         public override void PublicVirtualVoidMethodWithAttribute() { }
+    }
+
+    internal class TestClassForMethodSelectorWithAsync
+    {
+        public async virtual void PublicVirtualVoidAsyncMethod()
+        {
+            await Task.FromResult(42);
+        }
     }
 
     internal class TestClassForMethodReturnTypesSelector

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
@@ -283,8 +283,8 @@ namespace FluentAssertions.Specs.Types
             MethodInfo[] methods = type.Methods().ThatAreAsync().ToArray();
 
             // Assert
-            methods.Should().ContainSingle();
-            methods[0].Name.Should().Be("PublicVirtualVoidAsyncMethod");
+            methods.Should().ContainSingle()
+                .Which.Name.Should().Be("PublicVirtualVoidAsyncMethod");
         }
 
         [Fact]
@@ -297,8 +297,8 @@ namespace FluentAssertions.Specs.Types
             MethodInfo[] methods = type.Methods().ThatAreNotAsync().ToArray();
 
             // Assert
-            methods.Should().ContainSingle();
-            methods[0].Name.Should().Be("PublicVirtualVoidNotAsyncMethod");
+            methods.Should().ContainSingle()
+                .Which.Name.Should().Be("PublicVirtualVoidNotAsyncMethod");
         }
 
         [Fact]
@@ -398,12 +398,12 @@ namespace FluentAssertions.Specs.Types
 
     internal class TestClassForMethodSelectorWithAsyncAndNonAsyncMethod
     {
-        public async virtual void PublicVirtualVoidAsyncMethod()
+        public async void PublicVirtualVoidAsyncMethod()
         {
             await Task.Yield();
         }
 
-        public virtual void PublicVirtualVoidNotAsyncMethod() { }
+        public void PublicVirtualVoidNotAsyncMethod() { }
     }
 
     internal class TestClassForMethodReturnTypesSelector

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
@@ -277,26 +277,28 @@ namespace FluentAssertions.Specs.Types
         public void When_selecting_methods_that_are_async_it_should_only_return_the_applicable_methods()
         {
             // Arrange
-            Type type = typeof(TestClassForMethodSelectorWithAsync);
+            Type type = typeof(TestClassForMethodSelectorWithAsyncAndNonAsyncMethod);
 
             // Act
-            IEnumerable<MethodInfo> methods = type.Methods().ThatAreAsync().ToArray();
+            MethodInfo[] methods = type.Methods().ThatAreAsync().ToArray();
 
             // Assert
             methods.Should().ContainSingle();
+            methods[0].Name.Should().Be("PublicVirtualVoidAsyncMethod");
         }
 
         [Fact]
         public void When_selecting_methods_that_are_not_async_it_should_only_return_the_applicable_methods()
         {
             // Arrange
-            Type type = typeof(TestClassForMethodSelector);
+            Type type = typeof(TestClassForMethodSelectorWithAsyncAndNonAsyncMethod);
 
             // Act
             MethodInfo[] methods = type.Methods().ThatAreNotAsync().ToArray();
 
             // Assert
-            methods.Length.Should().Be(7);
+            methods.Should().ContainSingle();
+            methods[0].Name.Should().Be("PublicVirtualVoidNotAsyncMethod");
         }
 
         [Fact]
@@ -394,12 +396,14 @@ namespace FluentAssertions.Specs.Types
         public override void PublicVirtualVoidMethodWithAttribute() { }
     }
 
-    internal class TestClassForMethodSelectorWithAsync
+    internal class TestClassForMethodSelectorWithAsyncAndNonAsyncMethod
     {
         public async virtual void PublicVirtualVoidAsyncMethod()
         {
-            await Task.FromResult(42);
+            await Task.Yield();
         }
+
+        public virtual void PublicVirtualVoidNotAsyncMethod() { }
     }
 
     internal class TestClassForMethodReturnTypesSelector

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
@@ -284,7 +284,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             methods.Should().ContainSingle()
-                .Which.Name.Should().Be("PublicVirtualVoidAsyncMethod");
+                .Which.Name.Should().Be("PublicVoidAsyncMethod");
         }
 
         [Fact]
@@ -298,7 +298,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             methods.Should().ContainSingle()
-                .Which.Name.Should().Be("PublicVirtualVoidNotAsyncMethod");
+                .Which.Name.Should().Be("PublicVoidNotAsyncMethod");
         }
 
         [Fact]

--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
@@ -398,12 +398,12 @@ namespace FluentAssertions.Specs.Types
 
     internal class TestClassForMethodSelectorWithAsyncAndNonAsyncMethod
     {
-        public async void PublicVirtualVoidAsyncMethod()
+        public async void PublicVoidAsyncMethod()
         {
             await Task.Yield();
         }
 
-        public void PublicVirtualVoidNotAsyncMethod() { }
+        public void PublicVoidNotAsyncMethod() { }
     }
 
     internal class TestClassForMethodReturnTypesSelector

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -10,6 +10,7 @@ sidebar:
 ## Unreleased
 
 ### What's New
+* Adding `ThatAreAsync()` and `ThatAreNotAsync()` to `MethodInfoSelector`
 
 ### Fixes
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -10,7 +10,7 @@ sidebar:
 ## Unreleased
 
 ### What's New
-* Adding `ThatAreAsync()` and `ThatAreNotAsync()` to `MethodInfoSelector` [#645](https://github.com/fluentassertions/fluentassertions/pull/1725)
+* Adding `ThatAreAsync()` and `ThatAreNotAsync()` for filtering in method assertions - [#1725](https://github.com/fluentassertions/fluentassertions/pull/1725)
 
 ### Fixes
 

--- a/docs/_pages/releases.md
+++ b/docs/_pages/releases.md
@@ -10,7 +10,7 @@ sidebar:
 ## Unreleased
 
 ### What's New
-* Adding `ThatAreAsync()` and `ThatAreNotAsync()` to `MethodInfoSelector`
+* Adding `ThatAreAsync()` and `ThatAreNotAsync()` to `MethodInfoSelector` [#645](https://github.com/fluentassertions/fluentassertions/pull/1725)
 
 ### Fixes
 


### PR DESCRIPTION
## IMPORTANT 

* [x] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [x] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [x] If the contribution adds a feature or fixes a bug, please update [**the release notes**](https://github.com/fluentassertions/fluentassertions/tree/master/docs), which are published on the [website](https://fluentassertions.com/releases).
* [x] If the contribution changes the public API the changes needs to be included by running `AcceptApiChanges.ps1`/`AcceptApiChanges.sh`.
* [ ] If the contribution affects [the documentation](https://github.com/fluentassertions/fluentassertions/tree/develop/docs/_pages), please include your changes in this pull request so the documentation will appear on the [website](https://www.fluentassertions.com/introduction).