### PR TITLE
Return Task for async/non-async test method

### DIFF
--- a/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
+++ b/Tests/FluentAssertions.Specs/Types/MethodInfoSelectorSpecs.cs
@@ -284,7 +284,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             methods.Should().ContainSingle()
-                .Which.Name.Should().Be("PublicVoidAsyncMethod");
+                .Which.Name.Should().Be("PublicAsyncMethod");
         }
 
         [Fact]
@@ -298,7 +298,7 @@ namespace FluentAssertions.Specs.Types
 
             // Assert
             methods.Should().ContainSingle()
-                .Which.Name.Should().Be("PublicVoidNotAsyncMethod");
+                .Which.Name.Should().Be("PublicNonAsyncMethod");
         }
 
         [Fact]
@@ -398,12 +398,9 @@ namespace FluentAssertions.Specs.Types
 
     internal class TestClassForMethodSelectorWithAsyncAndNonAsyncMethod
     {
-        public async void PublicVoidAsyncMethod()
-        {
-            await Task.Yield();
-        }
+        public async Task PublicAsyncMethod() => await Task.Yield();
 
-        public void PublicVoidNotAsyncMethod() { }
+        public Task PublicNonAsyncMethod() => Task.CompletedTask;
     }
 
     internal class TestClassForMethodReturnTypesSelector


### PR DESCRIPTION
`MethodInfoExtensions.IsAsync` regards a method as async if and only if it is decorated with an `AsyncStateMachineAttribute`.
Returning `Task` is not enough.
Emphasize this by letting both methods in `TestClassForMethodSelectorWithAsyncAndNonAsyncMethod` return a `Task`.